### PR TITLE
fix vet error

### DIFF
--- a/stats_test.go
+++ b/stats_test.go
@@ -83,6 +83,6 @@ func TestStats_Snapshot(t *testing.T) {
 
 	bar := foo.Snapshot()
 	if bar.Name() != "server" || bar.Get("a") != 100 || bar.Get("b") != 600 {
-		t.Fatalf("stats snapshot returned unexpected result: %s", bar)
+		t.Fatalf("stats snapshot returned unexpected result: %#v", bar)
 	}
 }


### PR DESCRIPTION
Master was currently giving me this vet error:

```
$ go vet ./...
stats_test.go:86: arg bar for printf verb %s of wrong type: *github.com/influxdb/influxdb.Stats
exit status 1
```

I'm not sure how this was passing travis/circle on the servers.

Merging on green.

cc @otoolep 