### PR TITLE
Querying for missing measurements should return a 200

### DIFF
--- a/httpd/handler.go
+++ b/httpd/handler.go
@@ -417,11 +417,17 @@ func isAuthorizationError(err error) bool {
 	return ok
 }
 
+func isMeasurementNotFoundError(err error) bool {
+	return (err.Error() == "measurement not found")
+}
+
 // httpResult writes a Results array to the client.
 func httpResults(w http.ResponseWriter, results influxdb.Results, pretty bool) {
 	if results.Error() != nil {
 		if isAuthorizationError(results.Error()) {
 			w.WriteHeader(http.StatusUnauthorized)
+		} else if isMeasurementNotFoundError(results.Error()) {
+			w.WriteHeader(http.StatusOK)
 		} else {
 			w.WriteHeader(http.StatusInternalServerError)
 		}

--- a/httpd/handler.go
+++ b/httpd/handler.go
@@ -421,6 +421,10 @@ func isMeasurementNotFoundError(err error) bool {
 	return (err.Error() == "measurement not found")
 }
 
+func isFieldNotFoundError(err error) bool {
+	return (strings.HasPrefix(err.Error(), "field not found"))
+}
+
 // httpResult writes a Results array to the client.
 func httpResults(w http.ResponseWriter, results influxdb.Results, pretty bool) {
 	if results.Error() != nil {
@@ -428,7 +432,10 @@ func httpResults(w http.ResponseWriter, results influxdb.Results, pretty bool) {
 			w.WriteHeader(http.StatusUnauthorized)
 		} else if isMeasurementNotFoundError(results.Error()) {
 			w.WriteHeader(http.StatusOK)
+		} else if isFieldNotFoundError(results.Error()) {
+			w.WriteHeader(http.StatusOK)
 		} else {
+			fmt.Println(results.Error())
 			w.WriteHeader(http.StatusInternalServerError)
 		}
 	}

--- a/httpd/handler_test.go
+++ b/httpd/handler_test.go
@@ -1609,7 +1609,7 @@ func TestHandler_serveWriteSeriesInvalidQueryField(t *testing.T) {
 
 	query := map[string]string{"db": "foo", "q": "select bar from cpu"}
 	status, body := MustHTTP("GET", s.URL+`/query`, query, nil, "")
-	if status != http.StatusInternalServerError {
+	if status != http.StatusOK {
 		t.Logf("query %s\n", query)
 		t.Log(body)
 		t.Errorf("unexpected status: %d", status)


### PR DESCRIPTION
Currently, this returns a `500 Server Error`. It should return a `200 OK` with an error in the result set stating that the measurement name couldn't be found.