### PR TITLE
Look up Field by ID by direct indexing

### DIFF
--- a/database.go
+++ b/database.go
@@ -156,12 +156,10 @@ func (m *Measurement) createFieldIfNotExists(name string, typ influxql.DataType)
 
 // Field returns a field by id.
 func (m *Measurement) Field(id uint8) *Field {
-	for _, f := range m.Fields {
-		if f.ID == id {
-			return f
-		}
+	if int(id) > len(m.Fields) {
+		return nil
 	}
-	return nil
+	return m.Fields[id-1]
 }
 
 // FieldByName returns a field by name.


### PR DESCRIPTION
There is no need to iterate over the entire slice since IDs increase
lock-step with the position in the underlying Field array, so make this
lookup constant-time.