### PR TITLE
influxql: fix WHERE TAG KEY parsing

### DIFF
--- a/influxql/ast.go
+++ b/influxql/ast.go
@@ -91,6 +91,7 @@ func (_ *ParenExpr) node()       {}
 func (_ *SortField) node()       {}
 func (_ SortFields) node()       {}
 func (_ *StringLiteral) node()   {}
+func (_ *TagKeyIdent) node()     {}
 func (_ *Target) node()          {}
 func (_ *TimeLiteral) node()     {}
 func (_ *VarRef) node()          {}
@@ -176,6 +177,7 @@ func (_ *nilLiteral) expr()      {}
 func (_ *NumberLiteral) expr()   {}
 func (_ *ParenExpr) expr()       {}
 func (_ *StringLiteral) expr()   {}
+func (_ *TagKeyIdent) expr()     {}
 func (_ *TimeLiteral) expr()     {}
 func (_ *VarRef) expr()          {}
 func (_ *Wildcard) expr()        {}
@@ -1451,6 +1453,12 @@ type StringLiteral struct {
 
 // String returns a string representation of the literal.
 func (l *StringLiteral) String() string { return QuoteString(l.Val) }
+
+// TagKeyIdent represents a special TAG KEY identifier.
+type TagKeyIdent struct{}
+
+// String returns a string representation of the TagKeyIdent.
+func (t *TagKeyIdent) String() string { return "TAG KEY" }
 
 // TimeLiteral represents a point-in-time literal.
 type TimeLiteral struct {

--- a/influxql/parser.go
+++ b/influxql/parser.go
@@ -1447,6 +1447,11 @@ func (p *Parser) parseUnaryExpr() (Expr, error) {
 	case DURATION_VAL:
 		v, _ := ParseDuration(lit)
 		return &DurationLiteral{Val: v}, nil
+	case TAG:
+		if tok, pos, lit = p.scanIgnoreWhitespace(); tok != KEY {
+			return nil, newParseError(tokstr(tok, lit), []string{"KEY"}, pos)
+		}
+		return &TagKeyIdent{}, nil
 	default:
 		return nil, newParseError(tokstr(tok, lit), []string{"identifier", "string", "number", "bool"}, pos)
 	}

--- a/influxql/parser_test.go
+++ b/influxql/parser_test.go
@@ -242,6 +242,69 @@ func TestParser_ParseStatement(t *testing.T) {
 			},
 		},
 
+		// SHOW TAG VALUES ... TAG KEY =
+		{
+			s: `SHOW TAG VALUES FROM cpu WHERE TAG KEY = 'host' AND region = 'uswest'`,
+			stmt: &influxql.ShowTagValuesStatement{
+				Source: &influxql.Measurement{Name: "cpu"},
+				Condition: &influxql.BinaryExpr{
+					Op: influxql.AND,
+					LHS: &influxql.BinaryExpr{
+						Op:  influxql.EQ,
+						LHS: &influxql.TagKeyIdent{},
+						RHS: &influxql.StringLiteral{Val: "host"},
+					},
+					RHS: &influxql.BinaryExpr{
+						Op:  influxql.EQ,
+						LHS: &influxql.VarRef{Val: "region"},
+						RHS: &influxql.StringLiteral{Val: "uswest"},
+					},
+				},
+			},
+		},
+
+		// SHOW TAG VALUES ... AND TAG KEY =
+		{
+			s: `SHOW TAG VALUES FROM cpu WHERE region = 'uswest' AND TAG KEY = 'host'`,
+			stmt: &influxql.ShowTagValuesStatement{
+				Source: &influxql.Measurement{Name: "cpu"},
+				Condition: &influxql.BinaryExpr{
+					Op: influxql.AND,
+					LHS: &influxql.BinaryExpr{
+						Op:  influxql.EQ,
+						LHS: &influxql.VarRef{Val: "region"},
+						RHS: &influxql.StringLiteral{Val: "uswest"},
+					},
+					RHS: &influxql.BinaryExpr{
+						Op:  influxql.EQ,
+						LHS: &influxql.TagKeyIdent{},
+						RHS: &influxql.StringLiteral{Val: "host"},
+					},
+				},
+			},
+		},
+
+		// SHOW TAG VALUES ... AND ... = TAG KEY
+		{
+			s: `SHOW TAG VALUES FROM cpu WHERE region = 'uswest' AND 'host' = TAG KEY`,
+			stmt: &influxql.ShowTagValuesStatement{
+				Source: &influxql.Measurement{Name: "cpu"},
+				Condition: &influxql.BinaryExpr{
+					Op: influxql.AND,
+					LHS: &influxql.BinaryExpr{
+						Op:  influxql.EQ,
+						LHS: &influxql.VarRef{Val: "region"},
+						RHS: &influxql.StringLiteral{Val: "uswest"},
+					},
+					RHS: &influxql.BinaryExpr{
+						Op:  influxql.EQ,
+						LHS: &influxql.StringLiteral{Val: "host"},
+						RHS: &influxql.TagKeyIdent{},
+					},
+				},
+			},
+		},
+
 		// SHOW USERS
 		{
 			s:    `SHOW USERS`,

--- a/influxql/scanner_test.go
+++ b/influxql/scanner_test.go
@@ -124,6 +124,7 @@ func TestScanner_Scan(t *testing.T) {
 		{s: `INNER`, tok: influxql.INNER},
 		{s: `INSERT`, tok: influxql.INSERT},
 		{s: `INTO`, tok: influxql.INTO},
+		{s: `KEY`, tok: influxql.KEY},
 		{s: `KEYS`, tok: influxql.KEYS},
 		{s: `LIMIT`, tok: influxql.LIMIT},
 		{s: `SHOW`, tok: influxql.SHOW},

--- a/influxql/token.go
+++ b/influxql/token.go
@@ -77,6 +77,7 @@ const (
 	INNER
 	INSERT
 	INTO
+	KEY
 	KEYS
 	LIMIT
 	SHOW
@@ -167,6 +168,7 @@ var tokens = [...]string{
 	INNER:        "INNER",
 	INSERT:       "INSERT",
 	INTO:         "INTO",
+	KEY:          "KEY",
 	KEYS:         "KEYS",
 	LIMIT:        "LIMIT",
 	SHOW:         "SHOW",


### PR DESCRIPTION
InfluxQL now supports a special `TAG KEY` identifier in expressions...

```sql
SHOW TAG VALUES FROM cpu WHERE TAG KEY = 'host' AND region = 'uswest';

SHOW TAG VALUES FROM cpu WHERE region = 'uswest' AND TAG KEY = 'host';

-- And, for people who are weird...
SHOW TAG VALUES FROM cpu WHERE region = 'uswest' AND 'host' = TAG KEY;
```