### PR TITLE
malformed identifiers get through

### DIFF
--- a/influxql/scanner.go
+++ b/influxql/scanner.go
@@ -137,7 +137,7 @@ func (s *Scanner) scanIdent() (tok Token, pos Pos, lit string) {
 		} else if ch == '.' {
 			buf.WriteRune(ch)
 		} else if ch == '"' {
-			if tok0, pos0, lit0 := s.scanString(); tok == BADSTRING || tok == BADESCAPE {
+			if tok0, pos0, lit0 := s.scanString(); tok0 == BADSTRING || tok0 == BADESCAPE {
 				return tok0, pos0, lit0
 			} else {
 				_ = buf.WriteByte('"')

--- a/influxql/scanner_test.go
+++ b/influxql/scanner_test.go
@@ -60,6 +60,11 @@ func TestScanner_Scan(t *testing.T) {
 		{s: `foo`, tok: influxql.IDENT, lit: `foo`},
 		{s: `Zx12_3U_-`, tok: influxql.IDENT, lit: `Zx12_3U_`},
 		{s: `"foo".bar`, tok: influxql.IDENT, lit: `"foo".bar`},
+		{s: `"foo\\bar"`, tok: influxql.IDENT, lit: `"foo\bar"`},
+		{s: `"foo\bar"`, tok: influxql.BADESCAPE, lit: `\b`, pos: influxql.Pos{Line: 0, Char: 5}},
+		{s: `"foo\"bar\""`, tok: influxql.IDENT, lit: `"foo"bar""`},
+		{s: `test"`, tok: influxql.BADSTRING, lit: "", pos: influxql.Pos{Line: 0, Char: 3}},
+		{s: `"test`, tok: influxql.BADSTRING, lit: `test`},
 
 		{s: `true`, tok: influxql.TRUE},
 		{s: `false`, tok: influxql.FALSE},

--- a/influxql/token.go
+++ b/influxql/token.go
@@ -121,6 +121,8 @@ var tokens = [...]string{
 	NUMBER:       "NUMBER",
 	DURATION_VAL: "DURATION_VAL",
 	STRING:       "STRING",
+	BADSTRING:    "BADSTRING",
+	BADESCAPE:    "BADESCAPE",
 	TRUE:         "TRUE",
 	FALSE:        "FALSE",
 


### PR DESCRIPTION
Issue: 1768

We weren't checking return codes from scanString.
Added text descriptions for BADSTRING and BADESCAPE tokens.