### PR TITLE
Drop series failing Issue #1761

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - [#1752](https://github.com/influxdb/influxdb/pull/1752): remove debug log output from collectd.
 - [#1720](https://github.com/influxdb/influxdb/pull/1720): Parse Series IDs as unsigned 32-bits.
+- [#1767](https://github.com/influxdb/influxdb/pull/1767): Drop Series was failing across shards.  Issue #1761.
 
 ### Features
 

--- a/database.go
+++ b/database.go
@@ -1184,7 +1184,7 @@ func (db *database) dropSeries(seriesByMeasurement map[string][]uint32) error {
 			// Remove shard data
 			for _, rp := range db.policies {
 				if err := rp.dropSeries(id); err != nil {
-					return err
+					return fmt.Errorf("database.retentionPolicies.dropSeries: %s", err)
 				}
 			}
 		}

--- a/server.go
+++ b/server.go
@@ -2356,8 +2356,12 @@ func measurementsFromSourceOrDB(stmt influxql.Source, db *database) (Measurement
 			return nil, errors.New("identifiers in FROM clause must be measurement names")
 		}
 	} else {
-		// No measurements specified in FROM clause so get all measurements.
-		measurements = db.Measurements()
+		// No measurements specified in FROM clause so get all measurements that have series.
+		for _, m := range db.Measurements() {
+			if len(m.seriesIDs) > 0 {
+				measurements = append(measurements, m)
+			}
+		}
 	}
 	sort.Sort(measurements)
 

--- a/server.go
+++ b/server.go
@@ -1340,7 +1340,7 @@ func (s *Server) applyDropSeries(m *messaging.Message) error {
 
 		// Delete series from the database.
 		if err := database.dropSeries(c.SeriesByMeasurement); err != nil {
-			return fmt.Errorf("failed to remove series from index")
+			return fmt.Errorf("failed to remove series from index: %s", err)
 		}
 		return nil
 	})

--- a/server_test.go
+++ b/server_test.go
@@ -1096,7 +1096,7 @@ func TestServer_DropSeries(t *testing.T) {
 	}
 }
 
-// Ensure the server can drop a series from measurement.
+// Ensure the server can drop a series from measurement when more than one shard exists.
 func TestServer_DropSeriesFromMeasurement(t *testing.T) {
 	c := NewMessagingClient()
 	s := OpenServer(c)

--- a/shard.go
+++ b/shard.go
@@ -161,7 +161,11 @@ func (s *Shard) dropSeries(seriesID uint32) error {
 		return nil
 	}
 	return s.store.Update(func(tx *bolt.Tx) error {
-		return tx.DeleteBucket(u32tob(seriesID))
+		err := tx.DeleteBucket(u32tob(seriesID))
+		if err != bolt.ErrBucketNotFound {
+			return err
+		}
+		return nil
 	})
 }
 

--- a/tests/create_write_multiple_query.sh
+++ b/tests/create_write_multiple_query.sh
@@ -8,6 +8,7 @@ echo "inserting data"
 curl -d '{"database" : "foo", "retentionPolicy" : "bar", "points": [{"name": "cpu", "tags": {"host": "server01"},"timestamp": "2015-01-26T22:01:11.703Z","fields": {"value": 100}}]}' -H "Content-Type: application/json" http://localhost:8086/write
 curl -d '{"database" : "foo", "retentionPolicy" : "bar", "points": [{"name": "cpu", "tags": {"host": "server01"},"timestamp": "2015-01-27T22:01:11.703Z","fields": {"value": 100}}]}' -H "Content-Type: application/json" http://localhost:8086/write
 curl -d '{"database" : "foo", "retentionPolicy" : "bar", "points": [{"name": "cpu", "tags": {"host": "server01"},"timestamp": "2015-01-28T22:01:11.703Z","fields": {"value": 100}}]}' -H "Content-Type: application/json" http://localhost:8086/write
+curl -d '{"database" : "foo", "retentionPolicy" : "bar", "points": [{"name": "mem", "tags": {"host": "server01"},"timestamp": "2015-01-29T22:01:11.703Z","fields": {"value": 100}}]}' -H "Content-Type: application/json" http://localhost:8086/write
 
 echo "querying data"
 curl -G http://localhost:8086/query --data-urlencode "db=foo" --data-urlencode "q=SELECT sum(value) FROM \"foo\".\"bar\".cpu GROUP BY time(1h)"


### PR DESCRIPTION
Fixes #1761 

Drop series was failing when multiple shards exists from writing data across time boundaries for a retention policy.

Also uncovered that `SHOW SERIES` could return blank rows for measurements where all measurement series had been deleted.  This has been fixed as well.

Added some better error messages with context to assist in future debugging.

Enhanced a shell script test that allowed this bug to also be reproduced by hand.