### PR TITLE
Fix batched writes

### DIFF
--- a/client/influxdb.go
+++ b/client/influxdb.go
@@ -241,7 +241,7 @@ func (p *Point) UnmarshalJSON(b []byte) error {
 	var epoch struct {
 		Name      string                 `json:"name"`
 		Tags      map[string]string      `json:"tags"`
-		Timestamp int64                  `json:"timestamp"`
+		Timestamp *int64                 `json:"timestamp"`
 		Precision string                 `json:"precision"`
 		Values    map[string]interface{} `json:"values"`
 	}
@@ -251,10 +251,14 @@ func (p *Point) UnmarshalJSON(b []byte) error {
 		if err = json.Unmarshal(b, &epoch); err != nil {
 			return err
 		}
-		// Convert from epoch to time.Time
-		ts, err := EpochToTime(epoch.Timestamp, epoch.Precision)
-		if err != nil {
-			return err
+		// Convert from epoch to time.Time, but only if Timestamp
+		// was actually set.
+		var ts time.Time
+		if epoch.Timestamp != nil {
+			ts, err = EpochToTime(*epoch.Timestamp, epoch.Precision)
+			if err != nil {
+				return err
+			}
 		}
 		p.Name = epoch.Name
 		p.Tags = epoch.Tags

--- a/httpd/handler_test.go
+++ b/httpd/handler_test.go
@@ -90,7 +90,7 @@ func TestBatchWrite_UnmarshalEpoch(t *testing.T) {
 		var bp influxdb.BatchPoints
 		err := json.Unmarshal(data, &bp)
 		if err != nil {
-			t.Fatalf("unexpected error.  exptected: %v, actual: %v", nil, err)
+			t.Fatalf("unexpected error.  expected: %v, actual: %v", nil, err)
 		}
 		if !bp.Timestamp.Equal(test.expected) {
 			t.Fatalf("Unexpected time.  expected: %v, actual: %v", test.expected, bp.Timestamp)

--- a/httpd/handler_test.go
+++ b/httpd/handler_test.go
@@ -87,13 +87,13 @@ func TestBatchWrite_UnmarshalEpoch(t *testing.T) {
 		t.Logf("testing %q\n", test.name)
 		data := []byte(fmt.Sprintf(`{"timestamp": %d, "precision":"%s"}`, test.epoch, test.precision))
 		t.Logf("json: %s", string(data))
-		var br httpd.BatchWrite
-		err := json.Unmarshal(data, &br)
+		var bp influxdb.BatchPoints
+		err := json.Unmarshal(data, &bp)
 		if err != nil {
 			t.Fatalf("unexpected error.  exptected: %v, actual: %v", nil, err)
 		}
-		if !br.Timestamp.Equal(test.expected) {
-			t.Fatalf("Unexpected time.  expected: %v, actual: %v", test.expected, br.Timestamp)
+		if !bp.Timestamp.Equal(test.expected) {
+			t.Fatalf("Unexpected time.  expected: %v, actual: %v", test.expected, bp.Timestamp)
 		}
 	}
 }
@@ -125,13 +125,13 @@ func TestBatchWrite_UnmarshalRFC(t *testing.T) {
 		ts := test.now.Format(test.rfc)
 		data := []byte(fmt.Sprintf(`{"timestamp": %q}`, ts))
 		t.Logf("json: %s", string(data))
-		var br httpd.BatchWrite
-		err := json.Unmarshal(data, &br)
+		var bp influxdb.BatchPoints
+		err := json.Unmarshal(data, &bp)
 		if err != nil {
 			t.Fatalf("unexpected error.  exptected: %v, actual: %v", nil, err)
 		}
-		if !br.Timestamp.Equal(test.expected) {
-			t.Fatalf("Unexpected time.  expected: %v, actual: %v", test.expected, br.Timestamp)
+		if !bp.Timestamp.Equal(test.expected) {
+			t.Fatalf("Unexpected time.  expected: %v, actual: %v", test.expected, bp.Timestamp)
 		}
 	}
 }

--- a/influxdb.go
+++ b/influxdb.go
@@ -91,8 +91,14 @@ var (
 	// ErrInvalidQuery is returned when executing an unknown query type.
 	ErrInvalidQuery = errors.New("invalid query")
 
+	// ErrMeasurementNameRequired is returned when a point does not contain a name.
+	ErrMeasurementNameRequired = errors.New("measurement name required")
+
 	// ErrMeasurementNotFound is returned when a measurement does not exist.
 	ErrMeasurementNotFound = errors.New("measurement not found")
+
+	// ErrValuesRequired is returned when a point does not any values
+	ErrValuesRequired = errors.New("values required")
 
 	// ErrFieldOverflow is returned when too many fields are created on a measurement.
 	ErrFieldOverflow = errors.New("field overflow")

--- a/influxdb.go
+++ b/influxdb.go
@@ -196,6 +196,9 @@ func NormalizeBatchPoints(bp BatchPoints) ([]Point, error) {
 		}
 		p.Timestamp = client.Timestamp(client.SetPrecision(p.Timestamp.Time(), p.Precision))
 		if len(bp.Tags) > 0 {
+			if p.Tags == nil {
+				p.Tags = make(map[string]string)
+			}
 			for k := range bp.Tags {
 				if p.Tags[k] == "" {
 					p.Tags[k] = bp.Tags[k]

--- a/influxdb.go
+++ b/influxdb.go
@@ -5,6 +5,9 @@ import (
 	"errors"
 	"fmt"
 	"os"
+
+	"github.com/influxdb/influxdb/client"
+	"time"
 )
 
 var (
@@ -108,6 +111,102 @@ var (
 	// privilege for a user on the cluster or a database.
 	ErrInvalidGrantRevoke = errors.New("invalid privilege requested")
 )
+
+// BatchPoints is used to send batched data in a single write.
+type BatchPoints struct {
+	Points          []client.Point    `json:"points"`
+	Database        string            `json:"database"`
+	RetentionPolicy string            `json:"retentionPolicy"`
+	Tags            map[string]string `json:"tags"`
+	Timestamp       time.Time         `json:"timestamp"`
+	Precision       string            `json:"precision"`
+}
+
+// UnmarshalJSON decodes the data into the BatchPoints struct
+func (bp *BatchPoints) UnmarshalJSON(b []byte) error {
+	var normal struct {
+		Points          []client.Point    `json:"points"`
+		Database        string            `json:"database"`
+		RetentionPolicy string            `json:"retentionPolicy"`
+		Tags            map[string]string `json:"tags"`
+		Timestamp       time.Time         `json:"timestamp"`
+		Precision       string            `json:"precision"`
+	}
+	var epoch struct {
+		Points          []client.Point    `json:"points"`
+		Database        string            `json:"database"`
+		RetentionPolicy string            `json:"retentionPolicy"`
+		Tags            map[string]string `json:"tags"`
+		Timestamp       int64             `json:"timestamp"`
+		Precision       string            `json:"precision"`
+	}
+
+	if err := func() error {
+		var err error
+		if err = json.Unmarshal(b, &epoch); err != nil {
+			return err
+		}
+		// Convert from epoch to time.Time
+		ts, err := client.EpochToTime(epoch.Timestamp, epoch.Precision)
+		if err != nil {
+			return err
+		}
+		bp.Points = epoch.Points
+		bp.Database = epoch.Database
+		bp.RetentionPolicy = epoch.RetentionPolicy
+		bp.Tags = epoch.Tags
+		bp.Timestamp = ts
+		bp.Precision = epoch.Precision
+		return nil
+	}(); err == nil {
+		return nil
+	}
+
+	if err := json.Unmarshal(b, &normal); err != nil {
+		return err
+	}
+	normal.Timestamp = client.SetPrecision(normal.Timestamp, normal.Precision)
+	bp.Points = normal.Points
+	bp.Database = normal.Database
+	bp.RetentionPolicy = normal.RetentionPolicy
+	bp.Tags = normal.Tags
+	bp.Timestamp = normal.Timestamp
+	bp.Precision = normal.Precision
+
+	return nil
+}
+
+// NormalizeBatchPoints returns a slice of Points, created by populating individual
+// points within the batch, which do not have timestamps or tags, with the top-level
+// values.
+func NormalizeBatchPoints(bp BatchPoints) ([]Point, error) {
+	points := []Point{}
+	for _, p := range bp.Points {
+		if p.Timestamp.Time().IsZero() {
+			p.Timestamp = client.Timestamp(bp.Timestamp)
+		}
+		if p.Precision == "" && bp.Precision != "" {
+			p.Precision = bp.Precision
+		}
+		p.Timestamp = client.Timestamp(client.SetPrecision(p.Timestamp.Time(), p.Precision))
+		if len(bp.Tags) > 0 {
+			for k := range bp.Tags {
+				if p.Tags[k] == "" {
+					p.Tags[k] = bp.Tags[k]
+				}
+			}
+		}
+		// Need to convert from a client.Point to a influxdb.Point
+		points = append(points, Point{
+			Name:      p.Name,
+			Tags:      p.Tags,
+			Timestamp: p.Timestamp.Time(),
+			Values:    p.Values,
+		})
+	}
+
+	return points, nil
+}
 
 // ErrAuthorize represents an authorization error.
 type ErrAuthorize struct {

--- a/influxdb.go
+++ b/influxdb.go
@@ -6,8 +6,9 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/influxdb/influxdb/client"
 	"time"
+
+	"github.com/influxdb/influxdb/client"
 )
 
 var (
@@ -143,7 +144,7 @@ func (bp *BatchPoints) UnmarshalJSON(b []byte) error {
 		Database        string            `json:"database"`
 		RetentionPolicy string            `json:"retentionPolicy"`
 		Tags            map[string]string `json:"tags"`
-		Timestamp       int64             `json:"timestamp"`
+		Timestamp       *int64            `json:"timestamp"`
 		Precision       string            `json:"precision"`
 	}
 
@@ -153,9 +154,12 @@ func (bp *BatchPoints) UnmarshalJSON(b []byte) error {
 			return err
 		}
 		// Convert from epoch to time.Time
-		ts, err := client.EpochToTime(epoch.Timestamp, epoch.Precision)
-		if err != nil {
-			return err
+		var ts time.Time
+		if epoch.Timestamp != nil {
+			ts, err = client.EpochToTime(*epoch.Timestamp, epoch.Precision)
+			if err != nil {
+				return err
+			}
 		}
 		bp.Points = epoch.Points
 		bp.Database = epoch.Database

--- a/influxdb.go
+++ b/influxdb.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-
 	"time"
 
 	"github.com/influxdb/influxdb/client"

--- a/server.go
+++ b/server.go
@@ -1413,6 +1413,14 @@ func (s *Server) WriteSeries(database, retentionPolicy string, points []Point) (
 func (s *Server) writePoint(database, retentionPolicy string, point *Point) (uint64, error) {
 	name, tags, timestamp, values := point.Name, point.Tags, point.Timestamp, point.Values
 
+	// Sanity-check the data point.
+	if name == "" {
+		return 0, ErrMeasurementNameRequired
+	}
+	if len(values) == 0 {
+		return 0, ErrValuesRequired
+	}
+
 	// Find the id for the series and tagset
 	seriesID, err := s.createSeriesIfNotExists(database, name, tags)
 	if err != nil {


### PR DESCRIPTION
This change involved a significant refactor, and two bug fixes. This change fixes issues #1499.

- Move code that populates individual points with any missing tags or timestamps from the top-level, to the influxdb package. This was done so this code is available for transports other than HTTP.
- Fix a panic, which occurred when the individual point had no tags, but the top-level object did. The panic occurred during the copy of the tags.
- Correctly detect when the timestamp key was not set on a individual point, thereby triggering the population of individual points' timestamps from the top-level.

