### PR TITLE
Do not allow empy database names

### DIFF
--- a/database.go
+++ b/database.go
@@ -81,6 +81,10 @@ func (db *database) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	if o.Name == "" {
+		return ErrDatabaseNameRequired
+	}
+
 	// Copy over properties from intermediate type.
 	db.name = o.Name
 	db.defaultRetentionPolicy = o.DefaultRetentionPolicy

--- a/server.go
+++ b/server.go
@@ -747,6 +747,9 @@ func (s *Server) Databases() (a []string) {
 
 // CreateDatabase creates a new database.
 func (s *Server) CreateDatabase(name string) error {
+	if name == "" {
+		return ErrDatabaseNameRequired
+	}
 	c := &createDatabaseCommand{Name: name}
 	_, err := s.broadcast(createDatabaseMessageType, c)
 	return err

--- a/server.go
+++ b/server.go
@@ -1943,6 +1943,8 @@ func (s *Server) ExecuteQuery(q *influxql.Query, database string, user *User) Re
 			res = s.executeShowServersStatement(stmt, user)
 		case *influxql.CreateUserStatement:
 			res = s.executeCreateUserStatement(stmt, user)
+		case *influxql.DeleteStatement:
+			res = s.executeDeleteStatement()
 		case *influxql.DropUserStatement:
 			res = s.executeDropUserStatement(stmt, user)
 		case *influxql.ShowUsersStatement:
@@ -2635,6 +2637,10 @@ func (s *Server) executeAlterRetentionPolicyStatement(stmt *influxql.AlterRetent
 	}
 
 	return &Result{Err: err}
+}
+
+func (s *Server) executeDeleteStatement() *Result {
+	return &Result{Err: ErrInvalidQuery}
 }
 
 func (s *Server) executeDropRetentionPolicyStatement(q *influxql.DropRetentionPolicyStatement, user *User) *Result {

--- a/server_test.go
+++ b/server_test.go
@@ -290,6 +290,11 @@ func TestServer_CreateDatabase(t *testing.T) {
 	s := OpenServer(NewMessagingClient())
 	defer s.Close()
 
+	// Attempt creating empty name database.
+	if err := s.CreateDatabase(""); err != influxdb.ErrDatabaseNameRequired {
+		t.Fatal("expected error on empty database name")
+	}
+
 	// Create the "foo" database.
 	if err := s.CreateDatabase("foo"); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
As reported in #1950, return an error on empty database name (both create database and JSON unmarshalling).