### PR TITLE
Default Retention Policy incorrectly auto created

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Bugfixes
 - [#1917](https://github.com/influxdb/influxdb/pull/1902): Creating Infinite Retention Policy Failed.
 - [#1758](https://github.com/influxdb/influxdb/pull/1758): Add Graphite Integration Test.
+- [#1929](https://github.com/influxdb/influxdb/pull/1929): Default Retention Policy incorrectly auto created.
 
 ### Features
 - [#1902](https://github.com/influxdb/influxdb/pull/1902): Enforce retention policies to have a minimum duration.


### PR DESCRIPTION
This fixes two bugs:

1) When the default retention policy was auto created, it was passing the database name to the policy map, not the retention policy name.
2) This was not taking into account ShardGroupDuration during auto create.

Added test coverage for these scenarios.