### PR TITLE
Creating Infinite Retention Policy Failed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## v0.9.0-rc11 [unreleased]
 
+### Bugfixes
+- [#1917](https://github.com/influxdb/influxdb/pull/1902): Creating Infinite Retention Policy Failed.
+
 ### Features
 - [#1902](https://github.com/influxdb/influxdb/pull/1902): Enforce retention policies to have a minimum duraton.
 

--- a/server.go
+++ b/server.go
@@ -1273,7 +1273,7 @@ func (s *Server) RetentionPolicies(database string) ([]*RetentionPolicy, error) 
 // CreateRetentionPolicy creates a retention policy for a database.
 func (s *Server) CreateRetentionPolicy(database string, rp *RetentionPolicy) error {
 	// Enforce duration of at least retentionPolicyMinDuration
-	if rp.Duration < retentionPolicyMinDuration {
+	if rp.Duration < retentionPolicyMinDuration && rp.Duration != 0 {
 		return ErrRetentionPolicyMinDuration
 	}
 
@@ -1344,7 +1344,7 @@ type RetentionPolicyUpdate struct {
 // UpdateRetentionPolicy updates an existing retention policy on a database.
 func (s *Server) UpdateRetentionPolicy(database, name string, rpu *RetentionPolicyUpdate) error {
 	// Enforce duration of at least retentionPolicyMinDuration
-	if *rpu.Duration < retentionPolicyMinDuration {
+	if *rpu.Duration < retentionPolicyMinDuration && *rpu.Duration != 0 {
 		return ErrRetentionPolicyMinDuration
 	}
 


### PR DESCRIPTION
This is a follow up to a bug that @jnutzmann logged on PR #1902.  We were missing some test coverage on INF retention policy which I've added, and corrected the calculations for min shard duration.

Thanks @jnutzmann!