### PR TITLE
Raft stability

### DIFF
--- a/raft/errors.go
+++ b/raft/errors.go
@@ -28,10 +28,6 @@ var (
 	// ErrOutOfDateLog is returned when a candidate's log is not up to date.
 	ErrOutOfDateLog = errors.New("out of date log")
 
-	// ErrUncommittedIndex is returned when a stream is started from an
-	// uncommitted log index.
-	ErrUncommittedIndex = errors.New("uncommitted index")
-
 	// ErrAlreadyVoted is returned when a vote has already been cast for
 	// a different candidate in the same election term.
 	ErrAlreadyVoted = errors.New("already voted")
@@ -50,4 +46,14 @@ var (
 
 	// ErrDuplicateNodeURL is returned when adding a node with an existing URL.
 	ErrDuplicateNodeURL = errors.New("duplicate node url")
+
+	// ErrSnapshotRequired returned when reading from an out-of-order log.
+	// The snapshot will be retrieved on the next reader request.
+	ErrSnapshotRequired = errors.New("snapshot required")
+)
+
+// Internal marker errors.
+var (
+	errClosing       = errors.New("closing marker")
+	errTransitioning = errors.New("transitioning marker")
 )

--- a/raft/internal_test.go
+++ b/raft/internal_test.go
@@ -48,19 +48,22 @@ type IndexFSM struct {
 }
 
 // MustApply updates the index.
-func (fsm *IndexFSM) MustApply(entry *LogEntry) { fsm.index = entry.Index }
-
-// Index returns the highest applied index.
-func (fsm *IndexFSM) Index() (uint64, error) { return fsm.index, nil }
-
-// Snapshot writes the FSM's index as the snapshot.
-func (fsm *IndexFSM) Snapshot(w io.Writer) (uint64, error) {
-	return fsm.index, binary.Write(w, binary.BigEndian, fsm.index)
+func (fsm *IndexFSM) Apply(entry *LogEntry) error {
+	fsm.index = entry.Index
+	return nil
 }
 
-// Restore reads the snapshot from the reader.
-func (fsm *IndexFSM) Restore(r io.Reader) error {
-	return binary.Read(r, binary.BigEndian, &fsm.index)
+// Index returns the highest applied index.
+func (fsm *IndexFSM) Index() uint64 { return fsm.index }
+
+// WriteTo writes a snapshot of the FSM to w.
+func (fsm *IndexFSM) WriteTo(w io.Writer) (n int64, err error) {
+	return 0, binary.Write(w, binary.BigEndian, fsm.index)
+}
+
+// ReadFrom reads an FSM snapshot from r.
+func (fsm *IndexFSM) ReadFrom(r io.Reader) (n int64, err error) {
+	return 0, binary.Read(r, binary.BigEndian, &fsm.index)
 }
 
 // tempfile returns the path to a non-existent file in the temp directory.

--- a/raft/log.go
+++ b/raft/log.go
@@ -40,7 +40,7 @@ const logEntryHeaderSize = 8 + 8 + 8 // sz+index+term
 
 // WaitInterval represents the amount of time between checks to the applied index.
 // This is used by clients wanting to wait until a given index is processed.
-const WaitInterval = 100 * time.Millisecond
+const WaitInterval = 1 * time.Millisecond
 
 // State represents whether the log is a follower, candidate, or leader.
 type State int
@@ -1227,7 +1227,6 @@ func (l *Log) Wait(idx uint64) error {
 	for {
 		l.mu.Lock()
 		state, index := l.state, l.FSM.Index()
-		l.tracef("WAIT> I=%d, Aⁱ=%d, Cⁱ=%d, LLⁱ=%d", idx, index, l.commitIndex, l.lastLogIndex)
 		l.mu.Unlock()
 
 		if state == Stopped {
@@ -1700,11 +1699,6 @@ func (l *Log) writeTo(writer *logWriter, id, term, index uint64) error {
 		return err
 	}
 	flushWriter(w)
-
-	// // Write snapshot index at the end and flush.
-	// if err := binary.Write(w, binary.BigEndian, snapshotIndex); err != nil {
-	// 	return fmt.Errorf("write snapshot index: %s", err)
-	// }
 
 	// Write entries since the snapshot occurred and begin tailing writer.
 	if err := l.advanceWriter(writer); err != nil {

--- a/raft/log_test.go
+++ b/raft/log_test.go
@@ -599,7 +599,8 @@ func (c *Cluster) Apply(data []byte) (uint64, error) {
 			}
 			return index, err
 		}
-		time.Sleep(1 * time.Millisecond)
+		warn("no leader found in cluster, retrying in 100ms...")
+		time.Sleep(100 * time.Millisecond)
 	}
 }
 

--- a/raft/transport_test.go
+++ b/raft/transport_test.go
@@ -70,6 +70,23 @@ func TestHTTPTransport_Join_ErrInvalidID(t *testing.T) {
 	}
 }
 
+// Ensure the response from a join contains a valid leader id.
+func TestHTTPTransport_Join_ErrInvalidLeaderID(t *testing.T) {
+	// Start mock HTTP server.
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Raft-ID", "1")
+		w.Header().Set("X-Raft-Leader-ID", "xxx")
+	}))
+	defer s.Close()
+
+	// Execute join against test server.
+	u, _ := url.Parse(s.URL)
+	_, _, _, err := (&raft.HTTPTransport{}).Join(*u, url.URL{Host: "local"})
+	if err == nil || err.Error() != `invalid leader id: "xxx"` {
+		t.Fatalf("unexpected error: %s", err)
+	}
+}
+
 // Ensure the response from a join contains a valid config.
 func TestHTTPTransport_Join_ErrInvalidConfig(t *testing.T) {
 	// Start mock HTTP server.

--- a/raft/transport_test.go
+++ b/raft/transport_test.go
@@ -477,7 +477,7 @@ func (b *streamingBuffer) Read(p []byte) (n int, err error) {
 			}
 
 			// If not closed then wait a bit and try again.
-			time.Sleep(1 * time.Millisecond)
+			time.Sleep(10 * time.Millisecond)
 			continue
 		}
 
@@ -489,6 +489,11 @@ func (b *streamingBuffer) Read(p []byte) (n int, err error) {
 func (b *streamingBuffer) Write(p []byte) (n int, err error) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
+
+	if b.closed {
+		return 0, fmt.Errorf("streaming buffer closed")
+	}
+
 	return b.buf.Write(p)
 }
 


### PR DESCRIPTION
## Overview

This pull request adds several `raft` package clean up fixes.

A list of high level changes:

- Refactor "applied index" into the `FSM` only - previously this index was shared between the `raft.Log` and the `FSM`.

- Refactor `FSM` API to implement `io.WriterTo` and `io.ReaderFrom`. The "applied index" refactor above altered the API so conforming to a standard API makes this easier to test.

- Fix resnapshotting in some edge cases scenarios - the tradeoff of the temporary in-memory staging area for Raft entries requires that the snapshot be refetched in some election scenarios.

- Fix race detection on state loop startup.

- Fix race condition when setting the incoming stream.

- Fix edge cases in log truncation & trimming.

- Fix new term notification in follower & candidate states.

This pull request also documents the various internal fields in `raft.Log`.