### PR TITLE
Fix panic if a point doesn't have a value for a field.

### DIFF
--- a/tx.go
+++ b/tx.go
@@ -283,6 +283,11 @@ func (c *seriesCursor) Next(fieldName string, fieldID uint8, tmin, tmax int64) (
 			return 0, nil
 		}
 
+		// Skip to the next if we don't have a field value for this field for this point
+		if value == nil {
+			continue
+		}
+
 		// Evaluate condition. Move to next key/value if non-true.
 		if c.condition != nil {
 			if ok, _ := influxql.Eval(c.condition, map[string]interface{}{fieldName: value}).(bool); !ok {


### PR DESCRIPTION
Fixes #1530. Ensures that the series iterator doesn't yield points that don't have a value for the field that is being aggregated.

Ready for review. @otoolep, @corylanou 