### PR TITLE
Add server-level write batching.

### DIFF
--- a/server_test.go
+++ b/server_test.go
@@ -750,8 +750,12 @@ func TestServer_WriteSeries(t *testing.T) {
 		t.Fatalf("sync error: %s", err)
 	}
 
-	// Write another point 10 seconds later so it goes through "raw series".
-	index, err = s.WriteSeries("foo", "mypolicy", []influxdb.Point{{Name: "cpu_load", Tags: tags, Timestamp: mustParseTime("2000-01-01T00:00:10Z"), Values: map[string]interface{}{"value": float64(100)}}})
+	// Write more points seconds later so it goes through "raw series".
+	points := make([]influxdb.Point, 1000)
+	for i := range points {
+		points[i] = influxdb.Point{Name: "cpu_load", Tags: tags, Timestamp: mustParseTime("2000-01-01T00:00:10Z").Add(time.Duration(i) * time.Second), Values: map[string]interface{}{"value": float64(100)}}
+	}
+	index, err = s.WriteSeries("foo", "mypolicy", points)
 	if err != nil {
 		t.Fatal(err)
 	} else if err = s.Sync(index); err != nil {
@@ -778,7 +782,7 @@ func TestServer_WriteSeries(t *testing.T) {
 	}
 
 	// Retrieve non-existent series data point.
-	if v, err := s.ReadSeries("foo", "mypolicy", "cpu_load", tags, mustParseTime("2000-01-01T00:01:00Z")); err != nil {
+	if v, err := s.ReadSeries("foo", "mypolicy", "cpu_load", tags, mustParseTime("2000-01-02T00:00:00Z")); err != nil {
 		t.Fatal(err)
 	} else if v != nil {
 		t.Fatalf("expected nil values: %#v", v)

--- a/tests/siege/README.md
+++ b/tests/siege/README.md
@@ -17,7 +17,7 @@ You can do this with the following commands:
 
 ```sh
 $ curl -G http://localhost:8086/query --data-urlencode "q=CREATE DATABASE db"
-$ curl -G http://localhost:8086/query --data-urlencode "q=CREATE RETENTION POLICY raw ON db DURATION 1h REPLICATION 1 DEFAULT"
+$ curl -G http://localhost:8086/query --data-urlencode "q=CREATE RETENTION POLICY raw ON db DURATION 1h REPLICATION 3 DEFAULT"
 ```
 
 

--- a/tests/siege/urlgen
+++ b/tests/siege/urlgen
@@ -4,28 +4,16 @@
 
 PLATFORM=`uname`
 
-_date_to_unix_timestamp () {
-    if [  "$PLATFORM" = "Darwin" ] ; then
-        date -j -f "%b %d %T %Z %Y" "$1" "+%s"
-    elif [  "$PLATFORM" = "Linux" ] ; then
-        date -d "$1" "+%s"
-    else
-        echo "I don't know if your date can read a format and a time, failing"
-        exit 99
-    fi
-}
-
 _timestamp_to_time_string () {
     if [  "$PLATFORM" = "Darwin" ] ; then
-        date -j -f "%s" "$1" +"%Y-%m-%dT%H:%M:%SZ"
+        date -ju -f "%s" "$1" +"%Y-%m-%dT%H:%M:%SZ"
     elif [  "$PLATFORM" = "Linux" ] ; then
         date -d "@$1" +"%Y-%m-%dT%H:%M:%SZ"
     fi
 }
 
 # Starting the test at "Jan 01 00:00:00 EDT 2000"
-TIME=`_date_to_unix_timestamp "Jan 01 00:00:00 EDT 2000"`
-
+TIME=946684800
 
 # Set defaults.
 INTERVAL=10      # 1s
@@ -86,7 +74,7 @@ do
 		do
 			# Format the timestamp to ISO 8601.
 			let CURRTIME=TIME+j
-			TIMESTAMP=`date -j -f "%s" $CURRTIME +"%Y-%m-%dT%H:%M:%SZ"`
+			TIMESTAMP=`_timestamp_to_time_string $CURRTIME`
 
 			# Add comma separator.
 			if [ "$j" -ne "0" ]


### PR DESCRIPTION
## Overview

This commit changes the Server to batch writes together -- even across multiple requests. The server then periodically sends writes together to the broker by shard in a single message.

This approach uses a lot of goroutines but it allows for all points to manage the returned error and index. This simpler approach was used to get basic batching working. I'll submit a separate PR for optimizing batching to minimize goroutines.

## Notes

Batching is only implemented for raw writes. Non-raw writes only occur once for brand new series so I don't think it's worth implementing for that right now.