### PR TITLE
Fixup sample config SSL

### DIFF
--- a/etc/config.sample.toml
+++ b/etc/config.sample.toml
@@ -35,7 +35,7 @@ port   = 8083              # binding is disabled if the port isn't set
 # Configure the http api
 [api]
 port     = 8086    # binding is disabled if the node is not a Data node.
-# ssl-port = 8084    # Ssl support is enabled if you set a port and cert
+# ssl-port = 8084    # SSL support is enabled if you set a port and cert
 # ssl-cert = "/path/to/cert.pem"
 
 # connections will timeout after this amount of time. Ensures that clients that misbehave

--- a/etc/config.sample.toml
+++ b/etc/config.sample.toml
@@ -36,7 +36,7 @@ port   = 8083              # binding is disabled if the port isn't set
 [api]
 port     = 8086    # binding is disabled if the node is not a Data node.
 # ssl-port = 8084    # Ssl support is enabled if you set a port and cert
-# ssl-cert = /path/to/cert.pem
+# ssl-cert = "/path/to/cert.pem"
 
 # connections will timeout after this amount of time. Ensures that clients that misbehave
 # and keep alive connections they don't use won't end up connection a million times.


### PR DESCRIPTION
- Properly quote the path to ssl-cert
- Upcase SSL abbreviation

re: https://github.com/influxdb/influxdb.org/pull/78