### PR TITLE
Add chunked responses and streaming of raw queries

### DIFF
--- a/cmd/influxd/server_integration_test.go
+++ b/cmd/influxd/server_integration_test.go
@@ -1170,7 +1170,7 @@ func TestSingleServer(t *testing.T) {
 	nodes := createCombinedNodeCluster(t, testName, dir, 1, 8090, nil)
 
 	runTestsData(t, testName, nodes, "mydb", "myrp")
-	//runTest_rawDataReturnsInOrder(t, testName, nodes, "mydb", "myrp")
+	runTest_rawDataReturnsInOrder(t, testName, nodes, "mydb", "myrp")
 }
 
 func Test3NodeServer(t *testing.T) {

--- a/cmd/influxd/server_integration_test.go
+++ b/cmd/influxd/server_integration_test.go
@@ -612,6 +612,7 @@ func runTestsData(t *testing.T, testName string, nodes Cluster, database, retent
 			expected: `{"results":[{"series":[{"name":"cpu","columns":["time","alert_id"],"values":[["2015-02-28T01:03:36.703820946Z","alert"]]}]}]}`,
 		},
 		{
+			name: "xxx select where field greater than some value",
 			write: `{"database" : "%DB%", "retentionPolicy" : "%RP%", "points": [{"name": "cpu", "timestamp": "2009-11-10T23:00:02Z", "fields": {"load": 100}},
 			                                                                      {"name": "cpu", "timestamp": "2009-11-10T23:01:02Z", "fields": {"load": 80}}]}`,
 			query:    `select load from "%DB%"."%RP%".cpu where load > 100`,
@@ -1169,7 +1170,7 @@ func TestSingleServer(t *testing.T) {
 	nodes := createCombinedNodeCluster(t, testName, dir, 1, 8090, nil)
 
 	runTestsData(t, testName, nodes, "mydb", "myrp")
-	runTest_rawDataReturnsInOrder(t, testName, nodes, "mydb", "myrp")
+	//runTest_rawDataReturnsInOrder(t, testName, nodes, "mydb", "myrp")
 }
 
 func Test3NodeServer(t *testing.T) {

--- a/cmd/influxd/server_integration_test.go
+++ b/cmd/influxd/server_integration_test.go
@@ -612,7 +612,7 @@ func runTestsData(t *testing.T, testName string, nodes Cluster, database, retent
 			expected: `{"results":[{"series":[{"name":"cpu","columns":["time","alert_id"],"values":[["2015-02-28T01:03:36.703820946Z","alert"]]}]}]}`,
 		},
 		{
-			name: "xxx select where field greater than some value",
+			name: "select where field greater than some value",
 			write: `{"database" : "%DB%", "retentionPolicy" : "%RP%", "points": [{"name": "cpu", "timestamp": "2009-11-10T23:00:02Z", "fields": {"load": 100}},
 			                                                                      {"name": "cpu", "timestamp": "2009-11-10T23:01:02Z", "fields": {"load": 80}}]}`,
 			query:    `select load from "%DB%"."%RP%".cpu where load > 100`,

--- a/httpd/handler.go
+++ b/httpd/handler.go
@@ -18,11 +18,14 @@ import (
 	"time"
 
 	"code.google.com/p/go-uuid/uuid"
-
 	"github.com/bmizerany/pat"
 	"github.com/influxdb/influxdb"
 	"github.com/influxdb/influxdb/client"
 	"github.com/influxdb/influxdb/influxql"
+)
+
+const (
+	DefaultChunkSize = 10000
 )
 
 // TODO: Standard response headers (see: HeaderHandler)
@@ -173,12 +176,91 @@ func (h *Handler) serveQuery(w http.ResponseWriter, r *http.Request, user *influ
 		httpError(w, "error parsing query: "+err.Error(), pretty, http.StatusBadRequest)
 		return
 	}
-
-	// Execute query. One result will return for each statement.
-	results := h.server.ExecuteQuery(query, db, user)
+	chunked := q.Get("chunked") == "true"
+	chunkSize := influxdb.NoChunkingSize
+	if chunked {
+		cs, err := strconv.ParseInt(q.Get("chunk_size"), 10, 64)
+		if err != nil {
+			chunkSize = DefaultChunkSize
+		} else {
+			chunkSize = int(cs)
+		}
+	}
 
 	// Send results to client.
-	httpResults(w, results, pretty)
+	w.Header().Add("content-type", "application/json")
+	results, err := h.server.ExecuteQuery(query, db, user, chunkSize)
+	if err != nil {
+		if isAuthorizationError(err) {
+			w.WriteHeader(http.StatusUnauthorized)
+		} else {
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+		return
+	}
+
+	res := influxdb.Results{Results: make([]*influxdb.Result, 0)}
+
+	statusWritten := false
+
+	for r := range results {
+		// write the status header based on the first result returned in the channel
+		if !statusWritten {
+			if r != nil && r.Err != nil {
+				if isAuthorizationError(r.Err) {
+					w.WriteHeader(http.StatusUnauthorized)
+				} else if isMeasurementNotFoundError(r.Err) {
+					w.WriteHeader(http.StatusOK)
+				} else if isFieldNotFoundError(r.Err) {
+					w.WriteHeader(http.StatusOK)
+				} else {
+					w.WriteHeader(http.StatusInternalServerError)
+				}
+			} else {
+				w.WriteHeader(http.StatusOK)
+			}
+			statusWritten = true
+		}
+
+		if r == nil {
+			continue
+		}
+
+		// if chunked we write out this result and flush
+		if chunked {
+			w.Write(marshalPretty(r, pretty))
+			continue
+			//w.(http.Flusher).Flush()
+		}
+
+		// it's not chunked so buffer results in memory.
+		// results for statements need to be combined together. We need to check if this new result is
+		// for the same statement as the last result, or for the next statement
+		l := len(res.Results)
+		if l == 0 {
+			res.Results = append(res.Results, r)
+		} else if res.Results[l-1].StatementID == r.StatementID {
+			cr := res.Results[l-1]
+			cr.Series = append(cr.Series, r.Series...)
+		} else {
+			res.Results = append(res.Results, r)
+		}
+	}
+
+	// if it's not chunked we buffered everything in memory, so write it out
+	if !chunked {
+		w.Write(marshalPretty(res, pretty))
+	}
+}
+
+func marshalPretty(r interface{}, pretty bool) []byte {
+	var b []byte
+	if pretty {
+		b, _ = json.MarshalIndent(r, "", "    ")
+	} else {
+		b, _ = json.Marshal(r)
+	}
+	return b
 }
 
 func interfaceToString(v interface{}) string {
@@ -212,9 +294,14 @@ type Batch struct {
 // Return all the measurements from the given DB
 func (h *Handler) showMeasurements(db string, user *influxdb.User) ([]string, error) {
 	var measurements []string
-	results := h.server.ExecuteQuery(&influxql.Query{Statements: []influxql.Statement{&influxql.ShowMeasurementsStatement{}}}, db, user)
-	if results.Err != nil {
-		return measurements, results.Err
+	c, err := h.server.ExecuteQuery(&influxql.Query{Statements: []influxql.Statement{&influxql.ShowMeasurementsStatement{}}}, db, user, 0)
+	if err != nil {
+		return measurements, err
+	}
+	results := influxdb.Results{}
+
+	for r := range c {
+		results.Results = append(results.Results, r)
 	}
 
 	for _, result := range results.Results {
@@ -264,9 +351,14 @@ func (h *Handler) serveDump(w http.ResponseWriter, r *http.Request, user *influx
 			httpError(w, "error with dump: "+err.Error(), pretty, http.StatusInternalServerError)
 			return
 		}
-		//
-		results := h.server.ExecuteQuery(query, db, user)
-		for _, result := range results.Results {
+
+		res, err := h.server.ExecuteQuery(query, db, user, DefaultChunkSize)
+		if err != nil {
+			w.Write([]byte("*** SERVER-SIDE ERROR. MISSING DATA ***"))
+			w.Write(delim)
+			return
+		}
+		for result := range res {
 			for _, row := range result.Series {
 				points := make([]Point, 1)
 				var point Point
@@ -570,31 +662,6 @@ func isMeasurementNotFoundError(err error) bool {
 
 func isFieldNotFoundError(err error) bool {
 	return (strings.HasPrefix(err.Error(), "field not found"))
-}
-
-// httpResult writes a Results array to the client.
-func httpResults(w http.ResponseWriter, results influxdb.Results, pretty bool) {
-	w.Header().Add("content-type", "application/json")
-
-	if results.Error() != nil {
-		if isAuthorizationError(results.Error()) {
-			w.WriteHeader(http.StatusUnauthorized)
-		} else if isMeasurementNotFoundError(results.Error()) {
-			w.WriteHeader(http.StatusOK)
-		} else if isFieldNotFoundError(results.Error()) {
-			w.WriteHeader(http.StatusOK)
-		} else {
-			w.WriteHeader(http.StatusInternalServerError)
-		}
-	}
-
-	var b []byte
-	if pretty {
-		b, _ = json.MarshalIndent(results, "", "    ")
-	} else {
-		b, _ = json.Marshal(results)
-	}
-	w.Write(b)
 }
 
 // httpError writes an error to the client in a standard format.

--- a/httpd/handler_test.go
+++ b/httpd/handler_test.go
@@ -11,7 +11,6 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
-	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -1664,7 +1663,7 @@ func TestHandler_ChunkedResponses(t *testing.T) {
 		} else {
 			vals = [][]interface{}{{"2009-11-10T23:30:00Z", 25}}
 		}
-		if !reflect.DeepEqual(results.Results[0].Series[0].Values, vals) {
+		if mustMarshalJSON(vals) != mustMarshalJSON(results.Results[0].Series[0].Values) {
 			t.Fatalf("values weren't what was expected:\n  exp: %s\n  got: %s", mustMarshalJSON(vals), mustMarshalJSON(results.Results[0].Series[0].Values))
 		}
 	}

--- a/influxql/engine.go
+++ b/influxql/engine.go
@@ -576,7 +576,7 @@ func NewPlanner(db DB) *Planner {
 }
 
 // Plan creates an execution plan for the given SelectStatement and returns an Executor.
-func (p *Planner) Plan(stmt *SelectStatement) (*Executor, error) {
+func (p *Planner) Plan(stmt *SelectStatement, chunkSize int) (*Executor, error) {
 	now := p.Now().UTC()
 
 	// Replace instances of "now()" with the current time.

--- a/influxql/engine.go
+++ b/influxql/engine.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"hash/fnv"
+	"math"
 	"sort"
 	"time"
 )
@@ -17,10 +18,6 @@ const (
 	// Return an error if the user is trying to select more than this number of points in a group by statement.
 	// Most likely they specified a group by interval without time boundaries.
 	MaxGroupByPoints = 100000
-
-	// All queries that return raw non-aggregated data, will have 2 results returned from the ouptut of a reduce run.
-	// The first element will be a time that we ignore, and the second element will be an array of []*rawMapOutput
-	ResultCountInRawResults = 2
 
 	// Since time is always selected, the column count when selecting only a single other value will be 2
 	SelectColumnCountWithOneValue = 2
@@ -42,6 +39,7 @@ type MapReduceJob struct {
 	key             []byte           // a key that identifies the MRJob so it can be sorted
 	interval        int64            // the group by interval of the query
 	stmt            *SelectStatement // the select statement this job was created for
+	chunkSize       int              // the number of points to buffer in raw queries before returning a chunked response
 }
 
 func (m *MapReduceJob) Open() error {
@@ -68,6 +66,13 @@ func (m *MapReduceJob) Key() []byte {
 }
 
 func (m *MapReduceJob) Execute(out chan *Row, filterEmptyResults bool) {
+	// if it's a raw query we handle processing differently
+	if m.stmt.IsRawQuery {
+		m.processRawQuery(out, filterEmptyResults)
+		return
+	}
+
+	// get the aggregates and the associated reduce functions
 	aggregates := m.stmt.FunctionCalls()
 	reduceFuncs := make([]ReduceFunc, len(aggregates))
 	for i, c := range aggregates {
@@ -79,20 +84,11 @@ func (m *MapReduceJob) Execute(out chan *Row, filterEmptyResults bool) {
 		reduceFuncs[i] = reduceFunc
 	}
 
-	isRaw := false
-	// modify if it's a raw data query
-	if len(aggregates) == 0 {
-		isRaw = true
-		aggregates = []*Call{nil}
-		r, _ := InitializeReduceFunc(nil)
-		reduceFuncs = append(reduceFuncs, r)
-	}
-
 	// we'll have a fixed number of points with timestamps in buckets. Initialize those times and a slice to hold the associated values
 	var pointCountInResult int
 
 	// if the user didn't specify a start time or a group by interval, we're returning a single point that describes the entire range
-	if m.TMin == 0 || m.interval == 0 || isRaw {
+	if m.TMin == 0 || m.interval == 0 {
 		// they want a single aggregate point for the entire time range
 		m.interval = m.TMax - m.TMin
 		pointCountInResult = 1
@@ -104,7 +100,7 @@ func (m *MapReduceJob) Execute(out chan *Row, filterEmptyResults bool) {
 
 	// For group by time queries, limit the number of data points returned by the limit and offset
 	// raw query limits are handled elsewhere
-	if !m.stmt.IsRawQuery && (m.stmt.Limit > 0 || m.stmt.Offset > 0) {
+	if m.stmt.Limit > 0 || m.stmt.Offset > 0 {
 		// ensure that the offset isn't higher than the number of points we'd get
 		if m.stmt.Offset > pointCountInResult {
 			return
@@ -118,7 +114,7 @@ func (m *MapReduceJob) Execute(out chan *Row, filterEmptyResults bool) {
 	}
 
 	// If we are exceeding our MaxGroupByPoints and we aren't a raw query, error out
-	if !m.stmt.IsRawQuery && pointCountInResult > MaxGroupByPoints {
+	if pointCountInResult > MaxGroupByPoints {
 		out <- &Row{
 			Err: errors.New("too many points in the group by interval. maybe you forgot to specify a where time clause?"),
 		}
@@ -140,7 +136,7 @@ func (m *MapReduceJob) Execute(out chan *Row, filterEmptyResults bool) {
 		}
 
 		// If we start getting out of our max time range, then truncate values and return
-		if t > m.TMax && !isRaw {
+		if t > m.TMax {
 			resultValues = resultValues[:i]
 			break
 		}
@@ -152,7 +148,7 @@ func (m *MapReduceJob) Execute(out chan *Row, filterEmptyResults bool) {
 
 	// This just makes sure that if they specify a start time less than what the start time would be with the offset,
 	// we just reset the start time to the later time to avoid going over data that won't show up in the result.
-	if m.stmt.Offset > 0 && !m.stmt.IsRawQuery {
+	if m.stmt.Offset > 0 {
 		m.TMin = resultValues[0][0].(time.Time).UnixNano()
 	}
 
@@ -167,18 +163,6 @@ func (m *MapReduceJob) Execute(out chan *Row, filterEmptyResults bool) {
 
 			return
 		}
-	}
-
-	if isRaw {
-		row := m.processRawResults(resultValues)
-		if filterEmptyResults && m.resultsEmpty(row.Values) {
-			return
-		}
-		// do any post processing like math and stuff
-		row.Values = m.processResults(row.Values)
-
-		out <- row
-		return
 	}
 
 	// filter out empty results
@@ -210,6 +194,141 @@ func (m *MapReduceJob) Execute(out chan *Row, filterEmptyResults bool) {
 	out <- row
 }
 
+// processRawQuery will handle running the mappers and then reducing their output
+// for queries that pull back raw data values without computing any kind of aggregates.
+func (m *MapReduceJob) processRawQuery(out chan *Row, filterEmptyResults bool) {
+	// initialize the mappers
+	for _, mm := range m.Mappers {
+		if err := mm.Begin(nil, m.TMin); err != nil {
+			out <- &Row{Err: err}
+			return
+		}
+	}
+
+	mapperOutputs := make([][]*rawQueryMapOutput, len(m.Mappers))
+	// markers for which mappers have been completely emptied
+	mapperComplete := make([]bool, len(m.Mappers))
+
+	// we need to make sure that we send at least one row, even for queries with empty results
+	oneRowSent := false
+
+	// for limit and offset we need to track how many values we've swalloed for the offset and how many we've already set for the limit.
+	// we track the number set for the limit because they could be getting chunks. For instance if your limit is 10k, but chunk size is 1k
+	valuesSent := 0
+	valuesOffset := 0
+
+	// loop until we've emptied out all the mappers and sent everything out
+	for {
+		// collect up to the limit for each mapper
+		for j, mm := range m.Mappers {
+			// only pull from mappers that potentially have more data and whose last output has been completely sent out.
+			if mapperOutputs[j] != nil || mapperComplete[j] {
+				continue
+			}
+
+			mm.SetLimit(m.chunkSize)
+			res, err := mm.NextInterval(m.TMax)
+			if err != nil {
+				out <- &Row{Err: err}
+				return
+			}
+			if res != nil {
+				mapperOutputs[j] = res.([]*rawQueryMapOutput)
+			} else { // if we got a nil from the mapper it means that we've emptied all data from it
+				mapperComplete[j] = true
+			}
+		}
+
+		// process the mapper outputs. we can send out everything up to the min of the last time in the mappers
+		min := int64(math.MaxInt64)
+		for _, o := range mapperOutputs {
+			// some of the mappers could empty out before others so ignore them because they'll be nil
+			if o == nil {
+				continue
+			}
+
+			// find the min of the last point in each mapper
+			t := o[len(o)-1].timestamp
+			if t < min {
+				min = t
+			}
+		}
+
+		// now empty out all the mapper outputs up to the min time
+		var values []*rawQueryMapOutput
+		for j, o := range mapperOutputs {
+			// find the index of the point up to the min
+			ind := len(o)
+			for i, mo := range o {
+				if mo.timestamp > min {
+					ind = i
+					break
+				}
+			}
+
+			// add up to the index to the values
+			values = append(values, o[:ind]...)
+
+			// if we emptied out all the values, set this output to nil so that the mapper will get run again on the next loop
+			if ind == len(o) {
+				mapperOutputs[j] = nil
+			}
+		}
+
+		// if we didn't pull out any values, we're done here
+		if values == nil {
+			if !oneRowSent && !filterEmptyResults {
+				out <- m.processRawResults(nil)
+			}
+			return
+		}
+
+		// sort the values by time first so we can then handle offset and limit
+		sort.Sort(rawOutputs(values))
+
+		// get rid of any points that need to be offset
+		if valuesOffset < m.stmt.Offset {
+			offset := m.stmt.Offset - valuesOffset
+
+			// if offset is bigger than the number of values we have, move to the next batch from the mappers
+			if offset > len(values) {
+				valuesOffset += len(values)
+				continue
+			}
+
+			values = values[offset:]
+			valuesOffset += offset
+		}
+
+		// ensure we don't send more than the limit
+		if valuesSent < m.stmt.Limit {
+			limit := m.stmt.Limit - valuesSent
+			if len(values) > limit {
+				values = values[:limit]
+			}
+			valuesSent += len(values)
+		}
+
+		// convert the raw results into rows
+		row := m.processRawResults(values)
+		if filterEmptyResults && m.resultsEmpty(row.Values) {
+			return
+		}
+
+		// do any post processing like math and stuff
+		row.Values = m.processResults(row.Values)
+		oneRowSent = true
+
+		out <- row
+
+		// stop processing if we've hit the limit
+		if m.stmt.Limit != 0 && valuesSent >= m.stmt.Limit {
+			return
+		}
+	}
+}
+
+// processsResults will apply any math that was specified in the select statement against the passed in results
 func (m *MapReduceJob) processResults(results [][]interface{}) [][]interface{} {
 	hasMath := false
 	for _, f := range m.stmt.Fields {
@@ -245,8 +364,8 @@ func (m *MapReduceJob) processResults(results [][]interface{}) [][]interface{} {
 
 // processFill will take the results and return new reaults (or the same if no fill modifications are needed) with whatever fill options the query has.
 func (m *MapReduceJob) processFill(results [][]interface{}) [][]interface{} {
-	// don't do anything if it's raw query results or we're supposed to leave the nulls
-	if m.stmt.IsRawQuery || m.stmt.Fill == NullFill {
+	// don't do anything if we're supposed to leave the nulls
+	if m.stmt.Fill == NullFill {
 		return results
 	}
 
@@ -396,6 +515,7 @@ func newBinaryExprEvaluator(op Token, lhs, rhs processor) processor {
 	}
 }
 
+// resultsEmpty will return true if the all the result values are empty or contain only nulls
 func (m *MapReduceJob) resultsEmpty(resultValues [][]interface{}) bool {
 	for _, vals := range resultValues {
 		// start the loop at 1 because we want to skip over the time value
@@ -409,7 +529,7 @@ func (m *MapReduceJob) resultsEmpty(resultValues [][]interface{}) bool {
 }
 
 // processRawResults will handle converting the reduce results from a raw query into a Row
-func (m *MapReduceJob) processRawResults(resultValues [][]interface{}) *Row {
+func (m *MapReduceJob) processRawResults(values []*rawQueryMapOutput) *Row {
 	selectNames := m.stmt.NamesInSelect()
 
 	// ensure that time is in the select names and in the first position
@@ -440,14 +560,12 @@ func (m *MapReduceJob) processRawResults(resultValues [][]interface{}) *Row {
 	}
 
 	// return an empty row if there are no results
-	// resultValues should have exactly 1 array of interface. And for that array, the first element
-	// will be a time that we ignore, and the second element will be an array of []*rawMapOutput
-	if len(resultValues) == 0 || len(resultValues[0]) != ResultCountInRawResults {
+	if len(values) == 0 {
 		return row
 	}
 
 	// the results will have all of the raw mapper results, convert into the row
-	for _, v := range resultValues[0][1].([]*rawQueryMapOutput) {
+	for _, v := range values {
 		vals := make([]interface{}, len(selectNames))
 
 		if singleValue {
@@ -468,21 +586,6 @@ func (m *MapReduceJob) processRawResults(resultValues [][]interface{}) *Row {
 		row.Values = append(row.Values, vals)
 	}
 
-	// apply limit and offset, if applicable
-	// TODO: make this so it doesn't read the whole result set into memory
-	if m.stmt.Limit > 0 || m.stmt.Offset > 0 {
-		if m.stmt.Offset > len(row.Values) {
-			row.Values = nil
-		} else {
-			limit := m.stmt.Limit
-			if m.stmt.Offset+m.stmt.Limit > len(row.Values) {
-				limit = len(row.Values) - m.stmt.Offset
-			}
-
-			row.Values = row.Values[m.stmt.Offset : m.stmt.Offset+limit]
-		}
-	}
-
 	return row
 }
 
@@ -496,10 +599,10 @@ func (m *MapReduceJob) processAggregate(c *Call, reduceFunc ReduceFunc, resultVa
 		}
 	}
 
-	firstInterval := m.interval
-	if !m.stmt.IsRawQuery {
-		firstInterval = (m.TMin/m.interval*m.interval + m.interval) - m.TMin
-	}
+	// the first interval in a query with a group by may be smaller than the others. This happens when they have a
+	// where time > clause that is in the middle of the bucket that the group by time creates
+	firstInterval := (m.TMin/m.interval*m.interval + m.interval) - m.TMin
+
 	// populate the result values for each interval of time
 	for i, _ := range resultValues {
 		// collect the results from each mapper
@@ -542,9 +645,14 @@ type Mapper interface {
 
 	// NextInterval will get the time ordered next interval of the given interval size from the mapper. This is a
 	// forward only operation from the start time passed into Begin. Will return nil when there is no more data to be read.
-	// We pass the interval in here so that it can be varied over the period of the query. This is useful for the raw
-	// data queries where we'd like to gradually adjust the amount of time we scan over.
+	// We pass the interval in here so that it can be varied over the period of the query. This is useful for queries that
+	// must respect natural time boundaries like months or queries that span daylight savings time borders. Note that if
+	// a limit is set on the mapper, the interval passed here should represent the MaxTime in a nano epoch.
 	NextInterval(interval int64) (interface{}, error)
+
+	// Set limit will limit the number of data points yielded on the next interval. If a limit is set, the interval
+	// passed into NextInterval will be used as the MaxTime to scan until.
+	SetLimit(limit int)
 }
 
 type TagSet struct {
@@ -616,6 +724,7 @@ func (p *Planner) Plan(stmt *SelectStatement, chunkSize int) (*Executor, error) 
 	for _, j := range jobs {
 		j.interval = interval.Nanoseconds()
 		j.stmt = stmt
+		j.chunkSize = chunkSize
 	}
 
 	return &Executor{tx: tx, stmt: stmt, jobs: jobs, interval: interval.Nanoseconds()}, nil

--- a/server.go
+++ b/server.go
@@ -2034,7 +2034,7 @@ func (s *Server) ExecuteQuery(q *influxql.Query, database string, user *User, ch
 	// Authorize user to execute the query.
 	if s.authenticationEnabled {
 		if err := s.Authorize(user, q, database); err != nil {
-			return Results{Err: err}
+			return nil, err
 		}
 	}
 

--- a/server.go
+++ b/server.go
@@ -49,6 +49,9 @@ const (
 
 	// Defines the minimum duration allowed for all retention policies
 	retentionPolicyMinDuration = time.Hour
+
+	// When planning a select statement, passing zero tells it not to chunk results
+	NoChunkingSize = 0
 )
 
 // Server represents a collection of metadata and raw metric data.
@@ -2024,9 +2027,10 @@ func (s *Server) ReadSeries(database, retentionPolicy, name string, tags map[str
 }
 
 // ExecuteQuery executes an InfluxQL query against the server.
-// Returns a resultset for each statement in the query.
-// Stops on first execution error that occurs.
-func (s *Server) ExecuteQuery(q *influxql.Query, database string, user *User) Results {
+// If the user isn't authorized to access the database an error will be returned.
+// It sends results down the passed in chan and closes it when done. It will close the chan
+// on the first statement that throws an error.
+func (s *Server) ExecuteQuery(q *influxql.Query, database string, user *User, chunkSize int) (chan *Result, error) {
 	// Authorize user to execute the query.
 	if s.authenticationEnabled {
 		if err := s.Authorize(user, q, database); err != nil {
@@ -2034,128 +2038,142 @@ func (s *Server) ExecuteQuery(q *influxql.Query, database string, user *User) Re
 		}
 	}
 
-	// Build empty resultsets.
-	results := Results{Results: make([]*Result, len(q.Statements))}
 	s.stats.Add("queriesRx", int64(len(q.Statements)))
 
-	// Execute each statement.
-	for i, stmt := range q.Statements {
-		// Set default database and policy on the statement.
-		if err := s.NormalizeStatement(stmt, database); err != nil {
-			results.Results[i] = &Result{Err: err}
-			break
+	// Execute each statement. Keep the iterator external so we can
+	// track how many of the statements were executed
+	results := make(chan *Result)
+	go func() {
+		var i int
+		var stmt influxql.Statement
+		for i, stmt = range q.Statements {
+			// Set default database and policy on the statement.
+			if err := s.NormalizeStatement(stmt, database); err != nil {
+				results <- &Result{Err: err}
+				break
+			}
+
+			var res *Result
+			switch stmt := stmt.(type) {
+			case *influxql.SelectStatement:
+				if err := s.executeSelectStatement(i, stmt, database, user, results, chunkSize); err != nil {
+					results <- &Result{Err: err}
+					break
+				}
+			case *influxql.CreateDatabaseStatement:
+				res = s.executeCreateDatabaseStatement(stmt, user)
+			case *influxql.DropDatabaseStatement:
+				res = s.executeDropDatabaseStatement(stmt, user)
+			case *influxql.ShowDatabasesStatement:
+				res = s.executeShowDatabasesStatement(stmt, user)
+			case *influxql.ShowServersStatement:
+				res = s.executeShowServersStatement(stmt, user)
+			case *influxql.CreateUserStatement:
+				res = s.executeCreateUserStatement(stmt, user)
+			case *influxql.DeleteStatement:
+				res = s.executeDeleteStatement()
+			case *influxql.DropUserStatement:
+				res = s.executeDropUserStatement(stmt, user)
+			case *influxql.ShowUsersStatement:
+				res = s.executeShowUsersStatement(stmt, user)
+			case *influxql.DropSeriesStatement:
+				res = s.executeDropSeriesStatement(stmt, database, user)
+			case *influxql.ShowSeriesStatement:
+				res = s.executeShowSeriesStatement(stmt, database, user)
+			case *influxql.DropMeasurementStatement:
+				res = s.executeDropMeasurementStatement(stmt, database, user)
+			case *influxql.ShowMeasurementsStatement:
+				res = s.executeShowMeasurementsStatement(stmt, database, user)
+			case *influxql.ShowTagKeysStatement:
+				res = s.executeShowTagKeysStatement(stmt, database, user)
+			case *influxql.ShowTagValuesStatement:
+				res = s.executeShowTagValuesStatement(stmt, database, user)
+			case *influxql.ShowFieldKeysStatement:
+				res = s.executeShowFieldKeysStatement(stmt, database, user)
+			case *influxql.ShowStatsStatement:
+				res = s.executeShowStatsStatement(stmt, user)
+			case *influxql.GrantStatement:
+				res = s.executeGrantStatement(stmt, user)
+			case *influxql.RevokeStatement:
+				res = s.executeRevokeStatement(stmt, user)
+			case *influxql.CreateRetentionPolicyStatement:
+				res = s.executeCreateRetentionPolicyStatement(stmt, user)
+			case *influxql.AlterRetentionPolicyStatement:
+				res = s.executeAlterRetentionPolicyStatement(stmt, user)
+			case *influxql.DropRetentionPolicyStatement:
+				res = s.executeDropRetentionPolicyStatement(stmt, user)
+			case *influxql.ShowRetentionPoliciesStatement:
+				res = s.executeShowRetentionPoliciesStatement(stmt, user)
+			case *influxql.CreateContinuousQueryStatement:
+				res = s.executeCreateContinuousQueryStatement(stmt, user)
+			case *influxql.DropContinuousQueryStatement:
+				continue
+			case *influxql.ShowContinuousQueriesStatement:
+				res = s.executeShowContinuousQueriesStatement(stmt, database, user)
+			default:
+				panic(fmt.Sprintf("unsupported statement type: %T", stmt))
+			}
+
+			if res != nil {
+				// set the StatementID for the handler on the other side to combine results
+				res.StatementID = i
+
+				// If an error occurs then stop processing remaining statements.
+				results <- res
+				if res.Err != nil {
+					break
+				}
+			}
 		}
 
-		var res *Result
-		switch stmt := stmt.(type) {
-		case *influxql.SelectStatement:
-			res = s.executeSelectStatement(stmt, database, user)
-		case *influxql.CreateDatabaseStatement:
-			res = s.executeCreateDatabaseStatement(stmt, user)
-		case *influxql.DropDatabaseStatement:
-			res = s.executeDropDatabaseStatement(stmt, user)
-		case *influxql.ShowDatabasesStatement:
-			res = s.executeShowDatabasesStatement(stmt, user)
-		case *influxql.ShowServersStatement:
-			res = s.executeShowServersStatement(stmt, user)
-		case *influxql.CreateUserStatement:
-			res = s.executeCreateUserStatement(stmt, user)
-		case *influxql.DeleteStatement:
-			res = s.executeDeleteStatement()
-		case *influxql.DropUserStatement:
-			res = s.executeDropUserStatement(stmt, user)
-		case *influxql.ShowUsersStatement:
-			res = s.executeShowUsersStatement(stmt, user)
-		case *influxql.DropSeriesStatement:
-			res = s.executeDropSeriesStatement(stmt, database, user)
-		case *influxql.ShowSeriesStatement:
-			res = s.executeShowSeriesStatement(stmt, database, user)
-		case *influxql.DropMeasurementStatement:
-			res = s.executeDropMeasurementStatement(stmt, database, user)
-		case *influxql.ShowMeasurementsStatement:
-			res = s.executeShowMeasurementsStatement(stmt, database, user)
-		case *influxql.ShowTagKeysStatement:
-			res = s.executeShowTagKeysStatement(stmt, database, user)
-		case *influxql.ShowTagValuesStatement:
-			res = s.executeShowTagValuesStatement(stmt, database, user)
-		case *influxql.ShowFieldKeysStatement:
-			res = s.executeShowFieldKeysStatement(stmt, database, user)
-		case *influxql.ShowStatsStatement:
-			res = s.executeShowStatsStatement(stmt, user)
-		case *influxql.ShowDiagnosticsStatement:
-			res = s.executeShowDiagnosticsStatement(stmt, user)
-		case *influxql.GrantStatement:
-			res = s.executeGrantStatement(stmt, user)
-		case *influxql.RevokeStatement:
-			res = s.executeRevokeStatement(stmt, user)
-		case *influxql.CreateRetentionPolicyStatement:
-			res = s.executeCreateRetentionPolicyStatement(stmt, user)
-		case *influxql.AlterRetentionPolicyStatement:
-			res = s.executeAlterRetentionPolicyStatement(stmt, user)
-		case *influxql.DropRetentionPolicyStatement:
-			res = s.executeDropRetentionPolicyStatement(stmt, user)
-		case *influxql.ShowRetentionPoliciesStatement:
-			res = s.executeShowRetentionPoliciesStatement(stmt, user)
-		case *influxql.CreateContinuousQueryStatement:
-			res = s.executeCreateContinuousQueryStatement(stmt, user)
-		case *influxql.DropContinuousQueryStatement:
-			continue
-		case *influxql.ShowContinuousQueriesStatement:
-			res = s.executeShowContinuousQueriesStatement(stmt, database, user)
-		default:
-			panic(fmt.Sprintf("unsupported statement type: %T", stmt))
+		// if there was an error send results that the remaining statements weren't executed
+		for ; i < len(q.Statements)-1; i++ {
+			results <- &Result{Err: ErrNotExecuted}
 		}
 
-		// If an error occurs then stop processing remaining statements.
-		results.Results[i] = res
-		if res.Err != nil {
-			break
-		}
 		s.stats.Inc("queriesExecuted")
-	}
+		close(results)
+	}()
 
-	// Fill any empty results after error.
-	for i, res := range results.Results {
-		if res == nil {
-			results.Results[i] = &Result{Err: ErrNotExecuted}
-		}
-	}
-
-	return results
+	return results, nil
 }
 
 // executeSelectStatement plans and executes a select statement against a database.
-func (s *Server) executeSelectStatement(stmt *influxql.SelectStatement, database string, user *User) *Result {
+func (s *Server) executeSelectStatement(statementID int, stmt *influxql.SelectStatement, database string, user *User, results chan *Result, chunkSize int) error {
 	// Perform any necessary query re-writing.
 	stmt, err := s.rewriteSelectStatement(stmt)
 	if err != nil {
-		return &Result{Err: err}
+		return err
 	}
 
 	// Plan statement execution.
-	e, err := s.planSelectStatement(stmt)
+	e, err := s.planSelectStatement(stmt, chunkSize)
 	if err != nil {
-		return &Result{Err: err}
+		return err
 	}
 
 	// Execute plan.
 	ch, err := e.Execute()
 	if err != nil {
-		return &Result{Err: err}
+		return err
 	}
 
-	// Read all rows from channel.
-	res := &Result{Series: make([]*influxql.Row, 0)}
+	// Stream results from the channel. We should send an empty result if nothing comes through.
+	resultSent := false
 	for row := range ch {
 		if row.Err != nil {
-			res.Err = row.Err
-			return res
+			return row.Err
 		} else {
-			res.Series = append(res.Series, row)
+			resultSent = true
+			results <- &Result{StatementID: statementID, Series: []*influxql.Row{row}}
 		}
 	}
 
-	return res
+	if !resultSent {
+		results <- &Result{StatementID: statementID, Series: make([]*influxql.Row, 0)}
+	}
+
+	return nil
 }
 
 // rewriteSelectStatement performs any necessary query re-writing.
@@ -2289,14 +2307,14 @@ func (s *Server) expandSources(sources influxql.Sources) (influxql.Sources, erro
 }
 
 // plans a selection statement under lock.
-func (s *Server) planSelectStatement(stmt *influxql.SelectStatement) (*influxql.Executor, error) {
+func (s *Server) planSelectStatement(stmt *influxql.SelectStatement, chunkSize int) (*influxql.Executor, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
 	// Plan query.
 	p := influxql.NewPlanner(s)
 
-	return p.Plan(stmt)
+	return p.Plan(stmt, chunkSize)
 }
 
 func (s *Server) executeCreateDatabaseStatement(q *influxql.CreateDatabaseStatement, user *User) *Result {
@@ -3252,8 +3270,11 @@ func (s *Server) processor(conn MessagingConn, done chan struct{}) {
 
 // Result represents a resultset returned from a single statement.
 type Result struct {
-	Series influxql.Rows
-	Err    error
+	// StatementID is just the statement's position in the query. It's used
+	// to combine statement results if they're being buffered in memory.
+	StatementID int `json:"-"`
+	Series      influxql.Rows
+	Err         error
 }
 
 // MarshalJSON encodes the result into JSON.
@@ -3732,7 +3753,7 @@ func (s *Server) runContinuousQuery(cq *ContinuousQuery) {
 
 // runContinuousQueryAndWriteResult will run the query against the cluster and write the results back in
 func (s *Server) runContinuousQueryAndWriteResult(cq *ContinuousQuery) error {
-	e, err := s.planSelectStatement(cq.cq.Source)
+	e, err := s.planSelectStatement(cq.cq.Source, NoChunkingSize)
 
 	if err != nil {
 		return err

--- a/server.go
+++ b/server.go
@@ -50,7 +50,7 @@ const (
 	// Defines the minimum duration allowed for all retention policies
 	retentionPolicyMinDuration = time.Hour
 
-	// When planning a select statement, passing zero tells it not to chunk results
+	// When planning a select statement, passing zero tells it not to chunk results. Only applies to raw queries
 	NoChunkingSize = 0
 )
 

--- a/server_test.go
+++ b/server_test.go
@@ -1946,7 +1946,7 @@ func (s *Server) MustWriteSeries(database, retentionPolicy string, points []infl
 }
 
 func (s *Server) executeQuery(q *influxql.Query, db string, user *influxdb.User) influxdb.Results {
-	results, err := s.ExecuteQuery(q, db, user, influxdb.NoChunkingSize)
+	results, err := s.ExecuteQuery(q, db, user, 10000)
 	if err != nil {
 		return influxdb.Results{Err: err}
 	}

--- a/server_test.go
+++ b/server_test.go
@@ -757,7 +757,7 @@ func TestServer_AlterRetentionPolicy(t *testing.T) {
 
 	// Test update duration only.
 	duration = time.Hour
-	results := s.ExecuteQuery(MustParseQuery(`ALTER RETENTION POLICY bar ON foo DURATION 1h`), "foo", nil)
+	results := s.executeQuery(MustParseQuery(`ALTER RETENTION POLICY bar ON foo DURATION 1h`), "foo", nil)
 	if results.Error() != nil {
 		t.Fatalf("unexpected error: %s", results.Error())
 	}
@@ -775,7 +775,7 @@ func TestServer_AlterRetentionPolicy(t *testing.T) {
 
 	// set duration to infinite to catch edge case.
 	duration = 0
-	results = s.ExecuteQuery(MustParseQuery(`ALTER RETENTION POLICY bar ON foo DURATION INF`), "foo", nil)
+	results = s.executeQuery(MustParseQuery(`ALTER RETENTION POLICY bar ON foo DURATION INF`), "foo", nil)
 	if results.Error() != nil {
 		t.Fatalf("unexpected error: %s", results.Error())
 	}
@@ -842,7 +842,7 @@ func TestServer_AlterRetentionPolicy_Minduration(t *testing.T) {
 
 	// Test update duration only.
 	duration = time.Hour
-	results := s.ExecuteQuery(MustParseQuery(`ALTER RETENTION POLICY bar ON foo DURATION 1m`), "foo", nil)
+	results := s.executeQuery(MustParseQuery(`ALTER RETENTION POLICY bar ON foo DURATION 1m`), "foo", nil)
 	if results.Error() == nil {
 		t.Fatalf("unexpected error: %s", results.Error())
 	}
@@ -1061,7 +1061,7 @@ func TestServer_DropMeasurement(t *testing.T) {
 	c.Sync(index)
 
 	// Ensure measurement exists
-	results := s.ExecuteQuery(MustParseQuery(`SHOW MEASUREMENTS`), "foo", nil)
+	results := s.executeQuery(MustParseQuery(`SHOW MEASUREMENTS`), "foo", nil)
 	if res := results.Results[0]; res.Err != nil {
 		t.Fatalf("unexpected error: %s", res.Err)
 	} else if len(res.Series) != 1 {
@@ -1071,7 +1071,7 @@ func TestServer_DropMeasurement(t *testing.T) {
 	}
 
 	// Ensure series exists
-	results = s.ExecuteQuery(MustParseQuery(`SHOW SERIES`), "foo", nil)
+	results = s.executeQuery(MustParseQuery(`SHOW SERIES`), "foo", nil)
 	if res := results.Results[0]; res.Err != nil {
 		t.Fatalf("unexpected error: %s", res.Err)
 	} else if len(res.Series) != 1 {
@@ -1081,12 +1081,12 @@ func TestServer_DropMeasurement(t *testing.T) {
 	}
 
 	// Drop measurement
-	results = s.ExecuteQuery(MustParseQuery(`DROP MEASUREMENT cpu`), "foo", nil)
+	results = s.executeQuery(MustParseQuery(`DROP MEASUREMENT cpu`), "foo", nil)
 	if results.Error() != nil {
 		t.Fatalf("unexpected error: %s", results.Error())
 	}
 
-	results = s.ExecuteQuery(MustParseQuery(`SHOW MEASUREMENTS`), "foo", nil)
+	results = s.executeQuery(MustParseQuery(`SHOW MEASUREMENTS`), "foo", nil)
 	if res := results.Results[0]; res.Err != nil {
 		t.Fatalf("unexpected error: %s", res.Err)
 	} else if len(res.Series) != 0 {
@@ -1095,7 +1095,7 @@ func TestServer_DropMeasurement(t *testing.T) {
 		t.Fatalf("unexpected row(0): %s", s)
 	}
 
-	results = s.ExecuteQuery(MustParseQuery(`SHOW SERIES`), "foo", nil)
+	results = s.executeQuery(MustParseQuery(`SHOW SERIES`), "foo", nil)
 	if res := results.Results[0]; res.Err != nil {
 		t.Fatalf("unexpected error: %s", res.Err)
 	} else if len(res.Series) != 0 {
@@ -1116,7 +1116,7 @@ func TestServer_DropMeasurementNoneExists(t *testing.T) {
 	s.CreateUser("susy", "pass", false)
 
 	// Drop measurement
-	results := s.ExecuteQuery(MustParseQuery(`DROP MEASUREMENT bar`), "foo", nil)
+	results := s.executeQuery(MustParseQuery(`DROP MEASUREMENT bar`), "foo", nil)
 	if results.Error().Error() != `measurement not found` {
 		t.Fatalf("unexpected error: %s", results.Error())
 	}
@@ -1130,7 +1130,7 @@ func TestServer_DropMeasurementNoneExists(t *testing.T) {
 	c.Sync(index)
 
 	// Drop measurement after writing data to ensure we still get the same error
-	results = s.ExecuteQuery(MustParseQuery(`DROP MEASUREMENT bar`), "foo", nil)
+	results = s.executeQuery(MustParseQuery(`DROP MEASUREMENT bar`), "foo", nil)
 	if results.Error().Error() != `measurement not found` {
 		t.Fatalf("unexpected error: %s", results.Error())
 	}
@@ -1155,7 +1155,7 @@ func TestServer_DropSeries(t *testing.T) {
 	c.Sync(index)
 
 	// Ensure series exists
-	results := s.ExecuteQuery(MustParseQuery(`SHOW SERIES`), "foo", nil)
+	results := s.executeQuery(MustParseQuery(`SHOW SERIES`), "foo", nil)
 	if res := results.Results[0]; res.Err != nil {
 		t.Fatalf("unexpected error: %s", res.Err)
 	} else if len(res.Series) != 1 {
@@ -1165,12 +1165,12 @@ func TestServer_DropSeries(t *testing.T) {
 	}
 
 	// Drop series
-	results = s.ExecuteQuery(MustParseQuery(`DROP SERIES FROM cpu`), "foo", nil)
+	results = s.executeQuery(MustParseQuery(`DROP SERIES FROM cpu`), "foo", nil)
 	if results.Error() != nil {
 		t.Fatalf("unexpected error: %s", results.Error())
 	}
 
-	results = s.ExecuteQuery(MustParseQuery(`SHOW SERIES`), "foo", nil)
+	results = s.executeQuery(MustParseQuery(`SHOW SERIES`), "foo", nil)
 	if res := results.Results[0]; res.Err != nil {
 		t.Fatalf("unexpected error: %s", res.Err)
 	} else if len(res.Series) != 0 {
@@ -1206,12 +1206,12 @@ func TestServer_DropSeriesFromMeasurement(t *testing.T) {
 	c.Sync(index)
 
 	// Drop series
-	results := s.ExecuteQuery(MustParseQuery(`DROP SERIES FROM memory`), "foo", nil)
+	results := s.executeQuery(MustParseQuery(`DROP SERIES FROM memory`), "foo", nil)
 	if results.Error() != nil {
 		t.Fatalf("unexpected error: %s", results.Error())
 	}
 
-	results = s.ExecuteQuery(MustParseQuery(`SHOW SERIES`), "foo", nil)
+	results = s.executeQuery(MustParseQuery(`SHOW SERIES`), "foo", nil)
 	if res := results.Results[0]; res.Err != nil {
 		t.Fatalf("unexpected error: %s", res.Err)
 	} else if len(res.Series) != 1 {
@@ -1251,7 +1251,7 @@ func TestServer_DropSeriesTagsPreserved(t *testing.T) {
 	}
 	c.Sync(index)
 
-	results := s.ExecuteQuery(MustParseQuery(`SHOW SERIES`), "foo", nil)
+	results := s.executeQuery(MustParseQuery(`SHOW SERIES`), "foo", nil)
 	if res := results.Results[0]; res.Err != nil {
 		t.Fatalf("unexpected error: %s", res.Err)
 	} else if len(res.Series) != 1 {
@@ -1260,12 +1260,12 @@ func TestServer_DropSeriesTagsPreserved(t *testing.T) {
 		t.Fatalf("unexpected row(0): %s", s)
 	}
 
-	results = s.ExecuteQuery(MustParseQuery(`DROP SERIES FROM cpu where host='serverA'`), "foo", nil)
+	results = s.executeQuery(MustParseQuery(`DROP SERIES FROM cpu where host='serverA'`), "foo", nil)
 	if results.Error() != nil {
 		t.Fatalf("unexpected error: %s", results.Error())
 	}
 
-	results = s.ExecuteQuery(MustParseQuery(`SHOW SERIES`), "foo", nil)
+	results = s.executeQuery(MustParseQuery(`SHOW SERIES`), "foo", nil)
 	if res := results.Results[0]; res.Err != nil {
 		t.Fatalf("unexpected error: %s", res.Err)
 	} else if len(res.Series) != 1 {
@@ -1274,14 +1274,16 @@ func TestServer_DropSeriesTagsPreserved(t *testing.T) {
 		t.Fatalf("unexpected row(0): %s", s)
 	}
 
-	results = s.ExecuteQuery(MustParseQuery(`SELECT * FROM cpu where host='serverA'`), "foo", nil)
-	if res := results.Results[0]; res.Err != nil {
+	results = s.executeQuery(MustParseQuery(`SELECT * FROM cpu where host='serverA'`), "foo", nil)
+	if len(results.Results) == 0 {
+		t.Fatal("expected results to be non-empty")
+	} else if res := results.Results[0]; res.Err != nil {
 		t.Fatalf("unexpected error: %s", res.Err)
 	} else if len(res.Series) != 0 {
 		t.Fatalf("unexpected row count: %d", len(res.Series))
 	}
 
-	results = s.ExecuteQuery(MustParseQuery(`SELECT * FROM cpu where host='serverB'`), "foo", nil)
+	results = s.executeQuery(MustParseQuery(`SELECT * FROM cpu where host='serverB'`), "foo", nil)
 	if res := results.Results[0]; res.Err != nil {
 		t.Fatalf("unexpected error: %s", res.Err)
 	} else if len(res.Series) != 1 {
@@ -1290,7 +1292,7 @@ func TestServer_DropSeriesTagsPreserved(t *testing.T) {
 		t.Fatalf("unexpected row(0): %s", s)
 	}
 
-	results = s.ExecuteQuery(MustParseQuery(`SELECT * FROM cpu where region='uswest'`), "foo", nil)
+	results = s.executeQuery(MustParseQuery(`SELECT * FROM cpu where region='uswest'`), "foo", nil)
 	if res := results.Results[0]; res.Err != nil {
 		t.Fatalf("unexpected error: %s", res.Err)
 	} else if len(res.Series) != 1 {
@@ -1318,7 +1320,7 @@ func TestServer_ShowSeriesLimitOffset(t *testing.T) {
 	s.MustWriteSeries("foo", "raw", []influxdb.Point{{Name: "memory", Tags: map[string]string{"region": "us-east", "host": "serverA"}, Timestamp: mustParseTime("2000-01-01T00:00:00Z"), Fields: map[string]interface{}{"value": float64(100)}}})
 
 	// Select data from the server.
-	results := s.ExecuteQuery(MustParseQuery(`SHOW SERIES LIMIT 3 OFFSET 1`), "foo", nil)
+	results := s.executeQuery(MustParseQuery(`SHOW SERIES LIMIT 3 OFFSET 1`), "foo", nil)
 	if res := results.Results[0]; res.Err != nil {
 		t.Fatalf("unexpected error: %s", res.Err)
 	} else if len(res.Series) != 2 {
@@ -1328,7 +1330,7 @@ func TestServer_ShowSeriesLimitOffset(t *testing.T) {
 	}
 
 	// Select data from the server.
-	results = s.ExecuteQuery(MustParseQuery(`SHOW SERIES LIMIT 2 OFFSET 4`), "foo", nil)
+	results = s.executeQuery(MustParseQuery(`SHOW SERIES LIMIT 2 OFFSET 4`), "foo", nil)
 	if res := results.Results[0]; res.Err != nil {
 		t.Fatalf("unexpected error: %s", res.Err)
 	} else if len(res.Series) != 1 {
@@ -1338,7 +1340,7 @@ func TestServer_ShowSeriesLimitOffset(t *testing.T) {
 	}
 
 	// Select data from the server.
-	results = s.ExecuteQuery(MustParseQuery(`SHOW SERIES LIMIT 2 OFFSET 20`), "foo", nil)
+	results = s.executeQuery(MustParseQuery(`SHOW SERIES LIMIT 2 OFFSET 20`), "foo", nil)
 	if res := results.Results[0]; res.Err != nil {
 		t.Fatalf("unexpected error: %s", res.Err)
 	} else if len(res.Series) != 0 {
@@ -1346,7 +1348,7 @@ func TestServer_ShowSeriesLimitOffset(t *testing.T) {
 	}
 
 	// Select data from the server.
-	results = s.ExecuteQuery(MustParseQuery(`SHOW SERIES LIMIT 4 OFFSET 0`), "foo", nil)
+	results = s.executeQuery(MustParseQuery(`SHOW SERIES LIMIT 4 OFFSET 0`), "foo", nil)
 	if res := results.Results[0]; res.Err != nil {
 		t.Fatalf("unexpected error: %s", res.Err)
 	} else if len(res.Series) != 2 {
@@ -1354,7 +1356,7 @@ func TestServer_ShowSeriesLimitOffset(t *testing.T) {
 	}
 
 	// Select data from the server.
-	results = s.ExecuteQuery(MustParseQuery(`SHOW SERIES LIMIT 20`), "foo", nil)
+	results = s.executeQuery(MustParseQuery(`SHOW SERIES LIMIT 20`), "foo", nil)
 	if res := results.Results[0]; res.Err != nil {
 		t.Fatalf("unexpected error: %s", res.Err)
 	} else if len(res.Series) != 2 {
@@ -1742,7 +1744,7 @@ func TestServer_RunContinuousQueries(t *testing.T) {
 	time.Sleep(time.Millisecond * 100)
 
 	verify := func(num int, exp string) {
-		results := s.ExecuteQuery(MustParseQuery(`SELECT mean(mean) FROM cpu_region GROUP BY region`), "foo", nil)
+		results := s.executeQuery(MustParseQuery(`SELECT mean(mean) FROM cpu_region GROUP BY region`), "foo", nil)
 		if res := results.Results[0]; res.Err != nil {
 			t.Fatalf("unexpected error verify %d: %s", num, res.Err)
 		} else if len(res.Series) != 2 {
@@ -1941,6 +1943,25 @@ func (s *Server) MustWriteSeries(database, retentionPolicy string, points []infl
 	}
 	s.Client().(*test.MessagingClient).Sync(index)
 	return index
+}
+
+func (s *Server) executeQuery(q *influxql.Query, db string, user *influxdb.User) influxdb.Results {
+	results, err := s.ExecuteQuery(q, db, user, influxdb.NoChunkingSize)
+	if err != nil {
+		return influxdb.Results{Err: err}
+	}
+	res := influxdb.Results{}
+	for r := range results {
+		l := len(res.Results)
+		if l == 0 {
+			res.Results = append(res.Results, r)
+		} else if res.Results[l-1].StatementID == r.StatementID {
+			res.Results[l-1].Series = append(res.Results[l-1].Series, r.Series...)
+		} else {
+			res.Results = append(res.Results, r)
+		}
+	}
+	return res
 }
 
 // tempfile returns a temporary path.

--- a/tx.go
+++ b/tx.go
@@ -226,6 +226,7 @@ type LocalMapper struct {
 	selectFields    []*Field               // field names that occur in the select clause
 	selectTags      []string               // tag keys that occur in the select clause
 	isRaw           bool                   // if the query is a non-aggregate query
+	limit           int                    // used for raw queries to limit the amount of data read in before pushing out to client
 }
 
 func (l *LocalMapper) Open() error {
@@ -316,13 +317,16 @@ func (l *LocalMapper) Begin(c *influxql.Call, startingTime int64) error {
 
 // NextInterval will get the time ordered next interval of the given interval size from the mapper. This is a
 // forward only operation from the start time passed into Begin. Will return nil when there is no more data to be read.
+// If this is a raw query, interval should be the max time to hit in the query
 func (l *LocalMapper) NextInterval(interval int64) (interface{}, error) {
 	if l.cursorsEmpty || l.tmin > l.job.TMax {
 		return nil, nil
 	}
 
 	// Set the upper bound of the interval.
-	if interval > 0 {
+	if l.isRaw {
+		l.tmax = interval
+	} else if interval > 0 {
 		// Make sure the bottom of the interval lands on a natural boundary.
 		l.tmax = l.tmin + interval - 1
 	}
@@ -339,14 +343,26 @@ func (l *LocalMapper) NextInterval(interval int64) (interface{}, error) {
 		}
 	}
 
-	// Move the interval forward.
-	l.tmin += interval
+	// Move the interval forward if it's not a raw query. For raw queries we use the limit to advance intervals.
+	if !l.isRaw {
+		l.tmin += interval
+	}
 
 	return val, nil
 }
 
+// SetLimit will tell the mapper to only yield that number of points (or to the max time) to Next
+func (l *LocalMapper) SetLimit(limit int) {
+	l.limit = limit
+}
+
 func (l *LocalMapper) Next() (seriesID uint32, timestamp int64, value interface{}) {
 	for {
+		// if it's a raw query and we've hit the limit of the number of points to read in, bail
+		if l.isRaw && l.limit == 0 {
+			return uint32(0), int64(0), nil
+		}
+
 		// find the minimum timestamp
 		min := -1
 		minKey := int64(math.MaxInt64)
@@ -410,6 +426,11 @@ func (l *LocalMapper) Next() (seriesID uint32, timestamp int64, value interface{
 		// if the value didn't match our filter or if we didn't find the field keep iterating
 		if err != nil || value == nil {
 			continue
+		}
+
+		// if it's a raw query, we always limit the amount we read in
+		if l.isRaw {
+			l.limit--
 		}
 
 		return seriesID, timestamp, value


### PR DESCRIPTION
Refactored query engine to have different processing pipeline for raw queries. This enables queries that have a large offset to not keep everything in memory. It also makes it so that queries against raw data that have a limit will only process up to that limit and then bail out.

Raw data queries will only read up to a certain point in the map phase before yielding to the engine for further processing.

Fixes #2029 and fixes #2030

@corylanou and @benbjohnson 