### PR TITLE
Check for nil user in write handler

### DIFF
--- a/httpd/handler.go
+++ b/httpd/handler.go
@@ -178,7 +178,7 @@ func (h *Handler) serveWrite(w http.ResponseWriter, r *http.Request, user *influ
 	}
 
 	if h.requireAuthentication && user == nil {
-		writeError(influxdb.Result{Err: fmt.Errorf("<nil> user is not authorized to write to database %q", bp.Database)}, http.StatusUnauthorized)
+		writeError(influxdb.Result{Err: fmt.Errorf("user is required to write to database %q", bp.Database)}, http.StatusUnauthorized)
 		return
 	}
 

--- a/httpd/handler.go
+++ b/httpd/handler.go
@@ -177,6 +177,11 @@ func (h *Handler) serveWrite(w http.ResponseWriter, r *http.Request, user *influ
 		return
 	}
 
+	if h.requireAuthentication && user == nil {
+		writeError(influxdb.Result{Err: fmt.Errorf("<nil> user is not authorized to write to database %q", bp.Database)}, http.StatusUnauthorized)
+		return
+	}
+
 	if h.requireAuthentication && !user.Authorize(influxql.WritePrivilege, bp.Database) {
 		writeError(influxdb.Result{Err: fmt.Errorf("%q user is not authorized to write to database %q", user.Name, bp.Database)}, http.StatusUnauthorized)
 		return


### PR DESCRIPTION
On a server that required authentication, writing without passing in a user would panic.

Fixes #1568.