### PR TITLE
Send all time back as RFC3339Nano instead of UnixNano (int64)

### DIFF
--- a/influxql/engine.go
+++ b/influxql/engine.go
@@ -299,8 +299,13 @@ loop:
 	}
 
 	// Normalize rows and values.
+	// Convernt all times to timestamps
 	a := make(Rows, 0, len(rows))
 	for _, row := range rows {
+		for _, values := range row.Values {
+			t := time.Unix(0, values[0].(int64))
+			values[0] = t.UTC().Format(time.RFC3339Nano)
+		}
 		a = append(a, row)
 	}
 	sort.Sort(a)

--- a/influxql/engine.go
+++ b/influxql/engine.go
@@ -299,7 +299,7 @@ loop:
 	}
 
 	// Normalize rows and values.
-	// Convernt all times to timestamps
+	// Convert all times to timestamps
 	a := make(Rows, 0, len(rows))
 	for _, row := range rows {
 		for _, values := range row.Values {

--- a/influxql/engine_test.go
+++ b/influxql/engine_test.go
@@ -95,7 +95,7 @@ func TestPlanner_Plan_Count(t *testing.T) {
 	}
 
 	// Expected resultset.
-	exp := minify(`[{"name":"cpu","columns":["time","count"],"values":[[0,6]]}]`)
+	exp := minify(`[{"name":"cpu","columns":["time","count"],"values":[["1970-01-01T00:00:00Z",6]]}]`)
 
 	// Execute and compare.
 	rs := MustPlanAndExecute(NewDB(tx), `2000-01-01T12:00:00Z`,
@@ -128,7 +128,7 @@ func TestPlanner_Plan_Mean(t *testing.T) {
 	}
 
 	// Expected resultset.
-	exp := minify(`[{"name":"cpu","columns":["time","mean"],"values":[[946684800000000000,80],[946684860000000000,60]]}]`)
+	exp := minify(`[{"name":"cpu","columns":["time","mean"],"values":[["2000-01-01T00:00:00Z",80],["2000-01-01T00:01:00Z",60]]}]`)
 
 	// Execute and compare.
 	rs := MustPlanAndExecute(NewDB(tx), `2000-01-01T12:00:00Z`,
@@ -161,7 +161,7 @@ func TestPlanner_Plan_Percentile(t *testing.T) {
 	}
 
 	// Expected resultset.
-	exp := minify(`[{"name":"cpu","columns":["time","percentile"],"values":[[946684800000000000,80],[946684860000000000,60]]}]`)
+	exp := minify(`[{"name":"cpu","columns":["time","percentile"],"values":[["2000-01-01T00:00:00Z",80],["2000-01-01T00:01:00Z",60]]}]`)
 
 	// Execute and compare.
 	rs := MustPlanAndExecute(NewDB(tx), `2000-01-01T12:00:00Z`,
@@ -170,7 +170,7 @@ func TestPlanner_Plan_Percentile(t *testing.T) {
 		t.Fatalf("unexpected resultset: %s", act)
 	}
 
-	exp = minify(`[{"name":"cpu","columns":["time","percentile"],"values":[[946684800000000000,100],[946684860000000000,70]]}]`)
+	exp = minify(`[{"name":"cpu","columns":["time","percentile"],"values":[["2000-01-01T00:00:00Z",100],["2000-01-01T00:01:00Z",70]]}]`)
 	// Execute and compare.
 	rs = MustPlanAndExecute(NewDB(tx), `2000-01-01T12:00:00Z`,
 		`SELECT percentile(value, 99.9) FROM cpu WHERE time >= '2000-01-01' GROUP BY time(1m)`)
@@ -207,7 +207,7 @@ func TestPlanner_Plan_RawData(t *testing.T) {
 	}
 
 	// Expected resultset.
-	exp := minify(`[{"name":"cpu","columns":["time","value"],"values":[[946684800000000000,40],[946684810000000000,30],[946684820000000000,80],[946684822000000000,20],[946684824000000000,50],[946684890000000000,10],[946684900000000000,9],[946684910000000000,8]]}]`)
+	exp := minify(`[{"name":"cpu","columns":["time","value"],"values":[["2000-01-01T00:00:00Z",40],["2000-01-01T00:00:10Z",30],["2000-01-01T00:00:20Z",80],["2000-01-01T00:00:22Z",20],["2000-01-01T00:00:24Z",50],["2000-01-01T00:01:30Z",10],["2000-01-01T00:01:40Z",9],["2000-01-01T00:01:50Z",8]]}]`)
 
 	// Execute and compare.
 	rs := MustPlanAndExecute(NewDB(tx), `2000-01-01T12:00:00Z`,
@@ -240,10 +240,10 @@ func TestPlanner_Plan_GroupByInterval(t *testing.T) {
 		"name":"cpu",
 		"columns":["time","sum"],
 		"values":[
-			[946717200000000000,190],
-			[946719000000000000,80],
-			[946724400000000000,130],
-			[946726200000000000,50]
+			["2000-01-01T09:00:00Z",190],
+			["2000-01-01T09:30:00Z",80],
+			["2000-01-01T11:00:00Z",130],
+			["2000-01-01T11:30:00Z",50]
 		]
 	}]`)
 
@@ -291,18 +291,18 @@ func TestPlanner_Plan_GroupByIntervalAndTag(t *testing.T) {
 		"tags":{"host":"servera"},
 		"columns":["time","sum"],
 		"values":[
-			[946717200000000000,30],
-			[946720800000000000,0],
-			[946724400000000000,70]
+			["2000-01-01T09:00:00Z",30],
+			["2000-01-01T10:00:00Z",0],
+			["2000-01-01T11:00:00Z",70]
 		]
 	},{
 		"name":"cpu",
 		"tags":{"host":"serverb"},
 		"columns":["time","sum"],
 		"values":[
-			[946717200000000000,1],
-			[946720800000000000,0],
-			[946724400000000000,2]
+			["2000-01-01T09:00:00Z",1],
+			["2000-01-01T10:00:00Z",0],
+			["2000-01-01T11:00:00Z",2]
 		]
 	}]`)
 

--- a/server_test.go
+++ b/server_test.go
@@ -717,7 +717,7 @@ func TestServer_ExecuteQuery(t *testing.T) {
 		t.Fatalf("unexpected error: %s", res.Err)
 	} else if len(res.Rows) != 2 {
 		t.Fatalf("unexpected row count: %d", len(res.Rows))
-	} else if s := mustMarshalJSON(res); s != `{"rows":[{"name":"cpu","tags":{"region":"us-east"},"columns":["time","sum"],"values":[[946684800000000000,20],[946684810000000000,30]]},{"name":"cpu","tags":{"region":"us-west"},"columns":["time","sum"],"values":[[946684800000000000,100]]}]}` {
+	} else if s := mustMarshalJSON(res); s != `{"rows":[{"name":"cpu","tags":{"region":"us-east"},"columns":["time","sum"],"values":[["2000-01-01T00:00:00Z",20],["2000-01-01T00:00:10Z",30]]},{"name":"cpu","tags":{"region":"us-west"},"columns":["time","sum"],"values":[["2000-01-01T00:00:00Z",100]]}]}` {
 		t.Fatalf("unexpected row(0): %s", s)
 	}
 }


### PR DESCRIPTION
We are going to send all timestamp data back as a RFC3339Nano string so clients can work with it easier.