### PR TITLE
Drop measurement was taking to long due to transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - [#1975](https://github.com/influxdb/influxdb/pull/1975): Require `q` parameter for query endpoint.
 - [#1969](https://github.com/influxdb/influxdb/pull/1969): Print loaded config.
 - [#1987](https://github.com/influxdb/influxdb/pull/1987): Fix config print startup statement for when no config is provided.
+- [#1990](https://github.com/influxdb/influxdb/pull/1990): Drop measurement was taking to long due to transactions.
 
 ## v0.9.0-rc12 [2015-03-15]
 

--- a/database.go
+++ b/database.go
@@ -1128,10 +1128,8 @@ func (db *database) dropMeasurement(name string) error {
 
 	// remove series data from shards
 	for _, rp := range db.policies {
-		for _, id := range ids {
-			if err := rp.dropSeries(id); err != nil {
-				return err
-			}
+		if err := rp.dropSeries(ids...); err != nil {
+			return err
 		}
 	}
 
@@ -1139,9 +1137,9 @@ func (db *database) dropMeasurement(name string) error {
 }
 
 // dropSeries will delete all data with the seriesID
-func (rp *RetentionPolicy) dropSeries(seriesID uint32) error {
+func (rp *RetentionPolicy) dropSeries(seriesIDs ...uint32) error {
 	for _, g := range rp.shardGroups {
-		err := g.dropSeries(seriesID)
+		err := g.dropSeries(seriesIDs...)
 		if err != nil {
 			return err
 		}

--- a/shard.go
+++ b/shard.go
@@ -45,9 +45,9 @@ func (g *ShardGroup) Contains(min, max time.Time) bool {
 }
 
 // dropSeries will delete all data with the seriesID
-func (g *ShardGroup) dropSeries(seriesID uint32) error {
+func (g *ShardGroup) dropSeries(seriesIDs ...uint32) error {
 	for _, s := range g.Shards {
-		err := s.dropSeries(seriesID)
+		err := s.dropSeries(seriesIDs...)
 		if err != nil {
 			return err
 		}
@@ -201,14 +201,16 @@ func (s *Shard) writeSeries(index uint64, batch []byte) error {
 	})
 }
 
-func (s *Shard) dropSeries(seriesID uint32) error {
+func (s *Shard) dropSeries(seriesIDs ...uint32) error {
 	if s.store == nil {
 		return nil
 	}
 	return s.store.Update(func(tx *bolt.Tx) error {
-		err := tx.DeleteBucket(u32tob(seriesID))
-		if err != bolt.ErrBucketNotFound {
-			return err
+		for _, seriesID := range seriesIDs {
+			err := tx.DeleteBucket(u32tob(seriesID))
+			if err != bolt.ErrBucketNotFound {
+				return err
+			}
 		}
 		return nil
 	})


### PR DESCRIPTION
Previously, if you had 10k series, it was creating 10k bolt transactions, which of course, takes a lot of time.  Now, it creates significantly less transactions (only as many as you have shards).  I was seeing results of `DROP MEASUREMENT` taking a couple minutes, and now takes less than 20ms.