### PR TITLE
Fail faster on not-yet-implemented wildcard query

### DIFF
--- a/influxql/engine.go
+++ b/influxql/engine.go
@@ -121,6 +121,8 @@ func (p *Planner) planExpr(e *Executor, expr Expr) (Processor, error) {
 		return newLiteralProcessor(expr.Val), nil
 	case *DurationLiteral:
 		return newLiteralProcessor(expr.Val), nil
+	case *Wildcard:
+		panic("Wildcard operator not yet implemented")
 	}
 	panic("unreachable")
 }


### PR DESCRIPTION
Signed-off-by: Will Faurot <will@influxdb.com>

Previously was getting an `unreachable` panic.