### PR TITLE
CLI - New output formats: Column and CSV

### DIFF
--- a/cmd/influx/main.go
+++ b/cmd/influx/main.go
@@ -207,11 +207,6 @@ func (c *CommandLine) executeQuery(query string) {
 		fmt.Printf("ERR: %s\n", err)
 		return
 	}
-	if err != nil {
-		fmt.Printf("ERR: %s\n", err)
-		return
-	}
-
 	c.FormatResults(results, os.Stdout)
 	if results.Error() != nil && c.Database == "" {
 		fmt.Println("Warning: It is possible this error is due to not setting a database.")

--- a/cmd/influx/main.go
+++ b/cmd/influx/main.go
@@ -246,7 +246,7 @@ func WriteJSON(results *client.Results, pretty bool, w io.Writer) {
 func WriteCSV(results *client.Results, w io.Writer) {
 	csvw := csv.NewWriter(w)
 	for _, result := range results.Results {
-		// Create a tabbed writer for each result a they won't always line up
+		// Create a tabbed writer for each result as they won't always line up
 		rows := resultToCSV(result, "\t", false)
 		for _, r := range rows {
 			csvw.Write(strings.Split(r, "\t"))


### PR DESCRIPTION
You can now output in CSV or Column format responses to queries.

To switch to a format in the shell, use `format <format>`.  Either `csv`, `column`, or `json`.  Default is `column`.

You can also now echo out the current settings of the shell by issuing `settings`:
```sh
$ influx
InfluxDB shell
Connected to http://localhost:8086 version 0.9
> settings
Host            localhost:8086
Username
Database
Pretty          false
Format          column
```

Here is an example of getting results back in different formats:

```sh
InfluxDB shell
Connected to http://localhost:8086 version 0.9
> use foo
Using database foo
> format csv
> select value from "foo"."bar".cpu
name,tags,time,value
cpu,,1.422309671703e+18,100
cpu,,1.422396071703e+18,100
cpu,,1.422482471703e+18,100
> format column
> select value from "foo"."bar".cpu
name    tags    time                    value
----    ----    ----                    -----
cpu             1.422309671703e+18      100
cpu             1.422396071703e+18      100
cpu             1.422482471703e+18      100
> format json
> select value from "foo"."bar".cpu
{"results":[{"rows":[{"name":"cpu","columns":["time","value"],"values":[[1.422309671703e+18,100],[1.422396071703e+18,100],[1.422482471703e+18,100]]}]}]}
> pretty
Pretty print enabled
> select value from "foo"."bar".cpu
{
    "results": [
        {
            "rows": [
                {
                    "name": "cpu",
                    "columns": [
                        "time",
                        "value"
                    ],
                    "values": [
                        [
                            1.422309671703e+18,
                            100
                        ],
                        [
                            1.422396071703e+18,
                            100
                        ],
                        [
                            1.422482471703e+18,
                            100
                        ]
                    ]
                }
            ]
        }
    ]
}
```