### PR TITLE
Add time taken for request to the http server logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## v0.9.0-rc13 [unreleased]
 
+### Features
+- [#1974](https://github.com/influxdb/influxdb/pull/1974): Add time taken for request to the http server logs.
+
 ## v0.9.0-rc12 [2015-03-15]
 
 ### Bugfixes

--- a/httpd/response_logger.go
+++ b/httpd/response_logger.go
@@ -82,6 +82,7 @@ func buildLogLine(l *responseLogger, r *http.Request, start time.Time) string {
 		detect(referer, "-"),
 		detect(userAgent, "-"),
 		r.Header.Get("Request-Id"),
+		fmt.Sprintf("%s", time.Since(start)),
 	}
 
 	return strings.Join(fields, " ")


### PR DESCRIPTION
This will add a field to the end of the http log for time that it took to execute the request.  This is helpful for debugging.

```
[http] 2015/03/16 12:40:58 127.0.0.1 - - [16/Mar/2015:12:40:58 -0600] GET /query?db=foo&q=show+databases HTTP/1.1 200 62 - InfluxDBShell/0.9 fcc9cc32-cc0b-11e4-919b-60f81dab26ba 1.864595ms
```