### PR TITLE
Don't skip first byte when decoding values

### DIFF
--- a/httpd/handler_test.go
+++ b/httpd/handler_test.go
@@ -1415,6 +1415,24 @@ func TestHandler_serveWriteSeriesStringValues(t *testing.T) {
 	if result.Series[0].Values[0][1] != "disk full" {
 		t.Fatalf("unexpected string value, actual: %s", result.Series[0].Values[0][1])
 	}
+
+	// Test filtering by field value.
+	query = map[string]string{"db": "foo", "q": "select event from logs where event='nonsense'"}
+	status, body = MustHTTP("GET", s.URL+`/query`, query, nil, "")
+	if status != http.StatusOK {
+		t.Logf("query %s\n", query)
+		t.Log(body)
+		t.Errorf("unexpected status: %d", status)
+	}
+
+	if err := json.Unmarshal([]byte(body), r); err != nil {
+		t.Logf("query : %s\n", query)
+		t.Log(body)
+		t.Error(err)
+	}
+	if len(r.Results) != 0 {
+		t.Fatalf("unexpected results count, expected 0, got %d", len(r.Results))
+	}
 }
 
 func TestHandler_serveWriteSeriesBoolValues(t *testing.T) {

--- a/tx.go
+++ b/tx.go
@@ -390,7 +390,7 @@ func (c *seriesCursor) Next(fieldName string, fieldID uint8, tmin, tmax int64) (
 			// we'll need to marshal all the field values if the condition isn't nil
 			if c.condition != nil {
 				fieldValues := make(map[string]interface{})
-				values := c.tx.DecodeValues(c.fieldIDs, 0, data)[1:]
+				values := c.tx.DecodeValues(c.fieldIDs, 0, data)
 				for i, val := range values {
 					fieldValues[c.fieldNames[i]] = val
 				}


### PR DESCRIPTION
The first byte of a values byte slice is no longer the number of fields in the slice, so don't skip it.