### PR TITLE
Fix a simple printf fmt typo in server_test.go:574

### DIFF
--- a/server_test.go
+++ b/server_test.go
@@ -571,7 +571,7 @@ func TestServer_ExecuteQuery(t *testing.T) {
 	if res := results[0]; res.Err != nil {
 		t.Fatalf("unexpected error: %s", res.Err)
 	} else if len(res.Rows) != 1 {
-		t.Fatalf("unexpected row count: %s", len(res.Rows))
+		t.Fatalf("unexpected row count: %d", len(res.Rows))
 	} else if s := mustMarshalJSON(res); s != `{"rows":[{"name":"cpu","columns":["time","sum"],"values":[[0,150]]}]}` {
 		t.Fatalf("unexpected row(0): %s", s)
 	}


### PR DESCRIPTION
Hi,

I was poking around the source and stumbled upon the go vet error:

```server_test.go:574: arg len(res.Rows) for printf verb %s of wrong type: int```
Unless there's a reason I'm not aware of for using %s, it should be %d

Thanks.