### PR TITLE
Print config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Bugfixes
 - [#1971](https://github.com/influxdb/influxdb/pull/1971): Fix leader id initialization.
 - [#1975](https://github.com/influxdb/influxdb/pull/1975): Require `q` parameter for query endpoint.
+- [#1969](https://github.com/influxdb/influxdb/pull/1969): Print loaded config.
 
 ## v0.9.0-rc12 [2015-03-15]
 

--- a/cmd/influxd/config.go
+++ b/cmd/influxd/config.go
@@ -260,6 +260,11 @@ func (c *Config) ShardGroupPreCreateCheckPeriod() time.Duration {
 	return DefaultRetentionCreatePeriod
 }
 
+// WriteConfigFile writes the config to the specified writer
+func (c *Config) Write(w io.Writer) error {
+	return toml.NewEncoder(w).Encode(c)
+}
+
 // Size represents a TOML parseable file size.
 // Users can specify size using "m" for megabytes and "g" for gigabytes.
 type Size int
@@ -311,11 +316,6 @@ func (d *Duration) UnmarshalText(text []byte) error {
 	// Set duration and return.
 	*d = Duration(duration)
 	return nil
-}
-
-// WriteConfigFile writes the config to the specified writer
-func WriteConfigFile(c *Config, w io.Writer) error {
-	return toml.NewEncoder(w).Encode(c)
 }
 
 // ParseConfigFile parses a configuration file at a given path.

--- a/cmd/influxd/config.go
+++ b/cmd/influxd/config.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"log"
 	"net"
 	"net/url"
@@ -310,6 +311,11 @@ func (d *Duration) UnmarshalText(text []byte) error {
 	// Set duration and return.
 	*d = Duration(duration)
 	return nil
+}
+
+// WriteConfigFile writes the config to the specified writer
+func WriteConfigFile(c *Config, w io.Writer) error {
+	return toml.NewEncoder(w).Encode(c)
 }
 
 // ParseConfigFile parses a configuration file at a given path.

--- a/cmd/influxd/main.go
+++ b/cmd/influxd/main.go
@@ -70,6 +70,8 @@ func main() {
 		execRun(args)
 	case "version":
 		execVersion(args[1:])
+	case "config":
+		execConfig(args[1:])
 	case "help":
 		execHelp(args[1:])
 	default:
@@ -102,6 +104,9 @@ func execRun(args []string) {
 	log.SetFlags(log.LstdFlags)
 	writePIDFile(*pidPath)
 
+	if configPath != nil {
+		log.Println("No config provided, using default settings")
+	}
 	config := parseConfig(*configPath, *hostname)
 
 	// Create a logging writer.
@@ -138,6 +143,21 @@ func execVersion(args []string) {
 		s += fmt.Sprintf(" (git: %s)", commit)
 	}
 	log.Print(s)
+}
+
+// execConfig parses and prints the current config loaded.
+func execConfig(args []string) {
+	// Parse command flags.
+	fs := flag.NewFlagSet("", flag.ExitOnError)
+	var (
+		configPath = fs.String("config", "", "")
+		hostname   = fs.String("hostname", "", "")
+	)
+	fs.Parse(args)
+
+	config := parseConfig(*configPath, *hostname)
+
+	WriteConfigFile(config, os.Stdout)
 }
 
 // execHelp runs the "help" command.

--- a/cmd/influxd/main.go
+++ b/cmd/influxd/main.go
@@ -157,7 +157,7 @@ func execConfig(args []string) {
 
 	config := parseConfig(*configPath, *hostname)
 
-	WriteConfigFile(config, os.Stdout)
+	config.Write(os.Stdout)
 }
 
 // execHelp runs the "help" command.

--- a/cmd/influxd/run.go
+++ b/cmd/influxd/run.go
@@ -236,7 +236,6 @@ func writePIDFile(path string) {
 // parses the configuration from a given path. Sets overrides as needed.
 func parseConfig(path, hostname string) *Config {
 	if path == "" {
-		log.Println("No config provided, using default settings")
 		return NewConfig()
 	}
 


### PR DESCRIPTION
This will allow us to print out the config by issuing the command:

```sh
influxd config
```

You can also 

```sh
influxd config -config=conf.toml -host=foo.bar
```

And then this will parse/load the config you specified, and print it back out.  This will be valuable to make sure people are running what they think they are running.