### PR TITLE
Refactor raft state handling

### DIFF
--- a/raft/clock.go
+++ b/raft/clock.go
@@ -10,10 +10,10 @@ const (
 	DefaultApplyInterval = 10 * time.Millisecond
 
 	// DefaultElectionTimeout is the default time before starting an election.
-	DefaultElectionTimeout = 500 * time.Millisecond
+	DefaultElectionTimeout = 1 * time.Second
 
 	// DefaultHeartbeatInterval is the default time to wait between heartbeats.
-	DefaultHeartbeatInterval = 150 * time.Millisecond
+	DefaultHeartbeatInterval = 100 * time.Millisecond
 
 	// DefaultReconnectTimeout is the default time to wait before reconnecting.
 	DefaultReconnectTimeout = 10 * time.Millisecond

--- a/raft/clock.go
+++ b/raft/clock.go
@@ -1,6 +1,7 @@
 package raft
 
 import (
+	"math/rand"
 	"time"
 )
 
@@ -39,8 +40,11 @@ func NewClock() *Clock {
 // AfterApplyInterval returns a channel that fires after the apply interval.
 func (c *Clock) AfterApplyInterval() <-chan chan struct{} { return newClockChan(c.ApplyInterval) }
 
-// AfterElectionTimeout returns a channel that fires after the election timeout.
-func (c *Clock) AfterElectionTimeout() <-chan chan struct{} { return newClockChan(c.ElectionTimeout) }
+// AfterElectionTimeout returns a channel that fires after a duration that is
+// between the election timeout and double the election timeout.
+func (c *Clock) AfterElectionTimeout() <-chan chan struct{} {
+	return newClockChan(c.ElectionTimeout + time.Duration(rand.Intn(int(c.ElectionTimeout))))
+}
 
 // AfterHeartbeatInterval returns a channel that fires after the heartbeat interval.
 func (c *Clock) AfterHeartbeatInterval() <-chan chan struct{} {

--- a/raft/handler.go
+++ b/raft/handler.go
@@ -12,7 +12,7 @@ import (
 // Handler represents an HTTP endpoint for Raft to communicate over.
 type Handler struct {
 	Log interface {
-		AddPeer(u *url.URL) (uint64, uint64, *Config, error)
+		AddPeer(u *url.URL) (id uint64, leaderID uint64, config *Config, err error)
 		RemovePeer(id uint64) error
 		Heartbeat(term, commitIndex, leaderID uint64) (currentIndex uint64, err error)
 		WriteEntriesTo(w io.Writer, id, term, index uint64) error

--- a/raft/log.go
+++ b/raft/log.go
@@ -14,6 +14,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"runtime"
 	"runtime/debug"
 	"sort"
 	"strconv"
@@ -75,8 +76,9 @@ type Log struct {
 	path   string  // data directory
 	config *Config // cluster configuration
 
-	state State         // current node state
-	ch    chan struct{} // state change channel
+	state      State          // current node state
+	initialize chan struct{}  // initialization channel
+	heartbeats chan heartbeat // incoming heartbeat channel
 
 	term        uint64    // current election term
 	lastLogTerm uint64    // highest term in the log
@@ -93,7 +95,8 @@ type Log struct {
 
 	entries []*LogEntry
 
-	done []chan chan struct{} // list of channels to signal close.
+	wg      sync.WaitGroup // pending goroutines
+	closing chan struct{}  // close notification
 
 	// Network address to the reach the log.
 	URL *url.URL
@@ -103,11 +106,11 @@ type Log struct {
 
 	// The transport used to communicate with other nodes in the cluster.
 	Transport interface {
-		Join(u *url.URL, nodeURL *url.URL) (uint64, *Config, error)
+		Join(u *url.URL, nodeURL *url.URL) (id uint64, leaderID uint64, config *Config, err error)
 		Leave(u *url.URL, id uint64) error
-		Heartbeat(u *url.URL, term, commitIndex, leaderID uint64) (lastIndex, currentTerm uint64, err error)
+		Heartbeat(u *url.URL, term, commitIndex, leaderID uint64) (lastIndex uint64, err error)
 		ReadFrom(u *url.URL, id, term, index uint64) (io.ReadCloser, error)
-		RequestVote(u *url.URL, term, candidateID, lastLogIndex, lastLogTerm uint64) (uint64, error)
+		RequestVote(u *url.URL, term, candidateID, lastLogIndex, lastLogTerm uint64) error
 	}
 
 	// Clock is an abstraction of time.
@@ -135,6 +138,9 @@ func NewLog() *Log {
 		Clock:     NewClock(),
 		Transport: &HTTPTransport{},
 		Rand:      rand.Int63,
+
+		initialize: make(chan struct{}, 0),
+		heartbeats: make(chan heartbeat, 1),
 	}
 	l.SetLogOutput(os.Stderr)
 	return l
@@ -169,6 +175,27 @@ func (l *Log) State() State {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	return l.state
+}
+
+// Index returns the highest available index.
+func (l *Log) Index() uint64 {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.index
+}
+
+// CommtIndex returns the highest committed index.
+func (l *Log) CommitIndex() uint64 {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.commitIndex
+}
+
+// AppliedIndex returns the highest applied index.
+func (l *Log) AppliedIndex() uint64 {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.appliedIndex
 }
 
 // Term returns the current term.
@@ -220,6 +247,7 @@ func (l *Log) Open(path string) error {
 		return err
 	}
 	l.term = term
+	l.votedFor = 0
 	l.lastLogTerm = term
 
 	// Read config.
@@ -240,26 +268,27 @@ func (l *Log) Open(path string) error {
 	l.appliedIndex = index
 	l.commitIndex = index
 
-	// If this log is the only node then promote to leader immediately.
-	// Otherwise if there's any configuration then start it as a follower.
-	if c != nil && len(c.Nodes) == 1 && c.Nodes[0].ID == l.id {
-		l.Logger.Println("log open: promoting to leader immediately")
-		l.setState(Leader)
-	} else if l.config != nil {
-		l.setState(Follower)
-		l.lastContact = l.Clock.Now()
-	}
-
 	// Start goroutine to apply logs.
-	l.done = append(l.done, make(chan chan struct{}))
-	go l.applier(l.done[len(l.done)-1])
+	l.wg.Add(1)
+	l.closing = make(chan struct{})
+	go l.applier(l.closing)
 
-	// Start goroutine to check for election timeouts.
-	l.done = append(l.done, make(chan chan struct{}))
-	go l.elector(l.done[len(l.done)-1])
+	// If a log exists then start the state loop.
+	if c != nil {
+		l.Logger.Printf("log open: created at %s, with ID %d, term %d, last applied index of %d",
+			path, l.id, l.term, l.index)
 
-	l.Logger.Printf("log open: created at %s, with ID %d, term %d, last applied index of %d",
-		path, l.id, l.term, l.index)
+		// If the config only has one node then start it as the leader.
+		// Otherwise start as a follower.
+		if len(c.Nodes) == 1 && c.Nodes[0].ID == l.id {
+			l.Logger.Println("log open: promoting to leader immediately")
+			l.startStateLoop(l.closing, Leader)
+		} else {
+			l.startStateLoop(l.closing, Follower)
+		}
+	} else {
+		l.Logger.Printf("log pending: waiting for initialization or join")
+	}
 
 	return nil
 }
@@ -273,27 +302,22 @@ func (l *Log) Close() error {
 
 // close should be called under lock.
 func (l *Log) close() error {
+	l.tracef("closing...")
+
 	// Close the reader, if open.
 	if l.reader != nil {
 		_ = l.reader.Close()
 		l.reader = nil
 	}
 
-	// Stop the log.
-	l.setState(Stopped)
-
-	// Retrieve closing channels under lock.
-	a := l.done
-	l.done = nil
-
-	// Unlock while we shutdown all goroutines.
-	l.mu.Unlock()
-	for _, done := range a {
-		ch := make(chan struct{})
-		done <- ch
-		<-ch
+	// Notify goroutines of closing and wait outside of lock.
+	if l.closing != nil {
+		close(l.closing)
+		l.closing = nil
+		l.mu.Unlock()
+		l.wg.Wait()
+		l.mu.Lock()
 	}
-	l.mu.Lock()
 
 	// Close the writers.
 	for _, w := range l.writers {
@@ -301,13 +325,13 @@ func (l *Log) close() error {
 	}
 	l.writers = nil
 
-	l.tracef("close")
-
 	// Clear log info.
 	l.setID(0)
 	l.path = ""
-	l.index, l.term, l.lastLogTerm = 0, 0, 0
+	l.index, l.term, l.votedFor, l.lastLogTerm = 0, 0, 0, 0
 	l.config = nil
+
+	l.tracef("closed")
 
 	return nil
 }
@@ -443,8 +467,11 @@ func (l *Log) Initialize() error {
 			return fmt.Errorf("write term: %s", err)
 		}
 		l.term = term
+		l.votedFor = 0
 		l.lastLogTerm = term
-		l.setState(Leader)
+
+		// Begin state loop as leader.
+		l.startStateLoop(l.closing, Leader)
 
 		l.Logger.Printf("log initialize: promoted to 'leader' with cluster ID %d, log ID %d, term %d",
 			config.ClusterID, l.id, l.term)
@@ -453,6 +480,14 @@ func (l *Log) Initialize() error {
 	}()
 	if err != nil {
 		return err
+	}
+
+	// Wait until leader state change.
+	for {
+		if l.state == Leader {
+			break
+		}
+		runtime.Gosched()
 	}
 
 	// Set initial configuration.
@@ -544,10 +579,11 @@ func (l *Log) Join(u *url.URL) error {
 	l.tracef("Join: %s", u)
 
 	// Send join request.
-	id, config, err := l.Transport.Join(u, nodeURL)
+	id, leaderID, config, err := l.Transport.Join(u, nodeURL)
 	if err != nil {
 		return err
 	}
+	l.leaderID = leaderID
 
 	l.tracef("Join: confirmed")
 
@@ -567,8 +603,10 @@ func (l *Log) Join(u *url.URL) error {
 	}
 	l.config = config
 
+	// Begin state loop as follower.
+	l.startStateLoop(l.closing, Follower)
+
 	// Change to a follower state.
-	l.setState(Follower)
 	l.Logger.Println("log join: entered 'follower' state for cluster at", u, " with log ID", l.id)
 
 	return nil
@@ -586,289 +624,343 @@ func (l *Log) Leave() error {
 	return nil
 }
 
-// setState moves the log to a given state.
-func (l *Log) setState(state State) {
-	l.Logger.Printf("log state change: %s => %s", l.state, state)
+// startStateLoop begins the state loop in a separate goroutine.
+// Returns once the state has transitioned from "stopped".
+func (l *Log) startStateLoop(closing <-chan struct{}, state State) {
+	l.wg.Add(1)
+	go l.stateLoop(closing, state)
 
-	// Stop previous state.
-	if l.ch != nil {
-		close(l.ch)
-		l.ch = nil
-	}
-
-	// Remove previous reader, if one exists.
-	if l.reader != nil {
-		_ = l.reader.Close()
-	}
-
-	// Set the new state.
-	l.state = state
-
-	// Execute event loop for the given state.
-	switch state {
-	case Follower:
-		l.ch = make(chan struct{})
-		go l.followerLoop(l.ch)
-	case Candidate:
-		l.ch = make(chan struct{})
-		go l.candidateLoop(l.ch)
-	case Leader:
-		l.ch = make(chan struct{})
-		go l.leaderLoop(l.ch)
+	// Wait until state change.
+	for {
+		if l.state == state {
+			break
+		}
+		runtime.Gosched()
 	}
 }
 
-// followerLoop continually attempts to stream the log from the current leader.
-func (l *Log) followerLoop(done chan struct{}) {
-	l.tracef("followerLoop")
-	var rch chan struct{}
+// stateLoop runs in a separate goroutine and runs the appropriate state loop.
+func (l *Log) stateLoop(closing <-chan struct{}, state State) {
+	defer l.wg.Done()
 	for {
+		// Transition to new state.
+		l.Logger.Printf("log state change: %s => %s", l.state, state)
+		l.state = state
+
+		// Remove previous reader, if one exists.
+		if l.reader != nil {
+			_ = l.reader.Close()
+		}
+
+		// Execute the appropriate state loop.
+		// Each loop returns the next state to transition to.
+		switch state {
+		case Stopped:
+			return
+		case Follower:
+			state = l.followerLoop(closing)
+		case Candidate:
+			state = l.candidateLoop(closing)
+		case Leader:
+			state = l.leaderLoop(closing)
+		}
+	}
+}
+
+func (l *Log) followerLoop(closing <-chan struct{}) State {
+	l.tracef("followerLoop")
+	defer l.tracef("followerLoop: exit")
+
+	// Ensure all follower goroutines complete before transitioning.
+	var wg sync.WaitGroup
+	defer wg.Wait()
+	var transitioning = make(chan struct{})
+	defer close(transitioning)
+
+	// Read log from leader in a separate goroutine.
+	wg.Add(1)
+	go l.readFromLeader(&wg, transitioning)
+
+	for {
+		select {
+		case <-closing:
+			return Stopped
+		case <-l.initialize:
+			return Leader
+		case ch := <-l.Clock.AfterElectionTimeout():
+			close(ch)
+			return Candidate
+		case hb := <-l.heartbeats:
+			l.tracef("followerLoop: heartbeat: term=%d, idx=%d", hb.term, hb.commitIndex)
+
+			// Update term, commit index & leader.
+			l.mu.Lock()
+			if hb.term > l.term {
+				l.term = hb.term
+				l.votedFor = 0
+			}
+			if hb.commitIndex > l.commitIndex {
+				l.commitIndex = hb.commitIndex
+			}
+			l.leaderID = hb.leaderID
+			l.mu.Unlock()
+		}
+	}
+}
+
+func (l *Log) readFromLeader(wg *sync.WaitGroup, transitioning <-chan struct{}) {
+	defer wg.Done()
+	l.tracef("readFromLeader:")
+
+	for {
+		select {
+		case <-transitioning:
+			l.tracef("readFromLeader: exiting")
+			return
+		default:
+		}
+
 		// Retrieve the term, last index, & leader URL.
 		l.mu.Lock()
-		if err := check(done); err != nil {
-			l.mu.Unlock()
-			return
-		}
 		id, index, term := l.id, l.index, l.term
 		_, u := l.leader()
 		l.mu.Unlock()
 
 		// If no leader exists then wait momentarily and retry.
 		if u == nil {
-			l.tracef("followerLoop: no leader")
-			time.Sleep(1 * time.Millisecond)
+			l.tracef("readFromLeader: no leader")
+			time.Sleep(100 * time.Millisecond)
 			continue
 		}
 
 		// Connect to leader.
-		l.tracef("followerLoop: read from: %s, id=%d, term=%d, index=%d", u.String(), id, term, index)
+		l.tracef("readFromLeader: read from: %s, id=%d, term=%d, index=%d", u.String(), id, term, index)
 		r, err := l.Transport.ReadFrom(u, id, term, index)
 		if err != nil {
 			l.Logger.Printf("connect stream: %s", err)
 		}
 
-		// Stream the log in from a separate goroutine.
-		rch = make(chan struct{})
-		go func(u *url.URL, term, index uint64, rch chan struct{}) {
-			// Attach the stream to the log.
-			if err := l.ReadFrom(r); err != nil {
-				l.tracef("followerLoop: read from: disconnect: %s", err)
-				close(rch)
-			}
-		}(u, term, index, rch)
-
-		// Check if the state has changed, stream has closed, or an
-		// election timeout has passed.
-		select {
-		case <-done:
-			return
-		case <-rch:
-			time.Sleep(10 * time.Millisecond)
-			// FIX: l.Clock.Sleep(l.ReconnectTimeout)
-			continue
+		// Attach the stream to the log.
+		if err := l.ReadFrom(r); err != nil {
+			l.tracef("readFromLeader: read from: disconnect: %s", err)
 		}
 	}
 }
 
 // candidateLoop requests vote from other nodes in an attempt to become leader.
-func (l *Log) candidateLoop(done chan struct{}) {
+func (l *Log) candidateLoop(closing <-chan struct{}) State {
 	l.tracef("candidateLoop")
+	defer l.tracef("candidateLoop: exit")
+
+	// TODO: prevote
+
+	// Increment term and request votes.
+	l.mu.Lock()
+	l.term++
+	l.votedFor = l.id
+	term := l.term
+	l.mu.Unlock()
+
+	// Ensure all follower goroutines complete before transitioning.
+	var wg sync.WaitGroup
+	defer wg.Wait()
+	var transitioning = make(chan struct{})
+	defer close(transitioning)
+
+	// Read log from leader in a separate goroutine.
+	wg.Add(1)
+	elected := make(chan struct{}, 1)
+	go l.elect(term, elected, &wg, transitioning)
+
 	for {
-		// Retrieve config and term.
-		l.mu.Lock()
-		term, id := l.term, l.id
-		lastLogIndex, lastLogTerm := l.index, l.lastLogTerm
-		config := l.config
-		l.mu.Unlock()
-
-		// Request votes from all other nodes.
-		ch := l.sendVoteRequests(config.Nodes, term, id, lastLogIndex, lastLogTerm)
-
-		// Wait for respones or timeout.
-		voteN := 1
-		nodeN := len(config.Nodes)
-		after := l.Clock.AfterElectionTimeout()
-	loop:
-		for {
-			select {
-			case <-done:
-				return
-			case ch := <-after:
-				defer close(ch)
-				break loop
-			case resp := <-ch:
-				if resp.peerTerm > term {
-					l.Logger.Printf("higher term, stepping down: %d > %d", resp.peerTerm, term)
-					l.term = resp.peerTerm
-					l.setState(Follower)
-					return
-				}
-
-				voteN++
-				if voteN >= (nodeN/2)+1 {
-					break loop
-				}
-			}
-		}
-
-		// Retry if we don't have a quorum.
-		if voteN < (nodeN/2)+1 {
+		select {
+		case <-closing:
+			return Stopped
+		case hb := <-l.heartbeats:
 			l.mu.Lock()
-			l.term++
+			if hb.term > l.term {
+				l.term = hb.term
+				l.votedFor = 0
+				l.leaderID = hb.leaderID
+				l.mu.Unlock()
+				return Follower
+			}
 			l.mu.Unlock()
-			continue
+		case <-elected:
+			return Leader
+		case ch := <-l.Clock.AfterElectionTimeout():
+			close(ch)
+			return Candidate // retry
 		}
-
-		// Change to a leader state if we received a quorum.
-		l.mu.Lock()
-		l.setState(Leader)
-		l.mu.Unlock()
 	}
 }
 
-// sendVoteRequests sends vote requests to all peers.
-// Returns a channel that signals each response.
-func (l *Log) sendVoteRequests(nodes []*ConfigNode, term, id, lastLogIndex, lastLogTerm uint64) <-chan voteResponse {
-	ch := make(chan voteResponse, len(nodes))
-	for _, n := range nodes {
+func (l *Log) elect(term uint64, elected chan struct{}, wg *sync.WaitGroup, transitioning <-chan struct{}) {
+	defer wg.Done()
+
+	// Ensure we are in the same term and copy properties.
+	l.mu.Lock()
+	if term != l.term {
+		l.mu.Unlock()
+		return
+	}
+	id, lastLogIndex, lastLogTerm, config := l.id, l.index, l.lastLogTerm, l.config
+	l.mu.Unlock()
+
+	// Request votes from peers.
+	votes := make(chan struct{}, len(config.Nodes))
+	for _, n := range config.Nodes {
 		if n.ID == id {
 			continue
 		}
 		go func(n *ConfigNode) {
-			peerTerm, err := l.Transport.RequestVote(n.URL, term, id, lastLogIndex, lastLogTerm)
-			if err != nil {
+			if err := l.Transport.RequestVote(n.URL, term, id, lastLogIndex, lastLogTerm); err != nil {
 				l.tracef("sendVoteRequests: %s: %s", n.URL.String(), err)
 				return
 			}
-			ch <- voteResponse{peerTerm: peerTerm}
+			votes <- struct{}{}
 		}(n)
 	}
-	return ch
-}
 
-type voteResponse struct {
-	peerTerm uint64
+	// Wait until we have a quorum before responding.
+	voteN := 1
+	for {
+		// Signal channel that the log has been elected.
+		if voteN >= (len(config.Nodes)/2)+1 {
+			elected <- struct{}{}
+			return
+		}
+
+		// Wait until log transitions to another state or we receive a vote.
+		select {
+		case <-transitioning:
+			return
+		case <-votes:
+			voteN++
+		}
+	}
 }
 
 // leaderLoop periodically sends heartbeats to all followers to maintain dominance.
-func (l *Log) leaderLoop(done chan struct{}) {
-	l.tracef("leaderLoop: start")
-	confirm := make(chan struct{}, 0)
+func (l *Log) leaderLoop(closing <-chan struct{}) State {
+	l.tracef("leaderLoop")
+	defer l.tracef("leaderLoop: exit")
+
+	// Ensure all follower goroutines complete before transitioning.
+	var wg sync.WaitGroup
+	defer wg.Wait()
+	var transitioning = make(chan struct{})
+	defer close(transitioning)
+
+	// Retrieve leader's term.
+	l.mu.Lock()
+	term := l.term
+	l.mu.Unlock()
+
+	// Read log from leader in a separate goroutine.
 	for {
 		// Send hearbeat to followers.
-		if err := l.sendHeartbeat(done); err != nil {
-			close(confirm)
-			return
-		}
+		wg.Add(1)
+		committed := make(chan uint64, 1)
+		go l.heartbeater(term, committed, &wg, transitioning)
 
-		// Signal clock that the heartbeat has occurred.
-		close(confirm)
-		l.tracef("leaderLoop: ...")
-
+		// Wait for close, new leader, or new heartbeat response.
 		select {
-		case <-done: // wait for state change.
-			return
-		case confirm = <-l.Clock.AfterHeartbeatInterval(): // wait for next heartbeat
+		case <-closing: // wait for state change.
+			return Stopped
+
+		case hb := <-l.heartbeats: // step down on higher term
+			if hb.term > term {
+				return Follower
+			}
+			continue
+
+		case commitIndex, ok := <-committed:
+			// Quorum not reached, try again.
+			if !ok {
+				continue
+			}
+
+			// Quorum reached, set new commit index.
+			l.mu.Lock()
+			if commitIndex > l.commitIndex {
+				l.tracef("leaderLoop: committed: idx=%d", commitIndex)
+				l.commitIndex = commitIndex
+			}
+			l.mu.Unlock()
+			continue
 		}
-		l.tracef("leaderLoop: continue")
 	}
 }
 
-// sendHeartbeat sends heartbeats to all the nodes.
-func (l *Log) sendHeartbeat(done chan struct{}) error {
-	l.tracef("sendHeartbeat")
+// heartbeater continuoally sends heartbeats to all peers.
+func (l *Log) heartbeater(term uint64, committed chan uint64, wg *sync.WaitGroup, transitioning <-chan struct{}) {
+	defer wg.Done()
 
-	// Retrieve config and term.
+	// Ensure term is correct and retrieve current state.
 	l.mu.Lock()
-	commitIndex, localIndex := l.commitIndex, l.index
-	term, leaderID := l.term, l.id
-	config := l.config
+	if l.term != term {
+		l.mu.Unlock()
+		return
+	}
+	commitIndex, localIndex, leaderID, config := l.commitIndex, l.index, l.id, l.config
 	l.mu.Unlock()
 
-	// Ignore if there is no config or nodes yet.
+	// Commit latest index if there are no peers.
 	if config == nil || len(config.Nodes) <= 1 {
-		l.tracef("sendHeartbeat: no peers")
-		return nil
+		committed <- localIndex
+		return
 	}
+
+	l.tracef("heartbeater: start: n=%d", len(config.Nodes))
 
 	// Send heartbeats to all peers.
-	resps := l.sendHeartbeatRequests(config.Nodes, term, commitIndex, leaderID)
-
-	// Wait for heartbeat responses or timeout.
-	after := l.Clock.AfterHeartbeatInterval()
-	nodeN := len(config.Nodes)
-	indexes := make([]uint64, 1, nodeN)
-	indexes[0] = localIndex
-loop:
-	for {
-		select {
-		case <-done:
-			return errDone
-		case ch := <-after:
-			defer close(ch)
-			l.tracef("sendHeartbeat: timeout")
-			break loop
-		case resp := <-resps:
-			if resp.peerTerm > term {
-				l.tracef("sendHeartbeat: step down: peer=%d, term=%d", resp.peerTerm, term)
-				l.mu.Lock()
-				l.term = resp.peerTerm
-				l.setState(Follower)
-				l.mu.Unlock()
-				return nil
-			}
-
-			indexes = append(indexes, resp.peerIndex)
-			if len(indexes) == nodeN {
-				l.tracef("sendHeartbeat: received heartbeats")
-				break loop
-			}
-		}
-	}
-
-	// Ignore if we don't have enough for a quorum ((n / 2) + 1).
-	quorum := (nodeN / 2) + 1
-	if quorum > len(indexes) {
-		l.tracef("sendHeartbeat: no quorum: len=%d, n=%d", len(indexes), quorum)
-		return nil
-	}
-
-	// Determine commit index by quorum (n/2+1).
-	sort.Sort(sort.Reverse(uint64Slice(indexes)))
-	newCommitIndex := indexes[quorum-1]
-
-	// Update the commit index, if higher.
-	l.mu.Lock()
-	if err := check(done); err != nil {
-		l.mu.Unlock()
-		return err
-	}
-	if newCommitIndex > l.commitIndex {
-		l.tracef("sending heartbeat: commit index %d => %d", l.commitIndex, newCommitIndex)
-		l.commitIndex = newCommitIndex
-	}
-	l.mu.Unlock()
-	return nil
-}
-
-func (l *Log) sendHeartbeatRequests(nodes []*ConfigNode, term, commitIndex, leaderID uint64) <-chan heartbeatResponse {
-	ch := make(chan heartbeatResponse, len(nodes))
-	for _, n := range nodes {
+	peerIndices := make(chan uint64, len(config.Nodes))
+	for _, n := range config.Nodes {
 		if n.ID == leaderID {
 			continue
 		}
 		go func(n *ConfigNode) {
-			l.tracef("sendHeartbeatRequests: url=%s, term=%d, commit=%d, leaderID=%d", n.URL, term, commitIndex, leaderID)
-			peerIndex, peerTerm, err := l.Transport.Heartbeat(n.URL, term, commitIndex, leaderID)
-			l.tracef("sendHeartbeatRequest: response: url=%s, peerTerm=%d, peerIndex=%d, err=%s", n.URL, peerTerm, peerIndex, err)
+			//l.tracef("heartbeater: send: url=%s, term=%d, commit=%d, leaderID=%d", n.URL, term, commitIndex, leaderID)
+			peerIndex, err := l.Transport.Heartbeat(n.URL, term, commitIndex, leaderID)
+			//l.tracef("heartbeater: recv: url=%s, peerIndex=%d, err=%s", n.URL, peerIndex, err)
 			if err != nil {
-				l.Logger.Printf("heartbeat: error: %s", err)
+				l.Logger.Printf("heartbeater: error: %s", err)
 				return
 			}
-			ch <- heartbeatResponse{peerTerm: peerTerm, peerIndex: peerIndex}
+			peerIndices <- peerIndex
 		}(n)
 	}
-	return ch
+
+	// Wait for heartbeat responses or timeout.
+	after := l.Clock.AfterHeartbeatInterval()
+	indexes := make([]uint64, 1, len(config.Nodes))
+	indexes[0] = localIndex
+	for {
+		select {
+		case <-transitioning:
+			l.tracef("heartbeater: transitioning")
+			return
+		case peerIndex := <-peerIndices:
+			l.tracef("heartbeater: index: idx=%d, idxs=%+v", peerIndex, indexes)
+			indexes = append(indexes, peerIndex) // collect responses
+		case ch := <-after:
+			// Once we have enough indices then return the lowest index
+			// among the highest quorum of nodes.
+			quorumN := (len(config.Nodes) / 2) + 1
+			if len(indexes) >= quorumN {
+				// Return highest index reported by quorum.
+				sort.Sort(sort.Reverse(uint64Slice(indexes)))
+				committed <- indexes[quorumN-1]
+				l.tracef("heartbeater: commit: idx=%d, idxs=%+v", commitIndex, indexes)
+			} else {
+				l.tracef("heartbeater: no quorum: idxs=%+v", indexes)
+				close(committed)
+			}
+			close(ch)
+			return
+		}
+	}
 }
 
 type heartbeatResponse struct {
@@ -965,7 +1057,7 @@ func (l *Log) waitUncommitted(index uint64) error {
 	for {
 		l.mu.Lock()
 		uncommittedIndex := l.index
-		l.tracef("waitUncommitted: %s / %d", l.state, l.index)
+		//l.tracef("waitUncommitted: %s / %d", l.state, l.index)
 		l.mu.Unlock()
 
 		if uncommittedIndex >= index {
@@ -1008,13 +1100,14 @@ func (l *Log) append(e *LogEntry) {
 
 // applier runs in a separate goroutine and applies all entries between the
 // previously applied index and the current commit index.
-func (l *Log) applier(done chan chan struct{}) {
+func (l *Log) applier(closing <-chan struct{}) {
+	defer l.wg.Done()
+
 	for {
 		// Wait for a close signal or timeout.
 		var confirm chan struct{}
 		select {
-		case ch := <-done:
-			close(ch)
+		case <-closing:
 			return
 
 		case confirm = <-l.Clock.AfterApplyInterval():
@@ -1029,42 +1122,67 @@ func (l *Log) applier(done chan chan struct{}) {
 
 			// Verify, under lock, that we're not closing.
 			select {
-			case ch := <-done:
-				close(ch)
-				return errDone
+			case <-closing:
+				return nil
 			default:
 			}
 
 			// Ignore if there are no pending entries.
 			// Ignore if all entries are applied.
 			if len(l.entries) == 0 {
-				l.tracef("applier: no entries")
+				//l.tracef("applier: no entries")
 				return nil
 			} else if l.appliedIndex == l.commitIndex {
 				//l.tracef("applier: up to date")
 				return nil
 			}
 
-			// Calculate start index.
-			min := l.entries[0].Index
-			startIndex, endIndex := l.appliedIndex+1, l.commitIndex
-			if maxIndex := l.entries[len(l.entries)-1].Index; l.commitIndex > maxIndex {
-				l.tracef("applier: commit index above max: commit=%d, max=%d", l.commitIndex, maxIndex)
-				endIndex = maxIndex
+			// Determine the available range of indices on the log.
+			entmin, entmax := l.entries[0].Index, l.entries[len(l.entries)-1].Index
+			assert(entmin <= entmax, "apply: log out of order: min=%d, max=%d", entmin, entmax)
+			assert(uint64(len(l.entries)) == (entmax-entmin+1), "apply: missing entries: min=%d, max=%d, len=%d", entmin, entmax, len(l.entries))
+
+			// Determine the range of indices that should be processed.
+			// This should be the entry after the last applied index through to
+			// the committed index.
+			nextUnappliedIndex, commitIndex := l.appliedIndex+1, l.commitIndex
+			l.tracef("applier: entries: available=%d-%d, [next,commit]=%d-%d", entmin, entmax, nextUnappliedIndex, commitIndex)
+			assert(nextUnappliedIndex <= commitIndex, "next unapplied index after commit index: next=%d, commit=%d", nextUnappliedIndex, commitIndex)
+
+			l.tracef("applier.3")
+
+			// Determine the lowest index to start from.
+			// This should be the next entry after the last applied entry.
+			// Ignore if we don't have any entries after the last applied yet.
+			assert(entmin <= nextUnappliedIndex, "apply: missing entries: min=%d, next=%d", entmin, nextUnappliedIndex)
+			if nextUnappliedIndex > entmax {
+				return nil
+			}
+			imin := nextUnappliedIndex
+
+			l.tracef("applier.4")
+
+			// Determine the highest index to go to.
+			// This should be the committed index.
+			// If we haven't yet received the committed index then go to the last available.
+			var imax uint64
+			if commitIndex <= entmax {
+				imax = commitIndex
+			} else {
+				imax = entmax
 			}
 
 			// Determine entries to apply.
-			l.tracef("applier: entries: len=%d, min=%d, start=%d, end=%d <%d:%d>", len(l.entries), min, startIndex, endIndex, startIndex-min, endIndex-min+1)
-			entries := l.entries[startIndex-min : endIndex-min+1]
+			l.tracef("applier: entries: available=%d-%d, applying=%d-%d", entmin, entmax, imin, imax)
+			entries := l.entries[imin-entmin : imax-entmin+1]
 
 			// Determine low water mark for entries to cut off.
-			max := endIndex
 			for _, w := range l.writers {
-				if w.snapshotIndex > 0 && w.snapshotIndex < max {
-					max = w.snapshotIndex
+				if w.snapshotIndex > 0 && w.snapshotIndex < imax {
+					imax = w.snapshotIndex
 				}
 			}
-			l.entries = l.entries[max-min:]
+			l.entries = l.entries[imax-entmin:]
 
 			// Iterate over each entry and apply it.
 			for _, e := range entries {
@@ -1096,10 +1214,7 @@ func (l *Log) applier(done chan chan struct{}) {
 
 		// If error occurred then log it.
 		// The log will retry after a given timeout.
-		if err == errDone {
-			close(confirm)
-			return
-		} else if err != nil {
+		if err != nil {
 			l.Logger.Printf("apply error: %s", err)
 			// TODO(benbjohnson): Longer timeout before retry?
 		}
@@ -1170,20 +1285,20 @@ func (l *Log) mustApplyRemovePeer(e *LogEntry) error {
 
 // AddPeer creates a new peer in the cluster.
 // Returns the new peer's identifier and the current configuration.
-func (l *Log) AddPeer(u *url.URL) (uint64, *Config, error) {
+func (l *Log) AddPeer(u *url.URL) (uint64, uint64, *Config, error) {
 	// Validate URL.
 	if u == nil {
-		return 0, nil, fmt.Errorf("peer url required")
+		return 0, 0, nil, fmt.Errorf("peer url required")
 	}
 
 	// Apply command.
 	b, _ := json.Marshal(&ConfigNode{URL: u})
 	index, err := l.internalApply(LogEntryAddPeer, b)
 	if err != nil {
-		return 0, nil, err
+		return 0, 0, nil, err
 	}
 	if err := l.Wait(index); err != nil {
-		return 0, nil, err
+		return 0, 0, nil, err
 	}
 
 	// Lock while we look up the node.
@@ -1193,10 +1308,10 @@ func (l *Log) AddPeer(u *url.URL) (uint64, *Config, error) {
 	// Look up node.
 	n := l.config.NodeByURL(u)
 	if n == nil {
-		return 0, nil, fmt.Errorf("node not found")
+		return 0, 0, nil, fmt.Errorf("node not found")
 	}
 
-	return n.ID, l.config.Clone(), nil
+	return n.ID, l.leaderID, l.config.Clone(), nil
 }
 
 // RemovePeer removes an existing peer from the cluster by id.
@@ -1211,135 +1326,62 @@ func (l *Log) RemovePeer(id uint64) error {
 
 // Heartbeat establishes dominance by the current leader.
 // Returns the current term and highest written log entry index.
-func (l *Log) Heartbeat(term, commitIndex, leaderID uint64) (currentIndex, currentTerm uint64, err error) {
+func (l *Log) Heartbeat(term, commitIndex, leaderID uint64) (currentIndex uint64, err error) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
-
-	l.tracef("Heartbeat: term=%d, commit=%d, leaderID: %d", term, commitIndex, leaderID)
 
 	// Check if log is closed.
 	if !l.opened() || l.state == Stopped {
 		l.tracef("Heartbeat: closed")
-		return 0, 0, ErrClosed
+		return 0, ErrClosed
 	}
 
 	// Ignore if the incoming term is less than the log's term.
 	if term < l.term {
-		l.tracef("Heartbeat: stale term, ignore: %d < %d", term, l.term)
-		return l.index, l.term, nil
+		l.tracef("HB: stale term, ignore: %d < %d", term, l.term)
+		return l.index, ErrStaleTerm
 	}
 
-	// Step down if we see a higher term.
-	if term > l.term {
-		l.tracef("Heartbeat: higher term, stepping down")
-		l.term = term
-		l.setState(Follower)
+	// Send heartbeat to channel for the state loop to process.
+	select {
+	case l.heartbeats <- heartbeat{term: term, commitIndex: commitIndex, leaderID: leaderID}:
+	default:
 	}
 
-	l.commitIndex = commitIndex
-	l.leaderID = leaderID
-	l.lastContact = l.Clock.Now()
-
-	l.tracef("Heartbeat: return: index=%d, term=%d", l.index, l.term)
-	return l.index, l.term, nil
+	l.tracef("HB: (term=%d, commit=%d, leaderID: %d) (index=%d, term=%d)", term, commitIndex, leaderID, l.index, l.term)
+	return l.index, nil
 }
 
 // RequestVote requests a vote from the log.
-func (l *Log) RequestVote(term, candidateID, lastLogIndex, lastLogTerm uint64) (uint64, error) {
+func (l *Log) RequestVote(term, candidateID, lastLogIndex, lastLogTerm uint64) error {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
 	// Check if log is closed.
 	if !l.opened() {
-		return 0, ErrClosed
+		return ErrClosed
 	}
+
+	l.tracef("RV(term=%d, candidateID=%d, lastLogIndex=%d, lastLogTerm=%d) (err=%v)", term, candidateID, lastLogIndex, lastLogTerm)
 
 	// Deny vote if:
 	//   1. Candidate is requesting a vote from an earlier term. (§5.1)
 	//   2. Already voted for a different candidate in this term. (§5.2)
 	//   3. Candidate log is less up-to-date than local log. (§5.4)
 	if term < l.term {
-		return l.term, ErrStaleTerm
+		return ErrStaleTerm
 	} else if term == l.term && l.votedFor != 0 && l.votedFor != candidateID {
-		return l.term, ErrAlreadyVoted
+		return ErrAlreadyVoted
 	} else if lastLogTerm < l.term {
-		return l.term, ErrOutOfDateLog
+		return ErrOutOfDateLog
 	} else if lastLogTerm == l.term && lastLogIndex < l.index {
-		return l.term, ErrOutOfDateLog
+		return ErrOutOfDateLog
 	}
 
 	// Vote for candidate.
 	l.votedFor = candidateID
 
-	// TODO(benbjohnson): Update term.
-
-	return l.term, nil
-}
-
-// elector runs in a separate goroutine and checks for election timeouts.
-func (l *Log) elector(done chan chan struct{}) {
-	for {
-		// Wait for a close signal or election timeout.
-		var confirm chan struct{}
-		select {
-		case ch := <-done:
-			close(ch)
-			return
-		case confirm = <-l.Clock.AfterElectionTimeout(): // TODO(election): Randomize
-		}
-		l.tracef("elector")
-
-		// If log is a follower or candidate and an election timeout has passed
-		// since a contact from a heartbeat then start a new election.
-		err := func() error {
-			l.mu.Lock()
-			defer l.mu.Unlock()
-
-			// Verify, under lock, that we're not closing.
-			select {
-			case ch := <-done:
-				close(ch)
-				return errDone
-			default:
-			}
-
-			// Ignore if not a follower or a candidate.
-			// Ignore if the last contact was less than the election timeout.
-			if l.state != Follower && l.state != Candidate {
-				l.tracef("elector: log is not follower or candidate")
-				return nil
-			} else if l.lastContact.IsZero() {
-				l.tracef("elector: last contact is zero")
-				return nil
-			} else if l.Clock.Now().Sub(l.lastContact) < DefaultElectionTimeout { // TODO: Refactor into follower loop and candidate loop.
-				l.tracef("elector: last contact is less than election timeout")
-				return nil
-			}
-
-			l.tracef("elector: beginning election in term %d", l.term+1)
-
-			// Otherwise start a new election and promote.
-			term := l.term + 1
-			if err := l.writeTerm(term); err != nil {
-				return fmt.Errorf("write term: %s", err)
-			}
-			l.term = term
-			l.setState(Candidate)
-
-			return nil
-		}()
-
-		// Check if we exited because we're closing.
-		if err == errDone {
-			close(confirm)
-			return
-		} else if err != nil {
-			panic("unreachable")
-		}
-
-		// Signal clock that elector is done.
-		close(confirm)
-	}
+	return nil
 }
 
 // WriteEntriesTo attaches a writer to the log from a given index.
@@ -1404,17 +1446,14 @@ func (l *Log) initWriter(w io.Writer, id, term, index uint64) (*logWriter, error
 		return nil, ErrClosed
 	}
 
-	// Step down if from a higher term.
-	if term > l.term {
-		l.setState(Follower)
-	}
-
 	// Do not begin streaming if:
 	//   1. Node is not the leader.
 	//   2. Term is earlier than current term.
 	//   3. Index is after the commit index.
 	if l.state != Leader {
 		return nil, ErrNotLeader
+	} else if term > l.term {
+		return nil, ErrStaleTerm
 	} else if index > l.index {
 		return nil, ErrUncommittedIndex
 	}
@@ -1564,13 +1603,13 @@ func (l *Log) ReadFrom(r io.ReadCloser) error {
 			}
 			l.tracef("ReadFrom: snapshot: index=%d", index)
 
-			// Update the indicies.
+			// Update the indicies & clear the entries.
+			l.mu.Lock()
 			l.index = index
 			l.commitIndex = index
 			l.appliedIndex = index
-
-			// Clear entries.
 			l.entries = nil
+			l.mu.Unlock()
 
 			continue
 		}
@@ -1605,6 +1644,13 @@ func (l *Log) initReadFrom(r io.ReadCloser) error {
 	// Set new reader.
 	l.reader = r
 	return nil
+}
+
+// heartbeat represents an incoming heartbeat.
+type heartbeat struct {
+	term        uint64
+	commitIndex uint64
+	leaderID    uint64
 }
 
 // logWriter wraps writers to provide a channel for close notification.

--- a/raft/log_test.go
+++ b/raft/log_test.go
@@ -327,6 +327,7 @@ func benchmarkClusterApply(b *testing.B, logN int) {
 	warnf("== BenchmarkClusterApply (%d) ====================================", b.N)
 
 	c := NewRealTimeCluster(logN, indexFSMFunc)
+	defer c.Close()
 	b.ResetTimer()
 
 	// Apply commands to leader.

--- a/raft/log_test.go
+++ b/raft/log_test.go
@@ -7,11 +7,12 @@ import (
 	"io"
 	"io/ioutil"
 	"log"
+	"math/rand"
 	"net/url"
 	"os"
-	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/influxdb/influxdb/raft"
 )
@@ -79,7 +80,7 @@ func TestLog_Apply(t *testing.T) {
 
 	// Single node clusters should apply to FSM immediately.
 	l.Wait(index)
-	if n := len(l.FSM.Commands); n != 1 {
+	if n := len(l.FSM.(*FSM).Commands); n != 1 {
 		t.Fatalf("unexpected command count: %d", n)
 	}
 }
@@ -96,7 +97,7 @@ func TestLog_Config_Closed(t *testing.T) {
 
 // Ensure that log ids in a cluster are set sequentially.
 func TestCluster_ID_Sequential(t *testing.T) {
-	c := NewCluster()
+	c := NewCluster(fsmFunc)
 	defer c.Close()
 	for i, l := range c.Logs {
 		if l.ID() != uint64(i+1) {
@@ -107,7 +108,7 @@ func TestCluster_ID_Sequential(t *testing.T) {
 
 // Ensure that cluster starts with one leader and multiple followers.
 func TestCluster_State(t *testing.T) {
-	c := NewCluster()
+	c := NewCluster(fsmFunc)
 	defer c.Close()
 	if state := c.Logs[0].State(); state != raft.Leader {
 		t.Fatalf("unexpected state(0): %s", state)
@@ -122,7 +123,7 @@ func TestCluster_State(t *testing.T) {
 
 // Ensure that each node's configuration matches in the cluster.
 func TestCluster_Config(t *testing.T) {
-	c := NewCluster()
+	c := NewCluster(fsmFunc)
 	defer c.Close()
 	config := jsonify(c.Logs[0].Config())
 	for _, l := range c.Logs[1:] {
@@ -134,7 +135,7 @@ func TestCluster_Config(t *testing.T) {
 
 // Ensure that a command can be applied to a cluster and distributed appropriately.
 func TestCluster_Apply(t *testing.T) {
-	c := NewCluster()
+	c := NewCluster(fsmFunc)
 	defer c.Close()
 
 	// Apply a command.
@@ -149,41 +150,30 @@ func TestCluster_Apply(t *testing.T) {
 	c.Logs[2].MustWaitUncommitted(4)
 
 	// Should not apply immediately.
-	if n := len(leader.FSM.Commands); n != 0 {
+	if n := len(leader.FSM.(*FSM).Commands); n != 0 {
 		t.Fatalf("unexpected pre-heartbeat command count: %d", n)
 	}
 
 	// Run the heartbeat on the leader and have all logs apply.
 	// Only the leader should have the changes applied.
-	c.Logs[0].Clock.heartbeat()
+	c.Logs[0].HeartbeatUntil(4)
 	c.Logs[0].Clock.apply()
 	c.Logs[1].Clock.apply()
 	c.Logs[2].Clock.apply()
-	if n := len(c.Logs[0].FSM.Commands); n != 1 {
+	if n := len(c.Logs[0].FSM.(*FSM).Commands); n != 1 {
 		t.Fatalf("unexpected command count(0): %d", n)
 	}
-	if n := len(c.Logs[1].FSM.Commands); n != 0 {
+	if n := len(c.Logs[1].FSM.(*FSM).Commands); n != 1 {
 		t.Fatalf("unexpected command count(1): %d", n)
 	}
-	if n := len(c.Logs[2].FSM.Commands); n != 0 {
-		t.Fatalf("unexpected command count(2): %d", n)
-	}
-
-	// Wait for another heartbeat and all logs should be in sync.
-	c.Logs[0].Clock.heartbeat()
-	c.Logs[1].Clock.apply()
-	c.Logs[2].Clock.apply()
-	if n := len(c.Logs[1].FSM.Commands); n != 1 {
-		t.Fatalf("unexpected command count(1): %d", n)
-	}
-	if n := len(c.Logs[2].FSM.Commands); n != 1 {
+	if n := len(c.Logs[2].FSM.(*FSM).Commands); n != 1 {
 		t.Fatalf("unexpected command count(2): %d", n)
 	}
 }
 
 // Ensure that a new leader can be elected.
 func TestLog_Elect(t *testing.T) {
-	c := NewCluster()
+	c := NewCluster(fsmFunc)
 	defer c.Close()
 
 	// Stop leader.
@@ -222,7 +212,7 @@ func TestLog_Elect(t *testing.T) {
 	}
 
 	c.MustWaitUncommitted(index)
-	c.Logs[1].Clock.heartbeat()
+	c.Logs[1].HeartbeatUntil(index)
 	c.Logs[1].Clock.heartbeat()
 	c.Logs[0].Clock.apply()
 	c.Logs[1].Clock.apply()
@@ -251,94 +241,140 @@ func TestState_String(t *testing.T) {
 	}
 }
 
-func BenchmarkLogApply1(b *testing.B) { benchmarkLogApply(b, 1) }
-func BenchmarkLogApply2(b *testing.B) { benchmarkLogApply(b, 2) }
-func BenchmarkLogApply3(b *testing.B) { benchmarkLogApply(b, 3) }
+// Ensure a cluster of nodes can successfully re-elect while applying commands.
+func TestCluster_Elect_RealTime(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip: short mode")
+	}
+
+	// Create a cluster with a real-time clock.
+	c := NewRealTimeCluster(3, indexFSMFunc)
+	minIndex := c.Logs[0].AppliedIndex()
+	commandN := uint64(1000) - minIndex
+
+	// Run a loop to continually apply commands.
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		leader := c.Logs[0]
+		for i := uint64(0); i < commandN; i++ {
+			for {
+				// Apply entry to leader.
+				// If not leader, find new leader.
+				index, err := leader.Apply(make([]byte, 50))
+				if err == raft.ErrNotLeader {
+					for _, l := range c.Logs {
+						if l.State() == raft.Leader {
+							leader = l
+							break
+						}
+					}
+					continue
+				} else if err != nil {
+					t.Fatalf("apply: index=%d, err=%s", index, err)
+				} else {
+					break
+				}
+			}
+			time.Sleep(time.Duration(rand.Intn(10)) * time.Millisecond)
+		}
+	}()
+
+	// Run a loop to periodically kill off nodes.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		// Wait for nodes to get going.
+		time.Sleep(500 * time.Millisecond)
+
+		// Choose random log.
+		// i := rand.Intn(len(c.Logs))
+		i := 0
+		l := c.Logs[i]
+
+		// Restart the log.
+		path := l.Path()
+		l.Log.Close()
+		if err := l.Log.Open(path); err != nil {
+			t.Fatalf("reopen(%d): %s", i, err)
+		}
+	}()
+
+	// Wait for all logs to catch up.
+	wg.Wait()
+	for i, l := range c.Logs {
+		if err := l.Wait(commandN + minIndex); err != nil {
+			t.Errorf("wait(%d): %s", i, err)
+		}
+	}
+
+	// Verify FSM indicies match.
+	for i, l := range c.Logs {
+		if exp, fsm := commandN+minIndex, l.FSM.(*IndexFSM); exp != fsm.index {
+			t.Errorf("fsm index mismatch(%d): exp=%d, got=%d", i, exp, fsm.index)
+		}
+	}
+}
+
+func BenchmarkClusterApply1(b *testing.B) { benchmarkClusterApply(b, 1) }
+func BenchmarkClusterApply2(b *testing.B) { benchmarkClusterApply(b, 2) }
+func BenchmarkClusterApply3(b *testing.B) { benchmarkClusterApply(b, 3) }
 
 // Benchmarks an n-node cluster connected through an in-memory transport.
-func benchmarkLogApply(b *testing.B, logN int) {
-	warnf("== BenchmarkLogApply (%d) ====================================", b.N)
+func benchmarkClusterApply(b *testing.B, logN int) {
+	warnf("== BenchmarkClusterApply (%d) ====================================", b.N)
 
-	logs := make([]*raft.Log, logN)
-	t := NewTransport()
-	var ptrs []string
-	for i := 0; i < logN; i++ {
-		// Create log.
-		l := raft.NewLog()
-		l.URL = &url.URL{Host: fmt.Sprintf("log%d", i)}
-		l.FSM = &BenchmarkFSM{}
-		l.DebugEnabled = true
-		l.Transport = t
-		t.register(l)
-
-		// Open log.
-		if err := l.Open(tempfile()); err != nil {
-			b.Fatalf("open: %s", err)
-		}
-
-		// Initialize or join.
-		if i == 0 {
-			if err := l.Initialize(); err != nil {
-				b.Fatalf("initialize: %s", err)
-			}
-		} else {
-			if err := l.Join(logs[0].URL); err != nil {
-				b.Fatalf("initialize: %s", err)
-			}
-		}
-
-		ptrs = append(ptrs, fmt.Sprintf("%d/%p", i, l))
-		logs[i] = l
-	}
-	warn("LOGS:", strings.Join(ptrs, " "))
+	c := NewRealTimeCluster(logN, indexFSMFunc)
 	b.ResetTimer()
 
 	// Apply commands to leader.
 	var index uint64
 	var err error
 	for i := 0; i < b.N; i++ {
-		index, err = logs[0].Apply(make([]byte, 50))
+		index, err = c.Logs[0].Apply(make([]byte, 50))
 		if err != nil {
 			b.Fatalf("apply: %s", err)
 		}
 	}
 
 	// Wait for all logs to catch up.
-	for i, l := range logs {
-		if err := l.Wait(index); err != nil {
-			b.Fatalf("wait(%d): %s", i, err)
-		}
+	for _, l := range c.Logs {
+		l.MustWait(index)
 	}
 	b.StopTimer()
 
 	// Verify FSM indicies match.
-	for i, l := range logs {
-		if fsm := l.FSM.(*BenchmarkFSM); index != fsm.index {
+	for i, l := range c.Logs {
+		if fsm := l.FSM.(*IndexFSM); index != fsm.index {
 			b.Errorf("fsm index mismatch(%d): exp=%d, got=%d", i, index, fsm.index)
 		}
 	}
 }
 
-// BenchmarkFSM represents a state machine that records the command count.
-type BenchmarkFSM struct {
+// IndexFSM represents a state machine that only records the last applied index.
+type IndexFSM struct {
 	index uint64
 }
 
 // MustApply updates the index.
-func (fsm *BenchmarkFSM) MustApply(entry *raft.LogEntry) { fsm.index = entry.Index }
+func (fsm *IndexFSM) MustApply(entry *raft.LogEntry) { fsm.index = entry.Index }
 
 // Index returns the highest applied index.
-func (fsm *BenchmarkFSM) Index() (uint64, error) { return fsm.index, nil }
+func (fsm *IndexFSM) Index() (uint64, error) { return fsm.index, nil }
 
 // Snapshot writes the FSM's index as the snapshot.
-func (fsm *BenchmarkFSM) Snapshot(w io.Writer) (uint64, error) {
+func (fsm *IndexFSM) Snapshot(w io.Writer) (uint64, error) {
 	return fsm.index, binary.Write(w, binary.BigEndian, fsm.index)
 }
 
 // Restore reads the snapshot from the reader.
-func (fsm *BenchmarkFSM) Restore(r io.Reader) error {
+func (fsm *IndexFSM) Restore(r io.Reader) error {
 	return binary.Read(r, binary.BigEndian, &fsm.index)
 }
+
+func indexFSMFunc() raft.FSM { return &IndexFSM{} }
 
 // Cluster represents a collection of nodes that share the same mock clock.
 type Cluster struct {
@@ -346,13 +382,14 @@ type Cluster struct {
 }
 
 // NewCluster creates a new 3 log cluster.
-func NewCluster() *Cluster {
+func NewCluster(fsmFn func() raft.FSM) *Cluster {
 	c := &Cluster{}
 	t := NewTransport()
 
 	logN := 3
 	for i := 0; i < logN; i++ {
 		l := NewLog(&url.URL{Host: fmt.Sprintf("log%d", i)})
+		l.Log.FSM = fsmFn()
 		l.Transport = t
 		c.Logs = append(c.Logs, l)
 		t.register(l.Log)
@@ -383,7 +420,7 @@ func NewCluster() *Cluster {
 	go func() {
 		c.Logs[0].MustWaitUncommitted(3)
 		c.Logs[1].MustWaitUncommitted(3)
-		c.Logs[0].Clock.heartbeat()
+		c.Logs[0].HeartbeatUntil(3)
 		c.Logs[0].Clock.apply()
 		c.Logs[1].Clock.apply()
 		c.Logs[2].Clock.apply()
@@ -396,6 +433,43 @@ func NewCluster() *Cluster {
 	c.Logs[0].Clock.heartbeat()
 	c.Logs[1].Clock.apply()
 	c.Logs[2].Clock.apply()
+
+	return c
+}
+
+// NewRealTimeCluster a new cluster with n logs.
+// All logs use a real-time clock instead of a test clock.
+func NewRealTimeCluster(logN int, fsmFn func() raft.FSM) *Cluster {
+	c := &Cluster{}
+	t := NewTransport()
+
+	for i := 0; i < logN; i++ {
+		l := NewLog(&url.URL{Host: fmt.Sprintf("log%d", i)})
+		l.Log.FSM = fsmFn()
+		l.Clock = nil
+		l.Log.Clock = raft.NewClock()
+		l.Transport = t
+		c.Logs = append(c.Logs, l)
+		t.register(l.Log)
+		warnf("Log %s: %p", l.URL.String(), l.Log)
+	}
+	warn("")
+
+	// Initialize leader.
+	c.Logs[0].MustOpen()
+	c.Logs[0].MustInitialize()
+
+	// Join remaining nodes.
+	for i := 1; i < logN; i++ {
+		c.Logs[i].MustOpen()
+		c.Logs[i].MustJoin(c.Logs[0].URL)
+	}
+
+	// Ensure nodes are ready.
+	index := c.Logs[0].Index()
+	for i := 0; i < logN; i++ {
+		c.Logs[i].MustWait(index)
+	}
 
 	return c
 }
@@ -418,7 +492,7 @@ func (c *Cluster) Leader() *Log {
 	return leader
 }
 
-// WaitUncommitted waits until all logs in the cluster have reached a given uncomiitted index.
+// WaitCommitted waits until all logs in the cluster have reached a given uncommitted index.
 func (c *Cluster) MustWaitUncommitted(index uint64) {
 	for _, l := range c.Logs {
 		l.MustWaitUncommitted(index)
@@ -437,14 +511,12 @@ func (c *Cluster) flush() {
 type Log struct {
 	*raft.Log
 	Clock *Clock
-	FSM   *FSM
 }
 
 // NewLog returns a new instance of Log.
 func NewLog(u *url.URL) *Log {
-	l := &Log{Log: raft.NewLog(), Clock: NewClock(), FSM: &FSM{}}
+	l := &Log{Log: raft.NewLog(), Clock: NewClock()}
 	l.URL = u
-	l.Log.FSM = l.FSM
 	l.Log.Clock = l.Clock
 	l.Rand = seq()
 	l.DebugEnabled = true
@@ -457,6 +529,7 @@ func NewLog(u *url.URL) *Log {
 // NewInitializedLog returns a new initialized Node.
 func NewInitializedLog(u *url.URL) *Log {
 	l := NewLog(u)
+	l.Log.FSM = &FSM{}
 	l.MustOpen()
 	l.MustInitialize()
 	return l
@@ -473,10 +546,19 @@ func (l *Log) MustOpen() {
 func (l *Log) MustInitialize() {
 	go func() {
 		l.MustWaitUncommitted(1)
-		l.Clock.apply()
+		if l.Clock != nil {
+			l.Clock.apply()
+		}
 	}()
 	if err := l.Initialize(); err != nil {
 		panic("initialize: " + err.Error())
+	}
+}
+
+// MustJoin joins the log to another log. Panic on error.
+func (l *Log) MustJoin(u *url.URL) {
+	if err := l.Join(u); err != nil {
+		panic("join: " + err.Error())
 	}
 }
 
@@ -487,10 +569,35 @@ func (l *Log) Close() error {
 	return nil
 }
 
+// MustWaits waits for at least a given applied index. Panic on error.
+func (l *Log) MustWait(index uint64) {
+	if err := l.Log.Wait(index); err != nil {
+		panic(l.URL.String() + " wait: " + err.Error())
+	}
+}
+
+// MustCommitted waits for at least a given committed index. Panic on error.
+func (l *Log) MustWaitCommitted(index uint64) {
+	if err := l.Log.WaitCommitted(index); err != nil {
+		panic(l.URL.String() + " wait committed: " + err.Error())
+	}
+}
+
 // MustWaitUncommitted waits for at least a given uncommitted index. Panic on error.
 func (l *Log) MustWaitUncommitted(index uint64) {
 	if err := l.Log.WaitUncommitted(index); err != nil {
 		panic(l.URL.String() + " wait uncommitted: " + err.Error())
+	}
+}
+
+// HeartbeatUtil continues to heartbeat until an index is committed.
+func (l *Log) HeartbeatUntil(index uint64) {
+	for {
+		time.Sleep(1 * time.Millisecond)
+		l.Clock.heartbeat()
+		if l.CommitIndex() >= index {
+			return
+		}
 	}
 }
 
@@ -535,18 +642,7 @@ func (fsm *FSM) Restore(r io.Reader) error {
 	return nil
 }
 
-// MockFSM represents a state machine that can be mocked out.
-type MockFSM struct {
-	ApplyFunc    func(*raft.LogEntry) error
-	IndexFunc    func() (uint64, error)
-	SnapshotFunc func(w io.Writer) (index uint64, err error)
-	RestoreFunc  func(r io.Reader) error
-}
-
-func (fsm *MockFSM) Apply(e *raft.LogEntry) error         { return fsm.ApplyFunc(e) }
-func (fsm *MockFSM) Index() (uint64, error)               { return fsm.IndexFunc() }
-func (fsm *MockFSM) Snapshot(w io.Writer) (uint64, error) { return fsm.SnapshotFunc(w) }
-func (fsm *MockFSM) Restore(r io.Reader) error            { return fsm.RestoreFunc(r) }
+func fsmFunc() raft.FSM { return &FSM{} }
 
 // seq implements the raft.Log#Rand interface and returns incrementing ints.
 func seq() func() int64 {
@@ -587,3 +683,13 @@ func warnf(msg string, v ...interface{}) {
 		fmt.Fprintf(os.Stderr, msg+"\n", v...)
 	}
 }
+
+// u64tob converts a uint64 into an 8-byte slice.
+func u64tob(v uint64) []byte {
+	b := make([]byte, 8)
+	binary.BigEndian.PutUint64(b, v)
+	return b
+}
+
+// btou64 converts an 8-byte slice into an uint64.
+func btou64(b []byte) uint64 { return binary.BigEndian.Uint64(b) }


### PR DESCRIPTION
## Overview

This commit changes the state handling of the raft log. The actions for related to each raft state are strictly confined within that state's loop. To transition between states, the raft log now much clean up all its actions before moving on.

This fixes issues where goroutines were kicked off for one state but were delayed in their scheduling so they would begin after the log had already changed to another state.