### PR TITLE
Panic if admin server already running

### DIFF
--- a/admin/admin.go
+++ b/admin/admin.go
@@ -26,13 +26,13 @@ func (s *Server) ListenAndServe() {
 		return
 	}
 
-	s.closed = false
 	var err error
-	s.listener, _ = net.Listen("tcp", s.port)
+	s.listener, err = net.Listen("tcp", s.port)
 	if err != nil {
 		return
 	}
 
+	s.closed = false
 	statikFS, _ := fs.New()
 
 	err = http.Serve(s.listener, http.FileServer(statikFS))


### PR DESCRIPTION
If a second instance of InfluxDB is started, and both are running the admin server, we get a panic.
```
$ go test ./...
ok      github.com/influxdb/influxdb    28.063s
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xb code=0x1 addr=0x0 pc=0x534fd7]

goroutine 6 [running]:
net/http.(*Server).Serve(0xc20805c420, 0x0, 0x0, 0x0, 0x0)
        /home/philip/.gvm/gos/go1.4/src/net/http/server.go:1725 +0x377
net/http.Serve(0x0, 0x0, 0x7fd36be7f210, 0xc20800a890, 0x0, 0x0)
        /home/philip/.gvm/gos/go1.4/src/net/http/server.go:1606 +0xa1
github.com/influxdb/influxdb/admin.(*Server).ListenAndServe(0xc20803abd0)
        /home/philip/Dropbox/repos/influxdb/src/github.com/influxdb/influxdb/admin/admin.go:38 +0x1b6
github.com/influxdb/influxdb/admin_test.func·001()
        /home/philip/Dropbox/repos/influxdb/src/github.com/influxdb/influxdb/admin/admin_test.go:13 +0x2a
created by github.com/influxdb/influxdb/admin_test.Test_ServesIndexByDefault
        /home/philip/Dropbox/repos/influxdb/src/github.com/influxdb/influxdb/admin/admin_test.go:13 +0x121

goroutine 1 [chan receive]:
testing.RunTests(0x7b8698, 0xb20c50, 0x1, 0x1, 0x933d373e1dd17a01)
        /home/philip/.gvm/gos/go1.4/src/testing/testing.go:556 +0xad6
testing.(*M).Run(0xc20802e370, 0xb301e0)
        /home/philip/.gvm/gos/go1.4/src/testing/testing.go:485 +0x6c
main.main()
        github.com/influxdb/influxdb/admin/_test/_testmain.go:54 +0x1d5
```