### PR TITLE
1729 SHOW TAG VALUES should support keys wrapped in double quotes

### DIFF
--- a/influxql/parser.go
+++ b/influxql/parser.go
@@ -372,6 +372,17 @@ func (p *Parser) parseIdent() (string, error) {
 	return lit, nil
 }
 
+// parseIdentNoQuote parses an identifier and strips outermost double-quotes if present.
+func (p *Parser) parseIdentNoQuote() (string, error) {
+	tok, pos, lit := p.scanIgnoreWhitespace()
+	if tok != IDENT {
+		return "", newParseError(tokstr(tok, lit), []string{"identifier"}, pos)
+	}
+	lit = strings.TrimSuffix(lit, `"`)
+	lit = strings.TrimPrefix(lit, `"`)
+	return lit, nil
+}
+
 // parseIdentList parses a comma delimited list of identifiers.
 func (p *Parser) parseIdentList() ([]string, error) {
 	// Parse first (required) identifier.
@@ -822,7 +833,7 @@ func (p *Parser) parseTagKeys() ([]string, error) {
 		}
 	} else if tok == EQ {
 		// Parse required tag key.
-		ident, err := p.parseIdent()
+		ident, err := p.parseIdentNoQuote()
 		if err != nil {
 			return nil, err
 		}

--- a/influxql/scanner.go
+++ b/influxql/scanner.go
@@ -140,7 +140,9 @@ func (s *Scanner) scanIdent() (tok Token, pos Pos, lit string) {
 			if tok0, pos0, lit0 := s.scanString(); tok0 == BADSTRING || tok0 == BADESCAPE {
 				return tok0, pos0, lit0
 			} else {
+				_ = buf.WriteByte('"')
 				_, _ = buf.WriteString(lit0)
+				_ = buf.WriteByte('"')
 			}
 		} else if isIdentChar(ch) {
 			s.r.unread()


### PR DESCRIPTION
I couldn't think of a better way to do it. I'll also need to make a parseIdentListNoQuote if what I've done below seems reasonable.

@dgnorton, @pauldix, @benbjohnson I'd welcome your insight on this if y'all have any time.

Not to be discordant, but I think it's a little odd that we support unquoted strings on the RHS of the 'equals' operator in the first place.

Also, The code change in scanner.go isn't germane; I just couldn't see how that was working correctly.