### PR TITLE
Need to custom unmarshal results

### DIFF
--- a/server.go
+++ b/server.go
@@ -2184,6 +2184,24 @@ func (r *Result) MarshalJSON() ([]byte, error) {
 	return json.Marshal(&o)
 }
 
+// UnmarshalJSON decodes the data into the Result struct
+func (r *Result) UnmarshalJSON(b []byte) error {
+	var o struct {
+		Rows []*influxql.Row `json:"rows,omitempty"`
+		Err  string          `json:"error,omitempty"`
+	}
+
+	err := json.Unmarshal(b, &o)
+	if err != nil {
+		return err
+	}
+	r.Rows = o.Rows
+	if o.Err != "" {
+		r.Err = errors.New(o.Err)
+	}
+	return nil
+}
+
 // Results represents a list of statement results.
 type Results struct {
 	Results []*Result
@@ -2204,6 +2222,24 @@ func (r Results) MarshalJSON() ([]byte, error) {
 	}
 
 	return json.Marshal(&o)
+}
+
+// UnmarshalJSON decodes the data into the Results struct
+func (r *Results) UnmarshalJSON(b []byte) error {
+	var o struct {
+		Results []*Result `json:"results,omitempty"`
+		Err     string    `json:"error,omitempty"`
+	}
+
+	err := json.Unmarshal(b, &o)
+	if err != nil {
+		return err
+	}
+	r.Results = o.Results
+	if o.Err != "" {
+		r.Err = errors.New(o.Err)
+	}
+	return nil
 }
 
 // Error returns the first error from any statement.


### PR DESCRIPTION
When using the client library we connect to our http endpoint and unmarshal back into our `Results` struct.  Errors were being dropped without the custom unmarshaler.