### PR TITLE
fix #1832: support regex in FROM clause

### DIFF
--- a/cmd/influxd/server_integration_test.go
+++ b/cmd/influxd/server_integration_test.go
@@ -850,7 +850,7 @@ func TestSingleServer(t *testing.T) {
 
 	nodes := createCombinedNodeCluster(t, testName, dir, 1, 8090, nil)
 
-	runTestsData(t, testName, nodes, "mydb", "myrp", 7)
+	runTestsData(t, testName, nodes, "mydb", "myrp")
 }
 
 func Test3NodeServer(t *testing.T) {

--- a/database.go
+++ b/database.go
@@ -1438,6 +1438,17 @@ func (db *database) measurementsByTagFilters(filters []*TagFilter) Measurements 
 	return measurements
 }
 
+// measurementsByRegex returns the measurements that match the regex.
+func (db *database) measurementsByRegex(re *regexp.Regexp) Measurements {
+	var matches Measurements
+	for _, m := range db.measurements {
+		if re.MatchString(m.Name) {
+			matches = append(matches, m)
+		}
+	}
+	return matches
+}
+
 // Measurements returns a list of all measurements.
 func (db *database) Measurements() Measurements {
 	measurements := make(Measurements, 0, len(db.measurements))

--- a/influxql/ast.go
+++ b/influxql/ast.go
@@ -103,6 +103,7 @@ func (*ParenExpr) node()       {}
 func (*RegexLiteral) node()    {}
 func (*SortField) node()       {}
 func (SortFields) node()       {}
+func (Sources) node()          {}
 func (*StringLiteral) node()   {}
 func (*Target) node()          {}
 func (*TimeLiteral) node()     {}
@@ -202,9 +203,26 @@ type Source interface {
 	source()
 }
 
-func (*Join) source()        {}
-func (*Measurement) source() {}
-func (*Merge) source()       {}
+func (*Measurement) source()  {}
+func (*RegexLiteral) source() {}
+
+// Sources represents a list of sources.
+type Sources []Source
+
+// String returns a string representation of a Sources array.
+func (a Sources) String() string {
+	var buf bytes.Buffer
+
+	ubound := len(a) - 1
+	for i, src := range a {
+		_, _ = buf.WriteString(src.String())
+		if i < ubound {
+			_, _ = buf.WriteString(", ")
+		}
+	}
+
+	return buf.String()
+}
 
 // SortField represents a field to sort results by.
 type SortField struct {
@@ -556,8 +574,8 @@ type SelectStatement struct {
 	// Expressions used for grouping the selection.
 	Dimensions Dimensions
 
-	// Data source that fields are extracted from.
-	Source Source
+	// Data sources that fields are extracted from.
+	Sources Sources
 
 	// An expression evaluated on data point.
 	Condition Expr
@@ -592,11 +610,11 @@ type SelectStatement struct {
 
 // Clone returns a deep copy of the statement.
 func (s *SelectStatement) Clone() *SelectStatement {
-	other := &SelectStatement{
-		Fields:     make(Fields, len(s.Fields)),
-		Dimensions: make(Dimensions, len(s.Dimensions)),
-		Source:     cloneSource(s.Source),
-		SortFields: make(SortFields, len(s.SortFields)),
+	clone := &SelectStatement{
+		Fields:     make(Fields, 0, len(s.Fields)),
+		Dimensions: make(Dimensions, 0, len(s.Dimensions)),
+		Sources:    cloneSources(s.Sources),
+		SortFields: make(SortFields, 0, len(s.SortFields)),
 		Condition:  CloneExpr(s.Condition),
 		Limit:      s.Limit,
 		Offset:     s.Offset,
@@ -606,19 +624,26 @@ func (s *SelectStatement) Clone() *SelectStatement {
 		FillValue:  s.FillValue,
 	}
 	if s.Target != nil {
-		other.Target = &Target{Measurement: s.Target.Measurement, Database: s.Target.Database}
+		clone.Target = &Target{Measurement: s.Target.Measurement, Database: s.Target.Database}
 	}
-	for i, f := range s.Fields {
-		other.Fields[i] = &Field{Expr: CloneExpr(f.Expr), Alias: f.Alias}
+	for _, f := range s.Fields {
+		clone.Fields = append(clone.Fields, &Field{Expr: CloneExpr(f.Expr), Alias: f.Alias})
 	}
-	for i, d := range s.Dimensions {
-		other.Dimensions[i] = &Dimension{Expr: CloneExpr(d.Expr)}
+	for _, d := range s.Dimensions {
+		clone.Dimensions = append(clone.Dimensions, &Dimension{Expr: CloneExpr(d.Expr)})
 	}
-	// TODO: Copy sources.
-	for i, f := range s.SortFields {
-		other.SortFields[i] = &SortField{Name: f.Name, Ascending: f.Ascending}
+	for _, f := range s.SortFields {
+		clone.SortFields = append(clone.SortFields, &SortField{Name: f.Name, Ascending: f.Ascending})
 	}
-	return other
+	return clone
+}
+
+func cloneSources(sources Sources) Sources {
+	clone := make(Sources, 0, len(sources))
+	for _, s := range sources {
+		clone = append(clone, cloneSource(s))
+	}
+	return clone
 }
 
 func cloneSource(s Source) Source {
@@ -628,19 +653,14 @@ func cloneSource(s Source) Source {
 
 	switch s := s.(type) {
 	case *Measurement:
-		return &Measurement{Name: s.Name}
-	case *Join:
-		other := &Join{Measurements: make(Measurements, len(s.Measurements))}
-		for i, m := range s.Measurements {
-			other.Measurements[i] = &Measurement{Name: m.Name}
+		m := &Measurement{Name: s.Name}
+		if s.Regex != nil {
+			m.Regex = &RegexLiteral{Val: regexp.MustCompile(s.Regex.Val.String())}
 		}
-		return other
-	case *Merge:
-		other := &Merge{Measurements: make(Measurements, len(s.Measurements))}
-		for i, m := range s.Measurements {
-			other.Measurements[i] = &Measurement{Name: m.Name}
-		}
-		return other
+		return m
+	case *RegexLiteral:
+		re, _ := regexp.Compile(s.Val.String())
+		return &RegexLiteral{Val: re}
 	default:
 		panic("unreachable")
 	}
@@ -691,8 +711,10 @@ func (s *SelectStatement) String() string {
 		_, _ = buf.WriteString(" ")
 		_, _ = buf.WriteString(s.Target.String())
 	}
-	_, _ = buf.WriteString(" FROM ")
-	_, _ = buf.WriteString(s.Source.String())
+	if len(s.Sources) > 0 {
+		_, _ = buf.WriteString(" FROM ")
+		_, _ = buf.WriteString(s.Sources.String())
+	}
 	if s.Condition != nil {
 		_, _ = buf.WriteString(" WHERE ")
 		_, _ = buf.WriteString(s.Condition.String())
@@ -903,18 +925,18 @@ func (s *SelectStatement) Substatement(ref *VarRef) (*SelectStatement, error) {
 	}
 
 	// If there is only one series source then return it with the whole condition.
-	if _, ok := s.Source.(*Measurement); ok {
-		other.Source = s.Source
+	if len(s.Sources) == 1 {
+		other.Sources = s.Sources
 		other.Condition = s.Condition
 		return other, nil
 	}
 
 	// Find the matching source.
-	name := MatchSource(s.Source, ref.Val)
+	name := MatchSource(s.Sources, ref.Val)
 	if name == "" {
 		return nil, fmt.Errorf("field source not found: %s", ref.Val)
 	}
-	other.Source = &Measurement{Name: name}
+	other.Sources = append(other.Sources, &Measurement{Name: name})
 
 	// Filter out conditions.
 	if s.Condition != nil {
@@ -1040,22 +1062,12 @@ func filterExprBySource(name string, expr Expr) Expr {
 
 // MatchSource returns the source name that matches a field name.
 // Returns a blank string if no sources match.
-func MatchSource(src Source, name string) string {
-	switch src := src.(type) {
-	case *Measurement:
-		if strings.HasPrefix(name, src.Name) {
-			return src.Name
-		}
-	case *Join:
-		for _, m := range src.Measurements {
-			if strings.HasPrefix(name, m.Name) {
-				return m.Name
-			}
-		}
-	case *Merge:
-		for _, m := range src.Measurements {
-			if strings.HasPrefix(name, m.Name) {
-				return m.Name
+func MatchSource(sources Sources, name string) string {
+	for _, src := range sources {
+		switch src := src.(type) {
+		case *Measurement:
+			if strings.HasPrefix(name, src.Name) {
+				return src.Name
 			}
 		}
 	}
@@ -1673,11 +1685,21 @@ func (a Measurements) String() string {
 
 // Measurement represents a single measurement used as a datasource.
 type Measurement struct {
-	Name string
+	Name  string
+	Regex *RegexLiteral
 }
 
 // String returns a string representation of the measurement.
-func (m *Measurement) String() string { return m.Name }
+func (m *Measurement) String() string {
+	var buf bytes.Buffer
+	_, _ = buf.WriteString(m.Name)
+
+	if m.Regex != nil {
+		_, _ = buf.WriteString(m.Regex.String())
+	}
+
+	return buf.String()
+}
 
 // Join represents two datasources joined together.
 type Join struct {
@@ -1821,7 +1843,12 @@ type RegexLiteral struct {
 }
 
 // String returns a string representation of the literal.
-func (r *RegexLiteral) String() string { return r.Val.String() }
+func (r *RegexLiteral) String() string {
+	if r.Val != nil {
+		return fmt.Sprintf("/%s/", r.Val.String())
+	}
+	return ""
+}
 
 // Wildcard represents a wild card expression.
 type Wildcard struct{}
@@ -1958,7 +1985,7 @@ func Walk(v Visitor, node Node) {
 	case *SelectStatement:
 		Walk(v, n.Fields)
 		Walk(v, n.Dimensions)
-		Walk(v, n.Source)
+		Walk(v, n.Sources)
 		Walk(v, n.Condition)
 
 	case *ShowSeriesStatement:
@@ -2035,7 +2062,7 @@ func Rewrite(r Rewriter, node Node) Node {
 	case *SelectStatement:
 		n.Fields = Rewrite(r, n.Fields).(Fields)
 		n.Dimensions = Rewrite(r, n.Dimensions).(Dimensions)
-		n.Source = Rewrite(r, n.Source).(Source)
+		n.Sources = Rewrite(r, n.Sources).(Sources)
 		n.Condition = Rewrite(r, n.Condition).(Expr)
 
 	case Fields:

--- a/influxql/ast.go
+++ b/influxql/ast.go
@@ -203,8 +203,7 @@ type Source interface {
 	source()
 }
 
-func (*Measurement) source()  {}
-func (*RegexLiteral) source() {}
+func (*Measurement) source() {}
 
 // Sources represents a list of sources.
 type Sources []Source
@@ -658,9 +657,6 @@ func cloneSource(s Source) Source {
 			m.Regex = &RegexLiteral{Val: regexp.MustCompile(s.Regex.Val.String())}
 		}
 		return m
-	case *RegexLiteral:
-		re, _ := regexp.Compile(s.Val.String())
-		return &RegexLiteral{Val: re}
 	default:
 		panic("unreachable")
 	}

--- a/influxql/ast.go
+++ b/influxql/ast.go
@@ -2002,6 +2002,11 @@ func Walk(v Visitor, node Node) {
 		Walk(v, n.Condition)
 		Walk(v, n.SortFields)
 
+	case Sources:
+		for _, s := range n {
+			Walk(v, s)
+		}
+
 	case Fields:
 		for _, c := range n {
 			Walk(v, c)

--- a/influxql/ast_test.go
+++ b/influxql/ast_test.go
@@ -42,35 +42,35 @@ func TestSelectStatement_Substatement(t *testing.T) {
 
 		// 1. Simple join
 		{
-			stmt: `SELECT sum(aa.value) + sum(bb.value) FROM join(aa,bb)`,
+			stmt: `SELECT sum(aa.value) + sum(bb.value) FROM aa, bb`,
 			expr: &influxql.VarRef{Val: "aa.value"},
 			sub:  `SELECT aa.value FROM aa`,
 		},
 
 		// 2. Simple merge
 		{
-			stmt: `SELECT sum(aa.value) + sum(bb.value) FROM merge(aa, bb)`,
+			stmt: `SELECT sum(aa.value) + sum(bb.value) FROM aa, bb`,
 			expr: &influxql.VarRef{Val: "bb.value"},
 			sub:  `SELECT bb.value FROM bb`,
 		},
 
 		// 3. Join with condition
 		{
-			stmt: `SELECT sum(aa.value) + sum(bb.value) FROM join(aa, bb) WHERE aa.host = 'servera' AND bb.host = 'serverb'`,
+			stmt: `SELECT sum(aa.value) + sum(bb.value) FROM aa, bb WHERE aa.host = 'servera' AND bb.host = 'serverb'`,
 			expr: &influxql.VarRef{Val: "bb.value"},
 			sub:  `SELECT bb.value FROM bb WHERE bb.host = 'serverb'`,
 		},
 
 		// 4. Join with complex condition
 		{
-			stmt: `SELECT sum(aa.value) + sum(bb.value) FROM join(aa, bb) WHERE aa.host = 'servera' AND (bb.host = 'serverb' OR bb.host = 'serverc') AND 1 = 2`,
+			stmt: `SELECT sum(aa.value) + sum(bb.value) FROM aa, bb WHERE aa.host = 'servera' AND (bb.host = 'serverb' OR bb.host = 'serverc') AND 1 = 2`,
 			expr: &influxql.VarRef{Val: "bb.value"},
 			sub:  `SELECT bb.value FROM bb WHERE (bb.host = 'serverb' OR bb.host = 'serverc') AND 1.000 = 2.000`,
 		},
 
 		// 5. 4 with different condition order
 		{
-			stmt: `SELECT sum(aa.value) + sum(bb.value) FROM join(aa, bb) WHERE ((bb.host = 'serverb' OR bb.host = 'serverc') AND aa.host = 'servera') AND 1 = 2`,
+			stmt: `SELECT sum(aa.value) + sum(bb.value) FROM aa, bb WHERE ((bb.host = 'serverb' OR bb.host = 'serverc') AND aa.host = 'servera') AND 1 = 2`,
 			expr: &influxql.VarRef{Val: "bb.value"},
 			sub:  `SELECT bb.value FROM bb WHERE ((bb.host = 'serverb' OR bb.host = 'serverc')) AND 1.000 = 2.000`,
 		},

--- a/influxql/parser.go
+++ b/influxql/parser.go
@@ -38,32 +38,24 @@ func ParseExpr(s string) (Expr, error) { return NewParser(strings.NewReader(s)).
 
 // ParseQuery parses an InfluxQL string and returns a Query AST object.
 func (p *Parser) ParseQuery() (*Query, error) {
-	// If there's only whitespace then return no statements.
-	if tok, _, _ := p.scanIgnoreWhitespace(); tok == EOF {
-		return &Query{}, nil
-	}
-	p.unscan()
-
-	// Otherwise parse statements until EOF.
 	var statements Statements
+	var semi bool
+
 	for {
-
-		// Read the next statement.
-		s, err := p.ParseStatement()
-		if err != nil {
-			return nil, err
-		}
-		statements = append(statements, s)
-
-		// Expect a semicolon or EOF after the statement.
-		if tok, pos, lit := p.scanIgnoreWhitespace(); tok != SEMICOLON && tok != EOF {
-			return nil, newParseError(tokstr(tok, lit), []string{";", "EOF"}, pos)
-		} else if tok == EOF {
-			break
+		if tok, _, _ := p.scanIgnoreWhitespace(); tok == EOF {
+			return &Query{Statements: statements}, nil
+		} else if !semi && tok == SEMICOLON {
+			semi = true
+		} else {
+			p.unscan()
+			s, err := p.ParseStatement()
+			if err != nil {
+				return nil, err
+			}
+			statements = append(statements, s)
+			semi = false
 		}
 	}
-
-	return &Query{Statements: statements}, nil
 }
 
 // ParseStatement parses an InfluxQL string and returns a Statement AST object.
@@ -88,7 +80,7 @@ func (p *Parser) ParseStatement() (Statement, error) {
 	case ALTER:
 		return p.parseAlterStatement()
 	default:
-		return nil, newParseError(tokstr(tok, lit), []string{"SELECT"}, pos)
+		return nil, newParseError(tokstr(tok, lit), []string{"SELECT", "DELETE", "SHOW", "CREATE", "DROP", "GRANT", "REVOKE", "ALTER"}, pos)
 	}
 }
 
@@ -537,11 +529,11 @@ func (p *Parser) parseSelectStatement(tr targetRequirement) (*SelectStatement, e
 		return nil, err
 	}
 
-	// Parse source.
+	// Parse source: "FROM".
 	if tok, pos, lit := p.scanIgnoreWhitespace(); tok != FROM {
 		return nil, newParseError(tokstr(tok, lit), []string{"FROM"}, pos)
 	}
-	if stmt.Source, err = p.parseSource(); err != nil {
+	if stmt.Sources, err = p.parseSources(); err != nil {
 		return nil, err
 	}
 
@@ -1279,53 +1271,72 @@ func (p *Parser) parseAlias() (string, error) {
 	return lit, nil
 }
 
-// parseSource parses the "FROM" clause of the query.
-func (p *Parser) parseSource() (Source, error) {
-	// The first token can either be the series name or a join/merge call.
-	tok, pos, lit := p.scanIgnoreWhitespace()
-	if tok != IDENT {
-		return nil, newParseError(tokstr(tok, lit), []string{"identifier"}, pos)
-	}
+// parseSources parses a comma delimited list of sources.
+func (p *Parser) parseSources() (Sources, error) {
+	var sources Sources
 
-	// If the token is a string or the next token is not an LPAREN then return a measurement.
-	if next, _, _ := p.scan(); tok == STRING || (tok == IDENT && next != LPAREN) {
-		p.unscan()
-		return &Measurement{Name: lit}, nil
-	}
-
-	// Verify the source type is join/merge.
-	sourceType := strings.ToLower(lit)
-	if sourceType != "join" && sourceType != "merge" {
-		return nil, &ParseError{Message: "unknown merge type: " + sourceType, Pos: pos}
-	}
-
-	// Parse measurement list.
-	var measurements []*Measurement
 	for {
-		// Scan the measurement name.
-		tok, pos, lit := p.scanIgnoreWhitespace()
-		if tok != IDENT {
-			return nil, newParseError(tokstr(tok, lit), []string{"measurement name"}, pos)
+		s, err := p.parseSource()
+		if err != nil {
+			return nil, err
 		}
-		measurements = append(measurements, &Measurement{Name: lit})
+		sources = append(sources, s)
 
-		// If there's not a comma next then stop parsing measurements.
-		if tok, _, _ := p.scan(); tok != COMMA {
+		if tok, _, _ := p.scanIgnoreWhitespace(); tok != COMMA {
 			p.unscan()
 			break
 		}
 	}
 
-	// Expect a closing right paren.
-	if tok, pos, lit := p.scanIgnoreWhitespace(); tok != RPAREN {
-		return nil, newParseError(tokstr(tok, lit), []string{")"}, pos)
+	return sources, nil
+}
+
+// peekRune returns the next rune that would be read by the scanner.
+func (p *Parser) peekRune() rune {
+	r, _, _ := p.s.s.r.ReadRune()
+	if r != eof {
+		_ = p.s.s.r.UnreadRune()
 	}
 
-	// Return the appropriate source type.
-	if sourceType == "join" {
-		return &Join{Measurements: measurements}, nil
+	return r
+}
+
+// parseSource parses a single source.
+func (p *Parser) parseSource() (Source, error) {
+	m := &Measurement{}
+
+	for {
+		nextRune := p.peekRune()
+		if isWhitespace(nextRune) {
+			p.consumeWhitespace()
+		}
+
+		// If the next character is a '/', then parse a regex.
+		nextRune = p.peekRune()
+		if nextRune == '/' {
+			re, err := p.parseRegex()
+			if err != nil {
+				return nil, err
+			}
+			m.Regex = re.(*RegexLiteral)
+
+			// A regex is always the last part of the source so return. E.g.,
+			// db.rp./cpu.*/.  Regex not supported in database or retention
+			// policy names.
+			return m, nil
+		}
+
+		// Next character wasn't a '/' so parse a non-regex identifier.
+		if tok, pos, lit := p.scanIgnoreWhitespace(); tok == IDENT {
+			m.Name = lit
+		} else {
+			if m.Name == "" && m.Regex == nil {
+				return nil, newParseError(tokstr(tok, lit), []string{"identifier", "regex"}, pos)
+			}
+			p.unscan()
+			return m, nil
+		}
 	}
-	return &Merge{Measurements: measurements}, nil
 }
 
 // parseCondition parses the "WHERE" clause of the query, if it exists.
@@ -1659,7 +1670,7 @@ func (p *Parser) parseUnaryExpr() (Expr, error) {
 
 // parseRegex parses a regular expression.
 func (p *Parser) parseRegex() (Expr, error) {
-	tok, pos, lit := p.s.s.ScanRegex()
+	tok, pos, lit := p.s.ScanRegex()
 
 	if tok == BADESCAPE {
 		msg := fmt.Sprintf("bad escape: %s", lit)

--- a/server.go
+++ b/server.go
@@ -2105,6 +2105,8 @@ func (s *Server) rewriteSelectStatement(stmt *influxql.SelectStatement) (*influx
 	return stmt.RewriteWildcards(fields, dimensions), nil
 }
 
+//func (s *Server) expand
+
 // plans a selection statement under lock.
 func (s *Server) planSelectStatement(stmt *influxql.SelectStatement) (*influxql.Executor, error) {
 	s.mu.RLock()

--- a/server.go
+++ b/server.go
@@ -2073,39 +2073,133 @@ func (s *Server) executeSelectStatement(stmt *influxql.SelectStatement, database
 
 // rewriteSelectStatement performs any necessary query re-writing.
 func (s *Server) rewriteSelectStatement(stmt *influxql.SelectStatement) (*influxql.SelectStatement, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	var err error
+
+	// Expand regex expressions in the FROM clause.
+	sources, err := s.expandSources(stmt.Sources)
+	if err != nil {
+		return nil, err
+	}
+	stmt.Sources = sources
+
+	// Expand wildcards in the fields or GROUP BY.
+	if stmt.HasWildcard() {
+		stmt, err = s.expandWildcards(stmt)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return stmt, nil
+}
+
+// expandWildcards returns a new SelectStatement with wildcards in the fields
+// and/or GROUP BY exapnded with actual field names.
+func (s *Server) expandWildcards(stmt *influxql.SelectStatement) (*influxql.SelectStatement, error) {
+	// If there are no wildcards in the statement, return it as-is.
 	if !stmt.HasWildcard() {
 		return stmt, nil
 	}
 
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+	// Use sets to avoid duplicate field names.
+	fieldSet := map[string]struct{}{}
+	dimensionSet := map[string]struct{}{}
 
 	var fields influxql.Fields
 	var dimensions influxql.Dimensions
-	if measurement, ok := stmt.Source.(*influxql.Measurement); ok {
-		segments, err := influxql.SplitIdent(measurement.Name)
-		if err != nil {
-			return nil, fmt.Errorf("unable to parse measurement %s", measurement.Name)
-		}
-		db, m := segments[0], segments[2]
 
-		mm := s.databases[db].measurements[m]
-		if mm == nil {
-			return nil, fmt.Errorf("measurement not found: %s", measurement.Name)
-		}
+	// Iterate measurements in the FROM clause getting the fields & dimensions for each.
+	for _, src := range stmt.Sources {
+		if measurement, ok := src.(*influxql.Measurement); ok {
+			// Split the measurement name into its pieces (db, rp, & measurement).
+			segments, err := influxql.SplitIdent(measurement.Name)
+			if err != nil {
+				return nil, fmt.Errorf("unable to parse measurement %s", measurement.Name)
+			}
+			db, m := segments[0], segments[2]
 
-		for _, f := range mm.Fields {
-			fields = append(fields, &influxql.Field{Expr: &influxql.VarRef{Val: f.Name}})
-		}
-		for _, t := range mm.tagKeys() {
-			dimensions = append(dimensions, &influxql.Dimension{Expr: &influxql.VarRef{Val: t}})
+			// Lookup the measurement in the database.
+			mm := s.databases[db].measurements[m]
+			if mm == nil {
+				return nil, fmt.Errorf("measurement not found: %s", measurement.Name)
+			}
+
+			// Get the fields for this measurement.
+			for _, f := range mm.Fields {
+				if _, ok := fieldSet[f.Name]; ok {
+					continue
+				}
+				fieldSet[f.Name] = struct{}{}
+				fields = append(fields, &influxql.Field{Expr: &influxql.VarRef{Val: f.Name}})
+			}
+
+			// Get the dimensions for this measurement.
+			for _, t := range mm.tagKeys() {
+				if _, ok := dimensionSet[t]; ok {
+					continue
+				}
+				dimensionSet[t] = struct{}{}
+				dimensions = append(dimensions, &influxql.Dimension{Expr: &influxql.VarRef{Val: t}})
+			}
 		}
 	}
 
+	// Return a new SelectStatement with the wild cards rewritten.
 	return stmt.RewriteWildcards(fields, dimensions), nil
 }
 
-//func (s *Server) expand
+// expandSources expands regex sources and removes duplicates.
+func (s *Server) expandSources(sources influxql.Sources) (influxql.Sources, error) {
+	// Use a map as a set to prevent duplicates. Two regexes might produce
+	// duplicates when expanded.
+	set := map[string]influxql.Source{}
+
+	// Iterate all sources, expanding regexes when they're found.
+	for _, source := range sources {
+		switch src := source.(type) {
+		case *influxql.Measurement:
+			if src.Regex == nil {
+				set[src.Name] = src
+				continue
+			}
+
+			// Split out the database & retention policy names.
+			segments, err := influxql.SplitIdent(src.Name)
+			if err != nil {
+				return nil, err
+			}
+
+			// Lookup the database.
+			db := s.databases[segments[0]]
+			if db == nil {
+				return nil, ErrDatabaseNotFound
+			}
+
+			// Get measurements from the database that match the regex.
+			measurements := db.measurementsByRegex(src.Regex.Val)
+
+			// Add those measurments to the set.
+			for _, m := range measurements {
+				name := strings.Join([]string{src.Name, influxql.QuoteIdent([]string{m.Name})}, ".")
+				set[name] = &influxql.Measurement{Name: name}
+			}
+
+		default:
+			return nil, fmt.Errorf("expandSources: unsuported source type: %T", source)
+		}
+	}
+
+	// Convert set to a list of Sources.
+	expanded := make(influxql.Sources, 0, len(set))
+	for _, src := range set {
+		expanded = append(expanded, src)
+	}
+
+	return expanded, nil
+}
 
 // plans a selection statement under lock.
 func (s *Server) planSelectStatement(stmt *influxql.SelectStatement) (*influxql.Executor, error) {
@@ -2752,20 +2846,6 @@ func (s *Server) MeasurementNames(database string) []string {
 	return db.names
 }
 
-/*
-func (s *Server) MeasurementSeriesIDs(database, measurement string) []uint32 {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-
-	db := s.databases[database]
-	if db == nil {
-		return nil
-	}
-
-	return []uint32(db.SeriesIDs([]string{measurement}, nil))
-}
-*/
-
 // measurement returns a measurement by database and name.
 func (s *Server) measurement(database, name string) (*Measurement, error) {
 	db := s.databases[database]
@@ -2797,13 +2877,14 @@ func (s *Server) normalizeStatement(stmt influxql.Statement, defaultDatabase str
 		}
 		switch n := n.(type) {
 		case *influxql.Measurement:
-			name, e := s.normalizeMeasurement(n.Name, defaultDatabase)
+			nm, e := s.normalizeMeasurement(n, defaultDatabase)
 			if e != nil {
 				err = e
 				return
 			}
-			prefixes[n.Name] = name
-			n.Name = name
+			prefixes[n.Name] = nm.Name
+			n.Name = nm.Name
+			n.Regex = nm.Regex
 		}
 	})
 	if err != nil {
@@ -2826,17 +2907,35 @@ func (s *Server) normalizeStatement(stmt influxql.Statement, defaultDatabase str
 }
 
 // NormalizeMeasurement inserts the default database or policy into all measurement names.
-func (s *Server) NormalizeMeasurement(name string, defaultDatabase string) (string, error) {
+func (s *Server) NormalizeMeasurement(m *influxql.Measurement, defaultDatabase string) (*influxql.Measurement, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	return s.normalizeMeasurement(name, defaultDatabase)
+	return s.normalizeMeasurement(m, defaultDatabase)
 }
 
-func (s *Server) normalizeMeasurement(name string, defaultDatabase string) (string, error) {
-	// Split name into segments.
-	segments, err := influxql.SplitIdent(name)
-	if err != nil {
-		return "", fmt.Errorf("invalid measurement: %s", name)
+func (s *Server) normalizeMeasurement(m *influxql.Measurement, defaultDatabase string) (*influxql.Measurement, error) {
+	if m.Name == "" && m.Regex == nil {
+		return nil, errors.New("invalid measurement")
+	}
+
+	var segments []string
+	var err error
+
+	if m.Name != "" {
+		// Split measurement name into segments.
+		segments, err = influxql.SplitIdent(m.Name)
+		if err != nil {
+			return nil, fmt.Errorf("invalid measurement: %s", m.Name)
+		}
+	}
+
+	// Number of segments.
+	n := 3
+
+	// If there's a regex, add a placeholder segment
+	if m.Regex != nil {
+		segments = append(segments, "")
+		n = 2
 	}
 
 	// Normalize to 3 segments.
@@ -2848,34 +2947,39 @@ func (s *Server) normalizeMeasurement(name string, defaultDatabase string) (stri
 	case 3:
 		// nop
 	default:
-		return "", fmt.Errorf("invalid measurement: %s", name)
+		return nil, fmt.Errorf("measurement has too many segments: %s", m.String())
 	}
 
 	// Set database if unset.
-	if segment := segments[0]; segment == `` {
+	if segments[0] == `` {
 		segments[0] = defaultDatabase
 	}
 
 	// Find database.
 	db := s.databases[segments[0]]
 	if db == nil {
-		return "", fmt.Errorf("database not found: %s", segments[0])
+		return nil, fmt.Errorf("database not found: %s", segments[0])
 	}
 
 	// Set retention policy if unset.
-	if segment := segments[1]; segment == `` {
+	if segments[1] == `` {
 		if db.defaultRetentionPolicy == "" {
-			return "", fmt.Errorf("default retention policy not set for: %s", db.name)
+			return nil, fmt.Errorf("default retention policy not set for: %s", db.name)
 		}
 		segments[1] = db.defaultRetentionPolicy
 	}
 
 	// Check if retention policy exists.
 	if _, ok := db.policies[segments[1]]; !ok {
-		return "", fmt.Errorf("retention policy does not exist: %s.%s", segments[0], segments[1])
+		return nil, fmt.Errorf("retention policy does not exist: %s.%s", segments[0], segments[1])
 	}
 
-	return influxql.QuoteIdent(segments), nil
+	nm := &influxql.Measurement{
+		Name:  influxql.QuoteIdent(segments[:n]),
+		Regex: m.Regex,
+	}
+
+	return nm, nil
 }
 
 // processor runs in a separate goroutine and processes all incoming broker messages.


### PR DESCRIPTION
Changes:

- Change scanner / parser to accept regex in the `FROM` clause.  This part of the change is a little messy because the scanner can't recognize regex tokens on its own.  The parser has to ask the scanner to peek ahead to see if there is a regex and, if there is, tell the scanner to scan it.

- Change the AST and parser to accept multiple sources in the FROM clause.

- Remove old join / merge code from the AST & parser.

- Change the server to expand regexes in the FROM clause to individual measurements that match.

- Change the server so it doesn't produce duplicate field names when expanding wildcards now that the FROM clause accepts multiple sources from which to draw field names from.

- Change the engine so that it creates map-reduce jobs for multiple sources instead of just one.

- Fix bug with trailing semicolon on single statements.