### PR TITLE
trim command line before parse it

### DIFF
--- a/cmd/influx/main.go
+++ b/cmd/influx/main.go
@@ -221,12 +221,12 @@ func (c *CommandLine) SetAuth() {
 }
 
 func (c *CommandLine) use(cmd string) {
-	args := strings.Split(cmd, " ")
+	args := strings.Split(strings.TrimSpace(cmd), " ")
 	if len(args) != 2 {
 		fmt.Printf("Could not parse database name from %q.\n", cmd)
 		return
 	}
-	d := strings.TrimSpace(args[1])
+	d := args[1]
 	c.Database = d
 	fmt.Printf("Using database %s\n", d)
 }

--- a/cmd/influx/main_test.go
+++ b/cmd/influx/main_test.go
@@ -57,3 +57,21 @@ func TestParseCommand_Exit(t *testing.T) {
 		}
 	}
 }
+
+func TestParseCommand_Use(t *testing.T) {
+	c := main.CommandLine{}
+	tests := []struct {
+		cmd string
+	}{
+		{cmd: "use db"},
+		{cmd: " use db"},
+		{cmd: "use db "},
+		{cmd: "Use db"},
+	}
+
+	for _, test := range tests {
+		if !c.ParseCommand(test.cmd) {
+			t.Fatalf(`Command "use" failed for %q.`, test.cmd)
+		}
+	}
+}

--- a/server.go
+++ b/server.go
@@ -2433,7 +2433,8 @@ func (s *Server) executeAlterRetentionPolicyStatement(stmt *influxql.AlterRetent
 			if stmt.Replication == nil {
 				return nil
 			} else {
-				n := uint32(*stmt.Replication); return &n
+				n := uint32(*stmt.Replication)
+				return &n
 			}
 		}(),
 	}


### PR DESCRIPTION
This can avoid some errors caused by an additional space at the end of
the command line.

For example: 'use db ' will be trimed to 'use db' and parsed correctly.

Signed-off-by: Kai Zhang <zhangk1985@gmail.com>