### PR TITLE
Basic integration testing

### DIFF
--- a/cmd/influx/main.go
+++ b/cmd/influx/main.go
@@ -306,7 +306,7 @@ func WriteColumns(results *client.Results, w io.Writer) {
 	}
 }
 
-func resultToCSV(result *client.Result, seperator string, headerLines bool) []string {
+func resultToCSV(result client.Result, seperator string, headerLines bool) []string {
 	rows := []string{}
 	// Create a tabbed writer for each result a they won't always line up
 	columnNames := []string{"name", "tags"}

--- a/cmd/influxd/server_single_integration_test.go
+++ b/cmd/influxd/server_single_integration_test.go
@@ -37,7 +37,6 @@ func TestNewServer(t *testing.T) {
 	c.Data.Dir = tmpDataDir
 
 	now := time.Now()
-	var spinupTime time.Duration
 
 	s := main.Run(c, join, version, os.Stderr)
 
@@ -51,39 +50,6 @@ func TestNewServer(t *testing.T) {
 		err = os.RemoveAll(tmpDataDir)
 		if err != nil {
 			t.Logf("Failed to clean up %q: %s\n", tmpDataDir, err)
-		}
-	}()
-
-	ready := make(chan bool, 1)
-	go func() {
-		for {
-			resp, err := http.Get(c.BrokerURL().String() + "/ping")
-			if err != nil {
-				t.Fatalf("failed to spin up server: %s", err)
-			}
-			if resp.StatusCode != http.StatusNoContent {
-				time.Sleep(2 * time.Millisecond)
-			} else {
-				ready <- true
-				break
-			}
-		}
-	}()
-
-	// wait for the server to spin up
-	func() {
-		for {
-			select {
-			case <-ready:
-				spinupTime = time.Since(now)
-				t.Logf("Spinup time of server was %v\n", spinupTime)
-				return
-			case <-time.After(3 * time.Second):
-				if spinupTime == 0 {
-					ellapsed := time.Since(now)
-					t.Fatalf("server failed to spin up in time %v", ellapsed)
-				}
-			}
 		}
 	}()
 

--- a/cmd/influxd/server_single_integration_test.go
+++ b/cmd/influxd/server_single_integration_test.go
@@ -10,19 +10,17 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strconv"
 	"testing"
 	"time"
 
-	"github.com/influxdb/influxdb"
+	"github.com/influxdb/influxdb/client"
 	"github.com/influxdb/influxdb/influxql"
 
 	main "github.com/influxdb/influxdb/cmd/influxd"
 )
 
 func TestNewServer(t *testing.T) {
-	// Uncomment this to see the test fail when running for a second time in a row
-	//t.Skip()
-
 	var (
 		join    = ""
 		version = "x.x"
@@ -93,15 +91,15 @@ func TestNewServer(t *testing.T) {
 	t.Log("Creating database")
 
 	u := urlFor(c.BrokerURL(), "query", url.Values{"q": []string{"CREATE DATABASE foo"}})
-	client := http.Client{Timeout: 100 * time.Millisecond}
+	httpClient := http.Client{Timeout: 100 * time.Millisecond}
 
-	resp, err := client.Get(u.String())
+	resp, err := httpClient.Get(u.String())
 	if err != nil {
 		t.Fatalf("Couldn't create database: %s", err)
 	}
 	defer resp.Body.Close()
 
-	var results influxdb.Results
+	var results client.Results
 	err = json.NewDecoder(resp.Body).Decode(&results)
 	if err != nil {
 		t.Fatalf("Couldn't decode results: %v", err)
@@ -122,7 +120,7 @@ func TestNewServer(t *testing.T) {
 	// Query the database exists
 	u = urlFor(c.BrokerURL(), "query", url.Values{"q": []string{"SHOW DATABASES"}})
 
-	resp, err = client.Get(u.String())
+	resp, err = httpClient.Get(u.String())
 	if err != nil {
 		t.Fatalf("Couldn't query databases: %s", err)
 	}
@@ -141,21 +139,18 @@ func TestNewServer(t *testing.T) {
 		t.Fatalf("show databases failed.  Unexpected status code.  expected: %d, actual %d", http.StatusOK, resp.StatusCode)
 	}
 
-	if len(results.Results) != 1 {
-		t.Fatalf("show databases failed.  Unexpected results length.  expected: %d, actual %d", 1, len(results.Results))
+	expectedResults := client.Results{
+		Results: []client.Result{
+			{Rows: []influxql.Row{
+				influxql.Row{
+					Columns: []string{"name"},
+					Values:  [][]interface{}{{"foo"}},
+				},
+			}},
+		},
 	}
-
-	rows := results.Results[0].Rows
-	if len(rows) != 1 {
-		t.Fatalf("show databases failed.  Unexpected rows length.  expected: %d, actual %d", 1, len(rows))
-	}
-	row := rows[0]
-	expectedRow := &influxql.Row{
-		Columns: []string{"name"},
-		Values:  [][]interface{}{{"foo"}},
-	}
-	if !reflect.DeepEqual(row, expectedRow) {
-		t.Fatalf("show databases failed.  Unexpected row.  expected: %+v, actual %+v", expectedRow, row)
+	if !reflect.DeepEqual(results, expectedResults) {
+		t.Fatalf("show databases failed.  Unexpected results.  expected: %+v, actual %+v", expectedResults, results)
 	}
 
 	// Create a retention policy
@@ -163,7 +158,7 @@ func TestNewServer(t *testing.T) {
 
 	u = urlFor(c.BrokerURL(), "query", url.Values{"q": []string{"CREATE RETENTION POLICY bar ON foo DURATION 1h REPLICATION 1 DEFAULT"}})
 
-	resp, err = client.Get(u.String())
+	resp, err = httpClient.Get(u.String())
 	if err != nil {
 		t.Fatalf("Couldn't create retention policy: %s", err)
 	}
@@ -196,7 +191,7 @@ func TestNewServer(t *testing.T) {
 	buf := []byte(fmt.Sprintf(`{"database" : "foo", "retentionPolicy" : "bar", "points": [{"name": "cpu", "tags": {"host": "server01"},"timestamp": %d, "precision":"n","values": {"value": 100}}]}`, now.UnixNano()))
 	t.Logf("Writing raw data: %s", string(buf))
 
-	resp, err = client.Post(u.String(), "application/json", bytes.NewReader(buf))
+	resp, err = httpClient.Post(u.String(), "application/json", bytes.NewReader(buf))
 	if err != nil {
 		t.Fatalf("Couldn't write data: %s", err)
 	}
@@ -205,13 +200,14 @@ func TestNewServer(t *testing.T) {
 	}
 
 	// Need some time for server to get consensus and write data
+	// TODO corylanou query the status endpoint for the server and wait for the index to update to know the write was applied
 	time.Sleep(100 * time.Millisecond)
 
 	// Query the data exists
 	t.Log("Query data")
 	u = urlFor(c.BrokerURL(), "query", url.Values{"q": []string{`select value from "foo"."bar".cpu`}, "db": []string{"foo"}})
 
-	resp, err = client.Get(u.String())
+	resp, err = httpClient.Get(u.String())
 	if err != nil {
 		t.Fatalf("Couldn't query databases: %s", err)
 	}
@@ -238,24 +234,26 @@ func TestNewServer(t *testing.T) {
 		t.Fatalf("query databases failed.  Unexpected status code.  expected: %d, actual %d", http.StatusOK, resp.StatusCode)
 	}
 
-	if len(results.Results) != 1 {
-		t.Fatalf("query databases failed.  Unexpected results length.  expected: %d, actual %d", 1, len(results.Results))
-	}
-
-	rows = results.Results[0].Rows
-	if len(rows) != 1 {
-		t.Fatalf("query databases failed.  Unexpected rows length.  expected: %d, actual %d", 1, len(rows))
-	}
-	row = rows[0]
-	expectedRow = &influxql.Row{
-		Name:    "cpu",
-		Columns: []string{"time", "value"},
-		Values: [][]interface{}{
-			[]interface{}{now.UnixNano(), 100},
+	strNow := strconv.FormatInt(now.UnixNano(), 10)
+	expectedResults = client.Results{
+		Results: []client.Result{
+			{Rows: []influxql.Row{
+				{
+					Name:    "cpu",
+					Columns: []string{"time", "value"},
+					Values: [][]interface{}{
+						[]interface{}{json.Number(strNow), json.Number("100")},
+					},
+				}}},
 		},
 	}
-	if !reflect.DeepEqual(row, expectedRow) {
-		t.Fatalf("query databases failed.  Unexpected row.  expected: %+v, actual %+v", expectedRow, row)
+
+	if !reflect.DeepEqual(results, expectedResults) {
+		t.Logf("Expected:\n")
+		t.Logf("%#v\n", expectedResults)
+		t.Logf("Actual:\n")
+		t.Logf("%#v\n", results)
+		t.Fatalf("query databases failed.  Unexpected results.")
 	}
 }
 

--- a/cmd/influxd/server_single_integration_test.go
+++ b/cmd/influxd/server_single_integration_test.go
@@ -1,0 +1,266 @@
+package main_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/influxdb/influxdb"
+	"github.com/influxdb/influxdb/influxql"
+
+	main "github.com/influxdb/influxdb/cmd/influxd"
+)
+
+func TestNewServer(t *testing.T) {
+	// Uncomment this to see the test fail when running for a second time in a row
+	//t.Skip()
+
+	var (
+		join    = ""
+		version = "x.x"
+	)
+
+	tmpDir := os.TempDir()
+	tmpBrokerDir := filepath.Join(tmpDir, "broker")
+	tmpDataDir := filepath.Join(tmpDir, "data")
+	t.Logf("Using tmp directorie %q for broker\n", tmpBrokerDir)
+	t.Logf("Using tmp directorie %q for data\n", tmpDataDir)
+
+	c := main.NewConfig()
+	c.Broker.Dir = tmpBrokerDir
+	c.Data.Dir = tmpDataDir
+
+	now := time.Now()
+	var spinupTime time.Duration
+
+	s := main.Run(c, join, version, os.Stderr)
+
+	defer func() {
+		s.Close()
+		t.Log("Shutting down server and cleaning up tmp directories")
+		err := os.RemoveAll(tmpBrokerDir)
+		if err != nil {
+			t.Logf("Failed to clean up %q: %s\n", tmpBrokerDir, err)
+		}
+		err = os.RemoveAll(tmpDataDir)
+		if err != nil {
+			t.Logf("Failed to clean up %q: %s\n", tmpDataDir, err)
+		}
+	}()
+
+	ready := make(chan bool, 1)
+	go func() {
+		for {
+			resp, err := http.Get(c.BrokerURL().String() + "/ping")
+			if err != nil {
+				t.Fatalf("failed to spin up server: %s", err)
+			}
+			if resp.StatusCode != http.StatusNoContent {
+				time.Sleep(2 * time.Millisecond)
+			} else {
+				ready <- true
+				break
+			}
+		}
+	}()
+
+	// wait for the server to spin up
+	func() {
+		for {
+			select {
+			case <-ready:
+				spinupTime = time.Since(now)
+				t.Logf("Spinup time of server was %v\n", spinupTime)
+				return
+			case <-time.After(3 * time.Second):
+				if spinupTime == 0 {
+					ellapsed := time.Since(now)
+					t.Fatalf("server failed to spin up in time %v", ellapsed)
+				}
+			}
+		}
+	}()
+
+	// Create a database
+	t.Log("Creating database")
+
+	u := urlFor(c.BrokerURL(), "query", url.Values{"q": []string{"CREATE DATABASE foo"}})
+	client := http.Client{Timeout: 100 * time.Millisecond}
+
+	resp, err := client.Get(u.String())
+	if err != nil {
+		t.Fatalf("Couldn't create database: %s", err)
+	}
+	defer resp.Body.Close()
+
+	var results influxdb.Results
+	err = json.NewDecoder(resp.Body).Decode(&results)
+	if err != nil {
+		t.Fatalf("Couldn't decode results: %v", err)
+	}
+
+	if results.Error() != nil {
+		t.Logf("results.Error(): %q", results.Error().Error())
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("Create database failed.  Unexpected status code.  expected: %d, actual %d", http.StatusOK, resp.StatusCode)
+	}
+
+	if len(results.Results) != 1 {
+		t.Fatalf("Create database failed.  Unexpected results length.  expected: %d, actual %d", 1, len(results.Results))
+	}
+
+	// Query the database exists
+	u = urlFor(c.BrokerURL(), "query", url.Values{"q": []string{"SHOW DATABASES"}})
+
+	resp, err = client.Get(u.String())
+	if err != nil {
+		t.Fatalf("Couldn't query databases: %s", err)
+	}
+	defer resp.Body.Close()
+
+	err = json.NewDecoder(resp.Body).Decode(&results)
+	if err != nil {
+		t.Fatalf("Couldn't decode results: %v", err)
+	}
+
+	if results.Error() != nil {
+		t.Logf("results.Error(): %q", results.Error().Error())
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("show databases failed.  Unexpected status code.  expected: %d, actual %d", http.StatusOK, resp.StatusCode)
+	}
+
+	if len(results.Results) != 1 {
+		t.Fatalf("show databases failed.  Unexpected results length.  expected: %d, actual %d", 1, len(results.Results))
+	}
+
+	rows := results.Results[0].Rows
+	if len(rows) != 1 {
+		t.Fatalf("show databases failed.  Unexpected rows length.  expected: %d, actual %d", 1, len(rows))
+	}
+	row := rows[0]
+	expectedRow := &influxql.Row{
+		Columns: []string{"name"},
+		Values:  [][]interface{}{{"foo"}},
+	}
+	if !reflect.DeepEqual(row, expectedRow) {
+		t.Fatalf("show databases failed.  Unexpected row.  expected: %+v, actual %+v", expectedRow, row)
+	}
+
+	// Create a retention policy
+	t.Log("Creating retention policy")
+
+	u = urlFor(c.BrokerURL(), "query", url.Values{"q": []string{"CREATE RETENTION POLICY bar ON foo DURATION 1h REPLICATION 1 DEFAULT"}})
+
+	resp, err = client.Get(u.String())
+	if err != nil {
+		t.Fatalf("Couldn't create retention policy: %s", err)
+	}
+	defer resp.Body.Close()
+
+	err = json.NewDecoder(resp.Body).Decode(&results)
+	if err != nil {
+		t.Fatalf("Couldn't decode results: %v", err)
+	}
+
+	if results.Error() != nil {
+		t.Logf("results.Error(): %q", results.Error().Error())
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("Create retention policy failed.  Unexpected status code.  expected: %d, actual %d", http.StatusOK, resp.StatusCode)
+	}
+
+	if len(results.Results) != 1 {
+		t.Fatalf("Create retention policy failed.  Unexpected results length.  expected: %d, actual %d", 1, len(results.Results))
+	}
+
+	// TODO corylanou: Query the retention policy exists
+
+	// Write Data
+	t.Log("Write data")
+
+	u = urlFor(c.BrokerURL(), "write", url.Values{})
+
+	buf := []byte(fmt.Sprintf(`{"database" : "foo", "retentionPolicy" : "bar", "points": [{"name": "cpu", "tags": {"host": "server01"},"timestamp": %d, "precision":"n","values": {"value": 100}}]}`, now.UnixNano()))
+	t.Logf("Writing raw data: %s", string(buf))
+
+	resp, err = client.Post(u.String(), "application/json", bytes.NewReader(buf))
+	if err != nil {
+		t.Fatalf("Couldn't write data: %s", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("Write to database failed.  Unexpected status code.  expected: %d, actual %d", http.StatusOK, resp.StatusCode)
+	}
+
+	// Need some time for server to get consensus and write data
+	time.Sleep(100 * time.Millisecond)
+
+	// Query the data exists
+	t.Log("Query data")
+	u = urlFor(c.BrokerURL(), "query", url.Values{"q": []string{`select value from "foo"."bar".cpu`}, "db": []string{"foo"}})
+
+	resp, err = client.Get(u.String())
+	if err != nil {
+		t.Fatalf("Couldn't query databases: %s", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("Coulnd't read body of response: %s", err)
+	}
+	t.Logf("resp.Body: %s\n", string(body))
+
+	dec := json.NewDecoder(bytes.NewReader(body))
+	dec.UseNumber()
+	err = dec.Decode(&results)
+	if err != nil {
+		t.Fatalf("Couldn't decode results: %v", err)
+	}
+
+	if results.Error() != nil {
+		t.Logf("results.Error(): %q", results.Error().Error())
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("query databases failed.  Unexpected status code.  expected: %d, actual %d", http.StatusOK, resp.StatusCode)
+	}
+
+	if len(results.Results) != 1 {
+		t.Fatalf("query databases failed.  Unexpected results length.  expected: %d, actual %d", 1, len(results.Results))
+	}
+
+	rows = results.Results[0].Rows
+	if len(rows) != 1 {
+		t.Fatalf("query databases failed.  Unexpected rows length.  expected: %d, actual %d", 1, len(rows))
+	}
+	row = rows[0]
+	expectedRow = &influxql.Row{
+		Name:    "cpu",
+		Columns: []string{"time", "value"},
+		Values: [][]interface{}{
+			[]interface{}{now.UnixNano(), 100},
+		},
+	}
+	if !reflect.DeepEqual(row, expectedRow) {
+		t.Fatalf("query databases failed.  Unexpected row.  expected: %+v, actual %+v", expectedRow, row)
+	}
+}
+
+func urlFor(u *url.URL, path string, params url.Values) *url.URL {
+	u.Path = path
+	u.RawQuery = params.Encode()
+	return u
+}

--- a/cmd/influxd/server_single_integration_test.go
+++ b/cmd/influxd/server_single_integration_test.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
-	"strconv"
 	"testing"
 	"time"
 
@@ -202,7 +201,6 @@ func TestNewServer(t *testing.T) {
 		t.Fatalf("query databases failed.  Unexpected status code.  expected: %d, actual %d", http.StatusOK, resp.StatusCode)
 	}
 
-	strNow := strconv.FormatInt(now.UnixNano(), 10)
 	expectedResults = client.Results{
 		Results: []client.Result{
 			{Rows: []influxql.Row{
@@ -210,7 +208,7 @@ func TestNewServer(t *testing.T) {
 					Name:    "cpu",
 					Columns: []string{"time", "value"},
 					Values: [][]interface{}{
-						[]interface{}{json.Number(strNow), json.Number("100")},
+						[]interface{}{now.FormatTime(time.RFC3339Nano), json.Number("100")},
 					},
 				}}},
 		},

--- a/cmd/influxd/server_single_integration_test.go
+++ b/cmd/influxd/server_single_integration_test.go
@@ -34,7 +34,9 @@ func TestNewServer(t *testing.T) {
 
 	c := main.NewConfig()
 	c.Broker.Dir = tmpBrokerDir
+	c.Broker.Port = 8090
 	c.Data.Dir = tmpDataDir
+	c.Data.Port = 8090
 
 	now := time.Now()
 

--- a/cmd/influxd/server_single_integration_test.go
+++ b/cmd/influxd/server_single_integration_test.go
@@ -37,7 +37,7 @@ func TestNewServer(t *testing.T) {
 	c.Data.Dir = tmpDataDir
 	c.Data.Port = 8090
 
-	now := time.Now()
+	now := time.Now().UTC()
 
 	s := main.Run(c, join, version, os.Stderr)
 
@@ -208,7 +208,7 @@ func TestNewServer(t *testing.T) {
 					Name:    "cpu",
 					Columns: []string{"time", "value"},
 					Values: [][]interface{}{
-						[]interface{}{now.FormatTime(time.RFC3339Nano), json.Number("100")},
+						[]interface{}{now.Format(time.RFC3339Nano), json.Number("100")},
 					},
 				}}},
 		},


### PR DESCRIPTION
This adds an integration test that spins up a server in memory and does the following:

- Creates a database
- Creates a default retention policy
- Writes data
- Queries data

Two bugs were discovered during this refactoring.

1) We were sending back all time in microseconds.  This was due to a legacy business decision.  This has been fixed in PR https://github.com/influxdb/influxdb/pull/1487.

2) We had removed `json.UseNumber()` in a previous pr (https://github.com/influxdb/influxdb/pull/1384).  This was needed to stop the server from panicing.  The cause was due to the `shard.marshalValues` could only decode `float64`.  `json.UseNumber()` sends in data as a `json.Number`.  I created a normalization function that converts all json data from `json.Number` to `float64` before writing to the database to fix this.

One additional refactoring was in the `cmd/influxd` package where I teased out `execRun` from `Run` only for the purpose of creating integration tests without the need for physical config files.