### PR TITLE
json.Unmarshal errors not catch in method client.Write

### DIFF
--- a/client/influxdb.go
+++ b/client/influxdb.go
@@ -96,6 +96,9 @@ func (c *Client) Write(writes ...Write) (*Results, error) {
 
 	b := []byte{}
 	err := json.Unmarshal(b, &d)
+	if err != nil {
+		return nil, err
+	}
 
 	req, err := http.NewRequest("POST", c.url.String(), bytes.NewBuffer(b))
 	if err != nil {


### PR DESCRIPTION
... and so the result method.Unmarshal error 'json: cannot unmarshal number into Go value of type struct { Results []client.Result "json:\"results,omitempty\""; Err string "json:\"error,omitempty\"" }'