### PR TITLE
Add Broker over HTTP benchmark.

### DIFF
--- a/messaging/broker_test.go
+++ b/messaging/broker_test.go
@@ -194,6 +194,28 @@ func TestBroker_Unsubscribe_ErrReplicaNotFound(t *testing.T) {
 	}
 }
 
+// Benchmarks a single broker without HTTP.
+func BenchmarkBroker_Publish(b *testing.B) {
+	br := NewBroker(nil)
+	defer br.Close()
+
+	b.ResetTimer()
+
+	var index uint64
+	for i := 0; i < b.N; i++ {
+		var err error
+		index, err = br.Publish(&messaging.Message{Type: 0, TopicID: 1, Data: make([]byte, 50)})
+		if err != nil {
+			b.Fatalf("unexpected error: %s", err)
+		}
+	}
+
+	// Wait for the broker to commit.
+	if err := br.Sync(index); err != nil {
+		b.Fatalf("sync error: %s", err)
+	}
+}
+
 // Broker is a wrapper for broker.Broker that creates the broker in a temporary location.
 type Broker struct {
 	*messaging.Broker

--- a/messaging/intg_test.go
+++ b/messaging/intg_test.go
@@ -62,7 +62,8 @@ func TestBroker_Join(t *testing.T) {
 	}
 }
 
-func BenchmarkBroker_Publish(b *testing.B) {
+// Benchmarks a cluster of 3 brokers over HTTP.
+func BenchmarkCluster_Publish(b *testing.B) {
 	c := NewCluster(3)
 	defer c.Close()
 


### PR DESCRIPTION
## Overview

This pull request adds two benchmarks to `messaging`:

* Single broker, direct calls to `Broker.Publish()`
* 3 broker cluster over the HTTP protocol, calls made through `Client.Publish()`

The first test is to give us a baseline of the overhead of just the broker. It ignores much of Raft since it doesn't need a quorum and it avoids all the overhead of HTTP.

The second test is to give us a full end-to-end test of the messaging system.


## Caveats

This is meant solely as a starting point for performance optimization. There are currently several known bottlenecks that exist because we did not wish to prematurely optimize.

There is also a broker header snapshot currently performed on every message because the broker recovery code has not been written yet. Once broker recovery is added, this snapshot will no longer be necessary. The results show numbers for both with snapshotting and without.


## Running

The benchmarks are written using Go's testing utility so you simply need to run `go test` with the `-bench=.` flag set:

```sh
$ go test -bench=. ./messaging
```

## Results

### Single broker, direct connection

The following results were found from running the single broker:

```
NO SNAPSHOT: 266,453 msg/sec (4 µs/op)
SNAPSHOT:      6,422 msg/sec (155 µs/op)
```

The snapshotting obviously has a gigantic effect on throughput. When the snapshot occurs, it requires several memory allocations and it involves writing a small file to disk. Without the snapshot, the message simply gets appended to the end of the topic file.


### 3 broker cluster, connect via client over HTTP

The following results were found from running a 3 broker cluster over HTTP:

```
NO SNAPSHOT: 3,577 msg/sec (279 µs/op)
SNAPSHOT:    1,628 msg/sec (614 µs/op)
```

Now that we're adding HTTP and requiring a cluster quorum the impact of snapshotting is significantly less.


## Conclusion

Sending a single write over HTTP is a ridiculously slow way of inserting data although it may not be worth it to optimize it within the broker. Once `influxdb.Server` begins batching writes then the cost of HTTP amortizes well over each of those individual points.

For example, if the `Server` batches writes every 50ms to the broker then we only need to make 20 requests per second to the broker which is well within our existing performance bounds. Previous tests against the streaming raft implementation show that it can handle significant write load so we should be safe once we demultiplex the batches into messages on the broker. Streaming raft also doesn't suffer from heartbeat issues caused by large messages so we can safely send batches of writes to the server.