### PR TITLE
Prepare InfluxDB for the golang sub repos rename

### DIFF
--- a/cluster/user.go
+++ b/cluster/user.go
@@ -3,9 +3,9 @@ package cluster
 import (
 	"regexp"
 
-	"code.google.com/p/go.crypto/bcrypt"
 	"github.com/influxdb/go-cache"
 	"github.com/influxdb/influxdb/common"
+	"golang.org/x/crypto/bcrypt"
 )
 
 var userCache *cache.Cache


### PR DESCRIPTION
According to this thread https://groups.google.com/forum/#!msg/golang-nuts/eD8dh3T9yyA/l5Ail-xfMiAJ some of the sub repos of go are moving from `code.google.com/p/go.*` to `golang.org/x/*`. This pr is to have a patch ready to be merged in once the repos are actually moved