### PR TITLE
fix the memory leak on the wait API

### DIFF
--- a/httpd/handler.go
+++ b/httpd/handler.go
@@ -365,7 +365,6 @@ func (p *indexPoller) PollForIndex(index uint64, timeout time.Duration) error {
 	case <-done:
 		return nil
 	}
-	return nil
 }
 
 func (p *indexPoller) Quit() {

--- a/httpd/handler.go
+++ b/httpd/handler.go
@@ -359,6 +359,7 @@ func (p *indexPoller) PollForIndex(index uint64, timeout time.Duration) error {
 
 	select {
 	case <-time.After(timeout):
+		p.Quit()
 		return errPollTimedOut
 	case <-aborted:
 		return errAborted


### PR DESCRIPTION
The pollForIndex method starts a goroutine to check the latest index
periodically. But when the HTTP request finishs, the loop is still there
and the goroutine never exits.

This leads to a memory leak and goroutine leak after each request to the
"/wait/:index" API.

The problem can be reproduced by ```ab -c 10 -t 30 http://127.0.0.1:8086/wait/1```.
After several times of benchmark you'll find that the memory usage grows markedly.

Signed-off-by: Shijiang Wei <mountkin@gmail.com>