### PR TITLE
Add small delay for single node heartbeat.

### DIFF
--- a/raft/log.go
+++ b/raft/log.go
@@ -922,6 +922,7 @@ func (l *Log) heartbeater(term uint64, committed chan uint64, wg *sync.WaitGroup
 
 	// Commit latest index if there are no peers.
 	if config == nil || len(config.Nodes) <= 1 {
+		time.Sleep(10 * time.Millisecond)
 		committed <- localIndex
 		return
 	}


### PR DESCRIPTION
## Overview

This commit adds a small 10ms delay to the heartbeat when there is only one node in the cluster. This code needs a larger fix to avoid heartbeats with a single node cluster but this should work well in the short term.