### PR TITLE
Add show servers to query language

### DIFF
--- a/influxql/ast.go
+++ b/influxql/ast.go
@@ -71,6 +71,7 @@ func (*DropSeriesStatement) node()            {}
 func (*DropUserStatement) node()              {}
 func (*GrantStatement) node()                 {}
 func (*ShowContinuousQueriesStatement) node() {}
+func (*ShowServersStatement) node()           {}
 func (*ShowDatabasesStatement) node()         {}
 func (*ShowFieldKeysStatement) node()         {}
 func (*ShowRetentionPoliciesStatement) node() {}
@@ -161,6 +162,7 @@ func (*DropSeriesStatement) stmt()            {}
 func (*DropUserStatement) stmt()              {}
 func (*GrantStatement) stmt()                 {}
 func (*ShowContinuousQueriesStatement) stmt() {}
+func (*ShowServersStatement) stmt()           {}
 func (*ShowDatabasesStatement) stmt()         {}
 func (*ShowFieldKeysStatement) stmt()         {}
 func (*ShowMeasurementsStatement) stmt()      {}
@@ -1172,6 +1174,17 @@ func (s *ShowContinuousQueriesStatement) String() string { return "SHOW CONTINUO
 // RequiredPrivileges returns the privilege required to execute a ShowContinuousQueriesStatement.
 func (s *ShowContinuousQueriesStatement) RequiredPrivileges() ExecutionPrivileges {
 	return ExecutionPrivileges{{Name: "", Privilege: ReadPrivilege}}
+}
+
+// ShowServersStatement represents a command for listing all servers.
+type ShowServersStatement struct{}
+
+// String returns a string representation of the show servers command.
+func (s *ShowServersStatement) String() string { return "SHOW SERVERS" }
+
+// RequiredPrivileges returns the privilege required to execute a ShowServersStatement
+func (s *ShowServersStatement) RequiredPrivileges() ExecutionPrivileges {
+	return ExecutionPrivileges{{Name: "", Privilege: AllPrivileges}}
 }
 
 // ShowDatabasesStatement represents a command for listing all databases in the cluster.

--- a/influxql/parser.go
+++ b/influxql/parser.go
@@ -101,6 +101,8 @@ func (p *Parser) parseShowStatement() (Statement, error) {
 		return p.parseShowContinuousQueriesStatement()
 	case DATABASES:
 		return p.parseShowDatabasesStatement()
+	case SERVERS:
+		return p.parseShowServersStatement()
 	case FIELD:
 		tok, pos, lit := p.scanIgnoreWhitespace()
 		if tok == KEYS {
@@ -129,7 +131,7 @@ func (p *Parser) parseShowStatement() (Statement, error) {
 		return p.parseShowUsersStatement()
 	}
 
-	return nil, newParseError(tokstr(tok, lit), []string{"CONTINUOUS", "DATABASES", "FIELD", "MEASUREMENTS", "RETENTION", "SERIES", "TAG", "USERS"}, pos)
+	return nil, newParseError(tokstr(tok, lit), []string{"CONTINUOUS", "DATABASES", "FIELD", "MEASUREMENTS", "RETENTION", "SERIES", "SERVERS", "TAG", "USERS"}, pos)
 }
 
 // parseCreateStatement parses a string and returns a create statement.
@@ -944,6 +946,13 @@ func (p *Parser) parseShowContinuousQueriesStatement() (*ShowContinuousQueriesSt
 		return nil, newParseError(tokstr(tok, lit), []string{"QUERIES"}, pos)
 	}
 
+	return stmt, nil
+}
+
+// parseShowServersStatement parses a string and returns a ShowServersStatement.
+// This function assumes the "SHOW SERVERS" tokens have already been consumed.
+func (p *Parser) parseShowServersStatement() (*ShowServersStatement, error) {
+	stmt := &ShowServersStatement{}
 	return stmt, nil
 }
 

--- a/influxql/parser_test.go
+++ b/influxql/parser_test.go
@@ -183,6 +183,12 @@ func TestParser_ParseStatement(t *testing.T) {
 			},
 		},
 
+		// SHOW SERVERS
+		{
+			s:    `SHOW SERVERS`,
+			stmt: &influxql.ShowServersStatement{},
+		},
+
 		// SHOW DATABASES
 		{
 			s:    `SHOW DATABASES`,
@@ -738,7 +744,7 @@ func TestParser_ParseStatement(t *testing.T) {
 		{s: `SHOW CONTINUOUS`, err: `found EOF, expected QUERIES at line 1, char 17`},
 		{s: `SHOW RETENTION`, err: `found EOF, expected POLICIES at line 1, char 16`},
 		{s: `SHOW RETENTION POLICIES`, err: `found EOF, expected identifier at line 1, char 25`},
-		{s: `SHOW FOO`, err: `found FOO, expected CONTINUOUS, DATABASES, FIELD, MEASUREMENTS, RETENTION, SERIES, TAG, USERS at line 1, char 6`},
+		{s: `SHOW FOO`, err: `found FOO, expected CONTINUOUS, DATABASES, FIELD, MEASUREMENTS, RETENTION, SERIES, SERVERS, TAG, USERS at line 1, char 6`},
 		{s: `DROP CONTINUOUS`, err: `found EOF, expected QUERY at line 1, char 17`},
 		{s: `DROP CONTINUOUS QUERY`, err: `found EOF, expected identifier at line 1, char 23`},
 		{s: `CREATE CONTINUOUS`, err: `found EOF, expected QUERY at line 1, char 19`},

--- a/influxql/token.go
+++ b/influxql/token.go
@@ -103,6 +103,7 @@ const (
 	REVOKE
 	SELECT
 	SERIES
+	SERVERS
 	SHOW
 	SLIMIT
 	SOFFSET
@@ -203,6 +204,7 @@ var tokens = [...]string{
 	REVOKE:       "REVOKE",
 	SELECT:       "SELECT",
 	SERIES:       "SERIES",
+	SERVERS:      "SERVERS",
 	SHOW:         "SHOW",
 	SLIMIT:       "SLIMIT",
 	SOFFSET:      "SOFFSET",

--- a/server.go
+++ b/server.go
@@ -1929,6 +1929,8 @@ func (s *Server) ExecuteQuery(q *influxql.Query, database string, user *User) Re
 			res = s.executeDropDatabaseStatement(stmt, user)
 		case *influxql.ShowDatabasesStatement:
 			res = s.executeShowDatabasesStatement(stmt, user)
+		case *influxql.ShowServersStatement:
+			res = s.executeShowServersStatement(stmt, user)
 		case *influxql.CreateUserStatement:
 			res = s.executeCreateUserStatement(stmt, user)
 		case *influxql.DropUserStatement:
@@ -2074,6 +2076,14 @@ func (s *Server) executeShowDatabasesStatement(q *influxql.ShowDatabasesStatemen
 	row := &influxql.Row{Columns: []string{"name"}}
 	for _, name := range s.Databases() {
 		row.Values = append(row.Values, []interface{}{name})
+	}
+	return &Result{Series: []*influxql.Row{row}}
+}
+
+func (s *Server) executeShowServersStatement(q *influxql.ShowServersStatement, user *User) *Result {
+	row := &influxql.Row{Columns: []string{"id", "url"}}
+	for _, node := range s.DataNodes() {
+		row.Values = append(row.Values, []interface{}{node.ID, node.URL.String()})
 	}
 	return &Result{Series: []*influxql.Row{row}}
 }


### PR DESCRIPTION
Currently lists only data nodes, with the id/url:

```sql
> SHOW SERVERS
name    tags    id      url
----    ----    --      ---
                1       http://Corys-MacBook-Pro.local:8086
```

Questions:

1) Should this include brokers as well?
2) Original issue stated wanting to show IP and hostname.  If we want that, we'll have to change the way we start up the servers to capture IP address when starting.
3) We don't currently store any heartbeat information on data nodes
4) Do we want to return the current index of each data node?
5) Do we want to support any `where` clauses to show server?
6) Should it be `SHOW DATANODES` and `SHOW BROKERS` vs. `SHOW SERVERS`?  

Addresses #1469