### PR TITLE
Fix server close race condition.

### DIFF
--- a/graphite/graphite.go
+++ b/graphite/graphite.go
@@ -33,7 +33,7 @@ var (
 
 // SeriesWriter defines the interface for the destination of the data.
 type SeriesWriter interface {
-	WriteSeries(database, retentionPolicy, name string, tags map[string]string, timestamp time.Time, values map[string]interface{}) error
+	WriteSeries(database, retentionPolicy, name string, tags map[string]string, timestamp time.Time, values map[string]interface{}) (uint64, error)
 }
 
 // Metric represents a metric as processed by the Graphite parser.

--- a/metastore.go
+++ b/metastore.go
@@ -66,7 +66,7 @@ func (m *metastore) mustView(fn func(*metatx) error) (err error) {
 		err = fn(tx)
 		return nil
 	}); e != nil {
-		panic("metastore view: " + err.Error())
+		panic("metastore view: " + e.Error())
 	}
 	return
 }
@@ -78,7 +78,7 @@ func (m *metastore) mustUpdate(fn func(*metatx) error) (err error) {
 		err = fn(tx)
 		return nil
 	}); e != nil {
-		panic("metastore update: " + err.Error())
+		panic("metastore update: " + e.Error())
 	}
 	return
 }

--- a/server.go
+++ b/server.go
@@ -1239,7 +1239,7 @@ func (s *Server) WriteSeries(database, retentionPolicy, name string, tags map[st
 	// Retrieve shard group.
 	g, err := s.createShardGroupIfNotExists(database, retentionPolicy, timestamp)
 	if err != nil {
-		return 0, fmt.Errorf("create shard(%s/%d): %s", retentionPolicy, timestamp.Format(time.RFC3339Nano), err)
+		return 0, fmt.Errorf("create shard(%s/%s): %s", retentionPolicy, timestamp.Format(time.RFC3339Nano), err)
 	}
 
 	// Find appropriate shard within the shard group.

--- a/server.go
+++ b/server.go
@@ -172,14 +172,14 @@ func (s *Server) Close() error {
 		return ErrServerClosed
 	}
 
+	// Remove path.
+	s.path = ""
+
 	// Close message processing.
 	s.setClient(nil)
 
 	// Close metastore.
 	_ = s.meta.close()
-
-	// Remove path.
-	s.path = ""
 
 	return nil
 }
@@ -1211,18 +1211,19 @@ type createSeriesIfNotExistsCommand struct {
 }
 
 // WriteSeries writes series data to the database.
-func (s *Server) WriteSeries(database, retentionPolicy, name string, tags map[string]string, timestamp time.Time, values map[string]interface{}) error {
+// Returns the messaging index the data was written to.
+func (s *Server) WriteSeries(database, retentionPolicy, name string, tags map[string]string, timestamp time.Time, values map[string]interface{}) (uint64, error) {
 	// Find the id for the series and tagset
 	seriesID, err := s.createSeriesIfNotExists(database, name, tags)
 	if err != nil {
-		return err
+		return 0, err
 	}
 
 	// If the retention policy is not set, use the default for this database.
 	if retentionPolicy == "" {
 		rp, err := s.DefaultRetentionPolicy(database)
 		if err != nil {
-			return fmt.Errorf("failed to determine default retention policy: %s", err.Error())
+			return 0, fmt.Errorf("failed to determine default retention policy: %s", err.Error())
 		}
 		retentionPolicy = rp.Name
 	}
@@ -1230,15 +1231,15 @@ func (s *Server) WriteSeries(database, retentionPolicy, name string, tags map[st
 	// Retrieve measurement.
 	m, err := s.measurement(database, name)
 	if err != nil {
-		return err
+		return 0, err
 	} else if m == nil {
-		return ErrMeasurementNotFound
+		return 0, ErrMeasurementNotFound
 	}
 
 	// Retrieve shard group.
 	g, err := s.createShardGroupIfNotExists(database, retentionPolicy, timestamp)
 	if err != nil {
-		return fmt.Errorf("create shard(%s/%d): %s", retentionPolicy, timestamp.Format(time.RFC3339Nano), err)
+		return 0, fmt.Errorf("create shard(%s/%d): %s", retentionPolicy, timestamp.Format(time.RFC3339Nano), err)
 	}
 
 	// Find appropriate shard within the shard group.
@@ -1246,7 +1247,7 @@ func (s *Server) WriteSeries(database, retentionPolicy, name string, tags map[st
 
 	// Ignore requests that have no values.
 	if len(values) == 0 {
-		return nil
+		return 0, nil
 	}
 
 	// Convert string-key/values to fieldID-key/values.
@@ -1268,7 +1269,7 @@ func (s *Server) WriteSeries(database, retentionPolicy, name string, tags map[st
 			TopicID: sh.ID,
 			Data:    data,
 		})
-		return err
+		return 0, err
 	}
 
 	// If we can successfully encode the string keys to raw field ids then
@@ -1279,12 +1280,11 @@ func (s *Server) WriteSeries(database, retentionPolicy, name string, tags map[st
 	data = append(data, marshalValues(rawValues)...)
 
 	// Publish "raw write series" message on shard's topic to broker.
-	_, err = s.client.Publish(&messaging.Message{
+	return s.client.Publish(&messaging.Message{
 		Type:    writeRawSeriesMessageType,
 		TopicID: sh.ID,
 		Data:    data,
 	})
-	return err
 }
 
 type writeSeriesCommand struct {
@@ -1510,10 +1510,20 @@ func (s *Server) processor(client MessagingClient, done chan struct{}) {
 	for {
 		// Read incoming message.
 		var m *messaging.Message
+		var ok bool
 		select {
 		case <-done:
 			return
-		case m = <-client.C():
+		case m, ok = <-client.C():
+			if !ok {
+				return
+			}
+		}
+
+		// Exit if closed.
+		// TODO: Wrap this check in a lock with the apply itself.
+		if !s.opened() {
+			continue
 		}
 
 		// Process message.

--- a/server_test.go
+++ b/server_test.go
@@ -510,7 +510,7 @@ func TestServer_WriteSeries(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	} else if err = s.Sync(index); err != nil {
-		t.Fatal("sync error: %s", err)
+		t.Fatalf("sync error: %s", err)
 	}
 
 	// Write another point 10 seconds later so it goes through "raw series".
@@ -518,7 +518,7 @@ func TestServer_WriteSeries(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	} else if err = s.Sync(index); err != nil {
-		t.Fatal("sync error: %s", err)
+		t.Fatalf("sync error: %s", err)
 	}
 
 	// Verify a subscription was made.
@@ -571,7 +571,7 @@ func TestServer_Measurements(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	} else if err = s.Sync(index); err != nil {
-		t.Fatal("sync error: %s", err)
+		t.Fatalf("sync error: %s", err)
 	}
 
 	expectedMeasurementNames := []string{"cpu_load"}

--- a/server_test.go
+++ b/server_test.go
@@ -506,16 +506,20 @@ func TestServer_WriteSeries(t *testing.T) {
 	// Write series with one point to the database.
 	tags := map[string]string{"host": "servera.influx.com", "region": "uswest"}
 	values := map[string]interface{}{"value": 23.2}
-	if err := s.WriteSeries("foo", "mypolicy", "cpu_load", tags, mustParseTime("2000-01-01T00:00:00Z"), values); err != nil {
+	index, err := s.WriteSeries("foo", "mypolicy", "cpu_load", tags, mustParseTime("2000-01-01T00:00:00Z"), values)
+	if err != nil {
 		t.Fatal(err)
+	} else if err = s.Sync(index); err != nil {
+		t.Fatal("sync error: %s", err)
 	}
-	time.Sleep(1 * time.Second) // TEMP
 
 	// Write another point 10 seconds later so it goes through "raw series".
-	if err := s.WriteSeries("foo", "mypolicy", "cpu_load", tags, mustParseTime("2000-01-01T00:00:10Z"), values); err != nil {
+	index, err = s.WriteSeries("foo", "mypolicy", "cpu_load", tags, mustParseTime("2000-01-01T00:00:10Z"), values)
+	if err != nil {
 		t.Fatal(err)
+	} else if err = s.Sync(index); err != nil {
+		t.Fatal("sync error: %s", err)
 	}
-	time.Sleep(1 * time.Second) // TEMP
 
 	// Verify a subscription was made.
 	if !subscribed {
@@ -563,8 +567,11 @@ func TestServer_Measurements(t *testing.T) {
 	tags := map[string]string{"host": "servera.influx.com", "region": "uswest"}
 	values := map[string]interface{}{"value": 23.2}
 
-	if err := s.WriteSeries("foo", "mypolicy", "cpu_load", tags, timestamp, values); err != nil {
+	index, err := s.WriteSeries("foo", "mypolicy", "cpu_load", tags, timestamp, values)
+	if err != nil {
 		t.Fatal(err)
+	} else if err = s.Sync(index); err != nil {
+		t.Fatal("sync error: %s", err)
 	}
 
 	expectedMeasurementNames := []string{"cpu_load"}


### PR DESCRIPTION
## Overview

This pull request fixes a couple issues:

1. Closing the server means a client message can still sneak in afterward. If this happens then it tries to update the metastore but the metastore is closed so it panics. There is now a check for `Server.opened()` in the apply loop.

2. The `Server.mustUpdate()` and `Server.mustView()` functions were showing the user provided error instead of the system error so it was panicing with a nil error. This is fixed.

3. Changed `Server.WriteSeries()` to return the messaging index for the write. This allows us to use `Server.Sync()` in the test and not have to sleep.


## Notes

The check for a closed server isn't perfect. We need to lock around the "open" check and the apply function in one single lock block. That's some additional work since some apply functions need some special lock handling. I added a `TODO` so we can revisit it.