### PR TITLE
Group by takes invalid input for some reason

### DIFF
--- a/metastore/store.go
+++ b/metastore/store.go
@@ -225,3 +225,29 @@ func (self *Store) setFieldIdsFromCache(database string, series []*protocol.Seri
 	}
 	return true
 }
+
+func (self *Store) SeriesHasField(database string, series []string, field string) bool {
+	self.fieldsLock.RLock()
+	defer self.fieldsLock.RUnlock()
+
+	dbseries, ok := self.StringsToIds[database]
+	if !ok {
+		return false
+	}
+
+	// Iterate through the list of series passed by the caller.
+	for _, ser := range series {
+		// Is the series in the database?
+		s, ok := dbseries[ser]
+		if !ok {
+			continue
+		}
+		// The series is in the database.  Does it contain the field?
+		_, ok = s[field]
+		if ok {
+			return true
+		}
+	}
+
+	return false
+}

--- a/parser/from_clause.go
+++ b/parser/from_clause.go
@@ -77,3 +77,11 @@ func (self *FromClause) GetString() string {
 	}
 	return buffer.String()
 }
+
+func (fc *FromClause) GetTableNames() []string {
+	names := make([]string, len(fc.Names))
+	for i, name := range fc.Names {
+		names[i] = name.Name.Name
+	}
+	return names
+}


### PR DESCRIPTION
For example, `select count(value) from foo group by 1` will return results. This is undefined query assuming there is no column with the name 1 and the results are undefined. I'm guessing The group by column is ignored and the result is just the count of the entire range of points.