### PR TITLE
Fix markdown syntax error.

### DIFF
--- a/QUERIES.md
+++ b/QUERIES.md
@@ -43,7 +43,7 @@ REVOKE ALL [PRIVILEGES] FROM <user>
 -- delete a user
 DROP USER <name>
 ```
-<privilege> := READ | WRITE | All [PRIVILEGES]
+where `<privilege> := READ | WRITE | All [PRIVILEGES]`.
 
 # Select
 


### PR DESCRIPTION
Markdown parser processes `<somestring>` as html tag. So the line is not displayed as expected.
See github.


now: https://github.com/influxdb/influxdb/blob/master/QUERIES.md#users-and-permissions
fixed: https://github.com/sakamotomsh/influxdb/blob/fix-markdown_syntaxerror/QUERIES.md#users-and-permissions
