### PR TITLE
Support keys wrapped in dbl quotes

### DIFF
--- a/database.go
+++ b/database.go
@@ -1404,7 +1404,6 @@ func (m *Measurement) tagValuesByKeyAndSeriesID(tagKeys []string, ids seriesIDs)
 	// If no tag keys were passed, get all tag keys for the measurement.
 	if len(tagKeys) == 0 {
 		for k := range m.seriesByTagKeyValue {
-			k = strings.Trim(k, `"`)
 			tagKeys = append(tagKeys, k)
 		}
 	}
@@ -1422,6 +1421,7 @@ func (m *Measurement) tagValuesByKeyAndSeriesID(tagKeys []string, ids seriesIDs)
 		// Iterate the tag keys we're interested in and collect values
 		// from this series, if they exist.
 		for _, tagKey := range tagKeys {
+			tagKey = strings.Trim(tagKey, `"`)
 			if tagVal, ok := s.Tags[tagKey]; ok {
 				if _, ok = tagValues[tagKey]; !ok {
 					tagValues[tagKey] = newStringSet()

--- a/database.go
+++ b/database.go
@@ -1404,6 +1404,7 @@ func (m *Measurement) tagValuesByKeyAndSeriesID(tagKeys []string, ids seriesIDs)
 	// If no tag keys were passed, get all tag keys for the measurement.
 	if len(tagKeys) == 0 {
 		for k := range m.seriesByTagKeyValue {
+			k = strings.Trim(k, `"`)
 			tagKeys = append(tagKeys, k)
 		}
 	}

--- a/httpd/handler_test.go
+++ b/httpd/handler_test.go
@@ -2066,6 +2066,27 @@ func TestHandler_serveShowTagValues(t *testing.T) {
 				},
 			},
 		},
+		// SHOW TAG VALUES WITH KEY = "..."
+		{
+			q: `SHOW TAG VALUES WITH KEY = "host"`,
+			r: &influxdb.Results{
+				Results: []*influxdb.Result{
+					{
+						Series: []*influxql.Row{
+							{
+								Name:    "hostTagValues",
+								Columns: []string{"host"},
+								Values: [][]interface{}{
+									str2iface([]string{"server01"}),
+									str2iface([]string{"server02"}),
+									str2iface([]string{"server03"}),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 		// SHOW TAG VALUES FROM ...
 		{
 			q: `SHOW TAG VALUES FROM cpu WITH KEY = host`,

--- a/influxql/parser_test.go
+++ b/influxql/parser_test.go
@@ -293,6 +293,19 @@ func TestParser_ParseStatement(t *testing.T) {
 			},
 		},
 
+		// SHOW TAG VALUES WITH KEY = "..."
+		{
+			s: `SHOW TAG VALUES WITH KEY = "host" WHERE region = 'uswest'`,
+			stmt: &influxql.ShowTagValuesStatement{
+				TagKeys: []string{`"host"`},
+				Condition: &influxql.BinaryExpr{
+					Op:  influxql.EQ,
+					LHS: &influxql.VarRef{Val: "region"},
+					RHS: &influxql.StringLiteral{Val: "uswest"},
+				},
+			},
+		},
+
 		// SHOW USERS
 		{
 			s:    `SHOW USERS`,


### PR DESCRIPTION
Issue: 1729

Trim off any leading or lagging dbl quotes.

I could see where this could break if someone created 
a tag key like:
 "\"host\"": "server01",