### PR TITLE
Fix leader id initialization

### DIFF
--- a/messaging/handler.go
+++ b/messaging/handler.go
@@ -185,8 +185,6 @@ func (h *Handler) servePing(w http.ResponseWriter, r *http.Request) {
 		log.Printf("unable to write client config: %s", err)
 		return
 	}
-
-	w.WriteHeader(http.StatusOK)
 }
 
 // error writes an error to the client and sets the status code.

--- a/raft/log.go
+++ b/raft/log.go
@@ -513,6 +513,7 @@ func (l *Log) Initialize() error {
 		l.term = term
 		l.votedFor = 0
 		l.lastLogTerm = term
+		l.leaderID = l.id
 
 		// Begin state loop as leader.
 		l.startStateLoop(l.closing, Leader)


### PR DESCRIPTION
## Overview

This pull request initializes the in-memory leader ID inside raft. This was accidentally removed during the stateless broker refactor.