### PR TITLE
Add mean aggregate function

### DIFF
--- a/influxql/engine_test.go
+++ b/influxql/engine_test.go
@@ -116,6 +116,39 @@ func TestPlanner_Plan_Count(t *testing.T) {
 	}
 }
 
+// Ensure the planner can plan and execute a mean query
+func TestPlanner_Plan_Mean(t *testing.T) {
+	tx := NewTx()
+	tx.CreateIteratorsFunc = func(stmt *influxql.SelectStatement) ([]influxql.Iterator, error) {
+		return []influxql.Iterator{
+			NewIterator(nil, []Point{
+				{"2000-01-01T00:00:00Z", float64(100)},
+				{"2000-01-01T00:00:10Z", float64(90)},
+				{"2000-01-01T00:00:20Z", float64(80)},
+			}),
+			NewIterator(nil, []Point{
+				{"2000-01-01T00:00:00Z", float64(80)},
+				{"2000-01-01T00:00:10Z", float64(80)},
+				{"2000-01-01T00:00:20Z", float64(50)},
+			}),
+			NewIterator(nil, []Point{
+				{"2000-01-01T00:01:30Z", float64(70)},
+				{"2000-01-01T00:01:40Z", float64(60)},
+				{"2000-01-01T00:01:50Z", float64(50)},
+			})}, nil
+	}
+
+	// Expected resultset.
+	exp := minify(`[{"name":"cpu","columns":["time","mean"],"values":[[946684800000000,80],[946684860000000,60]]}]`)
+
+	// Execute and compare.
+	rs := MustPlanAndExecute(NewDB(tx), `2000-01-01T12:00:00Z`,
+		`SELECT mean(value) FROM cpu WHERE time >= '2000-01-01' GROUP BY time(1m)`)
+	if act := minify(jsonify(rs)); exp != act {
+		t.Fatalf("unexpected resultset: %s", act)
+	}
+}
+
 // Ensure the planner can plan and execute a count query grouped by hour.
 func TestPlanner_Plan_GroupByInterval(t *testing.T) {
 	tx := NewTx()


### PR DESCRIPTION
This adds the mean aggregate function. If you look it uses a struct as the intermediate value between the mapper and reducer. We're going to have to do some stuff to actually make this work in a distributed system since the map output will need to be marshaled and unmarshaled.

Have a peek @benbjohnson 