### PR TITLE
Require parameter for query endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ### Bugfixes
 - [#1971](https://github.com/influxdb/influxdb/pull/1971): Fix leader id initialization.
-- [#1975](https://github.com/influxdb/influxdb/pull/1975): Require parameter for query endpoint.
+- [#1975](https://github.com/influxdb/influxdb/pull/1975): Require `q` parameter for query endpoint.
 
 ## v0.9.0-rc12 [2015-03-15]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Bugfixes
 - [#1971](https://github.com/influxdb/influxdb/pull/1971): Fix leader id initialization.
+- [#1975](https://github.com/influxdb/influxdb/pull/1975): Require parameter for query endpoint.
 
 ## v0.9.0-rc12 [2015-03-15]
 

--- a/httpd/handler.go
+++ b/httpd/handler.go
@@ -157,9 +157,17 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // serveQuery parses an incoming query and, if valid, executes the query.
 func (h *Handler) serveQuery(w http.ResponseWriter, r *http.Request, user *influxdb.User) {
 	q := r.URL.Query()
-	p := influxql.NewParser(strings.NewReader(q.Get("q")))
-	db := q.Get("db")
+
 	pretty := q.Get("pretty") == "true"
+
+	qp := strings.TrimSpace(q.Get("q"))
+	if qp == "" {
+		httpError(w, `missing required parameter "q"`, pretty, http.StatusBadRequest)
+		return
+	}
+
+	p := influxql.NewParser(strings.NewReader(qp))
+	db := q.Get("db")
 
 	// Parse query from query string.
 	query, err := p.ParseQuery()

--- a/httpd/handler_test.go
+++ b/httpd/handler_test.go
@@ -904,6 +904,21 @@ func TestHandler_AuthenticatedDatabases_Unauthorized(t *testing.T) {
 	}
 }
 
+func TestHandler_QueryParamenterMissing(t *testing.T) {
+	c := test.NewMessagingClient()
+	defer c.Close()
+	srvr := OpenAuthlessServer(c)
+	s := NewHTTPServer(srvr)
+	defer s.Close()
+
+	status, body := MustHTTP("GET", s.URL+`/query`, nil, nil, "")
+	if status != http.StatusBadRequest {
+		t.Fatalf("unexpected status: %d", status)
+	} else if body != `{"error":"missing required parameter \"q\""}` {
+		t.Fatalf("unexpected body: %s", body)
+	}
+}
+
 func TestHandler_AuthenticatedDatabases_AuthorizedQueryParams(t *testing.T) {
 	c := test.NewMessagingClient()
 	defer c.Close()


### PR DESCRIPTION
There was a bug where if you issued a curl command like this and accidentally sent the wrong params (double encoded) and as a result, didn't send the `q` parameter, the endpoint would return 200 ok with an empty json result, instead of an error:

```
curl -G http://localhost:8086/query --data-urlencode "db=foo&q=show fred"
```

It now correctly returns this:

```
{"error":"missing required parameter \"q\""}   
```