### PR TITLE
added missing bounds check to SeriesIDs Intersect

### DIFF
--- a/database.go
+++ b/database.go
@@ -428,7 +428,7 @@ func (a SeriesIDs) Intersect(seriesIDs SeriesIDs) SeriesIDs {
 
 	ids := make([]uint32, 0, len(l))
 	for i < len(l) {
-		if l[i] == r[j] {
+		if l[i] == r[j] && j < len(r) {
 			ids = append(ids, l[i])
 			i += 1
 			j += 1


### PR DESCRIPTION
There's an intermittent index out of bounds panic when running go test on TestDatabase_SeriesIDsWhereTagFilter
It occurred here: https://travis-ci.org/influxdb/influxdb/builds/47176458

This fixes the panic, though the test case fails intermittently as well.