### PR TITLE
fix #1799: make scanner recognize regex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@
 - [#1644](https://github.com/influxdb/influxdb/pull/1644): Add batching support for significantly improved write performance
 - [#1704](https://github.com/influxdb/influxdb/pull/1704): Fix queries that pull back raw data (i.e. ones without aggregate functions)
 - [#1718](https://github.com/influxdb/influxdb/pull/1718): Return an error on write if any of the points are don't have at least one field
+- [#1806](https://github.com/influxdb/influxdb/pull/1806): Fix regex parsing.  Change regex syntax to use / delimiters.
 
 
 ## v0.9.0-rc1,2 [no public release]

--- a/httpd/handler_test.go
+++ b/httpd/handler_test.go
@@ -1913,7 +1913,7 @@ func TestHandler_serveShowSeries(t *testing.T) {
 
 		// SHOW SERIES WHERE =~ regex
 		{
-			q: `SHOW SERIES WHERE region =~ 'ca.*'`,
+			q: "SHOW SERIES WHERE region =~ `ca.*`",
 			r: &influxdb.Results{
 				Results: []*influxdb.Result{
 					{
@@ -1933,7 +1933,7 @@ func TestHandler_serveShowSeries(t *testing.T) {
 
 		// SHOW SERIES WHERE !~ regex
 		{
-			q: `SHOW SERIES WHERE host !~ 'server0[12]'`,
+			q: "SHOW SERIES WHERE host !~ `server0[12]`",
 			r: &influxdb.Results{
 				Results: []*influxdb.Result{
 					{
@@ -2046,13 +2046,13 @@ func TestHandler_serveShowMeasurements(t *testing.T) {
 
 		// SHOW MEASUREMENTS WHERE =~ regex
 		{
-			q: `SHOW MEASUREMENTS WHERE region =~ 'ca.*'`,
+			q: "SHOW MEASUREMENTS WHERE region =~ `ca.*`",
 			r: `{"results":[{"series":[{"name":"measurements","columns":["name"],"values":[["gpu"],["other"]]}]}]}`,
 		},
 
 		// SHOW MEASUREMENTS WHERE !~ regex
 		{
-			q: `SHOW MEASUREMENTS WHERE region !~ 'ca.*'`,
+			q: "SHOW MEASUREMENTS WHERE region !~ `ca.*`",
 			r: `{"results":[{"series":[{"name":"measurements","columns":["name"],"values":[["cpu"]]}]}]}`,
 		},
 	}
@@ -2302,7 +2302,7 @@ func TestHandler_serveShowTagValues(t *testing.T) {
 		},
 		// SHOW TAG VALUES FROM ... WHERE =~ regex
 		{
-			q: `SHOW TAG VALUES WITH KEY = host WHERE region =~ 'ca.*'`,
+			q: "SHOW TAG VALUES WITH KEY = host WHERE region =~ `ca.*`",
 			r: &influxdb.Results{
 				Results: []*influxdb.Result{
 					{
@@ -2321,7 +2321,7 @@ func TestHandler_serveShowTagValues(t *testing.T) {
 		},
 		// SHOW TAG VALUES FROM ... WHERE !~ regex
 		{
-			q: `SHOW TAG VALUES WITH KEY = region WHERE host !~ 'server0[12]'`,
+			q: "SHOW TAG VALUES WITH KEY = region WHERE host !~ `server0[12]`",
 			r: &influxdb.Results{
 				Results: []*influxdb.Result{
 					{

--- a/httpd/handler_test.go
+++ b/httpd/handler_test.go
@@ -1913,7 +1913,7 @@ func TestHandler_serveShowSeries(t *testing.T) {
 
 		// SHOW SERIES WHERE =~ regex
 		{
-			q: "SHOW SERIES WHERE region =~ `ca.*`",
+			q: `SHOW SERIES WHERE region =~ /ca.*/`,
 			r: &influxdb.Results{
 				Results: []*influxdb.Result{
 					{
@@ -1933,7 +1933,7 @@ func TestHandler_serveShowSeries(t *testing.T) {
 
 		// SHOW SERIES WHERE !~ regex
 		{
-			q: "SHOW SERIES WHERE host !~ `server0[12]`",
+			q: `SHOW SERIES WHERE host !~ /server0[12]/`,
 			r: &influxdb.Results{
 				Results: []*influxdb.Result{
 					{
@@ -2046,13 +2046,13 @@ func TestHandler_serveShowMeasurements(t *testing.T) {
 
 		// SHOW MEASUREMENTS WHERE =~ regex
 		{
-			q: "SHOW MEASUREMENTS WHERE region =~ `ca.*`",
+			q: `SHOW MEASUREMENTS WHERE region =~ /ca.*/`,
 			r: `{"results":[{"series":[{"name":"measurements","columns":["name"],"values":[["gpu"],["other"]]}]}]}`,
 		},
 
 		// SHOW MEASUREMENTS WHERE !~ regex
 		{
-			q: "SHOW MEASUREMENTS WHERE region !~ `ca.*`",
+			q: `SHOW MEASUREMENTS WHERE region !~ /ca.*/`,
 			r: `{"results":[{"series":[{"name":"measurements","columns":["name"],"values":[["cpu"]]}]}]}`,
 		},
 	}
@@ -2302,7 +2302,7 @@ func TestHandler_serveShowTagValues(t *testing.T) {
 		},
 		// SHOW TAG VALUES FROM ... WHERE =~ regex
 		{
-			q: "SHOW TAG VALUES WITH KEY = host WHERE region =~ `ca.*`",
+			q: `SHOW TAG VALUES WITH KEY = host WHERE region =~ /ca.*/`,
 			r: &influxdb.Results{
 				Results: []*influxdb.Result{
 					{
@@ -2321,7 +2321,7 @@ func TestHandler_serveShowTagValues(t *testing.T) {
 		},
 		// SHOW TAG VALUES FROM ... WHERE !~ regex
 		{
-			q: "SHOW TAG VALUES WITH KEY = region WHERE host !~ `server0[12]`",
+			q: `SHOW TAG VALUES WITH KEY = region WHERE host !~ /server0[12]/`,
 			r: &influxdb.Results{
 				Results: []*influxdb.Result{
 					{

--- a/influxql/INFLUXQL.md
+++ b/influxql/INFLUXQL.md
@@ -162,6 +162,12 @@ time_lit            = "2006-01-02 15:04:05.999999" | "2006-01-02"
 bool_lit            = TRUE | FALSE .
 ```
 
+### Regular Expressions
+
+```
+regex_lit           = "/" { unicode_char } "/" .
+```
+
 ## Queries
 
 A query is composed of one or more statements separated by a semicolon.
@@ -602,7 +608,7 @@ binary_op        = "+" | "-" | "*" | "/" | "AND" | "OR" | "=" | "!=" | "<" |
 expr             = unary_expr { binary_op unary_expr } .
 
 unary_expr       = "(" expr ")" | var_ref | time_lit | string_lit |
-                   number_lit | bool_lit | duration_lit .
+                   number_lit | bool_lit | duration_lit | regex_lit .
 ```
 
 ## Other

--- a/influxql/parser_test.go
+++ b/influxql/parser_test.go
@@ -136,9 +136,9 @@ func TestParser_ParseStatement(t *testing.T) {
 			},
 		},
 
-		// SELECT * FROM cpu WHERE host = 'serverC' AND region =~ `.*west.*`
+		// SELECT * FROM cpu WHERE host = 'serverC' AND region =~ /.*west.*/
 		{
-			s: "SELECT * FROM cpu WHERE host = 'serverC' AND region =~ `.*west.*`",
+			s: `SELECT * FROM cpu WHERE host = 'serverC' AND region =~ /.*west.*/`,
 			stmt: &influxql.SelectStatement{
 				Fields: []*influxql.Field{{Expr: &influxql.Wildcard{}}},
 				Source: &influxql.Measurement{Name: "cpu"},
@@ -861,23 +861,13 @@ func TestParser_ParseExpr(t *testing.T) {
 			},
 		},
 
-		// Binary expression with regex on right.
+		// Binary expression with regex.
 		{
-			s: "region =~ `us.*`",
+			s: "region =~ /us.*/",
 			expr: &influxql.BinaryExpr{
 				Op:  influxql.EQREGEX,
 				LHS: &influxql.VarRef{Val: "region"},
 				RHS: &influxql.RegexLiteral{Val: regexp.MustCompile(`us.*`)},
-			},
-		},
-
-		// Binary expression with NEQ regex on left.
-		{
-			s: "`us.*` !~ region",
-			expr: &influxql.BinaryExpr{
-				Op:  influxql.NEQREGEX,
-				RHS: &influxql.VarRef{Val: "region"},
-				LHS: &influxql.RegexLiteral{Val: regexp.MustCompile(`us.*`)},
 			},
 		},
 

--- a/influxql/scanner_test.go
+++ b/influxql/scanner_test.go
@@ -102,6 +102,10 @@ func TestScanner_Scan(t *testing.T) {
 		{s: `10w`, tok: influxql.DURATION_VAL, lit: `10w`},
 		{s: `10x`, tok: influxql.NUMBER, lit: `10`}, // non-duration unit
 
+		// Regular expressions
+		{s: "`.*`", tok: influxql.REGEX, lit: ".*"},
+		{s: "`.*\\``", tok: influxql.REGEX, lit: ".*`"},
+
 		// Keywords
 		{s: `ALL`, tok: influxql.ALL},
 		{s: `ALTER`, tok: influxql.ALTER},

--- a/influxql/scanner_test.go
+++ b/influxql/scanner_test.go
@@ -102,10 +102,6 @@ func TestScanner_Scan(t *testing.T) {
 		{s: `10w`, tok: influxql.DURATION_VAL, lit: `10w`},
 		{s: `10x`, tok: influxql.NUMBER, lit: `10`}, // non-duration unit
 
-		// Regular expressions
-		{s: "`.*`", tok: influxql.REGEX, lit: ".*"},
-		{s: "`.*\\``", tok: influxql.REGEX, lit: ".*`"},
-
 		// Keywords
 		{s: `ALL`, tok: influxql.ALL},
 		{s: `ALTER`, tok: influxql.ALTER},

--- a/influxql/token.go
+++ b/influxql/token.go
@@ -23,6 +23,8 @@ const (
 	BADESCAPE    // \q
 	TRUE         // true
 	FALSE        // false
+	REGEX        // Regular expressions
+	BADREGEX     // `.*
 	literal_end
 
 	operator_beg
@@ -125,6 +127,7 @@ var tokens = [...]string{
 	BADESCAPE:    "BADESCAPE",
 	TRUE:         "TRUE",
 	FALSE:        "FALSE",
+	REGEX:        "REGEX",
 
 	ADD: "+",
 	SUB: "-",
@@ -238,7 +241,7 @@ func (tok Token) Precedence() int {
 		return 1
 	case AND:
 		return 2
-	case EQ, NEQ, LT, LTE, GT, GTE:
+	case EQ, NEQ, EQREGEX, NEQREGEX, LT, LTE, GT, GTE:
 		return 3
 	case ADD, SUB:
 		return 4


### PR DESCRIPTION
Change the regex delimiter from single quotes to `/` and make
the scanner recognize regex tokens.

Single quotes are used for string literals. Using a unique delimiter for
regular expression literals allows the scanner to recognize regular
expression tokens, which is inline with the way the rest of the
scanner / parser work.

TODO:

- [x] Update docs
- [x] Update changelog