### PR TITLE
Don't send broker-only messages to Replicas

### DIFF
--- a/cmd/influxd/server_integration_test.go
+++ b/cmd/influxd/server_integration_test.go
@@ -494,7 +494,6 @@ func Test_Server3NodeIntegration(t *testing.T) {
 }
 
 func Test_Server5NodeIntegration(t *testing.T) {
-	t.Skip()
 	if testing.Short() {
 		t.Skip()
 	}
@@ -572,7 +571,6 @@ func Test_Server3NodeLargeBatchIntegration(t *testing.T) {
 }
 
 func Test_Server5NodeLargeBatchIntegration(t *testing.T) {
-	t.Skip()
 	if testing.Short() {
 		t.Skip()
 	}
@@ -588,7 +586,6 @@ func Test_Server5NodeLargeBatchIntegration(t *testing.T) {
 }
 
 func Test_ServerMultiLargeBatchIntegration(t *testing.T) {
-	t.Skip()
 	if testing.Short() {
 		t.Skip()
 	}

--- a/server.go
+++ b/server.go
@@ -2672,6 +2672,8 @@ func (s *Server) processor(client MessagingClient, done chan struct{}) {
 				err = s.applyCreateContinuousQueryCommand(m)
 			case dropSeriesMessageType:
 				err = s.applyDropSeries(m)
+			default:
+				panic(fmt.Sprintf("unknown message type: %v", m.Type))
 			}
 
 			// Sync high water mark and errors.


### PR DESCRIPTION
Because these messages were being sent to replicas (data nodes) data
nodes were sometimes receiving messages out-of-order from the broker,
where order is defined strictly by the Raft log index. This causes our
tests to fail, because the new "wait" endpoint on broker assumes this
can never happen. When told to wait for, say, index 23, but sees it is
at 25, it responds with 200. But the message with ID 23 has yet to
arrive.

This change also means that if unknown messages are seen by data nodes,
they will instead panic, which should flag this issue much sooner.

Fixes issue #1556