### PR TITLE
Add statement normalization before execution.

### DIFF
--- a/influxql/engine.go
+++ b/influxql/engine.go
@@ -144,7 +144,7 @@ func (p *Planner) planRawQuery(e *Executor, v *VarRef) (Processor, error) {
 		mappers[i] = NewMapper(MapRawQuery, itr, e.interval)
 	}
 	r := NewReducer(ReduceRawQuery, mappers)
-	r.name = stmt.Source.(*Measurement).Name
+	r.name = lastIdent(stmt.Source.(*Measurement).Name)
 
 	return r, nil
 
@@ -205,7 +205,7 @@ func (p *Planner) planCall(e *Executor, c *Call) (Processor, error) {
 		mappers[i] = NewMapper(mapFn, itr, e.interval)
 	}
 	r := NewReducer(reduceFn, mappers)
-	r.name = stmt.Source.(*Measurement).Name
+	r.name = lastIdent(stmt.Source.(*Measurement).Name)
 
 	return r, nil
 }

--- a/influxql/scanner.go
+++ b/influxql/scanner.go
@@ -522,6 +522,15 @@ func SplitIdent(s string) (segments []string, err error) {
 	}
 }
 
+// lastIdent returns the last identifier.
+func lastIdent(s string) string {
+	a, _ := SplitIdent(s)
+	if len(a) == 0 {
+		return ""
+	}
+	return a[len(a)-1]
+}
+
 var errInvalidIdentifier = errors.New("invalid identifier")
 
 // assert will panic with a given formatted message if the given condition is false.

--- a/server.go
+++ b/server.go
@@ -1835,6 +1835,7 @@ func (s *Server) measurement(database, name string) (*Measurement, error) {
 // Begin returns an unopened transaction associated with the server.
 func (s *Server) Begin() (influxql.Tx, error) { return newTx(s), nil }
 
+// NormalizeStatement adds a default database and policy to the measurements in statement.
 func (s *Server) NormalizeStatement(stmt influxql.Statement, defaultDatabase string) (err error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()

--- a/server.go
+++ b/server.go
@@ -1547,6 +1547,12 @@ func (s *Server) ExecuteQuery(q *influxql.Query, database string, user *User) Re
 
 	// Execute each statement.
 	for i, stmt := range q.Statements {
+		// Set default database and policy on the statement.
+		if err := s.NormalizeStatement(stmt, database); err != nil {
+			results.Results[i] = &Result{Err: err}
+			break
+		}
+
 		var res *Result
 		switch stmt := stmt.(type) {
 		case *influxql.SelectStatement:
@@ -1765,21 +1771,10 @@ func (s *Server) measurement(database, name string) (*Measurement, error) {
 // Begin returns an unopened transaction associated with the server.
 func (s *Server) Begin() (influxql.Tx, error) { return newTx(s), nil }
 
-// NormalizeQuery updates all measurements and fields to be fully qualified.
-// Uses db as the default database, where applicable.
-func (s *Server) NormalizeQuery(q *influxql.Query, defaultDatabase string) error {
+func (s *Server) NormalizeStatement(stmt influxql.Statement, defaultDatabase string) (err error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	for _, stmt := range q.Statements {
-		if err := s.normalizeStatement(stmt, defaultDatabase); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (s *Server) normalizeStatement(stmt influxql.Statement, defaultDatabase string) (err error) {
 	// Track prefixes for replacing field names.
 	prefixes := make(map[string]string)
 

--- a/server_test.go
+++ b/server_test.go
@@ -711,12 +711,12 @@ func TestServer_ExecuteQuery(t *testing.T) {
 	s.MustWriteSeries("foo", "raw", []influxdb.Point{{Name: "cpu", Tags: map[string]string{"region": "us-west"}, Timestamp: mustParseTime("2000-01-01T00:00:00Z"), Values: map[string]interface{}{"value": float64(100)}}})
 
 	// Select data from the server.
-	results := s.ExecuteQuery(MustParseQuery(`SELECT sum(value) FROM "foo"."raw".cpu GROUP BY time(10s), region`), "foo", nil)
+	results := s.ExecuteQuery(MustParseQuery(`SELECT sum(value) FROM cpu GROUP BY time(10s), region`), "foo", nil)
 	if res := results.Results[0]; res.Err != nil {
 		t.Fatalf("unexpected error: %s", res.Err)
 	} else if len(res.Rows) != 2 {
 		t.Fatalf("unexpected row count: %d", len(res.Rows))
-	} else if s := mustMarshalJSON(res); s != `{"rows":[{"name":"\"foo\".\"raw\".cpu","tags":{"region":"us-east"},"columns":["time","sum"],"values":[[946684800000000,20],[946684810000000,30]]},{"name":"\"foo\".\"raw\".cpu","tags":{"region":"us-west"},"columns":["time","sum"],"values":[[946684800000000,100]]}]}` {
+	} else if s := mustMarshalJSON(res); s != `{"rows":[{"name":"\"foo\".\"raw\".\"cpu\"","tags":{"region":"us-east"},"columns":["time","sum"],"values":[[946684800000000,20],[946684810000000,30]]},{"name":"\"foo\".\"raw\".\"cpu\"","tags":{"region":"us-west"},"columns":["time","sum"],"values":[[946684800000000,100]]}]}` {
 		t.Fatalf("unexpected row(0): %s", s)
 	}
 }
@@ -868,7 +868,7 @@ func TestServer_NormalizeQuery(t *testing.T) {
 	// Execute the tests
 	for i, tt := range tests {
 		out := MustParseQuery(tt.in)
-		err := s.NormalizeQuery(out, tt.db)
+		err := s.NormalizeStatement(out.Statements[0], tt.db)
 		if tt.err != errstr(err) {
 			t.Errorf("%d. %s/%s: error: exp: %s, got: %s", i, tt.db, tt.in, tt.err, errstr(err))
 		} else if err == nil && tt.out != out.String() {

--- a/server_test.go
+++ b/server_test.go
@@ -716,7 +716,7 @@ func TestServer_ExecuteQuery(t *testing.T) {
 		t.Fatalf("unexpected error: %s", res.Err)
 	} else if len(res.Rows) != 2 {
 		t.Fatalf("unexpected row count: %d", len(res.Rows))
-	} else if s := mustMarshalJSON(res); s != `{"rows":[{"name":"\"foo\".\"raw\".\"cpu\"","tags":{"region":"us-east"},"columns":["time","sum"],"values":[[946684800000000,20],[946684810000000,30]]},{"name":"\"foo\".\"raw\".\"cpu\"","tags":{"region":"us-west"},"columns":["time","sum"],"values":[[946684800000000,100]]}]}` {
+	} else if s := mustMarshalJSON(res); s != `{"rows":[{"name":"cpu","tags":{"region":"us-east"},"columns":["time","sum"],"values":[[946684800000000,20],[946684810000000,30]]},{"name":"cpu","tags":{"region":"us-west"},"columns":["time","sum"],"values":[[946684800000000,100]]}]}` {
 		t.Fatalf("unexpected row(0): %s", s)
 	}
 }


### PR DESCRIPTION
## Overview

This commit adds a call to Server.NormalizeStatement() immediately before execution. It defers normalization just before execution in case statements leading up it will alter the normalization process.