### PR TITLE
Allow leading underscores for IDENTs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Features
 - [#2076](https://github.com/influxdb/influxdb/pull/2076): Seperate stdout and stderr output in init.d script
 
+## Bugfixes
+- [#2084](https://github.com/influxdb/influxdb/pull/2084): Allowing leading underscores in identifiers.
 
 ## v0.9.0-rc16 [2015-03-24]
 

--- a/influxql/scanner.go
+++ b/influxql/scanner.go
@@ -28,10 +28,11 @@ func (s *Scanner) Scan() (tok Token, pos Pos, lit string) {
 	ch0, pos := s.r.read()
 
 	// If we see whitespace then consume all contiguous whitespace.
-	// If we see a letter then consume as an ident or reserved word.
+	// If we see a letter, or certain acceptable special characters, then consume
+	// as an ident or reserved word.
 	if isWhitespace(ch0) {
 		return s.scanWhitespace()
-	} else if isLetter(ch0) {
+	} else if isLetter(ch0) || ch0 == '_' {
 		s.r.unread()
 		return s.scanIdent()
 	} else if isDigit(ch0) {

--- a/influxql/scanner_test.go
+++ b/influxql/scanner_test.go
@@ -58,6 +58,7 @@ func TestScanner_Scan(t *testing.T) {
 
 		// Identifiers
 		{s: `foo`, tok: influxql.IDENT, lit: `foo`},
+		{s: `_foo`, tok: influxql.IDENT, lit: `_foo`},
 		{s: `Zx12_3U_-`, tok: influxql.IDENT, lit: `Zx12_3U_`},
 		{s: `"foo".bar`, tok: influxql.IDENT, lit: `"foo".bar`},
 		{s: `"foo\\bar"`, tok: influxql.IDENT, lit: `"foo\bar"`},


### PR DESCRIPTION
Check for digits first, then perform the isIdent() check.