### PR TITLE
Point Precision not getting marshaled correctly...

### DIFF
--- a/client/influxdb.go
+++ b/client/influxdb.go
@@ -295,10 +295,12 @@ func (p *Point) MarshalJSON() ([]byte, error) {
 		Tags      map[string]string      `json:"tags,omitempty"`
 		Timestamp string                 `json:"timestamp,omitempty"`
 		Fields    map[string]interface{} `json:"fields,omitempty"`
+		Precision string                 `json:"precision,omitempty"`
 	}{
-		Name:   p.Name,
-		Tags:   p.Tags,
-		Fields: p.Fields,
+		Name:      p.Name,
+		Tags:      p.Tags,
+		Fields:    p.Fields,
+		Precision: p.Precision,
 	}
 	// Let it omit empty if it's really zero
 	if !p.Timestamp.IsZero() {

--- a/client/influxdb_test.go
+++ b/client/influxdb_test.go
@@ -332,7 +332,7 @@ func TestPoint_MarshalOmitempty(t *testing.T) {
 			name:     "with precision",
 			point:    client.Point{Name: "cpu", Fields: map[string]interface{}{"value": 1.1}, Precision: "ms"},
 			now:      now,
-			expected: `{"name":"cpu","fields":{"value":1.1}}`,
+			expected: `{"name":"cpu","fields":{"value":1.1},"precision":"ms"}`,
 		},
 	}
 
@@ -390,14 +390,14 @@ func emptyTestServer() *httptest.Server {
 func TestBatchPoints_Normal(t *testing.T) {
 	var bp client.BatchPoints
 	data := []byte(`
-{                                                                                                                                                       
-    "database": "foo",                                                                                                                                    
-    "retentionPolicy": "bar",                                                                                                                              
-    "points": [                                                                                                                                            
-        {                                                                                                                                                   
-            "name": "cpu",                                                                                                                                   
-            "tags": {                                                                                                                                         
-                "host": "server01"                                                                                                                            
+{
+    "database": "foo",
+    "retentionPolicy": "bar",
+    "points": [
+        {
+            "name": "cpu",
+            "tags": {
+                "host": "server01"
             },
             "timestamp": 14244733039069373,
             "precision": "n",


### PR DESCRIPTION
Not sure if this is a bug or was intended as such. Ran into the use case while marsh/unmarsh a slice of client.Point. I was loosing the points precision during the marsh operation.

Corrected client code and associated test and ran tests successfully.