### PR TITLE
URL-Encode Password in influxdb/client

### DIFF
--- a/client/influxdb.go
+++ b/client/influxdb.go
@@ -97,8 +97,13 @@ func (self *Client) getUrl(path string) string {
 }
 
 func (self *Client) getUrlWithUserAndPass(path, username, password string) string {
-	return fmt.Sprintf("%s://%s%s?u=%s&p=%s", self.schema, self.host, path, username, password)
+	uPassword,err := url.QueryUnescape(password)
+    if err != nil {
+        return err
+    }
+    return fmt.Sprintf("%s://%s%s?u=%s&p=%s", self.schema, self.host, path, username, url.QueryEscape(uPassword))
 }
+
 
 func responseToError(response *http.Response, err error, closeResponse bool) error {
 	if err != nil {

--- a/client/influxdb.go
+++ b/client/influxdb.go
@@ -99,7 +99,7 @@ func (self *Client) getUrl(path string) string {
 func (self *Client) getUrlWithUserAndPass(path, username, password string) string {
 	uPassword,err := url.QueryUnescape(password)
     if err != nil {
-        return err
+        return "Can't unescape password"
     }
     return fmt.Sprintf("%s://%s%s?u=%s&p=%s", self.schema, self.host, path, username, url.QueryEscape(uPassword))
 }

--- a/client/influxdb.go
+++ b/client/influxdb.go
@@ -98,10 +98,10 @@ func (self *Client) getUrl(path string) string {
 
 func (self *Client) getUrlWithUserAndPass(path, username, password string) string {
 	uPassword,err := url.QueryUnescape(password)
-    if err != nil {
-        return "Can't unescape password"
-    }
-    return fmt.Sprintf("%s://%s%s?u=%s&p=%s", self.schema, self.host, path, username, url.QueryEscape(uPassword))
+	if err != nil {
+		return "Can't unescape password"
+	}
+	return fmt.Sprintf("%s://%s%s?u=%s&p=%s", self.schema, self.host, path, username, url.QueryEscape(uPassword))
 }
 
 


### PR DESCRIPTION


Hey

Password with special characters had to be escaped manually in order to work before. Because that is something the user shouldn't have to do, I added the encoding of the password.

In order to not brake other programs that fixed this themselves (influx-cli for example) I added an additional url.QueryUnescape before escaping it.

Was fixed for example in Dieterbe/influx-cli#15