### PR TITLE
Fix config print startup statement for when no config is provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [#1971](https://github.com/influxdb/influxdb/pull/1971): Fix leader id initialization.
 - [#1975](https://github.com/influxdb/influxdb/pull/1975): Require `q` parameter for query endpoint.
 - [#1969](https://github.com/influxdb/influxdb/pull/1969): Print loaded config.
+- [#1987](https://github.com/influxdb/influxdb/pull/1987): Fix config print startup statement for when no config is provided.
 
 ## v0.9.0-rc12 [2015-03-15]
 

--- a/cmd/influxd/main.go
+++ b/cmd/influxd/main.go
@@ -104,7 +104,7 @@ func execRun(args []string) {
 	log.SetFlags(log.LstdFlags)
 	writePIDFile(*pidPath)
 
-	if configPath != nil {
+	if *configPath == "" {
 		log.Println("No config provided, using default settings")
 	}
 	config := parseConfig(*configPath, *hostname)


### PR DESCRIPTION
Had the wrong logic.  Self merging on green.