### PR TITLE
Increase time "added" for single node test

### DIFF
--- a/raft/log_test.go
+++ b/raft/log_test.go
@@ -66,7 +66,6 @@ func TestLog_Reopen(t *testing.T) {
 func TestLog_Apply(t *testing.T) {
 	// TODO corylanou: this test is intermittently failing.  Fix and re-enable
 	// trace can be found here for failing test: https://gist.github.com/corylanou/1bb0a5d11447177e478f
-	t.Skip()
 	n := NewInitNode()
 	defer n.Close()
 
@@ -329,7 +328,7 @@ func NewNode() *Node {
 func NewInitNode() *Node {
 	n := NewNode()
 	n.Open()
-	go func() { n.Clock().Add(2 * n.Log.ApplyInterval) }()
+	go func() { n.Clock().Add(3 * n.Log.ApplyInterval) }()
 	if err := n.Log.Initialize(); err != nil {
 		panic("initialize: " + err.Error())
 	}


### PR DESCRIPTION
Wait()ing for the log to be applied can take 2 loops. Due to this, the
timer used to trigger the 3rd check is pushed too far into the future.
So push the clock even farther into the future so the test doesn't hang
and can then be re-enabled.