### PR TITLE
Wire up DROP CONTINUOUS QUERY

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [#2061](https://github.com/influxdb/influxdb/pull/2061): Implement SHOW DIAGNOSTICS.
 - [#2064](https://github.com/influxdb/influxdb/pull/2064): Allow init.d script to return influxd version.
 - [#2053](https://github.com/influxdb/influxdb/pull/2053): Implment backup and restore.
+- [#1631](https://github.com/influxdb/influxdb/pull/1631): Wire up DROP CONTINUOUS QUERY.
 
 ### Bugfixes
 - [#2037](https://github.com/influxdb/influxdb/pull/2037): Don't check 'configExists' at Run() level.

--- a/commands.go
+++ b/commands.go
@@ -40,6 +40,7 @@ const (
 
 	// Continuous Query messages
 	createContinuousQueryMessageType = messaging.MessageType(0x70)
+	dropContinuousQueryMessageType   = messaging.MessageType(0x71)
 
 	// Write series data messages (per-topic)
 	writeRawSeriesMessageType = messaging.MessageType(0x80)
@@ -205,4 +206,9 @@ type dropSeriesCommand struct {
 // createContinuousQueryCommand is the raft command for creating a continuous query on a database
 type createContinuousQueryCommand struct {
 	Query string `json:"query"`
+}
+
+type dropContinuousQueryCommand struct {
+	Name     string `json:"name"`
+	Database string `json:"database"`
 }

--- a/influxdb.go
+++ b/influxdb.go
@@ -131,6 +131,9 @@ var (
 
 	// ErrContinuousQueryExists is returned when creating a duplicate continuous query.
 	ErrContinuousQueryExists = errors.New("continuous query already exists")
+
+	// ErrContinuousQueryNotFound is returned when dropping a nonexistent continuous query.
+	ErrContinuousQueryNotFound = errors.New("continuous query not found")
 )
 
 // ErrAuthorize represents an authorization error.

--- a/influxql/ast.go
+++ b/influxql/ast.go
@@ -1271,7 +1271,8 @@ func (s *CreateContinuousQueryStatement) RequiredPrivileges() ExecutionPrivilege
 
 // DropContinuousQueryStatement represents a command for removing a continuous query.
 type DropContinuousQueryStatement struct {
-	Name string
+	Name     string
+	Database string
 }
 
 // String returns a string representation of the statement.

--- a/influxql/parser.go
+++ b/influxql/parser.go
@@ -1212,11 +1212,22 @@ func (p *Parser) parseDropContinuousQueryStatement() (*DropContinuousQueryStatem
 	}
 
 	// Read the id of the query to drop.
-	lit, err := p.parseIdent()
+	ident, err := p.parseIdent()
 	if err != nil {
 		return nil, err
 	}
-	stmt.Name = lit
+	stmt.Name = ident
+
+	// Expect an "ON" keyword.
+	if tok, pos, lit := p.scanIgnoreWhitespace(); tok != ON {
+		return nil, newParseError(tokstr(tok, lit), []string{"ON"}, pos)
+	}
+
+	// Read the name of the database to remove the query from.
+	if ident, err = p.parseIdent(); err != nil {
+		return nil, err
+	}
+	stmt.Database = ident
 
 	return stmt, nil
 }

--- a/influxql/parser_test.go
+++ b/influxql/parser_test.go
@@ -552,8 +552,8 @@ func TestParser_ParseStatement(t *testing.T) {
 
 		// DROP CONTINUOUS QUERY statement
 		{
-			s:    `DROP CONTINUOUS QUERY myquery`,
-			stmt: &influxql.DropContinuousQueryStatement{Name: "myquery"},
+			s:    `DROP CONTINUOUS QUERY myquery ON foo`,
+			stmt: &influxql.DropContinuousQueryStatement{Name: "myquery", Database: "foo"},
 		},
 
 		// DROP DATABASE statement
@@ -810,6 +810,8 @@ func TestParser_ParseStatement(t *testing.T) {
 		{s: `SHOW STATS ON`, err: `found EOF, expected string at line 1, char 15`},
 		{s: `DROP CONTINUOUS`, err: `found EOF, expected QUERY at line 1, char 17`},
 		{s: `DROP CONTINUOUS QUERY`, err: `found EOF, expected identifier at line 1, char 23`},
+		{s: `DROP CONTINUOUS QUERY myquery`, err: `found EOF, expected ON at line 1, char 31`},
+		{s: `DROP CONTINUOUS QUERY myquery ON`, err: `found EOF, expected identifier at line 1, char 34`},
 		{s: `CREATE CONTINUOUS`, err: `found EOF, expected QUERY at line 1, char 19`},
 		{s: `CREATE CONTINUOUS QUERY`, err: `found EOF, expected identifier at line 1, char 25`},
 		{s: `DROP FOO`, err: `found FOO, expected SERIES, CONTINUOUS, MEASUREMENT at line 1, char 6`},


### PR DESCRIPTION
Format is:

```sql
DROP CONTINUOUS QUERY foo ON bar
```

Where foo is the name of the query and bar is the database. It should only delete the continuous query. Shouldn't have to drop any data, just remove the CQ