### PR TITLE
fix wrong time range calculation

### DIFF
--- a/tx.go
+++ b/tx.go
@@ -114,7 +114,7 @@ func (tx *tx) CreateIterators(stmt *influxql.SelectStatement) ([]influxql.Iterat
 	// Find shard groups within time range.
 	var shardGroups []*ShardGroup
 	for _, group := range rp.shardGroups {
-		if timeBetweenInclusive(group.StartTime, tmin, tmax) || timeBetweenInclusive(group.EndTime, tmin, tmax) {
+		if timeBetweenInclusive(group.StartTime, tmin, tmax) || timeBetweenInclusive(group.EndTime, tmin, tmax) || (group.StartTime.Before(tmin) && group.EndTime.After(tmax)) {
 			shardGroups = append(shardGroups, group)
 		}
 	}


### PR DESCRIPTION
The code which was used to check whether a shard group should be
queried was wrong.

The if-condition was:

timeBetweenInclusive(group.StartTime, tmin, tmax) || timeBetweenInclusive(group.EndTime, tmin, tmax)

It excludes group if tmin > group.StartTime && tmax < group.EndTime.

This patch fixes the bug.

Signed-off-by: Kai Zhang <zhangk1985@gmail.com>