### PR TITLE
Fix errors for CORS Basic Authentication.

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -108,8 +108,8 @@ func NewHandler(s *Server) *Handler {
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	w.Header().Add("Access-Control-Allow-Origin", "*")
 	w.Header().Add("Access-Control-Max-Age", "2592000")
-	w.Header().Add("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE")
-	w.Header().Add("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept")
+	w.Header().Add("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
+	w.Header().Add("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept, Authorization")
 	w.Header().Add("X-Influxdb-Version", h.Version)
 
 	// If this is a CORS OPTIONS request then send back okie-dokie.

--- a/handler.go
+++ b/handler.go
@@ -108,7 +108,7 @@ func NewHandler(s *Server) *Handler {
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	w.Header().Add("Access-Control-Allow-Origin", "*")
 	w.Header().Add("Access-Control-Max-Age", "2592000")
-	w.Header().Add("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
+	w.Header().Add("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE")
 	w.Header().Add("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept, Authorization")
 	w.Header().Add("X-Influxdb-Version", h.Version)
 


### PR DESCRIPTION
- HTTP Access-Control-Allow-Method missing "OPTIONS".
- HTTP Access-Control-Allow-Headers missing "Authorization".

The same issue exists in current release v0.8.8. When Grafana is configured to use Basic Auth, the missing values in HTTP headers failed the authentication mechanism.