### PR TITLE
Fix for #1760:  influx doesn't create $HOME/.influx_history

### DIFF
--- a/cmd/influx/main.go
+++ b/cmd/influx/main.go
@@ -98,15 +98,18 @@ func main() {
 		if e != nil {
 			break
 		}
-		if !c.ParseCommand(l) {
+		if c.ParseCommand(l) {
 			// write out the history
-			if f, err := os.Create(historyFile); err == nil {
-				c.Line.WriteHistory(f)
-				f.Close()
+			if len(historyFile) > 0 {
+				c.Line.AppendHistory(l)
+				if f, err := os.Create(historyFile); err == nil {
+					c.Line.WriteHistory(f)
+					f.Close()
+				}
 			}
-			break
+		} else {
+			break // exit main loop
 		}
-		c.Line.AppendHistory(l)
 	}
 }
 


### PR DESCRIPTION
This patch should address #1760.  It will create the history file, and append each new command after it's been parsed.

Testing:
* with no history file:  a new one is properly created, and commands appended.
* with existing history file: old commands are properly read, and new commands properly appended.



