### PR TITLE
Fix error message.

### DIFF
--- a/httpd/handler.go
+++ b/httpd/handler.go
@@ -184,7 +184,7 @@ func (h *Handler) serveWrite(w http.ResponseWriter, r *http.Request, user *influ
 		}
 
 		if h.requireAuthentication && !user.Authorize(influxql.WritePrivilege, br.Database) {
-			writeError(influxdb.Result{Err: fmt.Errorf("%q user is not authorized to write to database %q", user.Name)}, http.StatusUnauthorized)
+			writeError(influxdb.Result{Err: fmt.Errorf("%q user is not authorized to write to database %q", user.Name, br.Database)}, http.StatusUnauthorized)
 			return
 		}
 


### PR DESCRIPTION
`go vet` claims to fix it.

```
httpd/handler.go:187: missing argument for Errorf("%q"): format reads arg 2, have only 1 args
exit status 1
```