### PR TITLE
Small fix for init.sh

### DIFF
--- a/etc/init.sh
+++ b/etc/init.sh
@@ -87,12 +87,12 @@ name=influxdb
 # Daemon name, where is the actual executable
 daemon=/usr/bin/$name
 
-if [ -z $pidfile ]; then
+if [ -z "$pidfile" ]; then
     # pid file for the daemon
     pidfile=/opt/$name/shared/influxdb.pid
 fi
 
-if [ -z $config ]; then
+if [ -z "$config" ]; then
     # Configuration file
     config=/opt/$name/shared/config.toml
 fi

--- a/etc/init.sh
+++ b/etc/init.sh
@@ -87,11 +87,15 @@ name=influxdb
 # Daemon name, where is the actual executable
 daemon=/usr/bin/$name
 
-# pid file for the daemon
-pidfile=/opt/influxdb/shared/influxdb.pid
+if [ -z $pidfile ]; then
+    # pid file for the daemon
+    pidfile=/opt/$name/shared/influxdb.pid
+fi
 
-# Configuration file
-config=/opt/$name/shared/config.toml
+if [ -z $config ]; then
+    # Configuration file
+    config=/opt/$name/shared/config.toml
+fi
 
 # If the daemon is not there, then exit.
 [ -x $daemon ] || exit 5


### PR DESCRIPTION
Want to be able to have influxdb's config and pidfile in another directory then /opt/influxdb/shared but $pidfile and $config gets overwritten even if /etc/default/influxdb contains those variables so here's a proposed fix and also changed so the default $pidfile-directory uses $name in its path as $config does for readability.

First pull-request here so be gentle. :D