### PR TITLE
Update retention policy before saving database

### DIFF
--- a/server.go
+++ b/server.go
@@ -834,6 +834,9 @@ func (s *Server) applyCreateShardGroupIfNotExists(m *messaging.Message) (err err
 			}
 		}
 
+		// Retention policy has a new shard group, so update the policy.
+		rp.shardGroups = append(rp.shardGroups, g)
+
 		return tx.saveDatabase(db)
 	}); err != nil {
 		g.close()
@@ -857,7 +860,6 @@ func (s *Server) applyCreateShardGroupIfNotExists(m *messaging.Message) (err err
 	for _, sh := range g.Shards {
 		s.shards[sh.ID] = sh
 	}
-	rp.shardGroups = append(rp.shardGroups, g)
 
 	// Subscribe to shard if it matches the server's index.
 	// TODO: Move subscription outside of command processing.

--- a/server.go
+++ b/server.go
@@ -229,6 +229,11 @@ func (s *Server) Close() error {
 	// Close metastore.
 	_ = s.meta.close()
 
+	// Close shards.
+	for _, sh := range s.shards {
+		_ = sh.close()
+	}
+
 	return nil
 }
 

--- a/server_test.go
+++ b/server_test.go
@@ -873,6 +873,9 @@ func TestServer_CreateShardGroupIfNotExist(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// Restart the server to ensure the shard group is not lost.
+	s.Restart()
+
 	if a, err := s.ShardGroups("foo"); err != nil {
 		t.Fatal(err)
 	} else if len(a) != 1 {


### PR DESCRIPTION
Without this change, new shard group information is not persisted in the
metastore and only when the next database-save took place would this
update be persisted. If the server shutdown before the update, the new
shard group would be lost.