### PR TITLE
Cleanup golint warnings for client code

### DIFF
--- a/client/influxdb.go
+++ b/client/influxdb.go
@@ -146,6 +146,8 @@ func (c *Client) Ping() (time.Duration, string, error) {
 	return time.Since(now), version, nil
 }
 
+// Dump connects to server and retrieves all data stored for specified database.
+// If successful, Dump returns the entire response body, which is an io.ReadCloser
 func (c *Client) Dump(db string) (io.ReadCloser, error) {
 	u := c.url
 	u.Path = "dump"
@@ -260,13 +262,13 @@ func (r *Results) UnmarshalJSON(b []byte) error {
 
 // Error returns the first error from any statement.
 // Returns nil if no errors occurred on any statements.
-func (a Results) Error() error {
-	if a.Err != nil {
-		return a.Err
+func (r Results) Error() error {
+	if r.Err != nil {
+		return r.Err
 	}
-	for _, r := range a.Results {
-		if r.Err != nil {
-			return r.Err
+	for _, result := range r.Results {
+		if result.Err != nil {
+			return result.Err
 		}
 	}
 	return nil


### PR DESCRIPTION
Fixes the following two warnings:

influxdb.go:149:1: exported method Client.Dump should have comment or be
unexported
- Adds comment for Client.Dump

influxdb.go:263:1: receiver name rs should be consistent with previous
receiver name r for Results
- Changes receiver name from "a" to "r"