### PR TITLE
Auto create database for graphite if not specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - [#1917](https://github.com/influxdb/influxdb/pull/1902): Creating Infinite Retention Policy Failed.
 - [#1758](https://github.com/influxdb/influxdb/pull/1758): Add Graphite Integration Test.
 - [#1929](https://github.com/influxdb/influxdb/pull/1929): Default Retention Policy incorrectly auto created.
+- [#1930](https://github.com/influxdb/influxdb/pull/): Auto create database for graphite if not specified.
 
 ### Features
 - [#1902](https://github.com/influxdb/influxdb/pull/1902): Enforce retention policies to have a minimum duration.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - [#1917](https://github.com/influxdb/influxdb/pull/1902): Creating Infinite Retention Policy Failed.
 - [#1758](https://github.com/influxdb/influxdb/pull/1758): Add Graphite Integration Test.
 - [#1929](https://github.com/influxdb/influxdb/pull/1929): Default Retention Policy incorrectly auto created.
-- [#1930](https://github.com/influxdb/influxdb/pull/): Auto create database for graphite if not specified.
+- [#1930](https://github.com/influxdb/influxdb/pull/1930): Auto create database for graphite if not specified.
 
 ### Features
 - [#1902](https://github.com/influxdb/influxdb/pull/1902): Enforce retention policies to have a minimum duration.

--- a/cmd/influxd/run.go
+++ b/cmd/influxd/run.go
@@ -163,6 +163,7 @@ func Run(config *Config, join, version string, logWriter *os.File) (*messaging.B
 			if strings.ToLower(c.Protocol) == "tcp" {
 				g := graphite.NewTCPServer(parser, s)
 				g.Database = c.Database
+				g.SetLogOutput(logWriter)
 				err := g.ListenAndServe(c.ConnectionString(config.BindAddress))
 				if err != nil {
 					log.Printf("failed to start TCP Graphite Server: %v\n", err.Error())
@@ -170,6 +171,7 @@ func Run(config *Config, join, version string, logWriter *os.File) (*messaging.B
 			} else if strings.ToLower(c.Protocol) == "udp" {
 				g := graphite.NewUDPServer(parser, s)
 				g.Database = c.Database
+				g.SetLogOutput(logWriter)
 				err := g.ListenAndServe(c.ConnectionString(config.BindAddress))
 				if err != nil {
 					log.Printf("failed to start UDP Graphite Server: %v\n", err.Error())

--- a/graphite/graphite.go
+++ b/graphite/graphite.go
@@ -16,6 +16,9 @@ const (
 
 	// DefaultGraphiteNameSeparator represents the default Graphite field separator.
 	DefaultGraphiteNameSeparator = "."
+
+	// DefaultDatabaseName is the default database that is created if none is specified
+	DefaultDatabaseName = "graphite"
 )
 
 var (
@@ -26,16 +29,16 @@ var (
 	// ErrServerClosed return when closing an already closed graphite server.
 	ErrServerClosed = errors.New("server already closed")
 
-	// ErrDatabaseNotSpecified retuned when no database was specified in the config file
-	ErrDatabaseNotSpecified = errors.New("database was not specified in config")
-
 	// ErrServerNotSpecified returned when Server is not specified.
 	ErrServerNotSpecified = errors.New("server not present")
 )
 
 // SeriesWriter defines the interface for the destination of the data.
-type SeriesWriter interface {
-	WriteSeries(database, retentionPolicy string, points []influxdb.Point) (uint64, error)
+type Server interface {
+	WriteSeries(string, string, []influxdb.Point) (uint64, error)
+	CreateDatabase(string) error
+	CreateRetentionPolicy(string, *influxdb.RetentionPolicy) error
+	DatabaseExists(string) bool
 }
 
 // Parser encapulates a Graphite Parser.

--- a/graphite/graphite_tcp.go
+++ b/graphite/graphite_tcp.go
@@ -2,6 +2,7 @@ package graphite
 
 import (
 	"bufio"
+	"io"
 	"log"
 	"net"
 	"strings"
@@ -11,18 +12,24 @@ import (
 
 // TCPServer processes Graphite data received over TCP connections.
 type TCPServer struct {
-	writer SeriesWriter
+	server Server
 	parser *Parser
 
 	Database string
+	Logger   *log.Logger
 }
 
 // NewTCPServer returns a new instance of a TCPServer.
-func NewTCPServer(p *Parser, w SeriesWriter) *TCPServer {
+func NewTCPServer(p *Parser, s Server) *TCPServer {
 	return &TCPServer{
 		parser: p,
-		writer: w,
+		server: s,
 	}
+}
+
+// SetLogOutput sets writer for all Graphite log output.
+func (s *TCPServer) SetLogOutput(w io.Writer) {
+	s.Logger = log.New(w, "[graphite] ", log.LstdFlags)
 }
 
 // ListenAndServe instructs the TCPServer to start processing Graphite data
@@ -30,8 +37,15 @@ func NewTCPServer(p *Parser, w SeriesWriter) *TCPServer {
 func (t *TCPServer) ListenAndServe(iface string) error {
 	if iface == "" { // Make sure we have an address
 		return ErrBindAddressRequired
-	} else if t.Database == "" { // Make sure they have a database
-		return ErrDatabaseNotSpecified
+	} else if t.Database == "" {
+		// If they didn't specify a database, create one and set a default retention policy.
+		if !t.server.DatabaseExists(DefaultDatabaseName) {
+			t.Logger.Printf("default database %q does not exist.  creating.\n", DefaultDatabaseName)
+			if e := t.server.CreateDatabase(DefaultDatabaseName); e != nil {
+				return e
+			}
+			t.Database = DefaultDatabaseName
+		}
 	}
 
 	ln, err := net.Listen("tcp", iface)
@@ -42,7 +56,7 @@ func (t *TCPServer) ListenAndServe(iface string) error {
 		for {
 			conn, err := ln.Accept()
 			if err != nil {
-				log.Println("error accepting TCP connection", err.Error())
+				t.Logger.Println("error accepting TCP connection", err.Error())
 				continue
 			}
 			go t.handleConnection(conn)
@@ -69,11 +83,14 @@ func (t *TCPServer) handleConnection(conn net.Conn) {
 		// Parse it.
 		point, err := t.parser.Parse(line)
 		if err != nil {
-			log.Printf("unable to parse data: %s", err)
+			t.Logger.Printf("unable to parse data: %s", err)
 			continue
 		}
 
 		// Send the data to database
-		t.writer.WriteSeries(t.Database, "", []influxdb.Point{point})
+		_, e := t.server.WriteSeries(t.Database, "", []influxdb.Point{point})
+		if e != nil {
+			t.Logger.Printf("failed to write data point to database %q: %s\n", t.Database, e)
+		}
 	}
 }

--- a/server.go
+++ b/server.go
@@ -1248,7 +1248,6 @@ func (s *Server) DefaultRetentionPolicy(database string) (*RetentionPolicy, erro
 		return nil, ErrDatabaseNotFound
 	}
 
-	log.Printf("db.defaultRetentionPolicy: %q\n", db.defaultRetentionPolicy)
 	return db.policies[db.defaultRetentionPolicy], nil
 }
 
@@ -1521,9 +1520,6 @@ func (s *Server) WriteSeries(database, retentionPolicy string, points []Point) (
 
 	// If the retention policy is not set, use the default for this database.
 	if retentionPolicy == "" {
-		if s.WriteTrace {
-			log.Printf("no retention policy specified.  looking up default retention policy.\n")
-		}
 		rp, err := s.DefaultRetentionPolicy(database)
 		if err != nil {
 			return 0, fmt.Errorf("failed to determine default retention policy: %s", err.Error())
@@ -1531,9 +1527,6 @@ func (s *Server) WriteSeries(database, retentionPolicy string, points []Point) (
 			return 0, ErrDefaultRetentionPolicyNotFound
 		}
 		retentionPolicy = rp.Name
-		if s.WriteTrace {
-			log.Printf("found default retention policy: %s.\n", rp.Name)
-		}
 	}
 
 	// Ensure all required Series and Measurement Fields are created cluster-wide.

--- a/server.go
+++ b/server.go
@@ -1248,6 +1248,7 @@ func (s *Server) DefaultRetentionPolicy(database string) (*RetentionPolicy, erro
 		return nil, ErrDatabaseNotFound
 	}
 
+	log.Printf("db.defaultRetentionPolicy: %q\n", db.defaultRetentionPolicy)
 	return db.policies[db.defaultRetentionPolicy], nil
 }
 
@@ -1520,6 +1521,9 @@ func (s *Server) WriteSeries(database, retentionPolicy string, points []Point) (
 
 	// If the retention policy is not set, use the default for this database.
 	if retentionPolicy == "" {
+		if s.WriteTrace {
+			log.Printf("no retention policy specified.  looking up default retention policy.\n")
+		}
 		rp, err := s.DefaultRetentionPolicy(database)
 		if err != nil {
 			return 0, fmt.Errorf("failed to determine default retention policy: %s", err.Error())
@@ -1527,6 +1531,9 @@ func (s *Server) WriteSeries(database, retentionPolicy string, points []Point) (
 			return 0, ErrDefaultRetentionPolicyNotFound
 		}
 		retentionPolicy = rp.Name
+		if s.WriteTrace {
+			log.Printf("found default retention policy: %s.\n", rp.Name)
+		}
 	}
 
 	// Ensure all required Series and Measurement Fields are created cluster-wide.


### PR DESCRIPTION
The graphite endpoint will now auto create a database called `graphite` if no database is specified in the config.

If the system is set to auto create default retention policies (which it should if you aren't going to specify a database), then the retention policy of `default` for an `INF` duration is also created.

Additional refactoring in this PR:

1) Added a `SetLogOutput` to the graphite servers.
2) Log if write's fail

This PR is waiting on PR #1929 to be merged as it fixes a bug that prevents this feature from working.

Fixes #1745 