### PR TITLE
Support epoch time with precision, RFC3339, RFC3339nano formats for writing via http

### DIFF
--- a/client/influxdb.go
+++ b/client/influxdb.go
@@ -205,12 +205,15 @@ func (a Results) Error() error {
 	return nil
 }
 
+// Timestamp is a custom type so we marshal JSON properly into UTC nanosecond time
 type Timestamp time.Time
 
+// Time returns the time represented by the Timestamp
 func (t Timestamp) Time() time.Time {
 	return time.Time(t)
 }
 
+// MarshalJSON returns time in UTC with nanoseconds
 func (t Timestamp) MarshalJSON() ([]byte, error) {
 	// Always send back in UTC with nanoseconds
 	s := t.Time().UTC().Format(time.RFC3339Nano)
@@ -279,21 +282,9 @@ func (c *Client) Addr() string {
 	return c.url.String()
 }
 
-//func (c *Client) urlFor(path string) (*url.URL, error) {
-//var u *url.URL
-//u, err := url.Parse(fmt.Sprintf("%s%s", c.addr, path))
-//if err != nil {
-//return nil, err
-//}
-//if c.username != "" {
-//u.User = url.UserPassword(c.username, c.password)
-//}
-//u.Scheme = "http"
-//return u, nil
-//}
-
 // helper functions
 
+// EpochToTime takes a unix epoch time and uses precision to return back a time.Time
 func EpochToTime(epoch int64, precision string) (time.Time, error) {
 	if precision == "" {
 		precision = "s"
@@ -316,7 +307,6 @@ func EpochToTime(epoch int64, precision string) (time.Time, error) {
 		return time.Time{}, fmt.Errorf("Unknowm precision %q", precision)
 	}
 	return t, nil
-
 }
 
 // SetPrecision will round a time to the specified precision

--- a/client/influxdb.go
+++ b/client/influxdb.go
@@ -231,6 +231,7 @@ func (p *Point) UnmarshalJSON(b []byte) error {
 		Name      string                 `json:"name"`
 		Tags      map[string]string      `json:"tags"`
 		Timestamp time.Time              `json:"timestamp"`
+		Precision string                 `json:"precision"`
 		Values    map[string]interface{} `json:"values"`
 	}
 	var epoch struct {
@@ -263,6 +264,7 @@ func (p *Point) UnmarshalJSON(b []byte) error {
 	if err := json.Unmarshal(b, &normal); err != nil {
 		return err
 	}
+	normal.Timestamp = SetPrecision(normal.Timestamp, normal.Precision)
 	p.Name = normal.Name
 	p.Tags = normal.Tags
 	p.Timestamp = Timestamp(normal.Timestamp)
@@ -315,6 +317,24 @@ func EpochToTime(epoch int64, precision string) (time.Time, error) {
 	}
 	return t, nil
 
+}
+
+// SetPrecision will round a time to the specified precision
+func SetPrecision(t time.Time, precision string) time.Time {
+	switch precision {
+	case "n":
+	case "u":
+		return t.Round(time.Microsecond)
+	case "ms":
+		return t.Round(time.Millisecond)
+	case "s":
+		return t.Round(time.Second)
+	case "m":
+		return t.Round(time.Minute)
+	case "h":
+		return t.Round(time.Hour)
+	}
+	return t
 }
 
 func detect(values ...string) string {

--- a/client/influxdb.go
+++ b/client/influxdb.go
@@ -226,6 +226,7 @@ type Point struct {
 	Tags      map[string]string      `json:"tags"`
 	Timestamp Timestamp              `json:"timestamp"`
 	Values    map[string]interface{} `json:"values"`
+	Precision string                 `json:"precision"`
 }
 
 // UnmarshalJSON decodes the data into the Point struct
@@ -258,6 +259,7 @@ func (p *Point) UnmarshalJSON(b []byte) error {
 		p.Name = epoch.Name
 		p.Tags = epoch.Tags
 		p.Timestamp = Timestamp(ts)
+		p.Precision = epoch.Precision
 		p.Values = epoch.Values
 		return nil
 	}(); err == nil {
@@ -271,6 +273,7 @@ func (p *Point) UnmarshalJSON(b []byte) error {
 	p.Name = normal.Name
 	p.Tags = normal.Tags
 	p.Timestamp = Timestamp(normal.Timestamp)
+	p.Precision = normal.Precision
 	p.Values = normal.Values
 
 	return nil

--- a/client/influxdb.go
+++ b/client/influxdb.go
@@ -205,12 +205,24 @@ func (a Results) Error() error {
 	return nil
 }
 
+type Timestamp time.Time
+
+func (t Timestamp) Time() time.Time {
+	return time.Time(t)
+}
+
+func (t Timestamp) MarshalJSON() ([]byte, error) {
+	// Always send back in UTC with nanoseconds
+	s := t.Time().UTC().Format(time.RFC3339Nano)
+	return []byte(`"` + s + `"`), nil
+}
+
 // Point defines the values that will be written to the database
 type Point struct {
-	Name      string
-	Tags      map[string]string
-	Timestamp time.Time
-	Values    map[string]interface{}
+	Name      string                 `json:"name"`
+	Tags      map[string]string      `json:"tags"`
+	Timestamp Timestamp              `json:"timestamp"`
+	Values    map[string]interface{} `json:"values"`
 }
 
 // UnmarshalJSON decodes the data into the Point struct
@@ -241,7 +253,7 @@ func (p *Point) UnmarshalJSON(b []byte) error {
 		}
 		p.Name = epoch.Name
 		p.Tags = epoch.Tags
-		p.Timestamp = ts
+		p.Timestamp = Timestamp(ts)
 		p.Values = epoch.Values
 		return nil
 	}(); err == nil {
@@ -253,7 +265,7 @@ func (p *Point) UnmarshalJSON(b []byte) error {
 	}
 	p.Name = normal.Name
 	p.Tags = normal.Tags
-	p.Timestamp = normal.Timestamp
+	p.Timestamp = Timestamp(normal.Timestamp)
 	p.Values = normal.Values
 
 	return nil

--- a/client/influxdb.go
+++ b/client/influxdb.go
@@ -3,6 +3,7 @@ package client
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/url"
 	"time"
@@ -129,6 +130,31 @@ func (c *Client) Addr() string {
 //}
 
 // helper functions
+
+func EpochToTime(epoch int64, precision string) (time.Time, error) {
+	if precision == "" {
+		precision = "s"
+	}
+	var t time.Time
+	switch precision {
+	case "h":
+		t = time.Unix(0, epoch*int64(time.Hour))
+	case "m":
+		t = time.Unix(0, epoch*int64(time.Minute))
+	case "s":
+		t = time.Unix(0, epoch*int64(time.Second))
+	case "ms":
+		t = time.Unix(0, epoch*int64(time.Millisecond))
+	case "u":
+		t = time.Unix(0, epoch*int64(time.Microsecond))
+	case "n":
+		t = time.Unix(0, epoch)
+	default:
+		return time.Time{}, fmt.Errorf("Unknowm precision %q", precision)
+	}
+	return t, nil
+
+}
 
 func detect(values ...string) string {
 	for _, v := range values {

--- a/client/influxdb_test.go
+++ b/client/influxdb_test.go
@@ -185,7 +185,7 @@ func TestPoint_UnmarshalEpoch(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error.  exptected: %v, actual: %v", nil, err)
 		}
-		if p.Timestamp != test.expected {
+		if p.Timestamp.Time() != test.expected {
 			t.Fatalf("Unexpected time.  expected: %v, actual: %v", test.expected, p.Timestamp)
 		}
 	}
@@ -223,7 +223,7 @@ func TestPoint_UnmarshalRFC(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error.  exptected: %v, actual: %v", nil, err)
 		}
-		if p.Timestamp != test.expected {
+		if p.Timestamp.Time() != test.expected {
 			t.Fatalf("Unexpected time.  expected: %v, actual: %v", test.expected, p.Timestamp)
 		}
 	}

--- a/client/influxdb_test.go
+++ b/client/influxdb_test.go
@@ -2,6 +2,7 @@ package client_test
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -114,6 +115,117 @@ func TestClient_Write(t *testing.T) {
 	_, err = c.Write(write)
 	if err != nil {
 		t.Fatalf("unexpected error.  expected %v, actual %v", nil, err)
+	}
+}
+
+func TestPoint_UnmarshalEpoch(t *testing.T) {
+	now := time.Now()
+	tests := []struct {
+		name      string
+		epoch     int64
+		precision string
+		expected  time.Time
+	}{
+		{
+			name:      "nanoseconds",
+			epoch:     now.UnixNano(),
+			precision: "n",
+			expected:  now,
+		},
+		{
+			name:      "microseconds",
+			epoch:     now.Round(time.Microsecond).UnixNano() / int64(time.Microsecond),
+			precision: "u",
+			expected:  now.Round(time.Microsecond),
+		},
+		{
+			name:      "milliseconds",
+			epoch:     now.Round(time.Millisecond).UnixNano() / int64(time.Millisecond),
+			precision: "ms",
+			expected:  now.Round(time.Millisecond),
+		},
+		{
+			name:      "seconds",
+			epoch:     now.Round(time.Second).UnixNano() / int64(time.Second),
+			precision: "s",
+			expected:  now.Round(time.Second),
+		},
+		{
+			name:      "minutes",
+			epoch:     now.Round(time.Minute).UnixNano() / int64(time.Minute),
+			precision: "m",
+			expected:  now.Round(time.Minute),
+		},
+		{
+			name:      "hours",
+			epoch:     now.Round(time.Hour).UnixNano() / int64(time.Hour),
+			precision: "h",
+			expected:  now.Round(time.Hour),
+		},
+		{
+			name:      "max int64",
+			epoch:     9223372036854775807,
+			precision: "n",
+			expected:  time.Unix(0, 9223372036854775807),
+		},
+		{
+			name:      "100 years from now",
+			epoch:     now.Add(time.Hour * 24 * 365 * 100).UnixNano(),
+			precision: "n",
+			expected:  now.Add(time.Hour * 24 * 365 * 100),
+		},
+	}
+
+	for _, test := range tests {
+		t.Logf("testing %q\n", test.name)
+		data := []byte(fmt.Sprintf(`{"timestamp": %d, "precision":"%s"}`, test.epoch, test.precision))
+		t.Logf("json: %s", string(data))
+		var p client.Point
+		err := json.Unmarshal(data, &p)
+		if err != nil {
+			t.Fatalf("unexpected error.  exptected: %v, actual: %v", nil, err)
+		}
+		if p.Timestamp != test.expected {
+			t.Fatalf("Unexpected time.  expected: %v, actual: %v", test.expected, p.Timestamp)
+		}
+	}
+}
+
+func TestPoint_UnmarshalRFC(t *testing.T) {
+	now := time.Now()
+	tests := []struct {
+		name     string
+		rfc      string
+		now      time.Time
+		expected time.Time
+	}{
+		{
+			name:     "RFC3339Nano",
+			rfc:      time.RFC3339Nano,
+			now:      now,
+			expected: now,
+		},
+		{
+			name:     "RFC3339",
+			rfc:      time.RFC3339,
+			now:      now.Round(time.Second),
+			expected: now.Round(time.Second),
+		},
+	}
+
+	for _, test := range tests {
+		t.Logf("testing %q\n", test.name)
+		ts := test.now.Format(test.rfc)
+		data := []byte(fmt.Sprintf(`{"timestamp": %q}`, ts))
+		t.Logf("json: %s", string(data))
+		var p client.Point
+		err := json.Unmarshal(data, &p)
+		if err != nil {
+			t.Fatalf("unexpected error.  exptected: %v, actual: %v", nil, err)
+		}
+		if p.Timestamp != test.expected {
+			t.Fatalf("Unexpected time.  expected: %v, actual: %v", test.expected, p.Timestamp)
+		}
 	}
 }
 

--- a/httpd/handler.go
+++ b/httpd/handler.go
@@ -141,6 +141,7 @@ func (h *Handler) serveQuery(w http.ResponseWriter, r *http.Request, user *influ
 	httpResults(w, results, pretty)
 }
 
+// BatchWrite is used to send batch write data to the http /write endpoint
 type BatchWrite struct {
 	Points          []client.Point    `json:"points"`
 	Database        string            `json:"database"`

--- a/httpd/handler.go
+++ b/httpd/handler.go
@@ -157,6 +157,7 @@ func (br *BatchWrite) UnmarshalJSON(b []byte) error {
 		RetentionPolicy string            `json:"retentionPolicy"`
 		Tags            map[string]string `json:"tags"`
 		Timestamp       time.Time         `json:"timestamp"`
+		Precision       string            `json:"precision"`
 	}
 	var epoch struct {
 		Points          []client.Point    `json:"points"`
@@ -190,6 +191,7 @@ func (br *BatchWrite) UnmarshalJSON(b []byte) error {
 	if err := json.Unmarshal(b, &normal); err != nil {
 		return err
 	}
+	normal.Timestamp = client.SetPrecision(normal.Timestamp, normal.Precision)
 	br.Points = normal.Points
 	br.Database = normal.Database
 	br.RetentionPolicy = normal.RetentionPolicy

--- a/httpd/handler.go
+++ b/httpd/handler.go
@@ -148,6 +148,7 @@ type BatchWrite struct {
 	RetentionPolicy string            `json:"retentionPolicy"`
 	Tags            map[string]string `json:"tags"`
 	Timestamp       time.Time         `json:"timestamp"`
+	Precision       string            `json:"precision"`
 }
 
 // UnmarshalJSON decodes the data into the batchWrite struct
@@ -184,6 +185,7 @@ func (br *BatchWrite) UnmarshalJSON(b []byte) error {
 		br.RetentionPolicy = epoch.RetentionPolicy
 		br.Tags = epoch.Tags
 		br.Timestamp = ts
+		br.Precision = epoch.Precision
 		return nil
 	}(); err == nil {
 		return nil
@@ -198,6 +200,7 @@ func (br *BatchWrite) UnmarshalJSON(b []byte) error {
 	br.RetentionPolicy = normal.RetentionPolicy
 	br.Tags = normal.Tags
 	br.Timestamp = normal.Timestamp
+	br.Precision = normal.Precision
 
 	return nil
 }
@@ -244,6 +247,10 @@ func (h *Handler) serveWrite(w http.ResponseWriter, r *http.Request, user *influ
 			if p.Timestamp.Time().IsZero() {
 				p.Timestamp = client.Timestamp(br.Timestamp)
 			}
+			if p.Precision == "" && br.Precision != "" {
+				p.Precision = br.Precision
+			}
+			p.Timestamp = client.Timestamp(client.SetPrecision(p.Timestamp.Time(), p.Precision))
 			if len(br.Tags) > 0 {
 				for k, _ := range br.Tags {
 					if p.Tags[k] == "" {

--- a/httpd/handler.go
+++ b/httpd/handler.go
@@ -174,7 +174,6 @@ func (br *BatchWrite) UnmarshalJSON(b []byte) error {
 		}
 		// Convert from epoch to time.Time
 		ts, err := client.EpochToTime(epoch.Timestamp, epoch.Precision)
-		log.Println(ts, err)
 		if err != nil {
 			return err
 		}

--- a/httpd/handler_test.go
+++ b/httpd/handler_test.go
@@ -103,23 +103,26 @@ func TestBatchWrite_UnmarshalRFC(t *testing.T) {
 	tests := []struct {
 		name     string
 		rfc      string
+		now      time.Time
 		expected time.Time
 	}{
 		{
 			name:     "RFC3339Nano",
 			rfc:      time.RFC3339Nano,
+			now:      now,
 			expected: now,
 		},
 		{
 			name:     "RFC3339",
 			rfc:      time.RFC3339,
+			now:      now.Round(time.Second),
 			expected: now.Round(time.Second),
 		},
 	}
 
 	for _, test := range tests {
 		t.Logf("testing %q\n", test.name)
-		ts := now.Format(test.rfc)
+		ts := test.now.Format(test.rfc)
 		data := []byte(fmt.Sprintf(`{"timestamp": %q}`, ts))
 		t.Logf("json: %s", string(data))
 		var br httpd.BatchWrite

--- a/httpd/handler_test.go
+++ b/httpd/handler_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -12,6 +13,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/influxdb/influxdb"
 	"github.com/influxdb/influxdb/httpd"
@@ -21,6 +23,114 @@ import (
 
 func init() {
 	influxdb.BcryptCost = 4
+}
+
+func TestBatchWrite_UnmarshalEpoch(t *testing.T) {
+	now := time.Now()
+	tests := []struct {
+		name      string
+		epoch     int64
+		precision string
+		expected  time.Time
+	}{
+		{
+			name:      "nanoseconds",
+			epoch:     now.UnixNano(),
+			precision: "n",
+			expected:  now,
+		},
+		{
+			name:      "microseconds",
+			epoch:     now.Round(time.Microsecond).UnixNano() / int64(time.Microsecond),
+			precision: "u",
+			expected:  now.Round(time.Microsecond),
+		},
+		{
+			name:      "milliseconds",
+			epoch:     now.Round(time.Millisecond).UnixNano() / int64(time.Millisecond),
+			precision: "ms",
+			expected:  now.Round(time.Millisecond),
+		},
+		{
+			name:      "seconds",
+			epoch:     now.Round(time.Second).UnixNano() / int64(time.Second),
+			precision: "s",
+			expected:  now.Round(time.Second),
+		},
+		{
+			name:      "minutes",
+			epoch:     now.Round(time.Minute).UnixNano() / int64(time.Minute),
+			precision: "m",
+			expected:  now.Round(time.Minute),
+		},
+		{
+			name:      "hours",
+			epoch:     now.Round(time.Hour).UnixNano() / int64(time.Hour),
+			precision: "h",
+			expected:  now.Round(time.Hour),
+		},
+		{
+			name:      "max int64",
+			epoch:     9223372036854775807,
+			precision: "n",
+			expected:  time.Unix(0, 9223372036854775807),
+		},
+		{
+			name:      "100 years from now",
+			epoch:     now.Add(time.Hour * 24 * 365 * 100).UnixNano(),
+			precision: "n",
+			expected:  now.Add(time.Hour * 24 * 365 * 100),
+		},
+	}
+
+	for _, test := range tests {
+		t.Logf("testing %q\n", test.name)
+		data := []byte(fmt.Sprintf(`{"timestamp": %d, "precision":"%s"}`, test.epoch, test.precision))
+		t.Logf("json: %s", string(data))
+		var br httpd.BatchWrite
+		err := json.Unmarshal(data, &br)
+		if err != nil {
+			t.Fatalf("unexpected error.  exptected: %v, actual: %v", nil, err)
+		}
+		if br.Timestamp != test.expected {
+			t.Fatalf("Unexpected time.  expected: %v, actual: %v", test.expected, br.Timestamp)
+		}
+	}
+}
+
+func TestBatchWrite_UnmarshalRFC(t *testing.T) {
+	now := time.Now()
+	tests := []struct {
+		name     string
+		rfc      string
+		expected time.Time
+	}{
+		{
+			name:     "RFC3339Nano",
+			rfc:      time.RFC3339Nano,
+			expected: now,
+		},
+		{
+			name:     "RFC3339",
+			rfc:      time.RFC3339,
+			expected: now.Round(time.Second),
+		},
+	}
+
+	for _, test := range tests {
+		t.Logf("testing %q\n", test.name)
+		ts := now.Format(test.rfc)
+		data := []byte(fmt.Sprintf(`{"timestamp": %q}`, ts))
+		t.Logf("json: %s", string(data))
+		var br httpd.BatchWrite
+		err := json.Unmarshal(data, &br)
+		if err != nil {
+			t.Fatalf("unexpected error.  exptected: %v, actual: %v", nil, err)
+		}
+		if br.Timestamp != test.expected {
+			t.Fatalf("Unexpected time.  expected: %v, actual: %v", test.expected, br.Timestamp)
+		}
+	}
 }
 
 func TestHandler_Databases(t *testing.T) {
@@ -1272,6 +1382,8 @@ func TestHandler_serveShowTagValues(t *testing.T) {
 		}
 	}
 }
+
+// batchWrite JSON Unmarshal tests
 
 // Utility functions for this test suite.
 

--- a/server.go
+++ b/server.go
@@ -1313,48 +1313,6 @@ type Point struct {
 	Values    map[string]interface{}
 }
 
-// UnmarshalJSON decodes the data into the Point struct
-func (p *Point) UnmarshalJSON(b []byte) error {
-	var normal struct {
-		Name      string
-		Tags      map[string]string
-		Timestamp time.Time
-		Values    map[string]interface{}
-	}
-	var epoch struct {
-		Name      string
-		Tags      map[string]string
-		Timestamp string `json:",string"`
-		Precision string // Can be h, m, s, ms, u, n, defaults to s if blank
-		Values    map[string]interface{}
-	}
-
-	err := json.Unmarshal(b, &epoch)
-	if err == nil {
-		// Convert from epoch to time.Time
-		switch epoch.Precision {
-		case "h":
-		case "m":
-		case "ms":
-		case "u":
-		case "n":
-		default: // defaults to seconds
-
-		}
-	}
-
-	err = json.Unmarshal(b, &normal)
-	if err != nil {
-		p = &Point{
-			Name:      normal.Name,
-			Tags:      normal.Tags,
-			Timestamp: normal.Timestamp,
-			Values:    normal.Values,
-		}
-	}
-	return nil
-}
-
 // WriteSeries writes series data to the database.
 // Returns the messaging index the data was written to.
 func (s *Server) WriteSeries(database, retentionPolicy string, points []Point) (uint64, error) {

--- a/server.go
+++ b/server.go
@@ -1313,6 +1313,48 @@ type Point struct {
 	Values    map[string]interface{}
 }
 
+// UnmarshalJSON decodes the data into the Point struct
+func (p *Point) UnmarshalJSON(b []byte) error {
+	var normal struct {
+		Name      string
+		Tags      map[string]string
+		Timestamp time.Time
+		Values    map[string]interface{}
+	}
+	var epoch struct {
+		Name      string
+		Tags      map[string]string
+		Timestamp string `json:",string"`
+		Precision string // Can be h, m, s, ms, u, n, defaults to s if blank
+		Values    map[string]interface{}
+	}
+
+	err := json.Unmarshal(b, &epoch)
+	if err == nil {
+		// Convert from epoch to time.Time
+		switch epoch.Precision {
+		case "h":
+		case "m":
+		case "ms":
+		case "u":
+		case "n":
+		default: // defaults to seconds
+
+		}
+	}
+
+	err = json.Unmarshal(b, &normal)
+	if err != nil {
+		p = &Point{
+			Name:      normal.Name,
+			Tags:      normal.Tags,
+			Timestamp: normal.Timestamp,
+			Values:    normal.Values,
+		}
+	}
+	return nil
+}
+
 // WriteSeries writes series data to the database.
 // Returns the messaging index the data was written to.
 func (s *Server) WriteSeries(database, retentionPolicy string, points []Point) (uint64, error) {

--- a/server_test.go
+++ b/server_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"net/url"
 	"os"
 	"reflect"
@@ -898,6 +899,37 @@ func TestDatabase_TagNames(t *testing.T)        { t.Skip("pending") }
 func TestServer_TagNamesBySeries(t *testing.T)  { t.Skip("pending") }
 func TestServer_TagValues(t *testing.T)         { t.Skip("pending") }
 func TestServer_TagValuesBySeries(t *testing.T) { t.Skip("pending") }
+
+// Point tests
+
+func TestPoint_UnmarshalEpoch(t *testing.T) {
+	var (
+		now     = time.Now()
+		nanos   = now.UnixNano()
+		micros  = nanos / int64(time.Microsecond)
+		millis  = nanos / int64(time.Millisecond)
+		seconds = nanos / int64(time.Second)
+		minutes = nanos / int64(time.Minute)
+		hours   = nanos / int64(time.Hour)
+	)
+
+	tests := []struct {
+		name  string
+		epoch int64
+	}{
+		{name: "nanos", epoch: nanos},
+		{name: "micros", epoch: micros},
+		{name: "millis", epoch: millis},
+		{name: "seconds", epoch: seconds},
+		{name: "minutes", epoch: minutes},
+		{name: "hours", epoch: hours},
+	}
+
+	for _, test := range tests {
+		log.Println(test.name)
+	}
+
+}
 
 // Server is a wrapping test struct for influxdb.Server.
 type Server struct {

--- a/server_test.go
+++ b/server_test.go
@@ -900,9 +900,9 @@ func TestServer_TagNamesBySeries(t *testing.T)  { t.Skip("pending") }
 func TestServer_TagValues(t *testing.T)         { t.Skip("pending") }
 func TestServer_TagValuesBySeries(t *testing.T) { t.Skip("pending") }
 
-// Point tests
+// Point JSON Unmarshal tests
 
-func TestPoint_UnmarshalEpoch(t *testing.T) {
+func TestbatchWrite_UnmarshalEpoch(t *testing.T) {
 	var (
 		now     = time.Now()
 		nanos   = now.UnixNano()
@@ -926,7 +926,9 @@ func TestPoint_UnmarshalEpoch(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		log.Println(test.name)
+		json := fmt.Sprintf(`"points": [{timestamp: "%d"}`, test.epoch)
+		log.Println(json)
+		t.Fatal("foo")
 	}
 
 }


### PR DESCRIPTION
Added support for writing json to the http endpoint `/write` that allows for the following formats:

- Epoch time, with precision in nanoseconds, microseconds, milliseconds, seconds, minutes, and hours ("n", "u", "ms", "s", "m", "h").
- Added testing to verify RFC3339 is accepted
- Added testing to verify RFC3339nano is accepted

In theory, many of the go time formats are accepted,but we officially only support the above.  There is no test coverage outside of those.  If we want to add more, we should add more tests.

Following are examples of what the json can look like for sending in epoch time:

### RFC3339 in UTC
```json
{
    "points": [
        {
            "name": "cpu",
            "tags": {
                "region": "us"
            },
            "timestamp": "2015-01-29T21:50:44Z",
            "values": {
                "cpu": 100
            }
        }
    ],
    "database": "foo",
    "retentionPolicy": "bar",
    "tags": {
        "region": "us"
    },
    "timestamp": "2015-01-29T21:50:44Z"
}
```
### RFC3339  with time zone
```json
{
    "points": [
        {
            "name": "cpu",
            "tags": {
                "region": "us"
            },
            "timestamp": "2015-01-29T14:49:23-07:00",
            "values": {
                "cpu": 100
            }
        }
    ],
    "database": "foo",
    "retentionPolicy": "bar",
    "tags": {
        "region": "us"
    },
    "timestamp": "2015-01-29T14:49:23-07:00"
}
```
### RFC3339Nano in UTC
```json
{
    "points": [
        {
            "name": "cpu",
            "tags": {
                "region": "us"
            },
            "timestamp": "2015-01-29T21:51:28.968422294Z",
            "values": {
                "cpu": 100
            }
        }
    ],
    "database": "foo",
    "retentionPolicy": "bar",
    "tags": {
        "region": "us"
    },
    "timestamp": "2015-01-29T21:51:28.968422294Z"
}
```

### RFC3339Nano with timezone
```json
{
    "points": [
        {
            "name": "cpu",
            "tags": {
                "region": "us"
            },
            "timestamp": "2015-01-29T14:48:36.127798015-07:00",
            "values": {
                "cpu": 100
            }
        }
    ],
    "database": "foo",
    "retentionPolicy": "bar",
    "tags": {
        "region": "us"
    },
    "timestamp": "2015-01-29T14:48:36.127798015-07:00"
}
``` 

### Time specified as epoch and precision

You can send in `timestamp` as in `int64`, as well as `precision`.

Precision can be:

- `n` nanoseconds
- `u` microseconds
- `ms` milliseconds
- `s` seconds (default if not specified)
- `m` minutes
- `h` hours

```json
{
    "points": [
        {
            "name": "cpu",
            "tags": {
                "region": "us"
            },
            "timestamp": 1422568543702900257,
            "precision": "n",
            "values": {
                "cpu": 100
            }
        }
    ],
    "database": "foo",
    "retentionPolicy": "bar",
    "tags": {
        "region": "us"
    },
    "timestamp": 1422568543702900257,
    "precision": "n"
}
{
    "points": [
        {
            "name": "cpu",
            "tags": {
                "region": "us"
            },
            "timestamp": 1422568543702900,
            "precision": "u",
            "values": {
                "cpu": 100
            }
        }
    ],
    "database": "foo",
    "retentionPolicy": "bar",
    "tags": {
        "region": "us"
    },
    "timestamp": 1422568543702900,
    "precision": "u"
}
{
    "points": [
        {
            "name": "cpu",
            "tags": {
                "region": "us"
            },
            "timestamp": 1422568543702,
            "precision": "ms",
            "values": {
                "cpu": 100
            }
        }
    ],
    "database": "foo",
    "retentionPolicy": "bar",
    "tags": {
        "region": "us"
    },
    "timestamp": 1422568543702,
    "precision": "ms"
}
{
    "points": [
        {
            "name": "cpu",
            "tags": {
                "region": "us"
            },
            "timestamp": 1422568543,
            "precision": "s",
            "values": {
                "cpu": 100
            }
        }
    ],
    "database": "foo",
    "retentionPolicy": "bar",
    "tags": {
        "region": "us"
    },
    "timestamp": 1422568543,
    "precision": "s"
}
{
    "points": [
        {
            "name": "cpu",
            "tags": {
                "region": "us"
            },
            "timestamp": 23709475,
            "precision": "m",
            "values": {
                "cpu": 100
            }
        }
    ],
    "database": "foo",
    "retentionPolicy": "bar",
    "tags": {
        "region": "us"
    },
    "timestamp": 23709475,
    "precision": "m"
}
{
    "points": [
        {
            "name": "cpu",
            "tags": {
                "region": "us"
            },
            "timestamp": 395157,
            "precision": "h",
            "values": {
                "cpu": 100
            }
        }
    ],
    "database": "foo",
    "retentionPolicy": "bar",
    "tags": {
        "region": "us"
    },
    "timestamp": 395157,
    "precision": "h"
}
```