### PR TITLE
Cosmetic CLI output fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [#1758](https://github.com/influxdb/influxdb/pull/1758): Add Graphite Integration Test.
 - [#1929](https://github.com/influxdb/influxdb/pull/1929): Default Retention Policy incorrectly auto created.
 - [#1930](https://github.com/influxdb/influxdb/pull/1930): Auto create database for graphite if not specified.
+- [#1908](https://github.com/influxdb/influxdb/pull/1908): Cosmetic CLI output fixes.
 
 ### Features
 - [#1902](https://github.com/influxdb/influxdb/pull/1902): Enforce retention policies to have a minimum duration.

--- a/cmd/influx/main.go
+++ b/cmd/influx/main.go
@@ -267,7 +267,7 @@ func (c *CommandLine) executeQuery(query string) {
 func (c *CommandLine) FormatResults(results *client.Results, w io.Writer) {
 	switch c.Format {
 	case "json":
-		c.writeJSON(results, c.Pretty, w)
+		c.writeJSON(results, w)
 	case "csv":
 		c.writeCSV(results, w)
 	case "column":
@@ -277,10 +277,10 @@ func (c *CommandLine) FormatResults(results *client.Results, w io.Writer) {
 	}
 }
 
-func (c *CommandLine) writeJSON(results *client.Results, pretty bool, w io.Writer) {
+func (c *CommandLine) writeJSON(results *client.Results, w io.Writer) {
 	var data []byte
 	var err error
-	if pretty {
+	if c.Pretty {
 		data, err = json.MarshalIndent(results, "", "    ")
 	} else {
 		data, err = json.Marshal(results)

--- a/cmd/influx/main.go
+++ b/cmd/influx/main.go
@@ -396,10 +396,10 @@ func (c *CommandLine) formatResults(result client.Result, separator string) []st
 				values = append(values, interfaceToString(vv))
 			}
 			rows = append(rows, strings.Join(values, separator))
-			// Outout a line separator if in column format
-			if c.Format == "column" {
-				rows = append(rows, "")
-			}
+		}
+		// Outout a line separator if in column format
+		if c.Format == "column" {
+			rows = append(rows, "")
 		}
 	}
 	return rows

--- a/cmd/influx/main.go
+++ b/cmd/influx/main.go
@@ -396,6 +396,10 @@ func (c *CommandLine) formatResults(result client.Result, separator string) []st
 				values = append(values, interfaceToString(vv))
 			}
 			rows = append(rows, strings.Join(values, separator))
+			// Outout a line separator if in column format
+			if c.Format == "column" {
+				rows = append(rows, "")
+			}
 		}
 	}
 	return rows

--- a/cmd/influx/main.go
+++ b/cmd/influx/main.go
@@ -267,17 +267,17 @@ func (c *CommandLine) executeQuery(query string) {
 func (c *CommandLine) FormatResults(results *client.Results, w io.Writer) {
 	switch c.Format {
 	case "json":
-		WriteJSON(results, c.Pretty, w)
+		c.writeJSON(results, c.Pretty, w)
 	case "csv":
-		WriteCSV(results, w)
+		c.writeCSV(results, w)
 	case "column":
-		WriteColumns(results, w)
+		c.writeColumns(results, w)
 	default:
 		fmt.Fprintf(w, "Unknown output format %q.\n", c.Format)
 	}
 }
 
-func WriteJSON(results *client.Results, pretty bool, w io.Writer) {
+func (c *CommandLine) writeJSON(results *client.Results, pretty bool, w io.Writer) {
 	var data []byte
 	var err error
 	if pretty {
@@ -292,11 +292,11 @@ func WriteJSON(results *client.Results, pretty bool, w io.Writer) {
 	fmt.Fprintln(w, string(data))
 }
 
-func WriteCSV(results *client.Results, w io.Writer) {
+func (c *CommandLine) writeCSV(results *client.Results, w io.Writer) {
 	csvw := csv.NewWriter(w)
 	for _, result := range results.Results {
 		// Create a tabbed writer for each result as they won't always line up
-		rows := resultToCSV(result, "\t", false)
+		rows := c.formatResults(result, "\t")
 		for _, r := range rows {
 			csvw.Write(strings.Split(r, "\t"))
 		}
@@ -304,12 +304,12 @@ func WriteCSV(results *client.Results, w io.Writer) {
 	}
 }
 
-func WriteColumns(results *client.Results, w io.Writer) {
+func (c *CommandLine) writeColumns(results *client.Results, w io.Writer) {
 	for _, result := range results.Results {
 		// Create a tabbed writer for each result a they won't always line up
 		w := new(tabwriter.Writer)
 		w.Init(os.Stdout, 0, 8, 1, '\t', 0)
-		csv := resultToCSV(result, "\t", false)
+		csv := c.formatResults(result, "\t")
 		for _, r := range csv {
 			fmt.Fprintln(w, r)
 		}
@@ -317,57 +317,83 @@ func WriteColumns(results *client.Results, w io.Writer) {
 	}
 }
 
-func resultToCSV(result client.Result, seperator string, headerLines bool) []string {
+// formatResults will behave differently if you are formatting for columns or csv
+func (c *CommandLine) formatResults(result client.Result, separator string) []string {
 	rows := []string{}
 	// Create a tabbed writer for each result a they won't always line up
 	for i, row := range result.Series {
 		// gather tags
-		var hasTags bool
 		tags := []string{}
 		for k, v := range row.Tags {
-			hasTags = true
 			tags = append(tags, fmt.Sprintf("%s=%s", k, v))
 		}
 
 		columnNames := []string{}
-		if hasTags {
-			columnNames = append([]string{"tags"}, columnNames...)
+
+		// Only put name/tags in a column if format is csv
+		if c.Format == "csv" {
+			if len(tags) > 0 {
+				columnNames = append([]string{"tags"}, columnNames...)
+			}
+
+			if row.Name != "" {
+				columnNames = append([]string{"name"}, columnNames...)
+			}
 		}
 
-		if row.Name != "" {
-			columnNames = append([]string{"name"}, columnNames...)
-		}
 		for _, column := range row.Columns {
 			columnNames = append(columnNames, column)
 		}
-		// Output a line seperator if we have more than one set or results
-		if i > 0 {
+
+		// Output a line separator if we have more than one set or results and format is column
+		if i > 0 && c.Format == "column" {
 			rows = append(rows, "")
 		}
-		rows = append(rows, strings.Join(columnNames, seperator))
 
-		if headerLines {
-			// create column underscores
+		// If we are column format, we breka out the name/tag to seperate lines
+		if c.Format == "column" {
+			if row.Name != "" {
+				rows = append(rows, row.Name)
+				if len(tags) == 0 {
+					l := strings.Repeat("-", len(row.Name))
+					rows = append(rows, l)
+				}
+			}
+			if len(tags) > 0 {
+				t := fmt.Sprintf("tags: %s", (strings.Join(tags, ", ")))
+				l := strings.Repeat("-", len(t))
+				rows = append(rows, l)
+				rows = append(rows, t)
+				rows = append(rows, l)
+			}
+		}
+
+		rows = append(rows, strings.Join(columnNames, separator))
+
+		// if format is column, break tags to their own line/format
+		if c.Format == "column" && len(tags) > 0 {
 			lines := []string{}
 			for _, columnName := range columnNames {
 				lines = append(lines, strings.Repeat("-", len(columnName)))
 			}
-			rows = append(rows, strings.Join(lines, seperator))
+			rows = append(rows, strings.Join(lines, separator))
 		}
 
 		for _, v := range row.Values {
 			var values []string
-			if row.Name != "" {
-				values = append(values, row.Name)
-			}
-			if len(tags) > 0 {
-				values = append(values, strings.Join(tags, ","))
+			if c.Format == "csv" {
+				if row.Name != "" {
+					values = append(values, row.Name)
+				}
+				if len(tags) > 0 {
+					values = append(values, strings.Join(tags, ","))
+				}
 			}
 
 			for _, vv := range v {
 				values = append(values, interfaceToString(vv))
 			}
-			rows = append(rows, strings.Join(values, seperator))
+			rows = append(rows, strings.Join(values, separator))
 		}
 	}
 	return rows

--- a/cmd/influx/main.go
+++ b/cmd/influx/main.go
@@ -350,7 +350,7 @@ func (c *CommandLine) formatResults(result client.Result, separator string) []st
 			rows = append(rows, "")
 		}
 
-		// If we are column format, we breka out the name/tag to seperate lines
+		// If we are column format, we break out the name/tag to seperate lines
 		if c.Format == "column" {
 			if row.Name != "" {
 				rows = append(rows, row.Name)

--- a/cmd/influx/main.go
+++ b/cmd/influx/main.go
@@ -355,18 +355,16 @@ func (c *CommandLine) formatResults(result client.Result, separator string) []st
 		// If we are column format, we break out the name/tag to seperate lines
 		if c.Format == "column" {
 			if row.Name != "" {
-				rows = append(rows, row.Name)
+				n := fmt.Sprintf("name: %s", row.Name)
+				rows = append(rows, n)
 				if len(tags) == 0 {
-					l := strings.Repeat("-", len(row.Name))
+					l := strings.Repeat("-", len(n))
 					rows = append(rows, l)
 				}
 			}
 			if len(tags) > 0 {
 				t := fmt.Sprintf("tags: %s", (strings.Join(tags, ", ")))
-				l := strings.Repeat("-", len(t))
-				rows = append(rows, l)
 				rows = append(rows, t)
-				rows = append(rows, l)
 			}
 		}
 

--- a/cmd/influx/main.go
+++ b/cmd/influx/main.go
@@ -309,7 +309,7 @@ func WriteColumns(results *client.Results, w io.Writer) {
 		// Create a tabbed writer for each result a they won't always line up
 		w := new(tabwriter.Writer)
 		w.Init(os.Stdout, 0, 8, 1, '\t', 0)
-		csv := resultToCSV(result, "\t", true)
+		csv := resultToCSV(result, "\t", false)
 		for _, r := range csv {
 			fmt.Fprintln(w, r)
 		}

--- a/cmd/influx/main.go
+++ b/cmd/influx/main.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/user"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"text/tabwriter"
@@ -326,6 +327,7 @@ func (c *CommandLine) formatResults(result client.Result, separator string) []st
 		tags := []string{}
 		for k, v := range row.Tags {
 			tags = append(tags, fmt.Sprintf("%s=%s", k, v))
+			sort.Strings(tags)
 		}
 
 		columnNames := []string{}

--- a/cmd/influx/main.go
+++ b/cmd/influx/main.go
@@ -320,7 +320,7 @@ func WriteColumns(results *client.Results, w io.Writer) {
 func resultToCSV(result client.Result, seperator string, headerLines bool) []string {
 	rows := []string{}
 	// Create a tabbed writer for each result a they won't always line up
-	for _, row := range result.Series {
+	for i, row := range result.Series {
 		// gather tags
 		var hasTags bool
 		tags := []string{}
@@ -339,6 +339,10 @@ func resultToCSV(result client.Result, seperator string, headerLines bool) []str
 		}
 		for _, column := range row.Columns {
 			columnNames = append(columnNames, column)
+		}
+		// Output a line seperator if we have more than one set or results
+		if i > 0 {
+			rows = append(rows, "")
 		}
 		rows = append(rows, strings.Join(columnNames, seperator))
 

--- a/cmd/influx/main.go
+++ b/cmd/influx/main.go
@@ -320,29 +320,25 @@ func WriteColumns(results *client.Results, w io.Writer) {
 func resultToCSV(result client.Result, seperator string, headerLines bool) []string {
 	rows := []string{}
 	// Create a tabbed writer for each result a they won't always line up
-	columnNames := []string{}
-	var hasTags bool
-
-	for i, row := range result.Series {
+	for _, row := range result.Series {
 		// gather tags
+		var hasTags bool
 		tags := []string{}
 		for k, v := range row.Tags {
 			hasTags = true
 			tags = append(tags, fmt.Sprintf("%s=%s", k, v))
 		}
 
-		// Output the column headings
-		if i == 0 {
-			if hasTags {
-				columnNames = append([]string{"tags"}, columnNames...)
-			}
+		columnNames := []string{}
+		if hasTags {
+			columnNames = append([]string{"tags"}, columnNames...)
+		}
 
-			if row.Name != "" {
-				columnNames = append([]string{"name"}, columnNames...)
-			}
-			for _, column := range row.Columns {
-				columnNames = append(columnNames, column)
-			}
+		if row.Name != "" {
+			columnNames = append([]string{"name"}, columnNames...)
+		}
+		for _, column := range row.Columns {
+			columnNames = append(columnNames, column)
 		}
 		rows = append(rows, strings.Join(columnNames, seperator))
 

--- a/tests/create_write_single_with_multiple_measurements_values_tags.sh
+++ b/tests/create_write_single_with_multiple_measurements_values_tags.sh
@@ -1,0 +1,23 @@
+echo "creating database"
+curl -G http://localhost:8086/query --data-urlencode "q=CREATE DATABASE foo"
+
+echo "creating retention policy"
+curl -G http://localhost:8086/query --data-urlencode "q=CREATE RETENTION POLICY bar ON foo DURATION 300d REPLICATION 3 DEFAULT"
+
+echo "inserting data"
+curl -d '{"database" : "foo", "retentionPolicy" : "bar", "points": [{"name": "cpu", "timestamp": "2015-02-26T22:01:11.703Z","fields": {"value": 8.9}}]}' -H "Content-Type: application/json" http://localhost:8086/write
+curl -d '{"database" : "foo", "retentionPolicy" : "bar", "points": [{"name": "cpu", "timestamp": "2015-02-27T22:01:11.703Z","fields": {"value": 1.3}}]}' -H "Content-Type: application/json" http://localhost:8086/write
+curl -d '{"database" : "foo", "retentionPolicy" : "bar", "points": [{"name": "cpu", "timestamp": "2015-02-28T22:01:11.703Z","fields": {"value": 50.4}}]}' -H "Content-Type: application/json" http://localhost:8086/write
+
+
+curl -d '{"database" : "foo", "retentionPolicy" : "bar", "points": [{"name": "mem", "tags": {"host": "server01"},"timestamp": "2015-02-26T22:01:11.703Z","fields": {"value": 16432}}]}' -H "Content-Type: application/json" http://localhost:8086/write
+curl -d '{"database" : "foo", "retentionPolicy" : "bar", "points": [{"name": "mem", "tags": {"host": "server01"},"timestamp": "2015-02-27T22:01:11.703Z","fields": {"value": 23453}}]}' -H "Content-Type: application/json" http://localhost:8086/write
+curl -d '{"database" : "foo", "retentionPolicy" : "bar", "points": [{"name": "mem", "tags": {"host": "server02"},"timestamp": "2015-02-28T22:01:11.703Z","fields": {"value": 90234}}]}' -H "Content-Type: application/json" http://localhost:8086/write
+
+curl -d '{"database" : "foo", "retentionPolicy" : "bar", "points": [{"name": "temp", "tags": {"host": "server01","region":"uswest"}, "timestamp": "2015-02-26T22:01:11.703Z","fields": {"value": 98.6}}]}' -H "Content-Type: application/json" http://localhost:8086/write
+curl -d '{"database" : "foo", "retentionPolicy" : "bar", "points": [{"name": "temp", "tags": {"host": "server01","region":"useast"}, "timestamp": "2015-02-27T22:01:11.703Z","fields": {"value": 101.1}}]}' -H "Content-Type: application/json" http://localhost:8086/write
+curl -d '{"database" : "foo", "retentionPolicy" : "bar", "points": [{"name": "temp", "tags": {"host": "server02","region":"useast"}, "timestamp": "2015-02-28T22:01:11.703Z","fields": {"value": 105.4}}]}' -H "Content-Type: application/json" http://localhost:8086/write
+
+curl -d '{"database" : "foo", "retentionPolicy" : "bar", "points": [{"name": "network", "tags": {"host": "server01","region":"uswest"},"timestamp": "2015-02-26T22:01:11.703Z","fields": {"rx": 2342,"tx": 9804}}]}' -H "Content-Type: application/json" http://localhost:8086/write
+curl -d '{"database" : "foo", "retentionPolicy" : "bar", "points": [{"name": "network", "tags": {"host": "server01","region":"useast"},"timestamp": "2015-02-27T22:01:11.703Z","fields": {"rx": 4324,"tx": 7930}}]}' -H "Content-Type: application/json" http://localhost:8086/write
+curl -d '{"database" : "foo", "retentionPolicy" : "bar", "points": [{"name": "network", "tags": {"host": "server02","region":"useast"},"timestamp": "2015-02-28T22:01:11.703Z","fields": {"rx": 2342,"tx": 8234}}]}' -H "Content-Type: application/json" http://localhost:8086/write


### PR DESCRIPTION
This fixes the following types of queries:

**FROM**:

```sql
> select * from cpu
name    tags    time                            value
----    ----    ----                            -----
cpu             2015-01-26T22:01:11.703Z        100
cpu             2015-01-27T22:01:11.703Z        100
cpu             2015-01-28T22:01:11.703Z        100
```

**TO**:

```sql
> select * from cpu
name    time                            value
----    ----                            -----
cpu     2015-01-26T22:01:11.703Z        100
cpu     2015-01-27T22:01:11.703Z        100
cpu     2015-01-28T22:01:11.703Z        100
```

**FROM**:

```sql
> show series
name    tags    id      host
----    ----    --      ----
cpu             1       server01
----    ----    --      ----
mem             2       server01
```

**TO**:

```sql
> show series
name    id      host
----    --      ----
cpu     1       server01
name    id      host
----    --      ----
mem     2       server01
```

**FROM**:

```sql
> show databases
name    tags    name
----    ----    ----
                foo
```

**TO**:

```sql
> show databases
name
----
foo
```