### PR TITLE
Add fill to select statements.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Features
 - [#1902](https://github.com/influxdb/influxdb/pull/1902): Enforce retention policies to have a minimum duration.
 - [#1906](https://github.com/influxdb/influxdb/pull/1906): Add show servers to query language.
+- [#1925](https://github.com/influxdb/influxdb/pull/1925): Add `fill(none)`, `fill(previous)`, and `fill(<num>)` to queries.
 
 ## v0.9.0-rc10 [2015-03-09]
 

--- a/influxql/INFLUXQL.md
+++ b/influxql/INFLUXQL.md
@@ -576,7 +576,7 @@ select_stmt = fields from_clause [ into_clause ] [ where_clause ]
 
 ```sql
 -- select mean value from the cpu measurement where region = 'uswest' grouped by 10 minute intervals
-SELECT mean(value) FROM cpu WHERE region = 'uswest' GROUP BY time(10m);
+SELECT mean(value) FROM cpu WHERE region = 'uswest' GROUP BY time(10m) fill(0);
 ```
 
 ## Clauses
@@ -584,7 +584,7 @@ SELECT mean(value) FROM cpu WHERE region = 'uswest' GROUP BY time(10m);
 ```
 from_clause     = "FROM" measurements .
 
-group_by_clause = "GROUP BY" dimensions .
+group_by_clause = "GROUP BY" dimensions fill(<option>).
 
 limit_clause    = "LIMIT" int_lit .
 

--- a/influxql/ast.go
+++ b/influxql/ast.go
@@ -529,6 +529,19 @@ func (s *AlterRetentionPolicyStatement) RequiredPrivileges() ExecutionPrivileges
 	return ExecutionPrivileges{{Name: "", Privilege: AllPrivileges}}
 }
 
+type FillOption int
+
+const (
+	// NullFill means that empty aggregate windows will just have null values.
+	NullFill FillOption = iota
+	// NoFill means that empty aggregate windows will be purged from the result.
+	NoFill
+	// NumberFill means that empty aggregate windwos will be filled with the given number
+	NumberFill
+	// PreviousFill means that empty aggregate windows will be filled with whatever the previous aggregate window had
+	PreviousFill
+)
+
 // SelectStatement represents a command for extracting data from the database.
 type SelectStatement struct {
 	// Expressions returned from the selection.
@@ -566,6 +579,12 @@ type SelectStatement struct {
 
 	// if it's a query for raw data values (i.e. not an aggregate)
 	RawQuery bool
+
+	// What fill option the select statement uses, if any
+	Fill FillOption
+
+	// The value to fill empty aggregate buckets with, if any
+	FillValue interface{}
 }
 
 // Clone returns a deep copy of the statement.

--- a/influxql/ast.go
+++ b/influxql/ast.go
@@ -536,7 +536,7 @@ const (
 	NullFill FillOption = iota
 	// NoFill means that empty aggregate windows will be purged from the result.
 	NoFill
-	// NumberFill means that empty aggregate windwos will be filled with the given number
+	// NumberFill means that empty aggregate windows will be filled with the given number
 	NumberFill
 	// PreviousFill means that empty aggregate windows will be filled with whatever the previous aggregate window had
 	PreviousFill

--- a/influxql/ast.go
+++ b/influxql/ast.go
@@ -599,6 +599,8 @@ func (s *SelectStatement) Clone() *SelectStatement {
 		Offset:     s.Offset,
 		SLimit:     s.SLimit,
 		SOffset:    s.SOffset,
+		Fill:       s.Fill,
+		FillValue:  s.FillValue,
 	}
 	if s.Target != nil {
 		other.Target = &Target{Measurement: s.Target.Measurement, Database: s.Target.Database}
@@ -693,6 +695,14 @@ func (s *SelectStatement) String() string {
 	if len(s.Dimensions) > 0 {
 		_, _ = buf.WriteString(" GROUP BY ")
 		_, _ = buf.WriteString(s.Dimensions.String())
+	}
+	switch s.Fill {
+	case NoFill:
+		_, _ = buf.WriteString(" fill(none)")
+	case NumberFill:
+		_, _ = buf.WriteString(fmt.Sprintf(" fill(%v)", s.FillValue))
+	case PreviousFill:
+		_, _ = buf.WriteString(" fill(previous)")
 	}
 	if len(s.SortFields) > 0 {
 		_, _ = buf.WriteString(" ORDER BY ")

--- a/influxql/ast_test.go
+++ b/influxql/ast_test.go
@@ -373,6 +373,12 @@ func TestSelectStatement_RewriteWildcards(t *testing.T) {
 			rewrite: `SELECT value FROM cpu GROUP BY host, region, time(1m)`,
 		},
 
+		// GROUP BY wildarde with fill
+		{
+			stmt:    `SELECT value FROM cpu GROUP BY *,time(1m) fill(0)`,
+			rewrite: `SELECT value FROM cpu GROUP BY host, region, time(1m) fill(0)`,
+		},
+
 		// GROUP BY wildcard with explicit
 		{
 			stmt:    `SELECT value FROM cpu GROUP BY *,host`,

--- a/influxql/parser_test.go
+++ b/influxql/parser_test.go
@@ -170,6 +170,49 @@ func TestParser_ParseStatement(t *testing.T) {
 			},
 		},
 
+		// SELECT statement with fill
+		{
+			s: `SELECT mean(value) FROM cpu GROUP BY time(5m) fill(1)`,
+			stmt: &influxql.SelectStatement{
+				Fields: []*influxql.Field{{
+					Expr: &influxql.Call{
+						Name: "mean",
+						Args: []influxql.Expr{&influxql.VarRef{Val: "value"}}}}},
+				Source: &influxql.Measurement{Name: "cpu"},
+				Dimensions: []*influxql.Dimension{
+					{Expr: &influxql.Call{
+						Name: "time",
+						Args: []influxql.Expr{
+							&influxql.DurationLiteral{Val: 5 * time.Minute},
+						},
+					}},
+				},
+				Fill:      influxql.NumberFill,
+				FillValue: float64(1),
+			},
+		},
+
+		// SELECT statement with previous fill
+		{
+			s: `SELECT mean(value) FROM cpu GROUP BY time(5m) fill(previous)`,
+			stmt: &influxql.SelectStatement{
+				Fields: []*influxql.Field{{
+					Expr: &influxql.Call{
+						Name: "mean",
+						Args: []influxql.Expr{&influxql.VarRef{Val: "value"}}}}},
+				Source: &influxql.Measurement{Name: "cpu"},
+				Dimensions: []*influxql.Dimension{
+					{Expr: &influxql.Call{
+						Name: "time",
+						Args: []influxql.Expr{
+							&influxql.DurationLiteral{Val: 5 * time.Minute},
+						},
+					}},
+				},
+				Fill: influxql.PreviousFill,
+			},
+		},
+
 		// DELETE statement
 		{
 			s: `DELETE FROM myseries WHERE host = 'hosta.influxdb.org'`,


### PR DESCRIPTION
Fixes #1913
Add `fill(none)`, `fill(<num>)`, and `fill(previous)` options for replacing null values in aggregates. The none option will remove any rows from values if there is a null value anywhere in there.