### PR TITLE
Pre-create shard groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Features
 - [#1875](https://github.com/influxdb/influxdb/pull/1875): Support trace logging of Raft.
 - [#1895](https://github.com/influxdb/influxdb/pull/1895): Auto-create a retention policy when a database is created.
+- [#1897](https://github.com/influxdb/influxdb/pull/1897): Pre-create shard groups.
 
 ## v0.9.0-rc9 [2015-03-06]
 

--- a/cmd/influxd/config.go
+++ b/cmd/influxd/config.go
@@ -40,8 +40,9 @@ const (
 	// DefaultJoinURLs represents the default URLs for joining a cluster.
 	DefaultJoinURLs = ""
 
-	// DefaultShardGroupPreCreatePeriod
-	DefaultShardGroupPreCreatePeriod = 45 * time.Minute
+	// DefaultRetentionCreatePeriod represents how often the server will check to see if new
+	// shard groups need to be created in advance for writing
+	DefaultRetentionCreatePeriod = 45 * time.Minute
 )
 
 // Config represents the configuration format for the influxd binary.
@@ -88,12 +89,12 @@ type Config struct {
 	} `toml:"broker"`
 
 	Data struct {
-		Dir                            string   `toml:"dir"`
-		Port                           int      `toml:"port"`
-		RetentionAutoCreate            bool     `toml:"retention-auto-create"`
-		RetentionCheckEnabled          bool     `toml:"retention-check-enabled"`
-		RetentionCheckPeriod           Duration `toml:"retention-check-period"`
-		ShardGroupPreCreateCheckPeriod Duration `toml:"shard-group-pre-create-check-period"`
+		Dir                   string   `toml:"dir"`
+		Port                  int      `toml:"port"`
+		RetentionAutoCreate   bool     `toml:"retention-auto-create"`
+		RetentionCheckEnabled bool     `toml:"retention-check-enabled"`
+		RetentionCheckPeriod  Duration `toml:"retention-check-period"`
+		RetentionCreatePeriod Duration `toml:"retention-create-period"`
 	} `toml:"data"`
 
 	Cluster struct {
@@ -152,7 +153,7 @@ func NewConfig() *Config {
 	c.Data.RetentionAutoCreate = true
 	c.Data.RetentionCheckEnabled = true
 	c.Data.RetentionCheckPeriod = Duration(10 * time.Minute)
-	c.Data.ShardGroupPreCreateCheckPeriod = Duration(DefaultShardGroupPreCreatePeriod)
+	c.Data.RetentionCreatePeriod = Duration(DefaultRetentionCreatePeriod)
 	c.Admin.Enabled = true
 	c.Admin.Port = 8083
 	c.ContinuousQuery.RecomputePreviousN = 2
@@ -237,10 +238,10 @@ func (c *Config) JoinURLs() string {
 // ShardGroupPreCreateCheckPeriod returns the check interval to pre-create shard groups.
 // If it was not defined in the config, it defaults to DefaultShardGroupPreCreatePeriod
 func (c *Config) ShardGroupPreCreateCheckPeriod() time.Duration {
-	if c.Data.ShardGroupPreCreateCheckPeriod != 0 {
-		return time.Duration(c.Data.ShardGroupPreCreateCheckPeriod)
+	if c.Data.RetentionCreatePeriod != 0 {
+		return time.Duration(c.Data.RetentionCreatePeriod)
 	}
-	return DefaultShardGroupPreCreatePeriod
+	return DefaultRetentionCreatePeriod
 }
 
 // Size represents a TOML parseable file size.

--- a/cmd/influxd/config.go
+++ b/cmd/influxd/config.go
@@ -39,6 +39,9 @@ const (
 
 	// DefaultJoinURLs represents the default URLs for joining a cluster.
 	DefaultJoinURLs = ""
+
+	// DefaultShardGroupPreCreatePeriod
+	DefaultShardGroupPreCreatePeriod = 45 * time.Minute
 )
 
 // Config represents the configuration format for the influxd binary.
@@ -85,11 +88,12 @@ type Config struct {
 	} `toml:"broker"`
 
 	Data struct {
-		Dir                   string   `toml:"dir"`
-		Port                  int      `toml:"port"`
-		RetentionAutoCreate   bool     `toml:"retention-auto-create"`
-		RetentionCheckEnabled bool     `toml:"retention-check-enabled"`
-		RetentionCheckPeriod  Duration `toml:"retention-check-period"`
+		Dir                            string   `toml:"dir"`
+		Port                           int      `toml:"port"`
+		RetentionAutoCreate            bool     `toml:"retention-auto-create"`
+		RetentionCheckEnabled          bool     `toml:"retention-check-enabled"`
+		RetentionCheckPeriod           Duration `toml:"retention-check-period"`
+		ShardGroupPreCreateCheckPeriod Duration `toml:"shard-group-pre-create-check-period"`
 	} `toml:"data"`
 
 	Cluster struct {
@@ -148,6 +152,7 @@ func NewConfig() *Config {
 	c.Data.RetentionAutoCreate = true
 	c.Data.RetentionCheckEnabled = true
 	c.Data.RetentionCheckPeriod = Duration(10 * time.Minute)
+	c.Data.ShardGroupPreCreateCheckPeriod = Duration(DefaultShardGroupPreCreatePeriod)
 	c.Admin.Enabled = true
 	c.Admin.Port = 8083
 	c.ContinuousQuery.RecomputePreviousN = 2
@@ -227,6 +232,15 @@ func (c *Config) JoinURLs() string {
 	} else {
 		return c.Initialization.JoinURLs
 	}
+}
+
+// ShardGroupPreCreateCheckPeriod returns the check interval to pre-create shard groups.
+// If it was not defined in the config, it defaults to DefaultShardGroupPreCreatePeriod
+func (c *Config) ShardGroupPreCreateCheckPeriod() time.Duration {
+	if c.Data.ShardGroupPreCreateCheckPeriod != 0 {
+		return time.Duration(c.Data.ShardGroupPreCreateCheckPeriod)
+	}
+	return DefaultShardGroupPreCreatePeriod
 }
 
 // Size represents a TOML parseable file size.

--- a/cmd/influxd/run.go
+++ b/cmd/influxd/run.go
@@ -89,6 +89,13 @@ func Run(config *Config, join, version string, logWriter *os.File) (*messaging.B
 		log.Printf("broker enforcing retention policies with check interval of %s", interval)
 	}
 
+	// Start shard group pre-create
+	interval := config.ShardGroupPreCreateCheckPeriod()
+	if err := s.StartShardGroupsPreCreate(interval); err != nil {
+		log.Fatalf("shard group pre-create failed: %s", err.Error())
+	}
+	log.Printf("shard group pre-create with check interval of %s", interval)
+
 	// Start the server handler. Attach to broker if listening on the same port.
 	if s != nil {
 		sh := httpd.NewHandler(s, config.Authentication.Enabled, version)

--- a/commands.go
+++ b/commands.go
@@ -28,8 +28,9 @@ const (
 	deleteUserMessageType = messaging.MessageType(0x32)
 
 	// Shard messages
-	createShardGroupIfNotExistsMessageType = messaging.MessageType(0x40)
-	deleteShardGroupMessageType            = messaging.MessageType(0x41)
+	createShardGroupIfNotExistsMessageType    = messaging.MessageType(0x40)
+	deleteShardGroupMessageType               = messaging.MessageType(0x41)
+	preCreateShardGroupIfNotExistsMessageType = messaging.MessageType(0x42)
 
 	// Series messages
 	dropSeriesMessageType = messaging.MessageType(0x50)
@@ -69,11 +70,19 @@ type createShardGroupIfNotExistsCommand struct {
 	Policy    string    `json:"policy"`
 	Timestamp time.Time `json:"timestamp"`
 }
+
 type deleteShardGroupCommand struct {
 	Database string `json:"database"`
 	Policy   string `json:"policy"`
 	ID       uint64 `json:"id"`
 }
+
+type preCreateShardGroupIfNotExistsCommand struct {
+	Database string `json:"database"`
+	Policy   string `json:"policy"`
+	ID       uint64 `json:"id"`
+}
+
 type createUserCommand struct {
 	Username string `json:"username"`
 	Password string `json:"password"`
@@ -94,11 +103,12 @@ type setPrivilegeCommand struct {
 	Database  string             `json:"database"`
 }
 type createRetentionPolicyCommand struct {
-	Database string        `json:"database"`
-	Name     string        `json:"name"`
-	Duration time.Duration `json:"duration"`
-	ReplicaN uint32        `json:"replicaN"`
-	SplitN   uint32        `json:"splitN"`
+	Database           string        `json:"database"`
+	Name               string        `json:"name"`
+	Duration           time.Duration `json:"duration"`
+	ShardGroupDuration time.Duration `json:"shardGroupDuration"`
+	ReplicaN           uint32        `json:"replicaN"`
+	SplitN             uint32        `json:"splitN"`
 }
 type updateRetentionPolicyCommand struct {
 	Database string                 `json:"database"`

--- a/commands.go
+++ b/commands.go
@@ -28,9 +28,8 @@ const (
 	deleteUserMessageType = messaging.MessageType(0x32)
 
 	// Shard messages
-	createShardGroupIfNotExistsMessageType    = messaging.MessageType(0x40)
-	deleteShardGroupMessageType               = messaging.MessageType(0x41)
-	preCreateShardGroupIfNotExistsMessageType = messaging.MessageType(0x42)
+	createShardGroupIfNotExistsMessageType = messaging.MessageType(0x40)
+	deleteShardGroupMessageType            = messaging.MessageType(0x41)
 
 	// Series messages
 	dropSeriesMessageType = messaging.MessageType(0x50)
@@ -72,12 +71,6 @@ type createShardGroupIfNotExistsCommand struct {
 }
 
 type deleteShardGroupCommand struct {
-	Database string `json:"database"`
-	Policy   string `json:"policy"`
-	ID       uint64 `json:"id"`
-}
-
-type preCreateShardGroupIfNotExistsCommand struct {
 	Database string `json:"database"`
 	Policy   string `json:"policy"`
 	ID       uint64 `json:"id"`

--- a/database.go
+++ b/database.go
@@ -1145,7 +1145,6 @@ func (rp *RetentionPolicy) UnmarshalJSON(data []byte) error {
 type retentionPolicyJSON struct {
 	Name               string        `json:"name"`
 	ReplicaN           uint32        `json:"replicaN,omitempty"`
-	SplitN             uint32        `json:"splitN,omitempty"`
 	Duration           time.Duration `json:"duration,omitempty"`
 	ShardGroupDuration time.Duration `json:"shardGroupDuration"`
 	ShardGroups        []*ShardGroup `json:"shardGroups,omitempty"`

--- a/database.go
+++ b/database.go
@@ -1016,6 +1016,9 @@ type RetentionPolicy struct {
 	// Length of time to keep data around. A zero duration means keep the data forever.
 	Duration time.Duration `json:"duration"`
 
+	// Length of time to create shard groups in.
+	ShardGroupDuration time.Duration `json:"shardGroupDuration"`
+
 	// The number of copies to make of each shard.
 	ReplicaN uint32 `json:"replicaN"`
 
@@ -1112,6 +1115,7 @@ func (rp *RetentionPolicy) MarshalJSON() ([]byte, error) {
 	var o retentionPolicyJSON
 	o.Name = rp.Name
 	o.Duration = rp.Duration
+	o.ShardGroupDuration = rp.ShardGroupDuration
 	o.ReplicaN = rp.ReplicaN
 	for _, g := range rp.shardGroups {
 		o.ShardGroups = append(o.ShardGroups, g)
@@ -1131,6 +1135,7 @@ func (rp *RetentionPolicy) UnmarshalJSON(data []byte) error {
 	rp.Name = o.Name
 	rp.ReplicaN = o.ReplicaN
 	rp.Duration = o.Duration
+	rp.ShardGroupDuration = o.ShardGroupDuration
 	rp.shardGroups = o.ShardGroups
 
 	return nil
@@ -1138,11 +1143,12 @@ func (rp *RetentionPolicy) UnmarshalJSON(data []byte) error {
 
 // retentionPolicyJSON represents an intermediate struct for JSON marshaling.
 type retentionPolicyJSON struct {
-	Name        string        `json:"name"`
-	ReplicaN    uint32        `json:"replicaN,omitempty"`
-	SplitN      uint32        `json:"splitN,omitempty"`
-	Duration    time.Duration `json:"duration,omitempty"`
-	ShardGroups []*ShardGroup `json:"shardGroups,omitempty"`
+	Name               string        `json:"name"`
+	ReplicaN           uint32        `json:"replicaN,omitempty"`
+	SplitN             uint32        `json:"splitN,omitempty"`
+	Duration           time.Duration `json:"duration,omitempty"`
+	ShardGroupDuration time.Duration `json:"shardGroupDuration"`
+	ShardGroups        []*ShardGroup `json:"shardGroups,omitempty"`
 }
 
 // TagFilter represents a tag filter when looking up other tags or measurements.

--- a/server.go
+++ b/server.go
@@ -208,6 +208,10 @@ func (s *Server) Close() error {
 		close(s.rpDone)
 	}
 
+	if s.sgpcDone != nil {
+		close(s.sgpcDone)
+	}
+
 	// Remove path.
 	s.path = ""
 	s.index = 0

--- a/server.go
+++ b/server.go
@@ -371,20 +371,38 @@ func (s *Server) ShardGroupPreCreate(checkInterval time.Duration) {
 	// This is a complete punt on optimization
 	cutoff := time.Now().Add(checkInterval * 2).UTC()
 
-	// Check all shard groups.
-	// See if they have a "future" shard group ready to write to
-	// If not, create the next shard group, as well as each shard for the shardGroup
-	for _, db := range s.databases {
-		for _, rp := range db.policies {
-			for _, g := range rp.shardGroups {
-				// Check to see if it is going to end before our interval
-				if g.EndTime.Before(cutoff) {
-					log.Printf("pre-creating shard group for %d, retention policy %s, database %s", g.ID, rp.Name, db.name)
-					if err := s.PreCreateShardGroupIfNotExists(db.name, rp.Name, g.ID); err != nil {
-						log.Printf("failed to request pre-creation of shard group %d: %s", g.ID, err.Error())
+	type group struct {
+		Database  string
+		Retention string
+		ID        uint64
+	}
+
+	groups := make([]group, 0)
+	// Only keep the lock while walking the shard groups, so the lock is not held while
+	// any deletions take place across the cluster.
+	func() {
+		s.mu.RLock()
+		defer s.mu.RUnlock()
+
+		// Check all shard groups.
+		// See if they have a "future" shard group ready to write to
+		// If not, create the next shard group, as well as each shard for the shardGroup
+		for _, db := range s.databases {
+			for _, rp := range db.policies {
+				for _, g := range rp.shardGroups {
+					// Check to see if it is going to end before our interval
+					if g.EndTime.Before(cutoff) {
+						log.Printf("pre-creating shard group for %d, retention policy %s, database %s", g.ID, rp.Name, db.name)
+						groups = append(groups, group{Database: db.name, Retention: rp.Name, ID: g.ID})
 					}
 				}
 			}
+		}
+	}()
+
+	for _, g := range groups {
+		if err := s.PreCreateShardGroupIfNotExists(g.Database, g.Retention, g.ID); err != nil {
+			log.Printf("failed to request pre-creation of shard group %d: %s", g.ID, err.Error())
 		}
 	}
 }
@@ -960,7 +978,7 @@ func (s *Server) PreCreateShardGroupIfNotExists(database, policy string, shardID
 	return err
 }
 
-// applyPreCreateShardGroupIfNotExists deletes shard data from disk and updates the metastore.
+// applyPreCreateShardGroupIfNotExists creates the shard groups and writes them to the metastore.
 func (s *Server) applyPreCreateShardGroupIfNotExists(m *messaging.Message) (err error) {
 	var c preCreateShardGroupIfNotExistsCommand
 	mustUnmarshalJSON(m.Data, &c)

--- a/server_test.go
+++ b/server_test.go
@@ -771,7 +771,7 @@ func TestServer_PreCreateRetentionPolices(t *testing.T) {
 	// Ensure enforcement is in effect across restarts.
 	s.Restart()
 
-	// First shard group should have been removed.
+	// Second shard group should now be created.
 	g, err = s.ShardGroups("foo")
 	if err != nil {
 		t.Fatal(err)

--- a/server_test.go
+++ b/server_test.go
@@ -765,7 +765,7 @@ func TestServer_PreCreateRetentionPolices(t *testing.T) {
 		t.Fatalf("expected 1 shard group but found %d", len(g))
 	}
 
-	// Run retention enforcement.
+	// Run shard group pre-create.
 	s.ShardGroupPreCreate(time.Hour)
 
 	// Ensure enforcement is in effect across restarts.

--- a/server_test.go
+++ b/server_test.go
@@ -532,9 +532,10 @@ func TestServer_CreateRetentionPolicy(t *testing.T) {
 
 	// Create a retention policy on the database.
 	rp := &influxdb.RetentionPolicy{
-		Name:     "bar",
-		Duration: time.Hour,
-		ReplicaN: 2,
+		Name:               "bar",
+		Duration:           time.Hour,
+		ShardGroupDuration: time.Hour,
+		ReplicaN:           2,
 	}
 	if err := s.CreateRetentionPolicy("foo", rp); err != nil {
 		t.Fatal(err)
@@ -706,7 +707,7 @@ func TestServer_SetDefaultRetentionPolicy(t *testing.T) {
 	defer s.Close()
 	s.CreateDatabase("foo")
 
-	rp := &influxdb.RetentionPolicy{Name: "bar"}
+	rp := &influxdb.RetentionPolicy{Name: "bar", ShardGroupDuration: 7 * time.Hour * 24}
 	if err := s.CreateRetentionPolicy("foo", rp); err != nil {
 		t.Fatal(err)
 	} else if rp, _ := s.RetentionPolicy("foo", "bar"); rp == nil {
@@ -743,6 +744,42 @@ func TestServer_SetDefaultRetentionPolicy_ErrRetentionPolicyNotFound(t *testing.
 	}
 }
 
+// Ensure the server pre-creates shard groups as needed.
+func TestServer_PreCreateRetentionPolices(t *testing.T) {
+	c := NewMessagingClient()
+	s := OpenServer(c)
+	defer s.Close()
+	s.CreateDatabase("foo")
+	s.CreateRetentionPolicy("foo", &influxdb.RetentionPolicy{Name: "mypolicy", Duration: 60 * time.Minute})
+
+	// Create two shard groups for the the new retention policy -- 1 which will age out immediately
+	// the other in more than an hour.
+	s.CreateShardGroupIfNotExists("foo", "mypolicy", time.Now().Add(-2*time.Hour))
+
+	// Check the two shard groups exist.
+	var g []*influxdb.ShardGroup
+	g, err := s.ShardGroups("foo")
+	if err != nil {
+		t.Fatal(err)
+	} else if len(g) != 1 {
+		t.Fatalf("expected 1 shard group but found %d", len(g))
+	}
+
+	// Run retention enforcement.
+	s.ShardGroupPreCreate(time.Hour)
+
+	// Ensure enforcement is in effect across restarts.
+	s.Restart()
+
+	// First shard group should have been removed.
+	g, err = s.ShardGroups("foo")
+	if err != nil {
+		t.Fatal(err)
+	} else if len(g) != 2 {
+		t.Fatalf("expected 2 shard group but found %d", len(g))
+	}
+}
+
 // Ensure the server prohibits a zero check interval for retention policy enforcement.
 func TestServer_StartRetentionPolicyEnforcement_ErrZeroInterval(t *testing.T) {
 	s := OpenServer(NewMessagingClient())
@@ -757,11 +794,11 @@ func TestServer_EnforceRetentionPolices(t *testing.T) {
 	s := OpenServer(c)
 	defer s.Close()
 	s.CreateDatabase("foo")
-	s.CreateRetentionPolicy("foo", &influxdb.RetentionPolicy{Name: "mypolicy", Duration: 30 * time.Minute})
+	s.CreateRetentionPolicy("foo", &influxdb.RetentionPolicy{Name: "mypolicy", Duration: 60 * time.Minute})
 
 	// Create two shard groups for the the new retention policy -- 1 which will age out immediately
 	// the other in more than an hour.
-	s.CreateShardGroupIfNotExists("foo", "mypolicy", time.Now().Add(-1*time.Hour))
+	s.CreateShardGroupIfNotExists("foo", "mypolicy", time.Now().Add(-2*time.Hour))
 	s.CreateShardGroupIfNotExists("foo", "mypolicy", time.Now().Add(time.Hour))
 
 	// Check the two shard groups exist.


### PR DESCRIPTION
1) Pre create shard groups

2) Calculate and save the ShardGroupDuration for Retention Policies. This should never change even if they alter a retention policy in the future

Fixes #1873
Fixes #1783