### PR TITLE
Change "code.google.com/p/go.*" to "golang.org/x/*"

### DIFF
--- a/server.go
+++ b/server.go
@@ -18,7 +18,7 @@ import (
 	"sync"
 	"time"
 
-	"code.google.com/p/go.crypto/bcrypt"
+	"golang.org/x/crypto/bcrypt"
 	"github.com/influxdb/influxdb/influxql"
 	"github.com/influxdb/influxdb/messaging"
 )

--- a/server_test.go
+++ b/server_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"time"
 
-	"code.google.com/p/go.crypto/bcrypt"
+	"golang.org/x/crypto/bcrypt"
 	"github.com/influxdb/influxdb"
 	"github.com/influxdb/influxdb/influxql"
 	"github.com/influxdb/influxdb/messaging"


### PR DESCRIPTION
Cleaning up the old format for external subrepos:

https://groups.google.com/forum/#!msg/golang-nuts/eD8dh3T9yyA/l5Ail-xfMiAJ