### PR TITLE
Distributed queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - [#2142](https://github.com/influxdb/influxdb/pull/2142): Support chunked queries
 - [#2154](https://github.com/influxdb/influxdb/pull/2154): Node redirection
 - [#2168](https://github.com/influxdb/influxdb/pull/2168): Return raft term from vote, add term logging
+- [#2116](https://github.com/influxdb/influxdb/pull/2116): Wire up the distributed query engine (still a few things to do, but the framework is there)
 
 ### Bugfixes
 - [#2147](https://github.com/influxdb/influxdb/pull/2147): Set Go Max procs in a better location

--- a/cmd/influxd/server_integration_test.go
+++ b/cmd/influxd/server_integration_test.go
@@ -1305,7 +1305,7 @@ func TestSingleServer(t *testing.T) {
 	defer nodes.Close()
 
 	runTestsData(t, testName, nodes, "mydb", "myrp")
-	//runTest_rawDataReturnsInOrder(t, testName, nodes, "mydb", "myrp")
+	runTest_rawDataReturnsInOrder(t, testName, nodes, "mydb", "myrp")
 }
 
 func Test3NodeServer(t *testing.T) {

--- a/cmd/influxd/server_integration_test.go
+++ b/cmd/influxd/server_integration_test.go
@@ -1305,7 +1305,7 @@ func TestSingleServer(t *testing.T) {
 	defer nodes.Close()
 
 	runTestsData(t, testName, nodes, "mydb", "myrp")
-	runTest_rawDataReturnsInOrder(t, testName, nodes, "mydb", "myrp")
+	//runTest_rawDataReturnsInOrder(t, testName, nodes, "mydb", "myrp")
 }
 
 func Test3NodeServer(t *testing.T) {

--- a/cmd/influxd/server_integration_test.go
+++ b/cmd/influxd/server_integration_test.go
@@ -625,9 +625,9 @@ func runTestsData(t *testing.T, testName string, nodes Cluster, database, retent
 		},
 		{
 			name:     "wildcard GROUP BY queries with time",
-			query:    `SELECT mean(value) FROM cpu GROUP BY *,time(1m)`,
+			query:    `SELECT mean(value) FROM cpu WHERE time >= '2000-01-01T00:00:00Z' AND time < '2000-01-01T00:01:00Z' GROUP BY *,time(1m)`,
 			queryDb:  "%DB%",
-			expected: `{"results":[{"series":[{"name":"cpu","tags":{"region":"us-east"},"columns":["time","mean"],"values":[["1970-01-01T00:00:00Z",15]]},{"name":"cpu","tags":{"region":"us-west"},"columns":["time","mean"],"values":[["1970-01-01T00:00:00Z",30]]}]}]}`,
+			expected: `{"results":[{"series":[{"name":"cpu","tags":{"region":"us-east"},"columns":["time","mean"],"values":[["2000-01-01T00:00:00Z",15]]},{"name":"cpu","tags":{"region":"us-west"},"columns":["time","mean"],"values":[["2000-01-01T00:00:00Z",30]]}]}]}`,
 		},
 
 		// WHERE tag queries

--- a/cmd/influxd/server_integration_test.go
+++ b/cmd/influxd/server_integration_test.go
@@ -558,7 +558,7 @@ func runTestsData(t *testing.T, testName string, nodes Cluster, database, retent
 				{"name": "load", "timestamp": "2000-01-01T00:00:10Z", "tags": {"region": "us-east", "host": "serverB"}, "fields": {"value": 30}},
 				{"name": "load", "timestamp": "2000-01-01T00:00:00Z", "tags": {"region": "us-west", "host": "serverC"}, "fields": {"value": 100}}
 			]}`,
-			query:    `SELECT sum(value) FROM load GROUP BY time(10s), region, host`,
+			query:    `SELECT sum(value) FROM load GROUP BY region, host`,
 			queryDb:  "%DB%",
 			expected: `{"results":[{"series":[{"name":"load","tags":{"host":"serverA","region":"us-east"},"columns":["time","sum"],"values":[["1970-01-01T00:00:00Z",20]]},{"name":"load","tags":{"host":"serverB","region":"us-east"},"columns":["time","sum"],"values":[["1970-01-01T00:00:00Z",30]]},{"name":"load","tags":{"host":"serverC","region":"us-west"},"columns":["time","sum"],"values":[["1970-01-01T00:00:00Z",100]]}]}]}`,
 		},

--- a/cmd/influxd/server_integration_test.go
+++ b/cmd/influxd/server_integration_test.go
@@ -1716,7 +1716,7 @@ func Test_ServerOpenTSDBIntegration(t *testing.T) {
 	nodes := createCombinedNodeCluster(t, testName, dir, nNodes, basePort, c)
 
 	createDatabase(t, testName, nodes, "opentsdb")
-	createRetentionPolicy(t, testName, nodes, "opentsdb", "raw")
+	createRetentionPolicy(t, testName, nodes, "opentsdb", "raw", len(nodes))
 
 	// Connect to the graphite endpoint we just spun up
 	conn, err := net.Dial("tcp", o.ListenAddress(c.BindAddress))
@@ -1767,7 +1767,7 @@ func Test_ServerOpenTSDBIntegration_WithTags(t *testing.T) {
 	nodes := createCombinedNodeCluster(t, testName, dir, nNodes, basePort, c)
 
 	createDatabase(t, testName, nodes, "opentsdb")
-	createRetentionPolicy(t, testName, nodes, "opentsdb", "raw")
+	createRetentionPolicy(t, testName, nodes, "opentsdb", "raw", len(nodes))
 
 	// Connect to the graphite endpoint we just spun up
 	conn, err := net.Dial("tcp", o.ListenAddress(c.BindAddress))
@@ -1821,7 +1821,7 @@ func Test_ServerOpenTSDBIntegration_BadData(t *testing.T) {
 	nodes := createCombinedNodeCluster(t, testName, dir, nNodes, basePort, c)
 
 	createDatabase(t, testName, nodes, "opentsdb")
-	createRetentionPolicy(t, testName, nodes, "opentsdb", "raw")
+	createRetentionPolicy(t, testName, nodes, "opentsdb", "raw", len(nodes))
 
 	// Connect to the graphite endpoint we just spun up
 	conn, err := net.Dial("tcp", o.ListenAddress(c.BindAddress))

--- a/cmd/influxd/server_integration_test.go
+++ b/cmd/influxd/server_integration_test.go
@@ -297,6 +297,10 @@ var limitAndOffset = func(t *testing.T, node *Node, database, retention string) 
 }
 
 func runTest_rawDataReturnsInOrder(t *testing.T, testName string, nodes Cluster, database, retention string, replicationFactor int) {
+	// skip this test if they're just looking to run some of thd data tests
+	if os.Getenv("TEST_PREFIX") != "" {
+		return
+	}
 	t.Logf("Running %s:rawDataReturnsInOrder against %d-node cluster", testName, len(nodes))
 
 	// Start by ensuring database and retention policy exist.
@@ -511,7 +515,7 @@ func runTestsData(t *testing.T, testName string, nodes Cluster, database, retent
 		// Aggregations
 		{
 			reset: true,
-			name:  "xxx aggregations",
+			name:  "aggregations",
 			write: `{"database" : "%DB%", "retentionPolicy" : "%RP%", "points": [
 				{"name": "cpu", "timestamp": "2000-01-01T00:00:00Z", "tags": {"region": "us-east"}, "fields": {"value": 20}},
 				{"name": "cpu", "timestamp": "2000-01-01T00:00:10Z", "tags": {"region": "us-east"}, "fields": {"value": 30}},
@@ -522,7 +526,7 @@ func runTestsData(t *testing.T, testName string, nodes Cluster, database, retent
 			expected: `{"results":[{"series":[{"name":"cpu","columns":["time","value"],"values":[["2000-01-01T00:00:10Z",30]]}]}]}`,
 		},
 		{
-			name:     "xxx sum aggregation",
+			name:     "sum aggregation",
 			query:    `SELECT sum(value) FROM cpu WHERE time >= '2000-01-01 00:00:05' AND time <= '2000-01-01T00:00:10Z' GROUP BY time(10s), region`,
 			queryDb:  "%DB%",
 			expected: `{"results":[{"series":[{"name":"cpu","tags":{"region":"us-east"},"columns":["time","sum"],"values":[["2000-01-01T00:00:00Z",null],["2000-01-01T00:00:10Z",30]]}]}]}`,
@@ -531,13 +535,13 @@ func runTestsData(t *testing.T, testName string, nodes Cluster, database, retent
 			write: `{"database" : "%DB%", "retentionPolicy" : "%RP%", "points": [
 				{"name": "cpu", "timestamp": "2000-01-01T00:00:03Z", "tags": {"region": "us-east"}, "fields": {"otherVal": 20}}
 			]}`,
-			name:     "xxx aggregation with a null field value",
+			name:     "aggregation with a null field value",
 			query:    `SELECT sum(value) FROM cpu GROUP BY region`,
 			queryDb:  "%DB%",
 			expected: `{"results":[{"series":[{"name":"cpu","tags":{"region":"us-east"},"columns":["time","sum"],"values":[["1970-01-01T00:00:00Z",50]]},{"name":"cpu","tags":{"region":"us-west"},"columns":["time","sum"],"values":[["1970-01-01T00:00:00Z",100]]}]}]}`,
 		},
 		{
-			name:     "xxx multiple aggregations",
+			name:     "multiple aggregations",
 			query:    `SELECT sum(value), mean(value) FROM cpu GROUP BY region`,
 			queryDb:  "%DB%",
 			expected: `{"results":[{"series":[{"name":"cpu","tags":{"region":"us-east"},"columns":["time","sum","mean"],"values":[["1970-01-01T00:00:00Z",50,25]]},{"name":"cpu","tags":{"region":"us-west"},"columns":["time","sum","mean"],"values":[["1970-01-01T00:00:00Z",100,100]]}]}]}`,
@@ -1328,6 +1332,7 @@ func Test3NodeServer(t *testing.T) {
 
 // ensure that all queries work if there are more nodes in a cluster than the replication factor
 func Test3NodeClusterPartiallyReplicated(t *testing.T) {
+	t.Skip("...")
 	testName := "3-node server integration"
 	if testing.Short() {
 		t.Skip(fmt.Sprintf("skipping '%s'", testName))

--- a/cmd/influxd/server_integration_test.go
+++ b/cmd/influxd/server_integration_test.go
@@ -1332,7 +1332,6 @@ func Test3NodeServer(t *testing.T) {
 
 // ensure that all queries work if there are more nodes in a cluster than the replication factor
 func Test3NodeClusterPartiallyReplicated(t *testing.T) {
-	t.Skip("...")
 	testName := "3-node server integration"
 	if testing.Short() {
 		t.Skip(fmt.Sprintf("skipping '%s'", testName))
@@ -1345,7 +1344,7 @@ func Test3NodeClusterPartiallyReplicated(t *testing.T) {
 	nodes := createCombinedNodeCluster(t, testName, dir, 3, 8190, nil)
 
 	runTestsData(t, testName, nodes, "mydb", "myrp", 2)
-	//runTest_rawDataReturnsInOrder(t, testName, nodes, "mydb", "myrp", 2)
+	runTest_rawDataReturnsInOrder(t, testName, nodes, "mydb", "myrp", 2)
 }
 
 func TestClientLibrary(t *testing.T) {

--- a/httpd/handler.go
+++ b/httpd/handler.go
@@ -31,11 +31,6 @@ const (
 	DefaultChunkSize = 10000
 )
 
-const (
-	// With raw data queries, mappers will read up to this amount before sending results back to the engine
-	DefaultChunkSize = 10000
-)
-
 // TODO: Standard response headers (see: HeaderHandler)
 // TODO: Compression (see: CompressionHeaderHandler)
 
@@ -211,9 +206,9 @@ func (h *Handler) serveQuery(w http.ResponseWriter, r *http.Request, user *influ
 	chunkSize := DefaultChunkSize
 	if chunked {
 		if cs, err := strconv.ParseInt(q.Get("chunk_size"), 10, 64); err == nil {
-			chunkSize = DefaultChunkSize
-		} else {
 			chunkSize = int(cs)
+		} else {
+			chunkSize = DefaultChunkSize
 		}
 	}
 

--- a/httpd/handler.go
+++ b/httpd/handler.go
@@ -703,7 +703,7 @@ func (h *Handler) serveRunMapper(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// create a local mapper and chunk out the reulsts to the other server
+	// create a local mapper and chunk out the results to the other server
 	lm, err := h.server.StartLocalMapper(&m)
 	if err != nil {
 		mapError(w, err)

--- a/httpd/handler.go
+++ b/httpd/handler.go
@@ -31,6 +31,7 @@ const (
 )
 
 const (
+	// With raw data queries, mappers will read up to this amount before sending results back to the engine
 	DefaultChunkSize = 10000
 )
 

--- a/httpd/handler.go
+++ b/httpd/handler.go
@@ -18,7 +18,6 @@ import (
 	"time"
 
 	"github.com/bmizerany/pat"
-	"github.com/davecgh/go-spew/spew"
 	"github.com/influxdb/influxdb"
 	"github.com/influxdb/influxdb/client"
 	"github.com/influxdb/influxdb/influxql"
@@ -698,21 +697,13 @@ func (h *Handler) serveRunMapper(w http.ResponseWriter, r *http.Request) {
 
 	// Read in the mapper info from the request body
 	var m influxdb.RemoteMapper
-	b, _ := ioutil.ReadAll(r.Body)
-	fmt.Println("RunMapper", string(b))
 
-	if err := json.Unmarshal(b, &m); err != nil {
+	if err := json.NewDecoder(r.Body).Decode(&m); err != nil {
 		mapError(w, err)
 		return
 	}
 
-	// if err := json.NewDecoder(r.Body).Decode(&m); err != nil {
-	// 	mapError(w, err)
-	// 	return
-	// }
-
 	// create a local mapper and chunk out the reulsts to the other server
-	spew.Dump(m)
 	lm, err := h.server.StartLocalMapper(&m)
 	if err != nil {
 		mapError(w, err)
@@ -728,24 +719,29 @@ func (h *Handler) serveRunMapper(w http.ResponseWriter, r *http.Request) {
 		mapError(w, err)
 		return
 	}
-	if err := lm.Begin(call, m.TMin, m.Limit); err != nil {
+
+	if err := lm.Begin(call, m.TMin, m.ChunkSize); err != nil {
 		mapError(w, err)
 		return
 	}
 
+	// see if this is an aggregate query or not
+	isRaw := true
+	if call != nil {
+		isRaw = false
+	}
+
 	// write results to the client until the next interval is empty
 	for {
-		fmt.Println("start interval")
 		v, err := lm.NextInterval()
 		if err != nil {
 			mapError(w, err)
 			return
 		}
-		spew.Dump(v)
 
-		// see if we're done
-		if v == nil {
-			fmt.Println("DONE")
+		// see if we're done. only bail if v is nil and we're empty. v could be nil for
+		// group by intervals that don't have data. We should keep iterating to get to the next interval.
+		if v == nil && lm.IsEmpty(m.TMax) {
 			break
 		}
 
@@ -755,15 +751,26 @@ func (h *Handler) serveRunMapper(w http.ResponseWriter, r *http.Request) {
 			mapError(w, err)
 			return
 		}
-		fmt.Println("> ", string(d))
 		b, err := json.Marshal(&influxdb.MapResponse{Data: d})
 		if err != nil {
 			mapError(w, err)
 			return
 		}
-		fmt.Println("> ", string(b))
 		w.Write(b)
 		w.(http.Flusher).Flush()
+
+		// if this is an aggregate query, we should only call next interval as many times as the chunk size
+		if !isRaw {
+			m.ChunkSize--
+			if m.ChunkSize == 0 {
+				break
+			}
+		}
+
+		// bail out if we're empty
+		if lm.IsEmpty(m.TMax) {
+			break
+		}
 	}
 
 	d, err := json.Marshal(&influxdb.MapResponse{Completed: true})
@@ -796,7 +803,6 @@ func isFieldNotFoundError(err error) bool {
 
 // mapError writes an error result after trying to start a mapper
 func mapError(w http.ResponseWriter, err error) {
-	fmt.Println("mapError: ", err.Error())
 	b, _ := json.Marshal(&influxdb.MapResponse{Err: err.Error()})
 	w.Write(b)
 }

--- a/httpd/handler.go
+++ b/httpd/handler.go
@@ -30,6 +30,10 @@ const (
 	DefaultChunkSize = 10000
 )
 
+const (
+	DefaultChunkSize = 10000
+)
+
 // TODO: Standard response headers (see: HeaderHandler)
 // TODO: Compression (see: CompressionHeaderHandler)
 
@@ -201,6 +205,8 @@ func (h *Handler) serveQuery(w http.ResponseWriter, r *http.Request, user *influ
 	chunkSize := DefaultChunkSize
 	if chunked {
 		if cs, err := strconv.ParseInt(q.Get("chunk_size"), 10, 64); err == nil {
+			chunkSize = DefaultChunkSize
+		} else {
 			chunkSize = int(cs)
 		}
 	}

--- a/httpd/handler_test.go
+++ b/httpd/handler_test.go
@@ -11,7 +11,6 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
-	"reflect"
 	"strings"
 	"testing"
 	"time"

--- a/httpd/handler_test.go
+++ b/httpd/handler_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"reflect"
 	"strings"
 	"testing"
 	"time"

--- a/influxdb.go
+++ b/influxdb.go
@@ -145,6 +145,9 @@ var (
 
 	// ErrContinuousQueryNotFound is returned when dropping a nonexistent continuous query.
 	ErrContinuousQueryNotFound = errors.New("continuous query not found")
+
+	// ErrShardNotLocal is thrown whan a server attempts to run a mapper against a shard it doesn't have a copy of.
+	ErrShardNotLocal = errors.New("shard not local")
 )
 
 // ErrAuthorize represents an authorization error.

--- a/influxql/engine.go
+++ b/influxql/engine.go
@@ -702,7 +702,6 @@ func (p *Planner) Plan(stmt *SelectStatement, chunkSize int) (*Executor, error) 
 	// Replace instances of "now()" with the current time.
 	stmt.Condition = Reduce(stmt.Condition, &nowValuer{Now: now})
 
-	warn("--- ", stmt.String())
 	// Begin an unopened transaction.
 	tx, err := p.DB.Begin()
 	if err != nil {

--- a/influxql/engine.go
+++ b/influxql/engine.go
@@ -303,6 +303,7 @@ func (m *MapReduceJob) processRawQuery(out chan *Row, filterEmptyResults bool) {
 			}
 			valuesSent += len(values)
 		}
+
 		valuesToReturn = append(valuesToReturn, values...)
 
 		// hit the chunk size? Send out what has been accumulated, but keep

--- a/influxql/engine.go
+++ b/influxql/engine.go
@@ -609,7 +609,9 @@ func (m *MapReduceJob) processAggregate(c *Call, reduceFunc ReduceFunc, resultVa
 
 	// intialize the mappers
 	for _, mm := range m.Mappers {
-		if err := mm.Begin(c, m.TMin, IgnoredChunkSize); err != nil {
+		// for agggregate queries, we use the chunk size to determine how many times NextInterval should be called.
+		// This is the number of buckets that we need to fill.
+		if err := mm.Begin(c, m.TMin, len(resultValues)); err != nil {
 			return err
 		}
 	}

--- a/influxql/engine.go
+++ b/influxql/engine.go
@@ -609,7 +609,7 @@ func (m *MapReduceJob) processAggregate(c *Call, reduceFunc ReduceFunc, resultVa
 
 	// intialize the mappers
 	for _, mm := range m.Mappers {
-		// for agggregate queries, we use the chunk size to determine how many times NextInterval should be called.
+		// for aggregate queries, we use the chunk size to determine how many times NextInterval should be called.
 		// This is the number of buckets that we need to fill.
 		if err := mm.Begin(c, m.TMin, len(resultValues)); err != nil {
 			return err

--- a/influxql/functions.go
+++ b/influxql/functions.go
@@ -7,22 +7,29 @@ package influxql
 // When adding an aggregate function, define a mapper, a reducer, and add them in the switch statement in the MapReduceFuncs function
 
 import (
+	"encoding/json"
 	"fmt"
 	"math"
 	"sort"
 	"strings"
 )
 
-// Iterator represents a forward-only iterator over a set of points. These are used by the MapFunctions in this file
+// Iterator represents a forward-only iterator over a set of points.
+// These are used by the MapFunctions in this file
 type Iterator interface {
 	Next() (seriesID uint32, timestamp int64, value interface{})
 }
 
-// MapFunc represents a function used for mapping over a sequential series of data. The iterator represents a single group by interval
+// MapFunc represents a function used for mapping over a sequential series of data.
+// The iterator represents a single group by interval
 type MapFunc func(Iterator) interface{}
 
 // ReduceFunc represents a function used for reducing mapper output.
 type ReduceFunc func([]interface{}) interface{}
+
+// UnmarshalFunc represents a function that can take bytes from a mapper from remote
+// server and marshal it into an interface the reduer can use
+type UnmarshalFunc func([]byte) (interface{}, error)
 
 // InitializeMapFunc takes an aggregate call from the query and returns the MapFunc
 func InitializeMapFunc(c *Call) (MapFunc, error) {
@@ -107,6 +114,52 @@ func InitializeReduceFunc(c *Call) (ReduceFunc, error) {
 		return ReducePercentile(lit.Val), nil
 	default:
 		return nil, fmt.Errorf("function not found: %q", c.Name)
+	}
+}
+
+func InitializeUnmarshaller(c *Call) (UnmarshalFunc, error) {
+	// if c is nil it's a raw data query
+	if c == nil {
+		return func(b []byte) (interface{}, error) {
+			warn("MARSHAL OUTPUT: ", string(b))
+			a := make([]*rawQueryMapOutput, 0)
+			err := json.Unmarshal(b, &a)
+			return a, err
+		}, nil
+	}
+
+	// Retrieve marshal function by name
+	switch strings.ToLower(c.Name) {
+	case "mean":
+		return func(b []byte) (interface{}, error) {
+			var o meanMapOutput
+			err := json.Unmarshal(b, &o)
+			return &o, err
+		}, nil
+	case "spread":
+		return func(b []byte) (interface{}, error) {
+			var o spreadMapOutput
+			err := json.Unmarshal(b, &o)
+			return &o, err
+		}, nil
+	case "first":
+		return func(b []byte) (interface{}, error) {
+			var o firstLastMapOutput
+			err := json.Unmarshal(b, &o)
+			return &o, err
+		}, nil
+	case "last":
+		return func(b []byte) (interface{}, error) {
+			var o firstLastMapOutput
+			err := json.Unmarshal(b, &o)
+			return &o, err
+		}, nil
+	default:
+		return func(b []byte) (interface{}, error) {
+			var val interface{}
+			err := json.Unmarshal(b, &val)
+			return val, err
+		}, nil
 	}
 }
 
@@ -519,12 +572,12 @@ func MapRawQuery(itr Iterator) interface{} {
 }
 
 type rawQueryMapOutput struct {
-	timestamp int64
-	values    interface{}
+	Timestamp int64
+	Values    interface{}
 }
 
 type rawOutputs []*rawQueryMapOutput
 
 func (a rawOutputs) Len() int           { return len(a) }
-func (a rawOutputs) Less(i, j int) bool { return a[i].timestamp < a[j].timestamp }
+func (a rawOutputs) Less(i, j int) bool { return a[i].Timestamp < a[j].Timestamp }
 func (a rawOutputs) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }

--- a/remote_mapper.go
+++ b/remote_mapper.go
@@ -1,0 +1,169 @@
+package influxdb
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/influxdb/influxdb/influxql"
+)
+
+const (
+	MAX_MAP_RESPONSE_SIZE = 1024 * 1024 * 1024
+)
+
+// RemoteMapper implements the influxql.Mapper interface. The engine uses the remote mapper
+// to pull map results from shards that only exist on other servers in the cluster.
+type RemoteMapper struct {
+	dataNodes []*DataNode
+	resp      *http.Response
+	results   chan interface{}
+	unmarshal influxql.UnmarshalFunc
+
+	Call            string
+	Database        string
+	MeasurementName string
+	TMin            int64
+	TMax            int64
+	SeriesIDs       []uint32
+	ShardID         uint64
+	Filters         []string
+	WhereFields     []*Field
+	SelectFields    []*Field
+	SelectTags      []string
+	Limit           int
+}
+
+type MapResponse struct {
+	Err  string
+	Data []byte
+}
+
+// Open is a no op, real work is done starting with Being
+func (m *RemoteMapper) Open() error { return nil }
+
+// Close the response body
+func (m *RemoteMapper) Close() {
+	if m.resp != nil && m.resp.Body != nil {
+		m.resp.Body.Close()
+	}
+}
+
+// Begin sends a request to the remote server
+func (m *RemoteMapper) Begin(c *influxql.Call, startingTime int64, limit int) error {
+	// get the function for unmarshaling results
+	f, err := influxql.InitializeUnmarshaller(c)
+	if err != nil {
+		return err
+	}
+	m.unmarshal = f
+
+	if c != nil {
+		m.Call = c.String()
+	}
+	m.Limit = limit
+
+	// send the request to map to the remote server
+	b, err := json.Marshal(m)
+	if err != nil {
+		return err
+	}
+
+	resp, err := http.Post(m.dataNodes[0].URL.String()+"/run_mapper", "application/json", bytes.NewReader(b))
+	if err != nil {
+		return err
+	}
+	m.resp = resp
+
+	return nil
+}
+
+func (m *RemoteMapper) NextInterval(interval int64) (interface{}, error) {
+	chunk := make([]byte, MAX_MAP_RESPONSE_SIZE, MAX_MAP_RESPONSE_SIZE)
+	n, err := m.resp.Body.Read(chunk)
+	if err != nil {
+		return nil, err
+	}
+	if n == 0 {
+		return nil, nil
+	}
+	warn("... ", string(chunk[:n]))
+	mr := &MapResponse{}
+	err = json.Unmarshal(chunk[:n], mr)
+	if err != nil {
+		return nil, err
+	}
+	if mr.Err != "" {
+		return nil, errors.New(mr.Err)
+	}
+	v, err := m.unmarshal(mr.Data)
+	if err != nil {
+		return nil, err
+	}
+	spew.Dump(v)
+	return v, nil
+}
+
+func (m *RemoteMapper) CallExpr() (*influxql.Call, error) {
+	if m.Call == "" {
+		return nil, nil
+	}
+
+	c, err := influxql.ParseExpr(m.Call)
+	if err != nil {
+		return nil, err
+	}
+	call, ok := c.(*influxql.Call)
+
+	if !ok {
+		return nil, errors.New("Could't marshal aggregate call")
+	}
+	return call, nil
+}
+
+func (m *RemoteMapper) FilterExprs() []influxql.Expr {
+	exprs := make([]influxql.Expr, len(m.SeriesIDs), len(m.SeriesIDs))
+
+	// if filters is empty, they're all nil. if filters has one element, all filters
+	// should be set to that. Otherwise marshal each filter
+	if len(m.Filters) == 1 {
+		f, _ := influxql.ParseExpr(m.Filters[0])
+		for i, _ := range exprs {
+			exprs[i] = f
+		}
+	} else if len(m.Filters) > 1 {
+		for i, s := range m.Filters {
+			f, _ := influxql.ParseExpr(s)
+			exprs[i] = f
+		}
+	}
+
+	return exprs
+}
+
+func (m *RemoteMapper) SetFilters(filters []influxql.Expr) {
+	l := filters[0]
+	allFiltersTheSame := true
+	for _, f := range filters {
+		if l != f {
+			allFiltersTheSame = false
+			break
+		}
+	}
+
+	// we don't need anything if they're all the same and nil
+	if l == nil && allFiltersTheSame {
+		return
+	} else if allFiltersTheSame { // just set one filter element since they're all the same
+		m.Filters = []string{l.String()}
+		return
+	}
+
+	// marshal all of them since there are different ones
+	m.Filters = make([]string, len(filters), len(filters))
+	for i, f := range filters {
+		m.Filters[i] = f.String()
+	}
+}

--- a/remote_mapper.go
+++ b/remote_mapper.go
@@ -142,7 +142,7 @@ func (m *RemoteMapper) CallExpr() (*influxql.Call, error) {
 	call, ok := c.(*influxql.Call)
 
 	if !ok {
-		return nil, errors.New("Could't marshal aggregate call")
+		return nil, errors.New("unable to marshal aggregate call")
 	}
 	return call, nil
 }

--- a/remote_mapper.go
+++ b/remote_mapper.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/influxdb/influxdb/influxql"
 )
 
@@ -23,21 +22,24 @@ type RemoteMapper struct {
 	unmarshal influxql.UnmarshalFunc
 	complete  bool
 
-	Call            string
-	Database        string
-	MeasurementName string
-	TMin            int64
-	TMax            int64
-	SeriesIDs       []uint32
-	ShardID         uint64
-	Filters         []string
-	WhereFields     []*Field
-	SelectFields    []*Field
-	SelectTags      []string
-	Limit           int
-	Interval        int64
+	Call            string   `json:",omitempty"`
+	Database        string   `json:",omitempty"`
+	MeasurementName string   `json:",omitempty"`
+	TMin            int64    `json:",omitempty"`
+	TMax            int64    `json:",omitempty"`
+	SeriesIDs       []uint32 `json:",omitempty"`
+	ShardID         uint64   `json:",omitempty"`
+	Filters         []string `json:",omitempty"`
+	WhereFields     []*Field `json:",omitempty"`
+	SelectFields    []*Field `json:",omitempty"`
+	SelectTags      []string `json:",omitempty"`
+	Limit           int      `json:",omitempty"`
+	Offset          int      `json:",omitempty"`
+	Interval        int64    `json:",omitempty"`
+	ChunkSize       int      `json:",omitempty"`
 }
 
+// Responses get streamed back to the remote mapper from the remote machine that runs a local mapper
 type MapResponse struct {
 	Err       string `json:",omitempty"`
 	Data      []byte
@@ -54,8 +56,8 @@ func (m *RemoteMapper) Close() {
 	}
 }
 
-// Begin sends a request to the remote server
-func (m *RemoteMapper) Begin(c *influxql.Call, startingTime int64, limit int) error {
+// Begin sends a request to the remote server to start streaming map results
+func (m *RemoteMapper) Begin(c *influxql.Call, startingTime int64, chunkSize int) error {
 	// get the function for unmarshaling results
 	f, err := influxql.InitializeUnmarshaller(c)
 	if err != nil {
@@ -66,7 +68,8 @@ func (m *RemoteMapper) Begin(c *influxql.Call, startingTime int64, limit int) er
 	if c != nil {
 		m.Call = c.String()
 	}
-	m.Limit = limit
+	m.ChunkSize = chunkSize
+	m.TMin = startingTime
 
 	// send the request to map to the remote server
 	b, err := json.Marshal(m)
@@ -74,6 +77,7 @@ func (m *RemoteMapper) Begin(c *influxql.Call, startingTime int64, limit int) er
 		return err
 	}
 
+	// request to start streaming results
 	resp, err := http.Post(m.dataNodes[0].URL.String()+"/run_mapper", "application/json", bytes.NewReader(b))
 	if err != nil {
 		return err
@@ -83,21 +87,24 @@ func (m *RemoteMapper) Begin(c *influxql.Call, startingTime int64, limit int) er
 	return nil
 }
 
+// NextInterval is part of the mapper interface. In this case we read the next chunk from the remote mapper
 func (m *RemoteMapper) NextInterval() (interface{}, error) {
+	// just return nil if the mapper has completed its run
 	if m.complete {
 		return nil, nil
 	}
 
+	// read the chunk
 	chunk := make([]byte, MAX_MAP_RESPONSE_SIZE, MAX_MAP_RESPONSE_SIZE)
 	n, err := m.resp.Body.Read(chunk)
 	if err != nil {
-		warn("NextInterval err:", n, err.Error())
 		return nil, err
 	}
 	if n == 0 {
 		return nil, nil
 	}
-	warn("... ", string(chunk[:n]))
+
+	// marshal the response
 	mr := &MapResponse{}
 	err = json.Unmarshal(chunk[:n], mr)
 	if err != nil {
@@ -106,18 +113,23 @@ func (m *RemoteMapper) NextInterval() (interface{}, error) {
 	if mr.Err != "" {
 		return nil, errors.New(mr.Err)
 	}
+
+	// if it's a complete message, we've emptied this mapper of all data
 	if mr.Completed {
 		m.complete = true
 		return nil, nil
 	}
+
+	// marshal the data that came from the MapFN
 	v, err := m.unmarshal(mr.Data)
 	if err != nil {
 		return nil, err
 	}
-	spew.Dump(v)
+
 	return v, nil
 }
 
+// CallExpr will parse the Call string into an expression or return nil
 func (m *RemoteMapper) CallExpr() (*influxql.Call, error) {
 	if m.Call == "" {
 		return nil, nil
@@ -135,6 +147,8 @@ func (m *RemoteMapper) CallExpr() (*influxql.Call, error) {
 	return call, nil
 }
 
+// FilterExprs will parse the filter strings and return any expressions. This array
+// will be the same size as the SeriesIDs array with each element having a filter (which could be nil)
 func (m *RemoteMapper) FilterExprs() []influxql.Expr {
 	exprs := make([]influxql.Expr, len(m.SeriesIDs), len(m.SeriesIDs))
 
@@ -155,6 +169,7 @@ func (m *RemoteMapper) FilterExprs() []influxql.Expr {
 	return exprs
 }
 
+// SetFilters will convert the given arrray of filters into filters that can be marshaled and sent to the remote system
 func (m *RemoteMapper) SetFilters(filters []influxql.Expr) {
 	l := filters[0]
 	allFiltersTheSame := true

--- a/server.go
+++ b/server.go
@@ -3100,6 +3100,7 @@ func (s *Server) StartLocalMapper(rm *RemoteMapper) (*LocalMapper, error) {
 		whereFields:  rm.WhereFields,
 		selectFields: rm.SelectFields,
 		selectTags:   rm.SelectTags,
+		interval:     rm.Interval,
 	}
 
 	return lm, nil

--- a/server.go
+++ b/server.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"math"
 	"net/http"
 	"net/url"
 	"os"
@@ -3090,6 +3091,14 @@ func (s *Server) StartLocalMapper(rm *RemoteMapper) (*LocalMapper, error) {
 		TMax:            rm.TMax,
 	}
 
+	// limits and offsets can't be evaluated at the local mapper so we need to read
+	// limit + offset points to be sure that the reducer will be able to correctly put things together
+	limit := uint64(rm.Limit) + uint64(rm.Offset)
+	// if limit is zero, just set to the max number since we use limit == 0 later to determine if the mapper is empty
+	if limit == 0 {
+		limit = math.MaxUint64
+	}
+
 	// now create and start the local mapper
 	lm := &LocalMapper{
 		seriesIDs:    rm.SeriesIDs,
@@ -3101,6 +3110,8 @@ func (s *Server) StartLocalMapper(rm *RemoteMapper) (*LocalMapper, error) {
 		selectFields: rm.SelectFields,
 		selectTags:   rm.SelectTags,
 		interval:     rm.Interval,
+		tmax:         rm.TMax,
+		limit:        limit,
 	}
 
 	return lm, nil

--- a/tx.go
+++ b/tx.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/boltdb/bolt"
-	// "github.com/davecgh/go-spew/spew"
 	"github.com/influxdb/influxdb/influxql"
 )
 

--- a/tx.go
+++ b/tx.go
@@ -170,7 +170,8 @@ func (tx *tx) CreateMapReduceJobs(stmt *influxql.SelectStatement, tagKeys []stri
 						WhereFields:     whereFields,
 						SelectFields:    selectFields,
 						SelectTags:      selectTags,
-						Limit:           stmt.Limit + stmt.Offset,
+						Limit:           stmt.Limit,
+						Offset:          stmt.Offset,
 						Interval:        interval,
 					}
 					mapper.(*RemoteMapper).SetFilters(t.Filters)
@@ -388,10 +389,8 @@ func (l *LocalMapper) NextInterval() (interface{}, error) {
 			// where time > clause that is in the middle of the bucket that the group by time creates. That will be the
 			// case on the first interval when the tmin % the interval isn't equal to zero
 			nextMin = l.tmin/l.interval*l.interval + l.interval
-			l.tmax = nextMin - 1
-		} else {
-			l.tmax = l.tmin + l.interval - 1
 		}
+		l.tmax = nextMin - 1
 	}
 
 	// Execute the map function. This local mapper acts as the iterator
@@ -497,6 +496,23 @@ func (l *LocalMapper) Next() (seriesID uint32, timestamp int64, value interface{
 
 		return seriesID, timestamp, value
 	}
+}
+
+// IsEmpty returns true if either all cursors are nil or all cursors are past the passed in max time
+func (l *LocalMapper) IsEmpty(tmax int64) bool {
+	if l.cursorsEmpty || l.limit == 0 {
+		return true
+	}
+
+	// look at the next time for each cursor
+	for _, t := range l.keyBuffer {
+		// if the time is less than the max, we haven't emptied this mapper yet
+		if t != 0 && t <= tmax {
+			return false
+		}
+	}
+
+	return true
 }
 
 // matchesFilter returns true if the value matches the where clause


### PR DESCRIPTION
Currently a WIP, but I wanted to get more eyes on it to look at the approach I took. Some basic tests already pass. Here's how it's implemented.

### Design

There is a `RemoteMapper` that implements all functions of the `influxql.Mapper` interface. I modified `NextInterval` to not take an interval amount. Every query should know the interval step sizes from the planning stage. Removing this meant that the engine didn't have to coordinate with the remote mappers to give them more info for each window of time.

During the planning stage `tx.go` determines if a mapper for a shard can be run locally or must hit a remote server and creates the appropriate mapper.

The remote mapper encodes all the metadata a `LocalMapper` will need to run. It then sends a request to a data node that has the shard the mapper needs to run against. The handler will then run the local mapper and write chunked responses for each group by window (or for raw queries each chunk of points).

### TODO

- [x] Create integration test for RF < Cluster size
- [x] Implement Remote Mapper
- [ ] Wire up queries where multiple shards must be queried in a shard group
- [ ] Implement max chunk size for large map responses to be pushed out through multiple messages
- [ ] Implement failover to other data nodes (if a data node serving a given shard is down)
- [ ] Implement tests for downed data nodes and nodes that go down in the middle of a query

Please to have a look @otoolep, @benbjohnson, @corylanou, @dgnorton, @jwilder, @toddboom 