### PR TITLE
added missing bounds check to SeriesIDs Intersect

### DIFF
--- a/database.go
+++ b/database.go
@@ -427,7 +427,7 @@ func (a SeriesIDs) Intersect(seriesIDs SeriesIDs) SeriesIDs {
 	var i, j int
 
 	ids := make([]uint32, 0, len(l))
-	for i < len(l) {
+	for i < len(l) && j < len(r) {
 		if l[i] == r[j] {
 			ids = append(ids, l[i])
 			i += 1

--- a/database_test.go
+++ b/database_test.go
@@ -545,6 +545,13 @@ func TestDatabase_SeriesIDsIntersect(t *testing.T) {
 			right:    []uint32{uint32(1), uint32(3), uint32(4), uint32(7)},
 		},
 
+		// both sides same size, right boundary checked.
+		{
+			expected: []uint32{},
+			left:     []uint32{uint32(2)},
+			right:    []uint32{uint32(1)},
+		},
+
 		// left side bigger
 		{
 			expected: []uint32{uint32(2)},


### PR DESCRIPTION
There's an intermittent index out of bounds panic when running go test on TestDatabase_SeriesIDsWhereTagFilter
It occurred here: https://travis-ci.org/influxdb/influxdb/builds/47176458

This fixes the panic, though the test case fails intermittently as well.