### PR TITLE
commit hook was inaccuratly reporting vet errors due to how we ran vet

### DIFF
--- a/.hooks/pre-commit
+++ b/.hooks/pre-commit
@@ -6,8 +6,7 @@ if [ $fmtcount -gt 0 ]; then
     exit 1
 fi
 
-GOTOOLDIR=$(go env GOTOOLDIR)
-vetcount=`git ls-files | grep '.go$' | xargs $GOTOOLDIR/vet 2>&1 | wc -l`
+vetcount=`go vet ./... 2>&1 | wc -l`
 if [ $vetcount -gt 0 ]; then
     echo "Some files aren't passing vet heuristics, please run 'go vet ./...' to see the errors it flags and correct your source code before committing"
     exit 1


### PR DESCRIPTION
This would inaccurately report errors like this:

```go

type foo []int

f := foo{1}
```

With the error like `composite literal uses unkeyed fields`

This fix will correct that invalid error as when you run `go vet` instead of `vet` it has package level knowledge.