### PR TITLE
Fixing intervals for group by.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - [#2057](https://github.com/influxdb/influxdb/pull/2057): Move racy "in order" test to integration test suite.
 - [#2060](https://github.com/influxdb/influxdb/pull/2060): Reload server shard map on restart.
 - [#2068](https://github.com/influxdb/influxdb/pull/2068): Fix misspelled JSON field.
+- [#2067](https://github.com/influxdb/influxdb/pull/2067): Fixing intervals for group by.
 
 ## v0.9.0-rc15 [2015-03-19]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 - [#2057](https://github.com/influxdb/influxdb/pull/2057): Move racy "in order" test to integration test suite.
 - [#2060](https://github.com/influxdb/influxdb/pull/2060): Reload server shard map on restart.
 - [#2068](https://github.com/influxdb/influxdb/pull/2068): Fix misspelled JSON field.
-- [#2067](https://github.com/influxdb/influxdb/pull/2067): Fixing intervals for group by.
+- [#2067](https://github.com/influxdb/influxdb/pull/2067): Fixing intervals for GROUP BY.
 
 ## v0.9.0-rc15 [2015-03-19]
 

--- a/cmd/influxd/server_integration_test.go
+++ b/cmd/influxd/server_integration_test.go
@@ -410,7 +410,7 @@ func runTestsData(t *testing.T, testName string, nodes Cluster, database, retent
 		// Data read and write tests using relative time
 		{
 			reset:    true,
-			name:     "single point with timestamp pre-calculated for relative time queries yesterday",
+			name:     "single point with timestamp pre-calculated for past time queries yesterday",
 			write:    `{"database" : "%DB%", "retentionPolicy" : "%RP%", "points": [{"name": "cpu", "timestamp": "` + yesterday.Format(time.RFC3339Nano) + `", "tags": {"host": "server01"}, "fields": {"value": 100}}]}`,
 			query:    `SELECT * FROM "%DB%"."%RP%".cpu where time >= '` + yesterday.Add(-1*time.Minute).Format(time.RFC3339Nano) + `'`,
 			expected: fmt.Sprintf(`{"results":[{"series":[{"name":"cpu","columns":["time","value"],"values":[["%s",100]]}]}]}`, yesterday.Format(time.RFC3339Nano)),

--- a/influxql/engine.go
+++ b/influxql/engine.go
@@ -497,9 +497,7 @@ func (m *MapReduceJob) processAggregate(c *Call, reduceFunc ReduceFunc, resultVa
 	}
 
 	firstInterval := m.interval
-	if !m.stmt.IsRawQuery {
-		firstInterval = (m.TMin/m.interval*m.interval + m.interval) - m.TMin
-	}
+	firstInterval = (m.TMin/m.interval*m.interval + m.interval) - m.TMin
 	// populate the result values for each interval of time
 	for i, _ := range resultValues {
 		// collect the results from each mapper

--- a/influxql/engine.go
+++ b/influxql/engine.go
@@ -497,7 +497,9 @@ func (m *MapReduceJob) processAggregate(c *Call, reduceFunc ReduceFunc, resultVa
 	}
 
 	firstInterval := m.interval
-	firstInterval = (m.TMin/m.interval*m.interval + m.interval) - m.TMin
+	if !m.stmt.IsRawQuery {
+		firstInterval = (m.TMin/m.interval*m.interval + m.interval) - m.TMin
+	}
 	// populate the result values for each interval of time
 	for i, _ := range resultValues {
 		// collect the results from each mapper

--- a/tx.go
+++ b/tx.go
@@ -317,7 +317,6 @@ func (l *LocalMapper) Begin(c *influxql.Call, startingTime int64) error {
 // NextInterval will get the time ordered next interval of the given interval size from the mapper. This is a
 // forward only operation from the start time passed into Begin. Will return nil when there is no more data to be read.
 func (l *LocalMapper) NextInterval(interval int64) (interface{}, error) {
-	warn("> ", time.Unix(0, l.tmin).UTC(), time.Unix(0, l.tmax).UTC())
 	if l.cursorsEmpty || l.tmin > l.job.TMax {
 		return nil, nil
 	}

--- a/tx.go
+++ b/tx.go
@@ -317,17 +317,15 @@ func (l *LocalMapper) Begin(c *influxql.Call, startingTime int64) error {
 // NextInterval will get the time ordered next interval of the given interval size from the mapper. This is a
 // forward only operation from the start time passed into Begin. Will return nil when there is no more data to be read.
 func (l *LocalMapper) NextInterval(interval int64) (interface{}, error) {
+	warn("> ", time.Unix(0, l.tmin).UTC(), time.Unix(0, l.tmax).UTC())
 	if l.cursorsEmpty || l.tmin > l.job.TMax {
 		return nil, nil
 	}
 
-	intervalBottom := l.tmin
-
 	// Set the upper bound of the interval.
 	if interval > 0 {
 		// Make sure the bottom of the interval lands on a natural boundary.
-		intervalBottom = intervalBottom / interval * interval
-		l.tmax = intervalBottom + interval - 1
+		l.tmax = l.tmin + interval - 1
 	}
 
 	// Execute the map function. This local mapper acts as the iterator
@@ -343,7 +341,7 @@ func (l *LocalMapper) NextInterval(interval int64) (interface{}, error) {
 	}
 
 	// Move the interval forward.
-	l.tmin = intervalBottom + interval
+	l.tmin += interval
 
 	return val, nil
 }


### PR DESCRIPTION
We previously accepted a PR that broke the interval buckets for group by.

Effectively, if you asked for a group by `10s`, and started your time query on a `05` second interval, the buckets didn't calculate properly.

The issue though, was real, so we created the proper fix for this PR that we also reverted at the same time: https://github.com/influxdb/influxdb/pull/2016

Also fixes Issue https://github.com/influxdb/influxdb/issues/2045