### PR TITLE
Add more test coverage in the parser for continuous queries`

### DIFF
--- a/influxql/parser_test.go
+++ b/influxql/parser_test.go
@@ -400,6 +400,39 @@ func TestParser_ParseStatement(t *testing.T) {
 			},
 		},
 
+		// CREATE CONTINUOUS QUERY for non-aggregate SELECT stmts
+		{
+			s: `CREATE CONTINUOUS QUERY myquery ON testdb BEGIN SELECT value INTO "policy1"."value" FROM myseries END`,
+			stmt: &influxql.CreateContinuousQueryStatement{
+				Name:     "myquery",
+				Database: "testdb",
+				Source: &influxql.SelectStatement{
+					Fields: []*influxql.Field{{Expr: &influxql.Call{Name: "value"}}},
+					Target: &influxql.Target{
+						Measurement: `"policy1"."value"`,
+					},
+					Source: &influxql.Measurement{Name: "myseries"},
+				},
+			},
+		},
+
+		// CREATE CONTINUOUS QUERY for non-aggregate SELECT stmts with multiple values
+		{
+			s: `CREATE CONTINUOUS QUERY myquery ON testdb BEGIN SELECT transmit_rx, transmit_tx INTO "policy1"."network" FROM myseries END`,
+			stmt: &influxql.CreateContinuousQueryStatement{
+				Name:     "myquery",
+				Database: "testdb",
+				Source: &influxql.SelectStatement{
+					Fields: []*influxql.Field{{Expr: &influxql.Call{Name: "transmit_rx"}},
+						{Expr: &influxql.Call{Name: "transmit_tx"}}},
+					Target: &influxql.Target{
+						Measurement: `"policy1"."network"`,
+					},
+					Source: &influxql.Measurement{Name: "myseries"},
+				},
+			},
+		},
+
 		// CREATE DATABASE statement
 		{
 			s: `CREATE DATABASE testdb`,
@@ -644,6 +677,8 @@ func TestParser_ParseStatement(t *testing.T) {
 		{s: `SHOW FOO`, err: `found FOO, expected CONTINUOUS, DATABASES, FIELD, MEASUREMENTS, RETENTION, SERIES, TAG, USERS at line 1, char 6`},
 		{s: `DROP CONTINUOUS`, err: `found EOF, expected QUERY at line 1, char 17`},
 		{s: `DROP CONTINUOUS QUERY`, err: `found EOF, expected identifier at line 1, char 23`},
+		{s: `CREATE CONTINUOUS`, err: `found EOF, expected QUERY at line 1, char 19`},
+		{s: `CREATE CONTINUOUS QUERY`, err: `found EOF, expected identifier at line 1, char 25`},
 		{s: `DROP FOO`, err: `found FOO, expected SERIES, CONTINUOUS, MEASUREMENT at line 1, char 6`},
 		{s: `DROP DATABASE`, err: `found EOF, expected identifier at line 1, char 15`},
 		{s: `DROP RETENTION`, err: `found EOF, expected POLICY at line 1, char 16`},
@@ -684,21 +719,19 @@ func TestParser_ParseStatement(t *testing.T) {
 		{s: `ALTER`, err: `found EOF, expected RETENTION at line 1, char 7`},
 		{s: `ALTER RETENTION`, err: `found EOF, expected POLICY at line 1, char 17`},
 		{s: `ALTER RETENTION POLICY`, err: `found EOF, expected identifier at line 1, char 24`},
-		{s: `ALTER RETENTION POLICY policy1`, err: `found EOF, expected ON at line 1, char 32`},
-		{s: `ALTER RETENTION POLICY policy1 ON`, err: `found EOF, expected identifier at line 1, char 35`},
+		{s: `ALTER RETENTION POLICY policy1`, err: `found EOF, expected ON at line 1, char 32`}, {s: `ALTER RETENTION POLICY policy1 ON`, err: `found EOF, expected identifier at line 1, char 35`},
 		{s: `ALTER RETENTION POLICY policy1 ON testdb`, err: `found EOF, expected DURATION, RETENTION, DEFAULT at line 1, char 42`},
 	}
 
 	for i, tt := range tests {
 		stmt, err := influxql.NewParser(strings.NewReader(tt.s)).ParseStatement()
 
-		// if it's a CQ, there is a non-exported field that gets memoized during parsing that needs to be set
-		if _, ok := stmt.(*influxql.CreateContinuousQueryStatement); ok {
-			tt.stmt.(*influxql.CreateContinuousQueryStatement).Source.GroupByInterval()
-		}
-
 		if !reflect.DeepEqual(tt.err, errstring(err)) {
 			t.Errorf("%d. %q: error mismatch:\n  exp=%s\n  got=%s\n\n", i, tt.s, tt.err, err)
+		} else if st, ok := stmt.(*influxql.CreateContinuousQueryStatement); ok { // if it's a CQ, there is a non-exported field that gets memoized during parsing that needs to be set
+			if st != nil && st.Source != nil {
+				tt.stmt.(*influxql.CreateContinuousQueryStatement).Source.GroupByInterval()
+			}
 		} else if tt.err == "" && !reflect.DeepEqual(tt.stmt, stmt) {
 			t.Errorf("%d. %q\n\nstmt mismatch:\n\nexp=%#v\n\ngot=%#v\n\n", i, tt.s, tt.stmt, stmt)
 		}


### PR DESCRIPTION
This was a pairing session with @ralfonso.

We added tests for incomplete statements.

We added tests to validate we an parse multiple fields

We added tests to validate an aggregate condition is not required.