### PR TITLE
Fix issue with time buckets and improve performance

### DIFF
--- a/influxql/engine.go
+++ b/influxql/engine.go
@@ -145,7 +145,8 @@ func (m *MapReduceJob) Execute(out chan *Row, filterEmptyResults bool) {
 		resultValues[i] = append(vals, time.Unix(0, t).UTC())
 	}
 
-	// set the minimum time if we should set the limit and the offset is greater than 0. This way we don't range over data we don't need to
+	// This just makes sure that if they specify a start time less than what the start time would be with the offset,
+	// we just reset the start time to the later time to avoid going over data that won't show up in the result.
 	if setLimit && m.stmt.Offset > 0 {
 		m.TMin = resultTimes[0]
 	}

--- a/influxql/engine.go
+++ b/influxql/engine.go
@@ -110,20 +110,12 @@ func (m *MapReduceJob) Execute(out chan *Row, filterEmptyResults bool) {
 		return
 	}
 
-	// initialize the times of the aggregate points
-	resultTimes := make([]int64, pointCountInResult)
-	resultValues := make([][]interface{}, pointCountInResult)
-	for i, _ := range resultTimes {
-		t := m.TMin + (int64(i) * m.interval)
-		resultTimes[i] = t
-		// we always include time so we need one more column than we have aggregates
-		vals := make([]interface{}, 0, len(aggregates)+1)
-		resultValues[i] = append(vals, time.Unix(0, t).UTC())
-	}
-
+	// check limits
 	// now limit the number of data points returned by the limit and offset
+	setLimit := false
 	if pointCountInResult > 1 && (m.stmt.Limit > 0 || m.stmt.Offset > 0) {
-		if m.stmt.Offset > len(resultValues) {
+		setLimit = true
+		if m.stmt.Offset > pointCountInResult {
 			out <- &Row{
 				Name: m.MeasurementName,
 				Tags: m.TagSet.Tags,
@@ -131,14 +123,30 @@ func (m *MapReduceJob) Execute(out chan *Row, filterEmptyResults bool) {
 
 			return
 		} else {
-			limit := m.stmt.Limit
-			if m.stmt.Offset+m.stmt.Limit > len(resultValues) {
-				limit = len(resultValues) - m.stmt.Offset
+			pointCountInResult = m.stmt.Limit
+			if m.stmt.Offset+m.stmt.Limit > pointCountInResult {
+				pointCountInResult = pointCountInResult - m.stmt.Offset
 			}
-
-			resultTimes = resultTimes[m.stmt.Offset : m.stmt.Offset+limit]
-			resultValues = resultValues[m.stmt.Offset : m.stmt.Offset+limit]
 		}
+	}
+
+	// initialize the times of the aggregate points
+	resultTimes := make([]int64, pointCountInResult)
+	resultValues := make([][]interface{}, pointCountInResult)
+
+	// ensure that the start time for the results is on the start of the window
+	startTimeBucket := m.TMin / m.interval * m.interval
+
+	for i, _ := range resultTimes {
+		t := startTimeBucket + (int64(i) * m.interval * int64(m.stmt.Offset+1))
+		resultTimes[i] = t
+		// we always include time so we need one more column than we have aggregates
+		vals := make([]interface{}, 0, len(aggregates)+1)
+		resultValues[i] = append(vals, time.Unix(0, t).UTC())
+	}
+
+	// set the minimum time if we should set the limit and the offset is greater than 0. This way we don't range over data we don't need to
+	if setLimit && m.stmt.Offset > 0 {
 		m.TMin = resultTimes[0]
 	}
 

--- a/server_test.go
+++ b/server_test.go
@@ -1455,7 +1455,7 @@ func TestServer_ExecuteQuery(t *testing.T) {
 	}
 
 	// Sum aggregation.
-	expected = `{"series":[{"name":"cpu","tags":{"region":"us-east"},"columns":["time","sum"],"values":[["2000-01-01T00:00:05Z",30]]}]}`
+	expected = `{"series":[{"name":"cpu","tags":{"region":"us-east"},"columns":["time","sum"],"values":[["2000-01-01T00:00:00Z",30]]}]}`
 	results = s.ExecuteQuery(MustParseQuery(`SELECT sum(value) FROM cpu WHERE time >= '2000-01-01 00:00:05' AND time <= '2000-01-01T00:00:10Z' GROUP BY time(10s), region`), "foo", nil)
 	if res := results.Results[0]; res.Err != nil {
 		t.Fatalf("unexpected error during SUM: %s", res.Err)


### PR DESCRIPTION
When the start time fell in the middle of a group by bucket, the times for all buckets would be off by the amount of that stat time. This fixes it so group by windows are always on the bucket. However, if the user specifies a start time in the middle of a bucket, the very first bucket will only have whatever data in it that is past the start time (so it'll be a partial)

Also fixed a performance bug where if someone issued a query like: `SELECT mean(value) FROM foo GROUP BY time(10s) LIMIT 3`. Previously, the engine would create emtpy values for every 10s window since 1970, then limit it afterwards. Now, it'll just create value holders for the 3 buckets we need.