### PR TITLE
do not allow empty database name, closes #1950

### DIFF
--- a/database.go
+++ b/database.go
@@ -81,10 +81,6 @@ func (db *database) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	if o.Name == "" {
-		return ErrDatabaseNameRequired
-	}
-
 	// Copy over properties from intermediate type.
 	db.name = o.Name
 	db.defaultRetentionPolicy = o.DefaultRetentionPolicy

--- a/database.go
+++ b/database.go
@@ -81,6 +81,10 @@ func (db *database) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	if o.Name == "" {
+		return ErrDatabaseNameRequired
+	}
+
 	// Copy over properties from intermediate type.
 	db.name = o.Name
 	db.defaultRetentionPolicy = o.DefaultRetentionPolicy

--- a/server.go
+++ b/server.go
@@ -747,6 +747,9 @@ func (s *Server) Databases() (a []string) {
 
 // CreateDatabase creates a new database.
 func (s *Server) CreateDatabase(name string) error {
+	if name == "" {
+		return ErrDatabaseNameRequired
+	}
 	c := &createDatabaseCommand{Name: name}
 	_, err := s.broadcast(createDatabaseMessageType, c)
 	return err

--- a/server.go
+++ b/server.go
@@ -798,6 +798,9 @@ func (s *Server) applyCreateDatabase(m *messaging.Message) (err error) {
 
 // DropDatabase deletes an existing database.
 func (s *Server) DropDatabase(name string) error {
+	if name == "" {
+		return ErrDatabaseNameRequired
+	}
 	c := &dropDatabaseCommand{Name: name}
 	_, err := s.broadcast(dropDatabaseMessageType, c)
 	return err

--- a/server_test.go
+++ b/server_test.go
@@ -290,6 +290,11 @@ func TestServer_CreateDatabase(t *testing.T) {
 	s := OpenServer(NewMessagingClient())
 	defer s.Close()
 
+	// Attempt creating empty name database.
+	if err := s.CreateDatabase(""); err != influxdb.ErrDatabaseNameRequired {
+		t.Fatal("expected error on empty database name")
+	}
+
 	// Create the "foo" database.
 	if err := s.CreateDatabase("foo"); err != nil {
 		t.Fatal(err)

--- a/server_test.go
+++ b/server_test.go
@@ -326,6 +326,11 @@ func TestServer_DropDatabase(t *testing.T) {
 	s := OpenServer(NewMessagingClient())
 	defer s.Close()
 
+	// Attempt creating empty name database.
+	if err := s.DropDatabase(""); err != influxdb.ErrDatabaseNameRequired {
+		t.Fatal("expected error on empty database name")
+	}
+
 	// Create the "foo" database and verify it exists.
 	if err := s.CreateDatabase("foo"); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
As reported in #1950, disallow empty database names in both DB creation and JSON unmarshalling.