### PR TITLE
Update system to either be auth-less or fully locked down via authentication.enabled

### DIFF
--- a/cmd/influxd/run.go
+++ b/cmd/influxd/run.go
@@ -52,7 +52,8 @@ func Run(config *Config, join, version string, logWriter *os.File) *influxdb.Ser
 	}
 
 	// Open server, initialize or join as necessary.
-	s := openServer(config.Authentication.Enabled, config.DataDir(), config.DataURL(), b, initializing, configExists, joinURLs, logWriter)
+	s := openServer(config.DataDir(), config.DataURL(), b, initializing, configExists, joinURLs, logWriter)
+	s.SetAuthenticationEnabled(config.Authentication.Enabled)
 
 	// Start the server handler. Attach to broker if listening on the same port.
 	if s != nil {
@@ -203,14 +204,14 @@ func joinBroker(b *messaging.Broker, joinURLs []*url.URL) {
 }
 
 // creates and initializes a server.
-func openServer(authenticationEnabled bool, path string, u *url.URL, b *messaging.Broker, initializing, configExists bool, joinURLs []*url.URL, w io.Writer) *influxdb.Server {
+func openServer(path string, u *url.URL, b *messaging.Broker, initializing, configExists bool, joinURLs []*url.URL, w io.Writer) *influxdb.Server {
 	// Ignore if there's no existing server and we're not initializing or joining.
 	if !fileExists(path) && !initializing && len(joinURLs) == 0 {
 		return nil
 	}
 
 	// Create and open the server.
-	s := influxdb.NewServer(authenticationEnabled)
+	s := influxdb.NewServer()
 	s.SetLogOutput(w)
 	if err := s.Open(path); err != nil {
 		log.Fatalf("failed to open data server: %v", err.Error())

--- a/cmd/influxd/run.go
+++ b/cmd/influxd/run.go
@@ -52,7 +52,7 @@ func Run(config *Config, join, version string, logWriter *os.File) *influxdb.Ser
 	}
 
 	// Open server, initialize or join as necessary.
-	s := openServer(config.DataDir(), config.DataURL(), b, initializing, configExists, joinURLs, logWriter)
+	s := openServer(config.Authentication.Enabled, config.DataDir(), config.DataURL(), b, initializing, configExists, joinURLs, logWriter)
 
 	// Start the server handler. Attach to broker if listening on the same port.
 	if s != nil {
@@ -203,14 +203,14 @@ func joinBroker(b *messaging.Broker, joinURLs []*url.URL) {
 }
 
 // creates and initializes a server.
-func openServer(path string, u *url.URL, b *messaging.Broker, initializing, configExists bool, joinURLs []*url.URL, w io.Writer) *influxdb.Server {
+func openServer(authenticationEnabled bool, path string, u *url.URL, b *messaging.Broker, initializing, configExists bool, joinURLs []*url.URL, w io.Writer) *influxdb.Server {
 	// Ignore if there's no existing server and we're not initializing or joining.
 	if !fileExists(path) && !initializing && len(joinURLs) == 0 {
 		return nil
 	}
 
 	// Create and open the server.
-	s := influxdb.NewServer()
+	s := influxdb.NewServer(authenticationEnabled)
 	s.SetLogOutput(w)
 	if err := s.Open(path); err != nil {
 		log.Fatalf("failed to open data server: %v", err.Error())

--- a/httpd/handler.go
+++ b/httpd/handler.go
@@ -287,6 +287,8 @@ func isAuthorizationError(err error) bool {
 
 // httpResult writes a Results array to the client.
 func httpResults(w http.ResponseWriter, results influxdb.Results, pretty bool) {
+	log.Printf("%+v\n", results)
+	log.Printf("%v\n", results.Error())
 	if results.Error() != nil {
 		if isAuthorizationError(results.Error()) {
 			w.WriteHeader(http.StatusUnauthorized)

--- a/httpd/handler.go
+++ b/httpd/handler.go
@@ -287,8 +287,6 @@ func isAuthorizationError(err error) bool {
 
 // httpResult writes a Results array to the client.
 func httpResults(w http.ResponseWriter, results influxdb.Results, pretty bool) {
-	log.Printf("%+v\n", results)
-	log.Printf("%v\n", results.Error())
 	if results.Error() != nil {
 		if isAuthorizationError(results.Error()) {
 			w.WriteHeader(http.StatusUnauthorized)

--- a/httpd/handler_test.go
+++ b/httpd/handler_test.go
@@ -138,7 +138,7 @@ func TestBatchWrite_UnmarshalRFC(t *testing.T) {
 }
 
 func TestHandler_Databases(t *testing.T) {
-	srvr := OpenServer(NewMessagingClient(), false)
+	srvr := OpenAuthlessServer(NewMessagingClient())
 	srvr.CreateDatabase("foo")
 	srvr.CreateDatabase("bar")
 	s := NewHTTPServer(srvr)
@@ -153,7 +153,7 @@ func TestHandler_Databases(t *testing.T) {
 }
 
 func TestHandler_DatabasesPrettyPrinted(t *testing.T) {
-	srvr := OpenServer(NewMessagingClient(), false)
+	srvr := OpenAuthlessServer(NewMessagingClient())
 	srvr.CreateDatabase("foo")
 	srvr.CreateDatabase("bar")
 	s := NewHTTPServer(srvr)
@@ -188,7 +188,7 @@ func TestHandler_DatabasesPrettyPrinted(t *testing.T) {
 }
 
 func TestHandler_CreateDatabase(t *testing.T) {
-	srvr := OpenServer(NewMessagingClient(), false)
+	srvr := OpenAuthlessServer(NewMessagingClient())
 	s := NewHTTPServer(srvr)
 	defer s.Close()
 
@@ -201,7 +201,7 @@ func TestHandler_CreateDatabase(t *testing.T) {
 }
 
 func TestHandler_CreateDatabase_BadRequest_NoName(t *testing.T) {
-	srvr := OpenServer(NewMessagingClient(), true)
+	srvr := OpenAuthlessServer(NewMessagingClient())
 	s := NewHTTPServer(srvr)
 	defer s.Close()
 
@@ -212,7 +212,7 @@ func TestHandler_CreateDatabase_BadRequest_NoName(t *testing.T) {
 }
 
 func TestHandler_CreateDatabase_Conflict(t *testing.T) {
-	srvr := OpenServer(NewMessagingClient(), false)
+	srvr := OpenAuthlessServer(NewMessagingClient())
 	srvr.CreateDatabase("foo")
 	s := NewHTTPServer(srvr)
 	defer s.Close()
@@ -226,7 +226,7 @@ func TestHandler_CreateDatabase_Conflict(t *testing.T) {
 }
 
 func TestHandler_DeleteDatabase(t *testing.T) {
-	srvr := OpenServer(NewMessagingClient(), false)
+	srvr := OpenAuthlessServer(NewMessagingClient())
 	srvr.CreateDatabase("foo")
 	s := NewHTTPServer(srvr)
 	defer s.Close()
@@ -240,7 +240,7 @@ func TestHandler_DeleteDatabase(t *testing.T) {
 }
 
 func TestHandler_DeleteDatabase_NotFound(t *testing.T) {
-	srvr := OpenServer(NewMessagingClient(), false)
+	srvr := OpenAuthlessServer(NewMessagingClient())
 	s := NewHTTPServer(srvr)
 	defer s.Close()
 
@@ -253,7 +253,7 @@ func TestHandler_DeleteDatabase_NotFound(t *testing.T) {
 }
 
 func TestHandler_RetentionPolicies(t *testing.T) {
-	srvr := OpenServer(NewMessagingClient(), false)
+	srvr := OpenAuthlessServer(NewMessagingClient())
 	srvr.CreateDatabase("foo")
 	srvr.CreateRetentionPolicy("foo", influxdb.NewRetentionPolicy("bar"))
 	s := NewHTTPServer(srvr)
@@ -269,7 +269,7 @@ func TestHandler_RetentionPolicies(t *testing.T) {
 }
 
 func TestHandler_RetentionPolicies_DatabaseNotFound(t *testing.T) {
-	srvr := OpenServer(NewMessagingClient(), false)
+	srvr := OpenAuthlessServer(NewMessagingClient())
 	s := NewHTTPServer(srvr)
 	defer s.Close()
 
@@ -283,7 +283,7 @@ func TestHandler_RetentionPolicies_DatabaseNotFound(t *testing.T) {
 }
 
 func TestHandler_CreateRetentionPolicy(t *testing.T) {
-	srvr := OpenServer(NewMessagingClient(), false)
+	srvr := OpenAuthlessServer(NewMessagingClient())
 	srvr.CreateDatabase("foo")
 	s := NewHTTPServer(srvr)
 	defer s.Close()
@@ -299,7 +299,7 @@ func TestHandler_CreateRetentionPolicy(t *testing.T) {
 }
 
 func TestHandler_CreateRetentionPolicyAsDefault(t *testing.T) {
-	srvr := OpenServer(NewMessagingClient(), false)
+	srvr := OpenAuthlessServer(NewMessagingClient())
 	srvr.CreateDatabase("foo")
 	s := NewHTTPServer(srvr)
 	defer s.Close()
@@ -322,7 +322,7 @@ func TestHandler_CreateRetentionPolicyAsDefault(t *testing.T) {
 }
 
 func TestHandler_CreateRetentionPolicy_DatabaseNotFound(t *testing.T) {
-	srvr := OpenServer(NewMessagingClient(), false)
+	srvr := OpenAuthlessServer(NewMessagingClient())
 	s := NewHTTPServer(srvr)
 	defer s.Close()
 
@@ -335,7 +335,7 @@ func TestHandler_CreateRetentionPolicy_DatabaseNotFound(t *testing.T) {
 }
 
 func TestHandler_CreateRetentionPolicy_Conflict(t *testing.T) {
-	srvr := OpenServer(NewMessagingClient(), false)
+	srvr := OpenAuthlessServer(NewMessagingClient())
 	srvr.CreateDatabase("foo")
 	s := NewHTTPServer(srvr)
 	defer s.Close()
@@ -351,7 +351,7 @@ func TestHandler_CreateRetentionPolicy_Conflict(t *testing.T) {
 }
 
 func TestHandler_CreateRetentionPolicy_BadRequest(t *testing.T) {
-	srvr := OpenServer(NewMessagingClient(), true)
+	srvr := OpenAuthlessServer(NewMessagingClient())
 	srvr.CreateDatabase("foo")
 	s := NewHTTPServer(srvr)
 	defer s.Close()
@@ -365,7 +365,7 @@ func TestHandler_CreateRetentionPolicy_BadRequest(t *testing.T) {
 }
 
 func TestHandler_UpdateRetentionPolicy(t *testing.T) {
-	srvr := OpenServer(NewMessagingClient(), false)
+	srvr := OpenAuthlessServer(NewMessagingClient())
 	srvr.CreateDatabase("foo")
 	srvr.CreateRetentionPolicy("foo", influxdb.NewRetentionPolicy("bar"))
 	s := NewHTTPServer(srvr)
@@ -395,7 +395,7 @@ func TestHandler_UpdateRetentionPolicy(t *testing.T) {
 }
 
 func TestHandler_UpdateRetentionPolicy_BadRequest(t *testing.T) {
-	srvr := OpenServer(NewMessagingClient(), true)
+	srvr := OpenAuthlessServer(NewMessagingClient())
 	srvr.CreateDatabase("foo")
 	srvr.CreateRetentionPolicy("foo", influxdb.NewRetentionPolicy("bar"))
 	s := NewHTTPServer(srvr)
@@ -411,7 +411,7 @@ func TestHandler_UpdateRetentionPolicy_BadRequest(t *testing.T) {
 }
 
 func TestHandler_UpdateRetentionPolicy_DatabaseNotFound(t *testing.T) {
-	srvr := OpenServer(NewMessagingClient(), false)
+	srvr := OpenAuthlessServer(NewMessagingClient())
 	s := NewHTTPServer(srvr)
 	defer s.Close()
 
@@ -425,7 +425,7 @@ func TestHandler_UpdateRetentionPolicy_DatabaseNotFound(t *testing.T) {
 }
 
 func TestHandler_UpdateRetentionPolicy_NotFound(t *testing.T) {
-	srvr := OpenServer(NewMessagingClient(), false)
+	srvr := OpenAuthlessServer(NewMessagingClient())
 	srvr.CreateDatabase("foo")
 	srvr.CreateRetentionPolicy("foo", influxdb.NewRetentionPolicy("bar"))
 	s := NewHTTPServer(srvr)
@@ -441,7 +441,7 @@ func TestHandler_UpdateRetentionPolicy_NotFound(t *testing.T) {
 }
 
 func TestHandler_DeleteRetentionPolicy(t *testing.T) {
-	srvr := OpenServer(NewMessagingClient(), false)
+	srvr := OpenAuthlessServer(NewMessagingClient())
 	srvr.CreateDatabase("foo")
 	srvr.CreateRetentionPolicy("foo", influxdb.NewRetentionPolicy("bar"))
 	s := NewHTTPServer(srvr)
@@ -458,7 +458,7 @@ func TestHandler_DeleteRetentionPolicy(t *testing.T) {
 }
 
 func TestHandler_DeleteRetentionPolicy_DatabaseNotFound(t *testing.T) {
-	srvr := OpenServer(NewMessagingClient(), false)
+	srvr := OpenAuthlessServer(NewMessagingClient())
 	s := NewHTTPServer(srvr)
 	defer s.Close()
 
@@ -473,7 +473,7 @@ func TestHandler_DeleteRetentionPolicy_DatabaseNotFound(t *testing.T) {
 }
 
 func TestHandler_DeleteRetentionPolicy_NotFound(t *testing.T) {
-	srvr := OpenServer(NewMessagingClient(), false)
+	srvr := OpenAuthlessServer(NewMessagingClient())
 	srvr.CreateDatabase("foo")
 	s := NewHTTPServer(srvr)
 	defer s.Close()
@@ -489,7 +489,7 @@ func TestHandler_DeleteRetentionPolicy_NotFound(t *testing.T) {
 }
 
 func TestHandler_GzipEnabled(t *testing.T) {
-	srvr := OpenServer(NewMessagingClient(), true)
+	srvr := OpenAuthlessServer(NewMessagingClient())
 	s := NewHTTPServer(srvr)
 	defer s.Close()
 
@@ -513,7 +513,7 @@ func TestHandler_GzipEnabled(t *testing.T) {
 }
 
 func TestHandler_GzipDisabled(t *testing.T) {
-	srvr := OpenServer(NewMessagingClient(), true)
+	srvr := OpenAuthlessServer(NewMessagingClient())
 	s := NewHTTPServer(srvr)
 	defer s.Close()
 
@@ -537,7 +537,7 @@ func TestHandler_GzipDisabled(t *testing.T) {
 }
 
 func TestHandler_Ping(t *testing.T) {
-	srvr := OpenServer(NewMessagingClient(), true)
+	srvr := OpenAuthlessServer(NewMessagingClient())
 	s := NewHTTPServer(srvr)
 	defer s.Close()
 
@@ -549,7 +549,7 @@ func TestHandler_Ping(t *testing.T) {
 }
 
 func TestHandler_Users_NoUsers(t *testing.T) {
-	srvr := OpenServer(NewMessagingClient(), false)
+	srvr := OpenAuthlessServer(NewMessagingClient())
 	srvr.CreateDatabase("foo")
 	s := NewHTTPServer(srvr)
 	defer s.Close()
@@ -564,7 +564,7 @@ func TestHandler_Users_NoUsers(t *testing.T) {
 }
 
 func TestHandler_Users_OneUser(t *testing.T) {
-	srvr := OpenServer(NewMessagingClient(), false)
+	srvr := OpenAuthlessServer(NewMessagingClient())
 	srvr.CreateUser("jdoe", "1337", true)
 	s := NewHTTPServer(srvr)
 	defer s.Close()
@@ -579,7 +579,7 @@ func TestHandler_Users_OneUser(t *testing.T) {
 }
 
 func TestHandler_Users_MultipleUsers(t *testing.T) {
-	srvr := OpenServer(NewMessagingClient(), false)
+	srvr := OpenAuthlessServer(NewMessagingClient())
 	srvr.CreateUser("jdoe", "1337", false)
 	srvr.CreateUser("mclark", "1337", true)
 	srvr.CreateUser("csmith", "1337", false)
@@ -596,7 +596,7 @@ func TestHandler_Users_MultipleUsers(t *testing.T) {
 }
 
 func TestHandler_CreateUser(t *testing.T) {
-	srvr := OpenServer(NewMessagingClient(), false)
+	srvr := OpenAuthlessServer(NewMessagingClient())
 	s := NewHTTPServer(srvr)
 	defer s.Close()
 
@@ -610,7 +610,7 @@ func TestHandler_CreateUser(t *testing.T) {
 }
 
 func TestHandler_CreateUser_BadRequest(t *testing.T) {
-	srvr := OpenServer(NewMessagingClient(), false)
+	srvr := OpenAuthlessServer(NewMessagingClient())
 	s := NewHTTPServer(srvr)
 	defer s.Close()
 
@@ -624,7 +624,7 @@ func TestHandler_CreateUser_BadRequest(t *testing.T) {
 }
 
 func TestHandler_CreateUser_BadRequest_NoName(t *testing.T) {
-	srvr := OpenServer(NewMessagingClient(), false)
+	srvr := OpenAuthlessServer(NewMessagingClient())
 	s := NewHTTPServer(srvr)
 	defer s.Close()
 
@@ -638,7 +638,7 @@ func TestHandler_CreateUser_BadRequest_NoName(t *testing.T) {
 }
 
 func TestHandler_CreateUser_BadRequest_NoPassword(t *testing.T) {
-	srvr := OpenServer(NewMessagingClient(), false)
+	srvr := OpenAuthlessServer(NewMessagingClient())
 	s := NewHTTPServer(srvr)
 	defer s.Close()
 
@@ -653,7 +653,7 @@ func TestHandler_CreateUser_BadRequest_NoPassword(t *testing.T) {
 
 func TestHandler_UpdateUser(t *testing.T) {
 	t.Skip()
-	srvr := OpenServer(NewMessagingClient(), false)
+	srvr := OpenAuthlessServer(NewMessagingClient())
 	srvr.CreateUser("jdoe", "1337", false)
 	s := NewHTTPServer(srvr)
 	defer s.Close()
@@ -674,7 +674,7 @@ func TestHandler_UpdateUser(t *testing.T) {
 
 func TestHandler_UpdateUser_PasswordBadRequest(t *testing.T) {
 	t.Skip()
-	srvr := OpenServer(NewMessagingClient(), false)
+	srvr := OpenAuthlessServer(NewMessagingClient())
 	srvr.CreateUser("jdoe", "1337", false)
 	s := NewHTTPServer(srvr)
 	defer s.Close()
@@ -688,7 +688,7 @@ func TestHandler_UpdateUser_PasswordBadRequest(t *testing.T) {
 }
 
 func TestHandler_DeleteUser(t *testing.T) {
-	srvr := OpenServer(NewMessagingClient(), false)
+	srvr := OpenAuthlessServer(NewMessagingClient())
 	srvr.CreateUser("jdoe", "1337", false)
 	s := NewHTTPServer(srvr)
 	defer s.Close()
@@ -703,7 +703,7 @@ func TestHandler_DeleteUser(t *testing.T) {
 }
 
 func TestHandler_DeleteUser_UserNotFound(t *testing.T) {
-	srvr := OpenServer(NewMessagingClient(), false)
+	srvr := OpenAuthlessServer(NewMessagingClient())
 	s := NewHTTPServer(srvr)
 	defer s.Close()
 
@@ -718,7 +718,7 @@ func TestHandler_DeleteUser_UserNotFound(t *testing.T) {
 
 func TestHandler_DataNodes(t *testing.T) {
 	t.Skip()
-	srvr := OpenUninitializedServer(NewMessagingClient(), false)
+	srvr := OpenAuthlessServer(NewMessagingClient())
 	srvr.CreateDataNode(MustParseURL("http://localhost:1000"))
 	srvr.CreateDataNode(MustParseURL("http://localhost:2000"))
 	srvr.CreateDataNode(MustParseURL("http://localhost:3000"))
@@ -735,7 +735,7 @@ func TestHandler_DataNodes(t *testing.T) {
 
 func TestHandler_CreateDataNode(t *testing.T) {
 	t.Skip()
-	srvr := OpenUninitializedServer(NewMessagingClient(), false)
+	srvr := OpenAuthlessServer(NewMessagingClient())
 	s := NewHTTPServer(srvr)
 	defer s.Close()
 
@@ -749,7 +749,7 @@ func TestHandler_CreateDataNode(t *testing.T) {
 
 func TestHandler_CreateDataNode_BadRequest(t *testing.T) {
 	t.Skip()
-	srvr := OpenServer(NewMessagingClient(), false)
+	srvr := OpenAuthlessServer(NewMessagingClient())
 	s := NewHTTPServer(srvr)
 	defer s.Close()
 
@@ -763,7 +763,7 @@ func TestHandler_CreateDataNode_BadRequest(t *testing.T) {
 
 func TestHandler_CreateDataNode_InternalServerError(t *testing.T) {
 	t.Skip()
-	srvr := OpenServer(NewMessagingClient(), false)
+	srvr := OpenAuthlessServer(NewMessagingClient())
 	s := NewHTTPServer(srvr)
 	defer s.Close()
 
@@ -777,7 +777,7 @@ func TestHandler_CreateDataNode_InternalServerError(t *testing.T) {
 
 func TestHandler_DeleteDataNode(t *testing.T) {
 	t.Skip()
-	srvr := OpenServer(NewMessagingClient(), false)
+	srvr := OpenAuthlessServer(NewMessagingClient())
 	srvr.CreateDataNode(MustParseURL("http://localhost:1000"))
 	s := NewHTTPServer(srvr)
 	defer s.Close()
@@ -792,7 +792,7 @@ func TestHandler_DeleteDataNode(t *testing.T) {
 
 func TestHandler_DeleteUser_DataNodeNotFound(t *testing.T) {
 	t.Skip()
-	srvr := OpenServer(NewMessagingClient(), false)
+	srvr := OpenAuthlessServer(NewMessagingClient())
 	s := NewHTTPServer(srvr)
 	defer s.Close()
 
@@ -807,7 +807,7 @@ func TestHandler_DeleteUser_DataNodeNotFound(t *testing.T) {
 // Perform a subset of endpoint testing, with authentication enabled.
 
 func TestHandler_AuthenticatedCreateAdminUser(t *testing.T) {
-	srvr := OpenServer(NewMessagingClient(), true)
+	srvr := OpenAuthenticatedServer(NewMessagingClient())
 	s := NewAuthenticatedHTTPServer(srvr)
 	defer s.Close()
 
@@ -828,7 +828,7 @@ func TestHandler_AuthenticatedCreateAdminUser(t *testing.T) {
 }
 
 func TestHandler_AuthenticatedDatabases_Unauthorized(t *testing.T) {
-	srvr := OpenServer(NewMessagingClient(), true)
+	srvr := OpenAuthenticatedServer(NewMessagingClient())
 	s := NewAuthenticatedHTTPServer(srvr)
 	defer s.Close()
 
@@ -839,7 +839,7 @@ func TestHandler_AuthenticatedDatabases_Unauthorized(t *testing.T) {
 }
 
 func TestHandler_AuthenticatedDatabases_AuthorizedQueryParams(t *testing.T) {
-	srvr := OpenServer(NewMessagingClient(), true)
+	srvr := OpenAuthenticatedServer(NewMessagingClient())
 	srvr.CreateUser("lisa", "password", true)
 	s := NewAuthenticatedHTTPServer(srvr)
 	defer s.Close()
@@ -852,7 +852,7 @@ func TestHandler_AuthenticatedDatabases_AuthorizedQueryParams(t *testing.T) {
 }
 
 func TestHandler_AuthenticatedDatabases_UnauthorizedQueryParams(t *testing.T) {
-	srvr := OpenServer(NewMessagingClient(), true)
+	srvr := OpenAuthenticatedServer(NewMessagingClient())
 	srvr.CreateUser("lisa", "password", true)
 	s := NewAuthenticatedHTTPServer(srvr)
 	defer s.Close()
@@ -865,7 +865,7 @@ func TestHandler_AuthenticatedDatabases_UnauthorizedQueryParams(t *testing.T) {
 }
 
 func TestHandler_AuthenticatedDatabases_AuthorizedBasicAuth(t *testing.T) {
-	srvr := OpenServer(NewMessagingClient(), true)
+	srvr := OpenAuthenticatedServer(NewMessagingClient())
 	srvr.CreateUser("lisa", "password", true)
 	s := NewAuthenticatedHTTPServer(srvr)
 	defer s.Close()
@@ -880,7 +880,7 @@ func TestHandler_AuthenticatedDatabases_AuthorizedBasicAuth(t *testing.T) {
 }
 
 func TestHandler_AuthenticatedDatabases_UnauthorizedBasicAuth(t *testing.T) {
-	srvr := OpenServer(NewMessagingClient(), true)
+	srvr := OpenAuthenticatedServer(NewMessagingClient())
 	srvr.CreateUser("lisa", "password", true)
 	s := NewAuthenticatedHTTPServer(srvr)
 	defer s.Close()
@@ -895,7 +895,7 @@ func TestHandler_AuthenticatedDatabases_UnauthorizedBasicAuth(t *testing.T) {
 }
 
 func TestHandler_GrantAdmin(t *testing.T) {
-	srvr := OpenServer(NewMessagingClient(), true)
+	srvr := OpenAuthenticatedServer(NewMessagingClient())
 	// Create a cluster admin that will grant admin to "john".
 	srvr.CreateUser("lisa", "password", true)
 	// Create user that will be granted cluster admin.
@@ -926,7 +926,7 @@ func TestHandler_GrantAdmin(t *testing.T) {
 }
 
 func TestHandler_GrantDBPrivilege(t *testing.T) {
-	srvr := OpenServer(NewMessagingClient(), true)
+	srvr := OpenAuthenticatedServer(NewMessagingClient())
 	// Create a cluster admin that will grant privilege to "john".
 	srvr.CreateUser("lisa", "password", true)
 	// Create user that will be granted a privilege.
@@ -963,7 +963,7 @@ func TestHandler_GrantDBPrivilege(t *testing.T) {
 }
 
 func TestHandler_RevokeAdmin(t *testing.T) {
-	srvr := OpenServer(NewMessagingClient(), true)
+	srvr := OpenAuthenticatedServer(NewMessagingClient())
 	// Create a cluster admin that will revoke admin from "john".
 	srvr.CreateUser("lisa", "password", true)
 	// Create user that will have cluster admin revoked.
@@ -995,7 +995,7 @@ func TestHandler_RevokeAdmin(t *testing.T) {
 }
 
 func TestHandler_RevokeDBPrivilege(t *testing.T) {
-	srvr := OpenServer(NewMessagingClient(), true)
+	srvr := OpenAuthenticatedServer(NewMessagingClient())
 	// Create a cluster admin that will revoke privilege from "john".
 	srvr.CreateUser("lisa", "password", true)
 	// Create user that will have privilege revoked.
@@ -1029,7 +1029,7 @@ func TestHandler_RevokeDBPrivilege(t *testing.T) {
 }
 
 func TestHandler_serveWriteSeries(t *testing.T) {
-	srvr := OpenServer(NewMessagingClient(), true)
+	srvr := OpenAuthenticatedServer(NewMessagingClient())
 	srvr.CreateDatabase("foo")
 	srvr.CreateRetentionPolicy("foo", influxdb.NewRetentionPolicy("bar"))
 	s := NewHTTPServer(srvr)
@@ -1043,7 +1043,7 @@ func TestHandler_serveWriteSeries(t *testing.T) {
 }
 
 func TestHandler_serveWriteSeries_noDatabaseExists(t *testing.T) {
-	srvr := OpenServer(NewMessagingClient(), true)
+	srvr := OpenAuthenticatedServer(NewMessagingClient())
 	s := NewHTTPServer(srvr)
 	defer s.Close()
 
@@ -1061,7 +1061,7 @@ func TestHandler_serveWriteSeries_noDatabaseExists(t *testing.T) {
 }
 
 func TestHandler_serveWriteSeries_invalidJSON(t *testing.T) {
-	srvr := OpenServer(NewMessagingClient(), true)
+	srvr := OpenAuthenticatedServer(NewMessagingClient())
 	s := NewHTTPServer(srvr)
 	defer s.Close()
 
@@ -1078,7 +1078,7 @@ func TestHandler_serveWriteSeries_invalidJSON(t *testing.T) {
 }
 
 func TestHandler_serveWriteSeries_noDatabaseSpecified(t *testing.T) {
-	srvr := OpenServer(NewMessagingClient(), true)
+	srvr := OpenAuthenticatedServer(NewMessagingClient())
 	s := NewHTTPServer(srvr)
 	defer s.Close()
 
@@ -1095,7 +1095,7 @@ func TestHandler_serveWriteSeries_noDatabaseSpecified(t *testing.T) {
 }
 
 func TestHandler_serveShowSeries(t *testing.T) {
-	srvr := OpenServer(NewMessagingClient(), false)
+	srvr := OpenAuthlessServer(NewMessagingClient())
 	srvr.CreateDatabase("foo")
 	srvr.CreateRetentionPolicy("foo", influxdb.NewRetentionPolicy("bar"))
 	srvr.SetDefaultRetentionPolicy("foo", "bar")
@@ -1270,7 +1270,7 @@ func str2iface(strs []string) []interface{} {
 }
 
 func TestHandler_serveShowMeasurements(t *testing.T) {
-	srvr := OpenServer(NewMessagingClient(), false)
+	srvr := OpenAuthlessServer(NewMessagingClient())
 	srvr.CreateDatabase("foo")
 	srvr.CreateRetentionPolicy("foo", influxdb.NewRetentionPolicy("bar"))
 	s := NewHTTPServer(srvr)
@@ -1325,7 +1325,7 @@ func TestHandler_serveShowMeasurements(t *testing.T) {
 }
 
 func TestHandler_serveShowTagKeys(t *testing.T) {
-	srvr := OpenServer(NewMessagingClient(), false)
+	srvr := OpenAuthlessServer(NewMessagingClient())
 	srvr.CreateDatabase("foo")
 	srvr.CreateRetentionPolicy("foo", influxdb.NewRetentionPolicy("bar"))
 	srvr.SetDefaultRetentionPolicy("foo", "bar")
@@ -1428,7 +1428,7 @@ func TestHandler_serveShowTagKeys(t *testing.T) {
 }
 
 func TestHandler_serveShowTagValues(t *testing.T) {
-	srvr := OpenServer(NewMessagingClient(), false)
+	srvr := OpenAuthlessServer(NewMessagingClient())
 	srvr.CreateDatabase("foo")
 	srvr.CreateRetentionPolicy("foo", influxdb.NewRetentionPolicy("bar"))
 	srvr.SetDefaultRetentionPolicy("foo", "bar")
@@ -1569,7 +1569,7 @@ func TestHandler_serveShowTagValues(t *testing.T) {
 }
 
 func TestHandler_serveShowFieldKeys(t *testing.T) {
-	srvr := OpenServer(NewMessagingClient(), false)
+	srvr := OpenAuthlessServer(NewMessagingClient())
 	srvr.CreateDatabase("foo")
 	srvr.CreateRetentionPolicy("foo", influxdb.NewRetentionPolicy("bar"))
 	srvr.SetDefaultRetentionPolicy("foo", "bar")
@@ -1743,16 +1743,23 @@ type Server struct {
 }
 
 // NewServer returns a new test server instance.
-func NewServer(authenticationEnabled bool) *Server {
-	return &Server{influxdb.NewServer(authenticationEnabled)}
+func NewServer() *Server {
+	return &Server{influxdb.NewServer()}
 }
 
-// OpenServer returns a new, open test server instance.
-func OpenServer(client influxdb.MessagingClient, authenticationEnabled bool) *Server {
-	s := OpenUninitializedServer(client, authenticationEnabled)
+// OpenAuthenticatedServer returns a new, open test server instance with authentication enabled.
+func OpenAuthenticatedServer(client influxdb.MessagingClient) *Server {
+	s := OpenUninitializedServer(client)
 	if err := s.Initialize(&url.URL{Host: "127.0.0.1:8080"}); err != nil {
 		panic(err.Error())
 	}
+	return s
+}
+
+// OpenAuthlessServer returns a new, open test server instance without authentication enabled.
+func OpenAuthlessServer(client influxdb.MessagingClient) *Server {
+	s := OpenAuthenticatedServer(client)
+	s.SetAuthenticationEnabled(false)
 	return s
 }
 
@@ -1781,8 +1788,8 @@ func (s *Server) Restart() {
 }
 
 // OpenUninitializedServer returns a new, uninitialized, open test server instance.
-func OpenUninitializedServer(client influxdb.MessagingClient, authenticationEnabled bool) *Server {
-	s := NewServer(authenticationEnabled)
+func OpenUninitializedServer(client influxdb.MessagingClient) *Server {
+	s := NewServer()
 	if err := s.Open(tempfile()); err != nil {
 		panic(err.Error())
 	}

--- a/httpd/handler_test.go
+++ b/httpd/handler_test.go
@@ -138,7 +138,7 @@ func TestBatchWrite_UnmarshalRFC(t *testing.T) {
 }
 
 func TestHandler_Databases(t *testing.T) {
-	srvr := OpenServer(NewMessagingClient())
+	srvr := OpenServer(NewMessagingClient(), false)
 	srvr.CreateDatabase("foo")
 	srvr.CreateDatabase("bar")
 	s := NewHTTPServer(srvr)
@@ -153,7 +153,7 @@ func TestHandler_Databases(t *testing.T) {
 }
 
 func TestHandler_DatabasesPrettyPrinted(t *testing.T) {
-	srvr := OpenServer(NewMessagingClient())
+	srvr := OpenServer(NewMessagingClient(), false)
 	srvr.CreateDatabase("foo")
 	srvr.CreateDatabase("bar")
 	s := NewHTTPServer(srvr)
@@ -188,7 +188,7 @@ func TestHandler_DatabasesPrettyPrinted(t *testing.T) {
 }
 
 func TestHandler_CreateDatabase(t *testing.T) {
-	srvr := OpenServer(NewMessagingClient())
+	srvr := OpenServer(NewMessagingClient(), false)
 	s := NewHTTPServer(srvr)
 	defer s.Close()
 
@@ -201,7 +201,7 @@ func TestHandler_CreateDatabase(t *testing.T) {
 }
 
 func TestHandler_CreateDatabase_BadRequest_NoName(t *testing.T) {
-	srvr := OpenServer(NewMessagingClient())
+	srvr := OpenServer(NewMessagingClient(), true)
 	s := NewHTTPServer(srvr)
 	defer s.Close()
 
@@ -212,7 +212,7 @@ func TestHandler_CreateDatabase_BadRequest_NoName(t *testing.T) {
 }
 
 func TestHandler_CreateDatabase_Conflict(t *testing.T) {
-	srvr := OpenServer(NewMessagingClient())
+	srvr := OpenServer(NewMessagingClient(), false)
 	srvr.CreateDatabase("foo")
 	s := NewHTTPServer(srvr)
 	defer s.Close()
@@ -226,7 +226,7 @@ func TestHandler_CreateDatabase_Conflict(t *testing.T) {
 }
 
 func TestHandler_DeleteDatabase(t *testing.T) {
-	srvr := OpenServer(NewMessagingClient())
+	srvr := OpenServer(NewMessagingClient(), false)
 	srvr.CreateDatabase("foo")
 	s := NewHTTPServer(srvr)
 	defer s.Close()
@@ -240,7 +240,7 @@ func TestHandler_DeleteDatabase(t *testing.T) {
 }
 
 func TestHandler_DeleteDatabase_NotFound(t *testing.T) {
-	srvr := OpenServer(NewMessagingClient())
+	srvr := OpenServer(NewMessagingClient(), false)
 	s := NewHTTPServer(srvr)
 	defer s.Close()
 
@@ -253,7 +253,7 @@ func TestHandler_DeleteDatabase_NotFound(t *testing.T) {
 }
 
 func TestHandler_RetentionPolicies(t *testing.T) {
-	srvr := OpenServer(NewMessagingClient())
+	srvr := OpenServer(NewMessagingClient(), false)
 	srvr.CreateDatabase("foo")
 	srvr.CreateRetentionPolicy("foo", influxdb.NewRetentionPolicy("bar"))
 	s := NewHTTPServer(srvr)
@@ -269,7 +269,7 @@ func TestHandler_RetentionPolicies(t *testing.T) {
 }
 
 func TestHandler_RetentionPolicies_DatabaseNotFound(t *testing.T) {
-	srvr := OpenServer(NewMessagingClient())
+	srvr := OpenServer(NewMessagingClient(), false)
 	s := NewHTTPServer(srvr)
 	defer s.Close()
 
@@ -283,7 +283,7 @@ func TestHandler_RetentionPolicies_DatabaseNotFound(t *testing.T) {
 }
 
 func TestHandler_CreateRetentionPolicy(t *testing.T) {
-	srvr := OpenServer(NewMessagingClient())
+	srvr := OpenServer(NewMessagingClient(), false)
 	srvr.CreateDatabase("foo")
 	s := NewHTTPServer(srvr)
 	defer s.Close()
@@ -299,7 +299,7 @@ func TestHandler_CreateRetentionPolicy(t *testing.T) {
 }
 
 func TestHandler_CreateRetentionPolicyAsDefault(t *testing.T) {
-	srvr := OpenServer(NewMessagingClient())
+	srvr := OpenServer(NewMessagingClient(), false)
 	srvr.CreateDatabase("foo")
 	s := NewHTTPServer(srvr)
 	defer s.Close()
@@ -322,7 +322,7 @@ func TestHandler_CreateRetentionPolicyAsDefault(t *testing.T) {
 }
 
 func TestHandler_CreateRetentionPolicy_DatabaseNotFound(t *testing.T) {
-	srvr := OpenServer(NewMessagingClient())
+	srvr := OpenServer(NewMessagingClient(), false)
 	s := NewHTTPServer(srvr)
 	defer s.Close()
 
@@ -335,7 +335,7 @@ func TestHandler_CreateRetentionPolicy_DatabaseNotFound(t *testing.T) {
 }
 
 func TestHandler_CreateRetentionPolicy_Conflict(t *testing.T) {
-	srvr := OpenServer(NewMessagingClient())
+	srvr := OpenServer(NewMessagingClient(), false)
 	srvr.CreateDatabase("foo")
 	s := NewHTTPServer(srvr)
 	defer s.Close()
@@ -351,7 +351,7 @@ func TestHandler_CreateRetentionPolicy_Conflict(t *testing.T) {
 }
 
 func TestHandler_CreateRetentionPolicy_BadRequest(t *testing.T) {
-	srvr := OpenServer(NewMessagingClient())
+	srvr := OpenServer(NewMessagingClient(), true)
 	srvr.CreateDatabase("foo")
 	s := NewHTTPServer(srvr)
 	defer s.Close()
@@ -365,7 +365,7 @@ func TestHandler_CreateRetentionPolicy_BadRequest(t *testing.T) {
 }
 
 func TestHandler_UpdateRetentionPolicy(t *testing.T) {
-	srvr := OpenServer(NewMessagingClient())
+	srvr := OpenServer(NewMessagingClient(), false)
 	srvr.CreateDatabase("foo")
 	srvr.CreateRetentionPolicy("foo", influxdb.NewRetentionPolicy("bar"))
 	s := NewHTTPServer(srvr)
@@ -395,7 +395,7 @@ func TestHandler_UpdateRetentionPolicy(t *testing.T) {
 }
 
 func TestHandler_UpdateRetentionPolicy_BadRequest(t *testing.T) {
-	srvr := OpenServer(NewMessagingClient())
+	srvr := OpenServer(NewMessagingClient(), true)
 	srvr.CreateDatabase("foo")
 	srvr.CreateRetentionPolicy("foo", influxdb.NewRetentionPolicy("bar"))
 	s := NewHTTPServer(srvr)
@@ -411,7 +411,7 @@ func TestHandler_UpdateRetentionPolicy_BadRequest(t *testing.T) {
 }
 
 func TestHandler_UpdateRetentionPolicy_DatabaseNotFound(t *testing.T) {
-	srvr := OpenServer(NewMessagingClient())
+	srvr := OpenServer(NewMessagingClient(), false)
 	s := NewHTTPServer(srvr)
 	defer s.Close()
 
@@ -425,7 +425,7 @@ func TestHandler_UpdateRetentionPolicy_DatabaseNotFound(t *testing.T) {
 }
 
 func TestHandler_UpdateRetentionPolicy_NotFound(t *testing.T) {
-	srvr := OpenServer(NewMessagingClient())
+	srvr := OpenServer(NewMessagingClient(), false)
 	srvr.CreateDatabase("foo")
 	srvr.CreateRetentionPolicy("foo", influxdb.NewRetentionPolicy("bar"))
 	s := NewHTTPServer(srvr)
@@ -441,7 +441,7 @@ func TestHandler_UpdateRetentionPolicy_NotFound(t *testing.T) {
 }
 
 func TestHandler_DeleteRetentionPolicy(t *testing.T) {
-	srvr := OpenServer(NewMessagingClient())
+	srvr := OpenServer(NewMessagingClient(), false)
 	srvr.CreateDatabase("foo")
 	srvr.CreateRetentionPolicy("foo", influxdb.NewRetentionPolicy("bar"))
 	s := NewHTTPServer(srvr)
@@ -458,7 +458,7 @@ func TestHandler_DeleteRetentionPolicy(t *testing.T) {
 }
 
 func TestHandler_DeleteRetentionPolicy_DatabaseNotFound(t *testing.T) {
-	srvr := OpenServer(NewMessagingClient())
+	srvr := OpenServer(NewMessagingClient(), false)
 	s := NewHTTPServer(srvr)
 	defer s.Close()
 
@@ -473,7 +473,7 @@ func TestHandler_DeleteRetentionPolicy_DatabaseNotFound(t *testing.T) {
 }
 
 func TestHandler_DeleteRetentionPolicy_NotFound(t *testing.T) {
-	srvr := OpenServer(NewMessagingClient())
+	srvr := OpenServer(NewMessagingClient(), false)
 	srvr.CreateDatabase("foo")
 	s := NewHTTPServer(srvr)
 	defer s.Close()
@@ -489,7 +489,7 @@ func TestHandler_DeleteRetentionPolicy_NotFound(t *testing.T) {
 }
 
 func TestHandler_GzipEnabled(t *testing.T) {
-	srvr := OpenServer(NewMessagingClient())
+	srvr := OpenServer(NewMessagingClient(), true)
 	s := NewHTTPServer(srvr)
 	defer s.Close()
 
@@ -513,7 +513,7 @@ func TestHandler_GzipEnabled(t *testing.T) {
 }
 
 func TestHandler_GzipDisabled(t *testing.T) {
-	srvr := OpenServer(NewMessagingClient())
+	srvr := OpenServer(NewMessagingClient(), true)
 	s := NewHTTPServer(srvr)
 	defer s.Close()
 
@@ -537,7 +537,7 @@ func TestHandler_GzipDisabled(t *testing.T) {
 }
 
 func TestHandler_Ping(t *testing.T) {
-	srvr := OpenServer(NewMessagingClient())
+	srvr := OpenServer(NewMessagingClient(), true)
 	s := NewHTTPServer(srvr)
 	defer s.Close()
 
@@ -549,7 +549,7 @@ func TestHandler_Ping(t *testing.T) {
 }
 
 func TestHandler_Users_NoUsers(t *testing.T) {
-	srvr := OpenServer(NewMessagingClient())
+	srvr := OpenServer(NewMessagingClient(), false)
 	srvr.CreateDatabase("foo")
 	s := NewHTTPServer(srvr)
 	defer s.Close()
@@ -564,7 +564,7 @@ func TestHandler_Users_NoUsers(t *testing.T) {
 }
 
 func TestHandler_Users_OneUser(t *testing.T) {
-	srvr := OpenServer(NewMessagingClient())
+	srvr := OpenServer(NewMessagingClient(), false)
 	srvr.CreateUser("jdoe", "1337", true)
 	s := NewHTTPServer(srvr)
 	defer s.Close()
@@ -579,7 +579,7 @@ func TestHandler_Users_OneUser(t *testing.T) {
 }
 
 func TestHandler_Users_MultipleUsers(t *testing.T) {
-	srvr := OpenServer(NewMessagingClient())
+	srvr := OpenServer(NewMessagingClient(), false)
 	srvr.CreateUser("jdoe", "1337", false)
 	srvr.CreateUser("mclark", "1337", true)
 	srvr.CreateUser("csmith", "1337", false)
@@ -596,7 +596,7 @@ func TestHandler_Users_MultipleUsers(t *testing.T) {
 }
 
 func TestHandler_CreateUser(t *testing.T) {
-	srvr := OpenServer(NewMessagingClient())
+	srvr := OpenServer(NewMessagingClient(), false)
 	s := NewHTTPServer(srvr)
 	defer s.Close()
 
@@ -610,7 +610,7 @@ func TestHandler_CreateUser(t *testing.T) {
 }
 
 func TestHandler_CreateUser_BadRequest(t *testing.T) {
-	srvr := OpenServer(NewMessagingClient())
+	srvr := OpenServer(NewMessagingClient(), false)
 	s := NewHTTPServer(srvr)
 	defer s.Close()
 
@@ -624,7 +624,7 @@ func TestHandler_CreateUser_BadRequest(t *testing.T) {
 }
 
 func TestHandler_CreateUser_BadRequest_NoName(t *testing.T) {
-	srvr := OpenServer(NewMessagingClient())
+	srvr := OpenServer(NewMessagingClient(), false)
 	s := NewHTTPServer(srvr)
 	defer s.Close()
 
@@ -638,7 +638,7 @@ func TestHandler_CreateUser_BadRequest_NoName(t *testing.T) {
 }
 
 func TestHandler_CreateUser_BadRequest_NoPassword(t *testing.T) {
-	srvr := OpenServer(NewMessagingClient())
+	srvr := OpenServer(NewMessagingClient(), false)
 	s := NewHTTPServer(srvr)
 	defer s.Close()
 
@@ -653,7 +653,7 @@ func TestHandler_CreateUser_BadRequest_NoPassword(t *testing.T) {
 
 func TestHandler_UpdateUser(t *testing.T) {
 	t.Skip()
-	srvr := OpenServer(NewMessagingClient())
+	srvr := OpenServer(NewMessagingClient(), false)
 	srvr.CreateUser("jdoe", "1337", false)
 	s := NewHTTPServer(srvr)
 	defer s.Close()
@@ -674,7 +674,7 @@ func TestHandler_UpdateUser(t *testing.T) {
 
 func TestHandler_UpdateUser_PasswordBadRequest(t *testing.T) {
 	t.Skip()
-	srvr := OpenServer(NewMessagingClient())
+	srvr := OpenServer(NewMessagingClient(), false)
 	srvr.CreateUser("jdoe", "1337", false)
 	s := NewHTTPServer(srvr)
 	defer s.Close()
@@ -688,7 +688,7 @@ func TestHandler_UpdateUser_PasswordBadRequest(t *testing.T) {
 }
 
 func TestHandler_DeleteUser(t *testing.T) {
-	srvr := OpenServer(NewMessagingClient())
+	srvr := OpenServer(NewMessagingClient(), false)
 	srvr.CreateUser("jdoe", "1337", false)
 	s := NewHTTPServer(srvr)
 	defer s.Close()
@@ -703,7 +703,7 @@ func TestHandler_DeleteUser(t *testing.T) {
 }
 
 func TestHandler_DeleteUser_UserNotFound(t *testing.T) {
-	srvr := OpenServer(NewMessagingClient())
+	srvr := OpenServer(NewMessagingClient(), false)
 	s := NewHTTPServer(srvr)
 	defer s.Close()
 
@@ -718,7 +718,7 @@ func TestHandler_DeleteUser_UserNotFound(t *testing.T) {
 
 func TestHandler_DataNodes(t *testing.T) {
 	t.Skip()
-	srvr := OpenUninitializedServer(NewMessagingClient())
+	srvr := OpenUninitializedServer(NewMessagingClient(), false)
 	srvr.CreateDataNode(MustParseURL("http://localhost:1000"))
 	srvr.CreateDataNode(MustParseURL("http://localhost:2000"))
 	srvr.CreateDataNode(MustParseURL("http://localhost:3000"))
@@ -735,7 +735,7 @@ func TestHandler_DataNodes(t *testing.T) {
 
 func TestHandler_CreateDataNode(t *testing.T) {
 	t.Skip()
-	srvr := OpenUninitializedServer(NewMessagingClient())
+	srvr := OpenUninitializedServer(NewMessagingClient(), false)
 	s := NewHTTPServer(srvr)
 	defer s.Close()
 
@@ -749,7 +749,7 @@ func TestHandler_CreateDataNode(t *testing.T) {
 
 func TestHandler_CreateDataNode_BadRequest(t *testing.T) {
 	t.Skip()
-	srvr := OpenServer(NewMessagingClient())
+	srvr := OpenServer(NewMessagingClient(), false)
 	s := NewHTTPServer(srvr)
 	defer s.Close()
 
@@ -763,7 +763,7 @@ func TestHandler_CreateDataNode_BadRequest(t *testing.T) {
 
 func TestHandler_CreateDataNode_InternalServerError(t *testing.T) {
 	t.Skip()
-	srvr := OpenServer(NewMessagingClient())
+	srvr := OpenServer(NewMessagingClient(), false)
 	s := NewHTTPServer(srvr)
 	defer s.Close()
 
@@ -777,7 +777,7 @@ func TestHandler_CreateDataNode_InternalServerError(t *testing.T) {
 
 func TestHandler_DeleteDataNode(t *testing.T) {
 	t.Skip()
-	srvr := OpenServer(NewMessagingClient())
+	srvr := OpenServer(NewMessagingClient(), false)
 	srvr.CreateDataNode(MustParseURL("http://localhost:1000"))
 	s := NewHTTPServer(srvr)
 	defer s.Close()
@@ -792,7 +792,7 @@ func TestHandler_DeleteDataNode(t *testing.T) {
 
 func TestHandler_DeleteUser_DataNodeNotFound(t *testing.T) {
 	t.Skip()
-	srvr := OpenServer(NewMessagingClient())
+	srvr := OpenServer(NewMessagingClient(), false)
 	s := NewHTTPServer(srvr)
 	defer s.Close()
 
@@ -807,7 +807,7 @@ func TestHandler_DeleteUser_DataNodeNotFound(t *testing.T) {
 // Perform a subset of endpoint testing, with authentication enabled.
 
 func TestHandler_AuthenticatedCreateAdminUser(t *testing.T) {
-	srvr := OpenServer(NewMessagingClient())
+	srvr := OpenServer(NewMessagingClient(), true)
 	s := NewAuthenticatedHTTPServer(srvr)
 	defer s.Close()
 
@@ -818,16 +818,7 @@ func TestHandler_AuthenticatedCreateAdminUser(t *testing.T) {
 		t.Fatalf("unexpected status: %d", status)
 	}
 
-	// Creating the first admin user, without supplying authentication
-	// credentials should be OK.
-	query = map[string]string{"q": "CREATE USER orla WITH PASSWORD 'pass' WITH ALL PRIVILEGES"}
-	status, _ = MustHTTP("GET", s.URL+`/query`, query, nil, "")
-	if status != http.StatusOK {
-		t.Fatalf("unexpected status: %d", status)
-	}
-
-	// Creating a second admin user, without supplying authentication
-	// credentials should fail.
+	// Creating an admin user, without supplying authentication credentials should fail.
 	query = map[string]string{"q": "CREATE USER louise WITH PASSWORD 'pass' WITH ALL PRIVILEGES"}
 	status, _ = MustHTTP("GET", s.URL+`/query`, query, nil, "")
 	if status != http.StatusUnauthorized {
@@ -837,7 +828,7 @@ func TestHandler_AuthenticatedCreateAdminUser(t *testing.T) {
 }
 
 func TestHandler_AuthenticatedDatabases_Unauthorized(t *testing.T) {
-	srvr := OpenServer(NewMessagingClient())
+	srvr := OpenServer(NewMessagingClient(), true)
 	s := NewAuthenticatedHTTPServer(srvr)
 	defer s.Close()
 
@@ -848,7 +839,7 @@ func TestHandler_AuthenticatedDatabases_Unauthorized(t *testing.T) {
 }
 
 func TestHandler_AuthenticatedDatabases_AuthorizedQueryParams(t *testing.T) {
-	srvr := OpenServer(NewMessagingClient())
+	srvr := OpenServer(NewMessagingClient(), true)
 	srvr.CreateUser("lisa", "password", true)
 	s := NewAuthenticatedHTTPServer(srvr)
 	defer s.Close()
@@ -861,7 +852,7 @@ func TestHandler_AuthenticatedDatabases_AuthorizedQueryParams(t *testing.T) {
 }
 
 func TestHandler_AuthenticatedDatabases_UnauthorizedQueryParams(t *testing.T) {
-	srvr := OpenServer(NewMessagingClient())
+	srvr := OpenServer(NewMessagingClient(), true)
 	srvr.CreateUser("lisa", "password", true)
 	s := NewAuthenticatedHTTPServer(srvr)
 	defer s.Close()
@@ -874,7 +865,7 @@ func TestHandler_AuthenticatedDatabases_UnauthorizedQueryParams(t *testing.T) {
 }
 
 func TestHandler_AuthenticatedDatabases_AuthorizedBasicAuth(t *testing.T) {
-	srvr := OpenServer(NewMessagingClient())
+	srvr := OpenServer(NewMessagingClient(), true)
 	srvr.CreateUser("lisa", "password", true)
 	s := NewAuthenticatedHTTPServer(srvr)
 	defer s.Close()
@@ -889,7 +880,7 @@ func TestHandler_AuthenticatedDatabases_AuthorizedBasicAuth(t *testing.T) {
 }
 
 func TestHandler_AuthenticatedDatabases_UnauthorizedBasicAuth(t *testing.T) {
-	srvr := OpenServer(NewMessagingClient())
+	srvr := OpenServer(NewMessagingClient(), true)
 	srvr.CreateUser("lisa", "password", true)
 	s := NewAuthenticatedHTTPServer(srvr)
 	defer s.Close()
@@ -904,7 +895,7 @@ func TestHandler_AuthenticatedDatabases_UnauthorizedBasicAuth(t *testing.T) {
 }
 
 func TestHandler_GrantAdmin(t *testing.T) {
-	srvr := OpenServer(NewMessagingClient())
+	srvr := OpenServer(NewMessagingClient(), true)
 	// Create a cluster admin that will grant admin to "john".
 	srvr.CreateUser("lisa", "password", true)
 	// Create user that will be granted cluster admin.
@@ -935,7 +926,7 @@ func TestHandler_GrantAdmin(t *testing.T) {
 }
 
 func TestHandler_GrantDBPrivilege(t *testing.T) {
-	srvr := OpenServer(NewMessagingClient())
+	srvr := OpenServer(NewMessagingClient(), true)
 	// Create a cluster admin that will grant privilege to "john".
 	srvr.CreateUser("lisa", "password", true)
 	// Create user that will be granted a privilege.
@@ -972,7 +963,7 @@ func TestHandler_GrantDBPrivilege(t *testing.T) {
 }
 
 func TestHandler_RevokeAdmin(t *testing.T) {
-	srvr := OpenServer(NewMessagingClient())
+	srvr := OpenServer(NewMessagingClient(), true)
 	// Create a cluster admin that will revoke admin from "john".
 	srvr.CreateUser("lisa", "password", true)
 	// Create user that will have cluster admin revoked.
@@ -1004,7 +995,7 @@ func TestHandler_RevokeAdmin(t *testing.T) {
 }
 
 func TestHandler_RevokeDBPrivilege(t *testing.T) {
-	srvr := OpenServer(NewMessagingClient())
+	srvr := OpenServer(NewMessagingClient(), true)
 	// Create a cluster admin that will revoke privilege from "john".
 	srvr.CreateUser("lisa", "password", true)
 	// Create user that will have privilege revoked.
@@ -1038,7 +1029,7 @@ func TestHandler_RevokeDBPrivilege(t *testing.T) {
 }
 
 func TestHandler_serveWriteSeries(t *testing.T) {
-	srvr := OpenServer(NewMessagingClient())
+	srvr := OpenServer(NewMessagingClient(), true)
 	srvr.CreateDatabase("foo")
 	srvr.CreateRetentionPolicy("foo", influxdb.NewRetentionPolicy("bar"))
 	s := NewHTTPServer(srvr)
@@ -1052,7 +1043,7 @@ func TestHandler_serveWriteSeries(t *testing.T) {
 }
 
 func TestHandler_serveWriteSeries_noDatabaseExists(t *testing.T) {
-	srvr := OpenServer(NewMessagingClient())
+	srvr := OpenServer(NewMessagingClient(), true)
 	s := NewHTTPServer(srvr)
 	defer s.Close()
 
@@ -1070,7 +1061,7 @@ func TestHandler_serveWriteSeries_noDatabaseExists(t *testing.T) {
 }
 
 func TestHandler_serveWriteSeries_invalidJSON(t *testing.T) {
-	srvr := OpenServer(NewMessagingClient())
+	srvr := OpenServer(NewMessagingClient(), true)
 	s := NewHTTPServer(srvr)
 	defer s.Close()
 
@@ -1087,7 +1078,7 @@ func TestHandler_serveWriteSeries_invalidJSON(t *testing.T) {
 }
 
 func TestHandler_serveWriteSeries_noDatabaseSpecified(t *testing.T) {
-	srvr := OpenServer(NewMessagingClient())
+	srvr := OpenServer(NewMessagingClient(), true)
 	s := NewHTTPServer(srvr)
 	defer s.Close()
 
@@ -1104,7 +1095,7 @@ func TestHandler_serveWriteSeries_noDatabaseSpecified(t *testing.T) {
 }
 
 func TestHandler_serveShowSeries(t *testing.T) {
-	srvr := OpenServer(NewMessagingClient())
+	srvr := OpenServer(NewMessagingClient(), false)
 	srvr.CreateDatabase("foo")
 	srvr.CreateRetentionPolicy("foo", influxdb.NewRetentionPolicy("bar"))
 	srvr.SetDefaultRetentionPolicy("foo", "bar")
@@ -1279,7 +1270,7 @@ func str2iface(strs []string) []interface{} {
 }
 
 func TestHandler_serveShowMeasurements(t *testing.T) {
-	srvr := OpenServer(NewMessagingClient())
+	srvr := OpenServer(NewMessagingClient(), false)
 	srvr.CreateDatabase("foo")
 	srvr.CreateRetentionPolicy("foo", influxdb.NewRetentionPolicy("bar"))
 	s := NewHTTPServer(srvr)
@@ -1334,7 +1325,7 @@ func TestHandler_serveShowMeasurements(t *testing.T) {
 }
 
 func TestHandler_serveShowTagKeys(t *testing.T) {
-	srvr := OpenServer(NewMessagingClient())
+	srvr := OpenServer(NewMessagingClient(), false)
 	srvr.CreateDatabase("foo")
 	srvr.CreateRetentionPolicy("foo", influxdb.NewRetentionPolicy("bar"))
 	srvr.SetDefaultRetentionPolicy("foo", "bar")
@@ -1437,7 +1428,7 @@ func TestHandler_serveShowTagKeys(t *testing.T) {
 }
 
 func TestHandler_serveShowTagValues(t *testing.T) {
-	srvr := OpenServer(NewMessagingClient())
+	srvr := OpenServer(NewMessagingClient(), false)
 	srvr.CreateDatabase("foo")
 	srvr.CreateRetentionPolicy("foo", influxdb.NewRetentionPolicy("bar"))
 	srvr.SetDefaultRetentionPolicy("foo", "bar")
@@ -1578,7 +1569,7 @@ func TestHandler_serveShowTagValues(t *testing.T) {
 }
 
 func TestHandler_serveShowFieldKeys(t *testing.T) {
-	srvr := OpenServer(NewMessagingClient())
+	srvr := OpenServer(NewMessagingClient(), false)
 	srvr.CreateDatabase("foo")
 	srvr.CreateRetentionPolicy("foo", influxdb.NewRetentionPolicy("bar"))
 	srvr.SetDefaultRetentionPolicy("foo", "bar")
@@ -1752,13 +1743,13 @@ type Server struct {
 }
 
 // NewServer returns a new test server instance.
-func NewServer() *Server {
-	return &Server{influxdb.NewServer()}
+func NewServer(authenticationEnabled bool) *Server {
+	return &Server{influxdb.NewServer(authenticationEnabled)}
 }
 
 // OpenServer returns a new, open test server instance.
-func OpenServer(client influxdb.MessagingClient) *Server {
-	s := OpenUninitializedServer(client)
+func OpenServer(client influxdb.MessagingClient, authenticationEnabled bool) *Server {
+	s := OpenUninitializedServer(client, authenticationEnabled)
 	if err := s.Initialize(&url.URL{Host: "127.0.0.1:8080"}); err != nil {
 		panic(err.Error())
 	}
@@ -1790,8 +1781,8 @@ func (s *Server) Restart() {
 }
 
 // OpenUninitializedServer returns a new, uninitialized, open test server instance.
-func OpenUninitializedServer(client influxdb.MessagingClient) *Server {
-	s := NewServer()
+func OpenUninitializedServer(client influxdb.MessagingClient, authenticationEnabled bool) *Server {
+	s := NewServer(authenticationEnabled)
 	if err := s.Open(tempfile()); err != nil {
 		panic(err.Error())
 	}

--- a/httpd/handler_test.go
+++ b/httpd/handler_test.go
@@ -718,7 +718,7 @@ func TestHandler_DeleteUser_UserNotFound(t *testing.T) {
 
 func TestHandler_DataNodes(t *testing.T) {
 	t.Skip()
-	srvr := OpenAuthlessServer(NewMessagingClient())
+	srvr := OpenUninitializedServer(NewMessagingClient())
 	srvr.CreateDataNode(MustParseURL("http://localhost:1000"))
 	srvr.CreateDataNode(MustParseURL("http://localhost:2000"))
 	srvr.CreateDataNode(MustParseURL("http://localhost:3000"))
@@ -735,7 +735,7 @@ func TestHandler_DataNodes(t *testing.T) {
 
 func TestHandler_CreateDataNode(t *testing.T) {
 	t.Skip()
-	srvr := OpenAuthlessServer(NewMessagingClient())
+	srvr := OpenUninitializedServer(NewMessagingClient())
 	s := NewHTTPServer(srvr)
 	defer s.Close()
 

--- a/influxdb.go
+++ b/influxdb.go
@@ -226,7 +226,7 @@ type ErrAuthorize struct {
 }
 
 // Error returns the text of the error.
-func (e *ErrAuthorize) Error() string {
+func (e ErrAuthorize) Error() string {
 	return e.text
 }
 

--- a/server.go
+++ b/server.go
@@ -124,8 +124,6 @@ func NewServer() *Server {
 
 // SetAuthenticationEnabled turns on or off server authentication
 func (s *Server) SetAuthenticationEnabled(enabled bool) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
 	s.authenticationEnabled = enabled
 }
 

--- a/server.go
+++ b/server.go
@@ -99,11 +99,13 @@ type Server struct {
 	shardsBySeriesID map[uint32][]*Shard // shards by series id
 
 	Logger *log.Logger
+
+	authenticationEnabled bool
 }
 
 // NewServer returns a new instance of Server.
-func NewServer() *Server {
-	return &Server{
+func NewServer(authenticationEnabled bool) *Server {
+	s := Server{
 		meta:      &metastore{},
 		errors:    make(map[uint64]error),
 		dataNodes: make(map[uint64]*DataNode),
@@ -114,6 +116,8 @@ func NewServer() *Server {
 		shardsBySeriesID: make(map[uint32][]*Shard),
 		Logger:           log.New(os.Stderr, "[server] ", log.LstdFlags),
 	}
+	s.authenticationEnabled = authenticationEnabled
+	return &s
 }
 
 // ID returns the data node id for the server.
@@ -905,7 +909,13 @@ func (s *Server) AdminUserExists() bool {
 func (s *Server) Authenticate(username, password string) (*User, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+
 	u := s.users[username]
+
+	// If authorization is not enabled and user is nil, we are authorized
+	if u == nil && !s.authenticationEnabled {
+		return nil, nil
+	}
 	if u == nil {
 		return nil, fmt.Errorf("invalid username or password")
 	}
@@ -1711,8 +1721,10 @@ func (s *Server) ReadSeries(database, retentionPolicy, name string, tags map[str
 // Stops on first execution error that occurs.
 func (s *Server) ExecuteQuery(q *influxql.Query, database string, user *User) Results {
 	// Authorize user to execute the query.
-	if err := Authorize(user, q, database); err != nil {
-		return Results{Err: err}
+	if s.authenticationEnabled {
+		if err := Authorize(user, q, database); err != nil {
+			return Results{Err: err}
+		}
 	}
 
 	// Build empty resultsets.
@@ -2570,6 +2582,9 @@ func (r *Results) UnmarshalJSON(b []byte) error {
 // Error returns the first error from any statement.
 // Returns nil if no errors occurred on any statements.
 func (r *Results) Error() error {
+	if r.Err != nil {
+		return r.Err
+	}
 	for _, rr := range r.Results {
 		if rr.Err != nil {
 			return rr.Err
@@ -2618,8 +2633,12 @@ func (p dataNodes) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
 // database can be "" for queries that do not require a database.
 // If u is nil, this means authorization is disabled.
 func Authorize(u *User, q *influxql.Query, database string) error {
+	if u == nil {
+		return ErrAuthorize{text: "no user provided"}
+	}
+
 	// Cluster admins can do anything.
-	if u == nil || u.Admin {
+	if u.Admin {
 		return nil
 	}
 
@@ -2647,7 +2666,7 @@ func Authorize(u *User, q *influxql.Query, database string) error {
 				} else {
 					msg = fmt.Sprintf("requires %s privilege on %s", p.Privilege.String(), dbname)
 				}
-				return &ErrAuthorize{
+				return ErrAuthorize{
 					text: fmt.Sprintf("%s not authorized to execute '%s'.  %s", u.Name, stmt.String(), msg),
 				}
 			}

--- a/server.go
+++ b/server.go
@@ -104,7 +104,7 @@ type Server struct {
 }
 
 // NewServer returns a new instance of Server.
-func NewServer(authenticationEnabled bool) *Server {
+func NewServer() *Server {
 	s := Server{
 		meta:      &metastore{},
 		errors:    make(map[uint64]error),
@@ -116,8 +116,17 @@ func NewServer(authenticationEnabled bool) *Server {
 		shardsBySeriesID: make(map[uint32][]*Shard),
 		Logger:           log.New(os.Stderr, "[server] ", log.LstdFlags),
 	}
-	s.authenticationEnabled = authenticationEnabled
+	// Server will always return with authentication enabled.
+	// To set the server to 'authless mode', call server.SetAuthenticationEnabled(false)
+	s.authenticationEnabled = true
 	return &s
+}
+
+// SetAuthenticationEnabled turns on or off server authentication
+func (s *Server) SetAuthenticationEnabled(enabled bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.authenticationEnabled = enabled
 }
 
 // ID returns the data node id for the server.

--- a/server.go
+++ b/server.go
@@ -117,7 +117,8 @@ func NewServer() *Server {
 		Logger:           log.New(os.Stderr, "[server] ", log.LstdFlags),
 	}
 	// Server will always return with authentication enabled.
-	// To set the server to 'authless mode', call server.SetAuthenticationEnabled(false)
+	// This ensures that disabling authentication must be an explicit decision.
+	// To set the server to 'authless mode', call server.SetAuthenticationEnabled(false).
 	s.authenticationEnabled = true
 	return &s
 }

--- a/server_test.go
+++ b/server_test.go
@@ -986,7 +986,9 @@ type Server struct {
 
 // NewServer returns a new test server instance.
 func NewServer() *Server {
-	return &Server{influxdb.NewServer(false)}
+	s := influxdb.NewServer()
+	s.SetAuthenticationEnabled(false)
+	return &Server{s}
 }
 
 // OpenServer returns a new, open test server instance.

--- a/server_test.go
+++ b/server_test.go
@@ -986,7 +986,7 @@ type Server struct {
 
 // NewServer returns a new test server instance.
 func NewServer() *Server {
-	return &Server{influxdb.NewServer()}
+	return &Server{influxdb.NewServer(false)}
 }
 
 // OpenServer returns a new, open test server instance.


### PR DESCRIPTION
We previously had some scenarios that would allow a the system to be configured to use authorization, but an admin could still be created once.

The server also had no knowledge of if it should be requiring Authorization.  This became problematic to enforce security.

The changes are fairly minor, with the biggest affect updating tests so they know if the server is locked down or not while the tests run.