### PR TITLE
Server.Ready()

### DIFF
--- a/httpd/handler.go
+++ b/httpd/handler.go
@@ -286,7 +286,11 @@ func (h *Handler) serveMetastore(w http.ResponseWriter, r *http.Request) {
 
 // servePing returns a simple response to let the client know the server is running.
 func (h *Handler) servePing(w http.ResponseWriter, r *http.Request) {
-	w.WriteHeader(http.StatusNoContent)
+	if h.server.Ready() {
+		w.WriteHeader(http.StatusNoContent)
+	} else {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}
 }
 
 // serveDataNodes returns a list of all data nodes in the cluster.

--- a/httpd/handler.go
+++ b/httpd/handler.go
@@ -296,7 +296,7 @@ func (h *Handler) servePing(w http.ResponseWriter, r *http.Request) {
 // serveDataNodes returns a list of all data nodes in the cluster.
 func (h *Handler) serveDataNodes(w http.ResponseWriter, r *http.Request) {
 	// Generate a list of objects for encoding to the API.
-	a := make([]*dataNodeJSON, 0)
+	var a = make([]*dataNodeJSON, 0)
 	for _, n := range h.server.DataNodes() {
 		a = append(a, &dataNodeJSON{
 			ID:  n.ID,
@@ -423,9 +423,8 @@ func parseCredentials(r *http.Request) (string, string, error) {
 	}
 	if u, p, ok := r.BasicAuth(); ok {
 		return u, p, nil
-	} else {
-		return "", "", fmt.Errorf("unable to parse Basic Auth credentials")
 	}
+	return "", "", fmt.Errorf("unable to parse Basic Auth credentials")
 }
 
 // authenticate wraps a handler and ensures that if user credentials are passed in

--- a/httpd/handler_test.go
+++ b/httpd/handler_test.go
@@ -1663,6 +1663,11 @@ func NewMessagingClient() *MessagingClient {
 	return c
 }
 
+// Opened returns true if the messaging client has been opened
+func (c *MessagingClient) Opened() bool {
+	return true
+}
+
 // Publish attaches an autoincrementing index to the message.
 // This function also execute's the client's PublishFunc mock function.
 func (c *MessagingClient) Publish(m *messaging.Message) (uint64, error) {

--- a/messaging/client.go
+++ b/messaging/client.go
@@ -149,6 +149,14 @@ func (c *Client) Open(path string, urls []*url.URL) error {
 	return nil
 }
 
+// Opened returns the status of if the client is ready to accept messages
+func (c *Client) Opened() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return c.opened
+}
+
 // Close disconnects the client from the broker cluster.
 func (c *Client) Close() error {
 	c.mu.Lock()

--- a/messaging/client_test.go
+++ b/messaging/client_test.go
@@ -75,6 +75,32 @@ func TestClient_Open_ErrBrokerURLRequired(t *testing.T) {
 	}
 }
 
+// Ensure that a client can check Opened status.
+func TestClient_Opened(t *testing.T) {
+	c := NewClient(1000)
+	defer c.Close()
+
+	// Create replica on broker.
+	c.Server.Handler.Broker().CreateReplica(1000)
+
+	// Open client to broker.
+	f := NewTempFile()
+	defer os.Remove(f)
+	u, _ := url.Parse(c.Server.URL)
+	if err := c.Open(f, []*url.URL{u}); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	if !c.Opened() {
+		t.Fatalf("expected server to be opened")
+	}
+
+	// Close connection to the broker.
+	if err := c.Client.Close(); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+}
+
 // Ensure that a client can close while a message is pending.
 func TestClient_Close(t *testing.T) {
 	c := NewClient(1000)

--- a/server.go
+++ b/server.go
@@ -124,6 +124,14 @@ func (s *Server) ID() uint64 {
 	return s.id
 }
 
+// Ready indicates when the server is ready to accept connections and write data
+func (s *Server) Ready() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return s.client.Opened()
+}
+
 // Path returns the path used when opening the server.
 // Returns an empty string when the server is closed.
 func (s *Server) Path() string {
@@ -2474,6 +2482,9 @@ type MessagingClient interface {
 
 	// Deletes an existing replica with a given ID from the broker.
 	DeleteReplica(replicaID uint64) error
+
+	// Opened returns true if the messaging client has been opened
+	Opened() bool
 
 	// Creates a subscription for a replica to a topic.
 	Subscribe(replicaID, topicID uint64) error

--- a/server_test.go
+++ b/server_test.go
@@ -1036,6 +1036,11 @@ func NewMessagingClient() *MessagingClient {
 	return c
 }
 
+// Opened returns true if the messaging client has been opened
+func (c *MessagingClient) Opened() bool {
+	return true
+}
+
 // Publish attaches an autoincrementing index to the message.
 // This function also execute's the client's PublishFunc mock function.
 func (c *MessagingClient) Publish(m *messaging.Message) (uint64, error) {


### PR DESCRIPTION
Adding a "Ready" state to the server so we can push that out via a ping.  This will be necessary when creating integration tests that fire up a server in memory and know when they can continue the test and push data.