### PR TITLE
Client user agent is configurable

### DIFF
--- a/cmd/influx/main.go
+++ b/cmd/influx/main.go
@@ -18,6 +18,11 @@ import (
 	"github.com/peterh/liner"
 )
 
+// These variables are populated via the Go linker.
+var (
+	version string = "0.9"
+)
+
 const (
 	default_host   = "localhost"
 	default_port   = 8086
@@ -60,7 +65,7 @@ func main() {
 	}
 
 	// TODO Determine if we are an ineractive shell or running commands
-	fmt.Println("InfluxDB shell")
+	fmt.Println("InfluxDB shell " + version)
 
 	c.Line = liner.NewLiner()
 	defer c.Line.Close()
@@ -185,7 +190,7 @@ func (c *CommandLine) connect(cmd string) {
 			URL:       u,
 			Username:  c.Username,
 			Password:  c.Password,
-			UserAgent: "InfluxDB shell",
+			UserAgent: "InfluxDBShell/" + version,
 		})
 	if err != nil {
 		fmt.Printf("Could not create client %s", err)

--- a/cmd/influx/main.go
+++ b/cmd/influx/main.go
@@ -182,9 +182,10 @@ func (c *CommandLine) connect(cmd string) {
 	}
 	cl, err := client.NewClient(
 		client.Config{
-			URL:      u,
-			Username: c.Username,
-			Password: c.Password,
+			URL:       u,
+			Username:  c.Username,
+			Password:  c.Password,
+			UserAgent: "InfluxDB shell",
 		})
 	if err != nil {
 		fmt.Printf("Could not create client %s", err)


### PR DESCRIPTION
When setting the agent in the shell client, I would have preferred to include the current version (e.g. "InfluxDB shell/0.9") but we don't seem to expose the current version in the code.

Now, instead of lines like this in the influxd log:

> [http] 127.0.0.1 - - [10/Feb/2015:17:11:39 -0800] GET /query?db=&q=SHOW+DATABASES HTTP/1.1 200 84 - Go 1.1 package http ee7a2b85-b18a-11e4-adfb-60f81db8dfb6

There's a more meaningful user agent displayed:

> [http] 127.0.0.1 - - [11/Feb/2015:11:20:06 -0800] GET /query?db=&q=SHOW+DATABASES HTTP/1.1 200 84 - InfluxDB shell fc55cf96-b222-11e4-8bc3-60f81db8dfb6