### PR TITLE
Parser refactor

### DIFF
--- a/database.go
+++ b/database.go
@@ -1540,7 +1540,6 @@ func (m *Measurement) tagValuesByKeyAndSeriesID(tagKeys []string, ids seriesIDs)
 		// Iterate the tag keys we're interested in and collect values
 		// from this series, if they exist.
 		for _, tagKey := range tagKeys {
-			tagKey = strings.Trim(tagKey, `"`)
 			if tagVal, ok := s.Tags[tagKey]; ok {
 				if _, ok = tagValues[tagKey]; !ok {
 					tagValues[tagKey] = newStringSet()

--- a/influxdb.go
+++ b/influxdb.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"runtime"
 	"time"
 
 	"github.com/influxdb/influxdb/client"
@@ -47,9 +48,6 @@ var (
 
 	// ErrDatabaseExists is returned when creating a duplicate database.
 	ErrDatabaseExists = errors.New("database exists")
-
-	// ErrDatabaseNotFound is returned when dropping a non-existent database.
-	ErrDatabaseNotFound = errors.New("database not found")
 
 	// ErrDatabaseRequired is returned when using a blank database name.
 	ErrDatabaseRequired = errors.New("database required")
@@ -107,9 +105,6 @@ var (
 	// ErrMeasurementNameRequired is returned when a point does not contain a name.
 	ErrMeasurementNameRequired = errors.New("measurement name required")
 
-	// ErrMeasurementNotFound is returned when a measurement does not exist.
-	ErrMeasurementNotFound = errors.New("measurement not found")
-
 	// ErrFieldsRequired is returned when a point does not any fields.
 	ErrFieldsRequired = errors.New("fields required")
 
@@ -146,6 +141,20 @@ var (
 	// ErrContinuousQueryNotFound is returned when dropping a nonexistent continuous query.
 	ErrContinuousQueryNotFound = errors.New("continuous query not found")
 )
+
+func ErrDatabaseNotFound(name string) error { return Errorf("database not found: %s", name) }
+
+func ErrMeasurementNotFound(name string) error { return Errorf("measurement not found: %s", name) }
+
+func Errorf(format string, a ...interface{}) (err error) {
+	if _, file, line, ok := runtime.Caller(2); ok {
+		a = append(a, file, line)
+		err = fmt.Errorf(format+" (%s:%d)", a...)
+	} else {
+		err = fmt.Errorf(format, a...)
+	}
+	return
+}
 
 // ErrAuthorize represents an authorization error.
 type ErrAuthorize struct {

--- a/influxql/parser.go
+++ b/influxql/parser.go
@@ -438,6 +438,48 @@ func (p *Parser) parseIdentList() ([]string, error) {
 	}
 }
 
+// parseSegmentedIdents parses a segmented identifiers.
+// e.g.,  "db"."rp".measurement  or  "db"..measurement
+func (p *Parser) parseSegmentedIdents() ([]string, error) {
+	ident, err := p.parseIdent()
+	if err != nil {
+		return nil, err
+	}
+	idents := []string{ident}
+
+	// Parse remaining (optional) identifiers.
+	for {
+		if tok, _, _ := p.scan(); tok != DOT {
+			// No more segments so we're done.
+			p.unscan()
+			break
+		}
+
+		if ch := p.peekRune(); ch == '/' {
+			// Next segment is a regex so we're done.
+			break
+		} else if ch == '.' {
+			// Add an empty identifier.
+			idents = append(idents, "")
+			continue
+		}
+
+		// Parse the next identifier.
+		if ident, err = p.parseIdent(); err != nil {
+			return nil, err
+		}
+
+		idents = append(idents, ident)
+	}
+
+	if len(idents) > 3 {
+		msg := fmt.Sprintf("too many segments in %s", QuoteIdent(idents...))
+		return nil, &ParseError{Message: msg}
+	}
+
+	return idents, nil
+}
+
 // parserString parses a string.
 func (p *Parser) parseString() (string, error) {
 	tok, pos, lit := p.scanIgnoreWhitespace()
@@ -651,28 +693,27 @@ func (p *Parser) parseTarget(tr targetRequirement) (*Target, error) {
 		return nil, nil
 	}
 
-	// Parse identifier.  Could be policy or measurement name.
-	ident, err := p.parseIdent()
+	// db, rp, and / or measurement
+	idents, err := p.parseSegmentedIdents()
 	if err != nil {
 		return nil, err
 	}
 
-	target := &Target{}
-	target.Measurement = ident
+	t := &Target{Measurement: &Measurement{}}
 
-	// Parse optional ON.
-	if tok, _, _ := p.scanIgnoreWhitespace(); tok != ON {
-		p.unscan()
-		return target, nil
+	switch len(idents) {
+	case 1:
+		t.Measurement.Name = idents[0]
+	case 2:
+		t.Measurement.RetentionPolicy = idents[0]
+		t.Measurement.Name = idents[1]
+	case 3:
+		t.Measurement.Database = idents[0]
+		t.Measurement.RetentionPolicy = idents[1]
+		t.Measurement.Name = idents[2]
 	}
 
-	// Found an ON token so parse required identifier.
-	if ident, err = p.parseIdent(); err != nil {
-		return nil, err
-	}
-	target.Database = ident
-
-	return target, nil
+	return t, nil
 }
 
 // parseDeleteStatement parses a delete string and returns a DeleteStatement.
@@ -1371,42 +1412,55 @@ func (p *Parser) peekRune() rune {
 	return r
 }
 
-// parseSource parses a single source.
 func (p *Parser) parseSource() (Source, error) {
 	m := &Measurement{}
 
-	for {
-		nextRune := p.peekRune()
-		if isWhitespace(nextRune) {
-			p.consumeWhitespace()
-		}
+	// Attempt to parse a regex.
+	re, err := p.parseRegex()
+	if err != nil {
+		return nil, err
+	} else if re != nil {
+		m.Regex = re
+		// Regex is always last so we're done.
+		return m, nil
+	}
 
-		// If the next character is a '/', then parse a regex.
-		nextRune = p.peekRune()
-		if nextRune == '/' {
-			re, err := p.parseRegex()
-			if err != nil {
-				return nil, err
-			}
-			m.Regex = re.(*RegexLiteral)
+	// Didn't find a regex so parse segmented identifiers.
+	idents, err := p.parseSegmentedIdents()
+	if err != nil {
+		return nil, err
+	}
 
-			// A regex is always the last part of the source so return. E.g.,
-			// db.rp./cpu.*/.  Regex not supported in database or retention
-			// policy names.
-			return m, nil
-		}
+	// If we already have the max allowed idents, we're done.
+	if len(idents) == 3 {
+		m.Database, m.RetentionPolicy, m.Name = idents[0], idents[1], idents[2]
+		return m, nil
+	}
+	// Check again for regex.
+	re, err = p.parseRegex()
+	if err != nil {
+		return nil, err
+	} else if re != nil {
+		m.Regex = re
+	}
 
-		// Next character wasn't a '/' so parse a non-regex identifier.
-		if tok, pos, lit := p.scanIgnoreWhitespace(); tok == IDENT {
-			m.Name = lit
+	// Assign identifiers to their proper locations.
+	switch len(idents) {
+	case 1:
+		if re != nil {
+			m.RetentionPolicy = idents[0]
 		} else {
-			if m.Name == "" && m.Regex == nil {
-				return nil, newParseError(tokstr(tok, lit), []string{"identifier", "regex"}, pos)
-			}
-			p.unscan()
-			return m, nil
+			m.Name = idents[0]
+		}
+	case 2:
+		if re != nil {
+			m.Database, m.RetentionPolicy = idents[0], idents[1]
+		} else {
+			m.RetentionPolicy, m.Name = idents[0], idents[1]
 		}
 	}
+
+	return m, nil
 }
 
 // parseCondition parses the "WHERE" clause of the query, if it exists.
@@ -1617,6 +1671,19 @@ func (p *Parser) parseSortField() (*SortField, error) {
 	return field, nil
 }
 
+// parseVarRef parses a reference to a measurement or field.
+func (p *Parser) parseVarRef() (*VarRef, error) {
+	// Parse the segments of the variable ref.
+	segments, err := p.parseSegmentedIdents()
+	if err != nil {
+		return nil, err
+	}
+
+	vr := &VarRef{Val: strings.Join(segments, ".")}
+
+	return vr, nil
+}
+
 // ParseExpr parses an expression.
 func (p *Parser) ParseExpr() (Expr, error) {
 	var err error
@@ -1691,8 +1758,12 @@ func (p *Parser) parseUnaryExpr() (Expr, error) {
 		if tok0, _, _ := p.scan(); tok0 == LPAREN {
 			return p.parseCall(lit)
 		}
-		p.unscan()
-		return &VarRef{Val: lit}, nil
+
+		p.unscan() // unscan the last token (wasn't an LPAREN)
+		p.unscan() // unscan the IDENT token
+
+		// Parse it as a VarRef.
+		return p.parseVarRef()
 	case STRING:
 		// If literal looks like a date time then parse it as a time literal.
 		if isDateTimeString(lit) {
@@ -1739,7 +1810,18 @@ func (p *Parser) parseUnaryExpr() (Expr, error) {
 }
 
 // parseRegex parses a regular expression.
-func (p *Parser) parseRegex() (Expr, error) {
+func (p *Parser) parseRegex() (*RegexLiteral, error) {
+	nextRune := p.peekRune()
+	if isWhitespace(nextRune) {
+		p.consumeWhitespace()
+	}
+
+	// If the next character is not a '/', then return nils.
+	nextRune = p.peekRune()
+	if nextRune != '/' {
+		return nil, nil
+	}
+
 	tok, pos, lit := p.s.ScanRegex()
 
 	if tok == BADESCAPE {
@@ -1910,19 +1992,41 @@ func QuoteString(s string) string {
 }
 
 // QuoteIdent returns a quoted identifier from multiple bare identifiers.
-func QuoteIdent(segments []string) string {
+func QuoteIdent(segments ...string) string {
 	r := strings.NewReplacer("\n", `\n`, `\`, `\\`, `"`, `\"`)
 
 	var buf bytes.Buffer
 	for i, segment := range segments {
-		_ = buf.WriteByte('"')
+		needQuote := IdentNeedsQuotes(segment) ||
+			((i < len(segments)-1) && segment != "") // not last segment && not ""
+
+		if needQuote {
+			_ = buf.WriteByte('"')
+		}
+
 		_, _ = buf.WriteString(r.Replace(segment))
-		_ = buf.WriteByte('"')
+
+		if needQuote {
+			_ = buf.WriteByte('"')
+		}
+
 		if i < len(segments)-1 {
 			_ = buf.WriteByte('.')
 		}
 	}
 	return buf.String()
+}
+
+// IdentNeedsQuotes returns true if the ident string given would require quotes.
+func IdentNeedsQuotes(ident string) bool {
+	for i, r := range ident {
+		if i == 0 && !isIdentFirstChar(r) {
+			return true
+		} else if i > 0 && !isIdentChar(r) {
+			return true
+		}
+	}
+	return false
 }
 
 // split splits a string into a slice of runes.

--- a/influxql/scanner_test.go
+++ b/influxql/scanner_test.go
@@ -60,10 +60,10 @@ func TestScanner_Scan(t *testing.T) {
 		{s: `foo`, tok: influxql.IDENT, lit: `foo`},
 		{s: `_foo`, tok: influxql.IDENT, lit: `_foo`},
 		{s: `Zx12_3U_-`, tok: influxql.IDENT, lit: `Zx12_3U_`},
-		{s: `"foo".bar`, tok: influxql.IDENT, lit: `"foo".bar`},
-		{s: `"foo\\bar"`, tok: influxql.IDENT, lit: `"foo\bar"`},
+		{s: `"foo"`, tok: influxql.IDENT, lit: `foo`},
+		{s: `"foo\\bar"`, tok: influxql.IDENT, lit: `foo\bar`},
 		{s: `"foo\bar"`, tok: influxql.BADESCAPE, lit: `\b`, pos: influxql.Pos{Line: 0, Char: 5}},
-		{s: `"foo\"bar\""`, tok: influxql.IDENT, lit: `"foo"bar""`},
+		{s: `"foo\"bar\""`, tok: influxql.IDENT, lit: `foo"bar"`},
 		{s: `test"`, tok: influxql.BADSTRING, lit: "", pos: influxql.Pos{Line: 0, Char: 3}},
 		{s: `"test`, tok: influxql.BADSTRING, lit: `test`},
 
@@ -251,39 +251,6 @@ func TestScanString(t *testing.T) {
 		if tt.err != errstring(err) {
 			t.Errorf("%d. %s: error: exp=%s, got=%s", i, tt.in, tt.err, err)
 		} else if tt.out != out {
-			t.Errorf("%d. %s: out: exp=%s, got=%s", i, tt.in, tt.out, out)
-		}
-	}
-}
-
-// Ensure identifiers can be split into multiple quoted and unquoted parts.
-func TestSplitIdent(t *testing.T) {
-	var tests = []struct {
-		in  string
-		out []string
-		err string
-	}{
-		{in: `"db"."rp"."measurement"`, out: []string{`db`, `rp`, `measurement`}},
-		{in: `"db"."rp".measurement`, out: []string{`db`, `rp`, `measurement`}},
-		{in: `cpu.load.total`, out: []string{`cpu.load.total`}},
-		{in: `"rp".cpu.load.total`, out: []string{`rp`, `cpu.load.total`}},
-		{in: `"db"..cpu.load.total`, out: []string{`db`, ``, `cpu.load.total`}},
-		{in: `db."rp".cpu.total`, out: []string{`db`, `rp`, `cpu.total`}},
-		{in: `db...cpu`, out: []string{`db`, ``, ``, `cpu`}},
-		{in: `"db.rp".cpu`, out: []string{`db.rp`, `cpu`}},
-
-		{in: ``, err: "invalid identifier"},
-		{in: `.`, err: "invalid identifier"},
-		{in: `.cpu`, err: "invalid identifier"},
-		{in: `db.`, err: "invalid identifier"},
-		{in: `hello world`, err: "invalid identifier"},
-	}
-
-	for i, tt := range tests {
-		out, err := influxql.SplitIdent(tt.in)
-		if tt.err != errstring(err) {
-			t.Errorf("%d. %s: error: exp=%s, got=%s", i, tt.in, tt.err, err)
-		} else if !reflect.DeepEqual(tt.out, out) {
 			t.Errorf("%d. %s: out: exp=%s, got=%s", i, tt.in, tt.out, out)
 		}
 	}

--- a/server.go
+++ b/server.go
@@ -993,7 +993,7 @@ func (s *Server) applyDropDatabase(m *messaging.Message) (err error) {
 	mustUnmarshalJSON(m.Data, &c)
 
 	if s.databases[c.Name] == nil {
-		return ErrDatabaseNotFound
+		return ErrDatabaseNotFound(c.Name)
 	}
 
 	// Remove from metastore.
@@ -1015,7 +1015,7 @@ func (s *Server) Shard(id uint64) *Shard {
 func (s *Server) shardGroupByTimestamp(database, policy string, timestamp time.Time) (*ShardGroup, error) {
 	db := s.databases[database]
 	if db == nil {
-		return nil, ErrDatabaseNotFound
+		return nil, ErrDatabaseNotFound(database)
 	}
 	return db.shardGroupByTimestamp(policy, timestamp)
 }
@@ -1029,7 +1029,7 @@ func (s *Server) ShardGroups(database string) ([]*ShardGroup, error) {
 	// Lookup database.
 	db := s.databases[database]
 	if db == nil {
-		return nil, ErrDatabaseNotFound
+		return nil, ErrDatabaseNotFound(database)
 	}
 
 	// Retrieve groups from database.
@@ -1056,7 +1056,7 @@ func (s *Server) applyCreateShardGroupIfNotExists(m *messaging.Message) (err err
 	// Retrieve database.
 	db := s.databases[c.Database]
 	if s.databases[c.Database] == nil {
-		return ErrDatabaseNotFound
+		return ErrDatabaseNotFound(c.Database)
 	}
 
 	// Validate retention policy.
@@ -1168,7 +1168,7 @@ func (s *Server) applyDeleteShardGroup(m *messaging.Message) (err error) {
 	// Retrieve database.
 	db := s.databases[c.Database]
 	if s.databases[c.Database] == nil {
-		return ErrDatabaseNotFound
+		return ErrDatabaseNotFound(c.Database)
 	}
 
 	// Validate retention policy.
@@ -1413,7 +1413,7 @@ func (s *Server) RetentionPolicy(database, name string) (*RetentionPolicy, error
 	// Lookup database.
 	db := s.databases[database]
 	if db == nil {
-		return nil, ErrDatabaseNotFound
+		return nil, ErrDatabaseNotFound(database)
 	}
 
 	return db.policies[name], nil
@@ -1428,7 +1428,7 @@ func (s *Server) DefaultRetentionPolicy(database string) (*RetentionPolicy, erro
 	// Lookup database.
 	db := s.databases[database]
 	if db == nil {
-		return nil, ErrDatabaseNotFound
+		return nil, ErrDatabaseNotFound(database)
 	}
 
 	return db.policies[db.defaultRetentionPolicy], nil
@@ -1443,7 +1443,7 @@ func (s *Server) RetentionPolicies(database string) ([]*RetentionPolicy, error) 
 	// Lookup database.
 	db := s.databases[database]
 	if db == nil {
-		return nil, ErrDatabaseNotFound
+		return nil, ErrDatabaseNotFound(database)
 	}
 
 	// Retrieve the policies.
@@ -1515,7 +1515,7 @@ func (s *Server) applyCreateRetentionPolicy(m *messaging.Message) error {
 	// Retrieve the database.
 	db := s.databases[c.Database]
 	if s.databases[c.Database] == nil {
-		return ErrDatabaseNotFound
+		return ErrDatabaseNotFound(c.Database)
 	} else if c.Name == "" {
 		return ErrRetentionPolicyNameRequired
 	} else if db.policies[c.Name] != nil {
@@ -1565,7 +1565,7 @@ func (s *Server) applyUpdateRetentionPolicy(m *messaging.Message) (err error) {
 	// Validate command.
 	db := s.databases[c.Database]
 	if s.databases[c.Database] == nil {
-		return ErrDatabaseNotFound
+		return ErrDatabaseNotFound(c.Database)
 	} else if c.Name == "" {
 		return ErrRetentionPolicyNameRequired
 	}
@@ -1615,7 +1615,7 @@ func (s *Server) applyDeleteRetentionPolicy(m *messaging.Message) (err error) {
 	// Retrieve the database.
 	db := s.databases[c.Database]
 	if s.databases[c.Database] == nil {
-		return ErrDatabaseNotFound
+		return ErrDatabaseNotFound(c.Database)
 	} else if c.Name == "" {
 		return ErrRetentionPolicyNameRequired
 	} else if db.policies[c.Name] == nil {
@@ -1647,7 +1647,7 @@ func (s *Server) applySetDefaultRetentionPolicy(m *messaging.Message) (err error
 	// Validate command.
 	db := s.databases[c.Database]
 	if s.databases[c.Database] == nil {
-		return ErrDatabaseNotFound
+		return ErrDatabaseNotFound(c.Database)
 	} else if db.policies[c.Name] == nil {
 		return ErrRetentionPolicyNotFound
 	}
@@ -1669,7 +1669,7 @@ func (s *Server) applyDropSeries(m *messaging.Message) error {
 
 	database := s.databases[c.Database]
 	if database == nil {
-		return ErrDatabaseNotFound
+		return ErrDatabaseNotFound(c.Database)
 	}
 
 	// Remove from metastore.
@@ -1766,7 +1766,7 @@ func (s *Server) WriteSeries(database, retentionPolicy string, points []Point) (
 
 		db := s.databases[database]
 		if db == nil {
-			return ErrDatabaseNotFound
+			return ErrDatabaseNotFound(database)
 		}
 		for _, p := range points {
 			measurement, series := db.MeasurementAndSeries(p.Name, p.Tags)
@@ -1857,7 +1857,7 @@ func (s *Server) createMeasurementsIfNotExists(database, retentionPolicy string,
 
 		db := s.databases[database]
 		if db == nil {
-			return fmt.Errorf("database not found %q", database)
+			return ErrDatabaseNotFound(database)
 		}
 
 		for _, p := range points {
@@ -1907,7 +1907,7 @@ func (s *Server) applyCreateMeasurementsIfNotExists(m *messaging.Message) error 
 	// Validate command.
 	db := s.databases[c.Database]
 	if db == nil {
-		return ErrDatabaseNotFound
+		return ErrDatabaseNotFound(c.Database)
 	}
 
 	// Process command within a transaction.
@@ -1975,12 +1975,12 @@ func (s *Server) applyDropMeasurement(m *messaging.Message) error {
 
 	database := s.databases[c.Database]
 	if database == nil {
-		return ErrDatabaseNotFound
+		return ErrDatabaseNotFound(c.Database)
 	}
 
 	measurement := database.measurements[c.Name]
 	if measurement == nil {
-		return ErrMeasurementNotFound
+		return ErrMeasurementNotFound(c.Name)
 	}
 
 	err := s.meta.mustUpdate(m.Index, func(tx *metatx) error {
@@ -2029,13 +2029,13 @@ func (s *Server) ReadSeries(database, retentionPolicy, name string, tags map[str
 	// Find database.
 	db := s.databases[database]
 	if db == nil {
-		return nil, ErrDatabaseNotFound
+		return nil, ErrDatabaseNotFound(database)
 	}
 
 	// Find series.
 	mm, series := db.MeasurementAndSeries(name, tags)
 	if mm == nil {
-		return nil, ErrMeasurementNotFound
+		return nil, ErrMeasurementNotFound("")
 	} else if series == nil {
 		return nil, ErrSeriesNotFound
 	}
@@ -2111,10 +2111,22 @@ func (s *Server) ExecuteQuery(q *influxql.Query, database string, user *User, ch
 		var i int
 		var stmt influxql.Statement
 		for i, stmt = range q.Statements {
-			// Set default database and policy on the statement.
-			if err := s.NormalizeStatement(stmt, database); err != nil {
-				results <- &Result{Err: err}
-				break
+			// If a default database wasn't passed in by the caller,
+			// try to get it from the statement.
+			defaultDB := database
+			if defaultDB == "" {
+				if s, ok := stmt.(influxql.HasDefaultDatabase); ok {
+					defaultDB = s.DefaultDatabase()
+				}
+
+			}
+
+			// If we have a default database, normalize the statement with it.
+			if defaultDB != "" {
+				if err := s.NormalizeStatement(stmt, defaultDB); err != nil {
+					results <- &Result{Err: err}
+					break
+				}
 			}
 
 			var res *Result
@@ -2286,18 +2298,17 @@ func (s *Server) expandWildcards(stmt *influxql.SelectStatement) (*influxql.Sele
 
 	// Iterate measurements in the FROM clause getting the fields & dimensions for each.
 	for _, src := range stmt.Sources {
-		if measurement, ok := src.(*influxql.Measurement); ok {
-			// Split the measurement name into its pieces (db, rp, & measurement).
-			segments, err := influxql.SplitIdent(measurement.Name)
-			if err != nil {
-				return nil, fmt.Errorf("unable to parse measurement %s", measurement.Name)
+		if m, ok := src.(*influxql.Measurement); ok {
+			// Lookup the database.
+			db, ok := s.databases[m.Database]
+			if !ok {
+				return nil, ErrDatabaseNotFound(m.Database)
 			}
-			db, m := segments[0], segments[2]
 
 			// Lookup the measurement in the database.
-			mm := s.databases[db].measurements[m]
+			mm := db.measurements[m.Name]
 			if mm == nil {
-				return nil, fmt.Errorf("measurement not found: %s", measurement.Name)
+				return nil, ErrMeasurementNotFound(m.String())
 			}
 
 			// Get the fields for this measurement.
@@ -2325,30 +2336,28 @@ func (s *Server) expandWildcards(stmt *influxql.SelectStatement) (*influxql.Sele
 }
 
 // expandSources expands regex sources and removes duplicates.
+// NOTE: sources must be normalized (db and rp set) before calling this function.
 func (s *Server) expandSources(sources influxql.Sources) (influxql.Sources, error) {
 	// Use a map as a set to prevent duplicates. Two regexes might produce
 	// duplicates when expanded.
 	set := map[string]influxql.Source{}
+	names := []string{}
 
 	// Iterate all sources, expanding regexes when they're found.
 	for _, source := range sources {
 		switch src := source.(type) {
 		case *influxql.Measurement:
 			if src.Regex == nil {
-				set[src.Name] = src
+				name := src.String()
+				set[name] = src
+				names = append(names, name)
 				continue
 			}
 
-			// Split out the database & retention policy names.
-			segments, err := influxql.SplitIdent(src.Name)
-			if err != nil {
-				return nil, err
-			}
-
 			// Lookup the database.
-			db := s.databases[segments[0]]
+			db := s.databases[src.Database]
 			if db == nil {
-				return nil, ErrDatabaseNotFound
+				return nil, ErrDatabaseNotFound(src.Database)
 			}
 
 			// Get measurements from the database that match the regex.
@@ -2356,8 +2365,17 @@ func (s *Server) expandSources(sources influxql.Sources) (influxql.Sources, erro
 
 			// Add those measurments to the set.
 			for _, m := range measurements {
-				name := strings.Join([]string{src.Name, influxql.QuoteIdent([]string{m.Name})}, ".")
-				set[name] = &influxql.Measurement{Name: name}
+				m2 := &influxql.Measurement{
+					Database:        src.Database,
+					RetentionPolicy: src.RetentionPolicy,
+					Name:            m.Name,
+				}
+
+				name := m2.String()
+				if _, ok := set[name]; !ok {
+					set[name] = m2
+					names = append(names, name)
+				}
 			}
 
 		default:
@@ -2365,10 +2383,13 @@ func (s *Server) expandSources(sources influxql.Sources) (influxql.Sources, erro
 		}
 	}
 
+	// Sort the list of source names.
+	sort.Strings(names)
+
 	// Convert set to a list of Sources.
 	expanded := make(influxql.Sources, 0, len(set))
-	for _, src := range set {
-		expanded = append(expanded, src)
+	for _, name := range names {
+		expanded = append(expanded, set[name])
 	}
 
 	return expanded, nil
@@ -2453,7 +2474,7 @@ func (s *Server) executeDropSeriesStatement(stmt *influxql.DropSeriesStatement, 
 	db := s.databases[database]
 	if db == nil {
 		s.mu.RUnlock()
-		return &Result{Err: ErrDatabaseNotFound}
+		return &Result{Err: ErrDatabaseNotFound(database)}
 	}
 
 	// Get the list of measurements we're interested in.
@@ -2490,7 +2511,7 @@ func (s *Server) executeShowSeriesStatement(stmt *influxql.ShowSeriesStatement, 
 	// Find the database.
 	db := s.databases[database]
 	if db == nil {
-		return &Result{Err: ErrDatabaseNotFound}
+		return &Result{Err: ErrDatabaseNotFound(database)}
 	}
 
 	// Get the list of measurements we're interested in.
@@ -2593,7 +2614,7 @@ func (s *Server) executeShowMeasurementsStatement(stmt *influxql.ShowMeasurement
 	// Find the database.
 	db := s.databases[database]
 	if db == nil {
-		return &Result{Err: ErrDatabaseNotFound}
+		return &Result{Err: ErrDatabaseNotFound(database)}
 	}
 
 	var measurements Measurements
@@ -2655,7 +2676,7 @@ func (s *Server) executeShowTagKeysStatement(stmt *influxql.ShowTagKeysStatement
 	// Find the database.
 	db := s.databases[database]
 	if db == nil {
-		return &Result{Err: ErrDatabaseNotFound}
+		return &Result{Err: ErrDatabaseNotFound(database)}
 	}
 
 	// Get the list of measurements we're interested in.
@@ -2705,7 +2726,7 @@ func (s *Server) executeShowTagValuesStatement(stmt *influxql.ShowTagValuesState
 	// Find the database.
 	db := s.databases[database]
 	if db == nil {
-		return &Result{Err: ErrDatabaseNotFound}
+		return &Result{Err: ErrDatabaseNotFound(database)}
 	}
 
 	// Get the list of measurements we're interested in.
@@ -2841,7 +2862,7 @@ func (s *Server) executeShowFieldKeysStatement(stmt *influxql.ShowFieldKeysState
 	// Find the database.
 	db := s.databases[database]
 	if db == nil {
-		return &Result{Err: ErrDatabaseNotFound}
+		return &Result{Err: ErrDatabaseNotFound(database)}
 	}
 
 	// Get the list of measurements we're interested in.
@@ -2899,21 +2920,12 @@ func measurementsFromSourceOrDB(stmt influxql.Source, db *database) (Measurement
 	if stmt != nil {
 		// TODO: handle multiple measurement sources
 		if m, ok := stmt.(*influxql.Measurement); ok {
-			segments, err := influxql.SplitIdent(m.Name)
-			if err != nil {
-				return nil, err
-			}
-			name := m.Name
-			if len(segments) == 3 {
-				name = segments[2]
-			}
-
-			measurement := db.measurements[name]
+			measurement := db.measurements[m.Name]
 			if measurement == nil {
-				return nil, fmt.Errorf(`measurement "%s" not found`, name)
+				return nil, ErrMeasurementNotFound(m.Name)
 			}
 
-			measurements = append(measurements, db.measurements[name])
+			measurements = append(measurements, measurement)
 		} else {
 			return nil, errors.New("identifiers in FROM clause must be measurement names")
 		}
@@ -3058,7 +3070,7 @@ func (s *Server) MeasurementNames(database string) []string {
 func (s *Server) measurement(database, name string) (*Measurement, error) {
 	db := s.databases[database]
 	if db == nil {
-		return nil, ErrDatabaseNotFound
+		return nil, ErrDatabaseNotFound(database)
 	}
 
 	return db.measurements[name], nil
@@ -3085,14 +3097,12 @@ func (s *Server) normalizeStatement(stmt influxql.Statement, defaultDatabase str
 		}
 		switch n := n.(type) {
 		case *influxql.Measurement:
-			nm, e := s.normalizeMeasurement(n, defaultDatabase)
+			e := s.normalizeMeasurement(n, defaultDatabase)
 			if e != nil {
 				err = e
 				return
 			}
-			prefixes[n.Name] = nm.Name
-			n.Name = nm.Name
-			n.Regex = nm.Regex
+			prefixes[n.Name] = n.Name
 		}
 	})
 	if err != nil {
@@ -3105,7 +3115,7 @@ func (s *Server) normalizeStatement(stmt influxql.Statement, defaultDatabase str
 		case *influxql.VarRef:
 			for k, v := range prefixes {
 				if strings.HasPrefix(n.Val, k+".") {
-					n.Val = v + "." + influxql.QuoteIdent([]string{n.Val[len(k)+1:]})
+					n.Val = v + "." + influxql.QuoteIdent(n.Val[len(k)+1:])
 				}
 			}
 		}
@@ -3115,79 +3125,44 @@ func (s *Server) normalizeStatement(stmt influxql.Statement, defaultDatabase str
 }
 
 // NormalizeMeasurement inserts the default database or policy into all measurement names.
-func (s *Server) NormalizeMeasurement(m *influxql.Measurement, defaultDatabase string) (*influxql.Measurement, error) {
+func (s *Server) NormalizeMeasurement(m *influxql.Measurement, defaultDatabase string) error {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return s.normalizeMeasurement(m, defaultDatabase)
 }
 
-func (s *Server) normalizeMeasurement(m *influxql.Measurement, defaultDatabase string) (*influxql.Measurement, error) {
+func (s *Server) normalizeMeasurement(m *influxql.Measurement, defaultDatabase string) error {
+	if defaultDatabase == "" {
+		return errors.New("no default database specified")
+	}
 	if m.Name == "" && m.Regex == nil {
-		return nil, errors.New("invalid measurement")
+		return errors.New("invalid measurement")
 	}
 
-	var segments []string
-	var err error
-
-	if m.Name != "" {
-		// Split measurement name into segments.
-		segments, err = influxql.SplitIdent(m.Name)
-		if err != nil {
-			return nil, fmt.Errorf("invalid measurement: %s", m.Name)
-		}
-	}
-
-	// Number of segments.
-	n := 3
-
-	// If there's a regex, add a placeholder segment
-	if m.Regex != nil {
-		segments = append(segments, "")
-		n = 2
-	}
-
-	// Normalize to 3 segments.
-	switch len(segments) {
-	case 1:
-		segments = append([]string{"", ""}, segments...)
-	case 2:
-		segments = append([]string{""}, segments...)
-	case 3:
-		// nop
-	default:
-		return nil, fmt.Errorf("measurement has too many segments: %s", m.String())
-	}
-
-	// Set database if unset.
-	if segments[0] == `` {
-		segments[0] = defaultDatabase
+	if m.Database == "" {
+		m.Database = defaultDatabase
 	}
 
 	// Find database.
-	db := s.databases[segments[0]]
+	db := s.databases[m.Database]
 	if db == nil {
-		return nil, fmt.Errorf("database not found: %s", segments[0])
+		return ErrDatabaseNotFound(m.Database)
 	}
 
-	// Set retention policy if unset.
-	if segments[1] == `` {
+	// If no retention policy was specified, use the default.
+	if m.RetentionPolicy == "" {
 		if db.defaultRetentionPolicy == "" {
-			return nil, fmt.Errorf("default retention policy not set for: %s", db.name)
+			return fmt.Errorf("default retention policy not set for: %s", db.name)
 		}
-		segments[1] = db.defaultRetentionPolicy
+		m.RetentionPolicy = db.defaultRetentionPolicy
 	}
 
-	// Check if retention policy exists.
-	if _, ok := db.policies[segments[1]]; !ok {
-		return nil, fmt.Errorf("retention policy does not exist: %s.%s", segments[0], segments[1])
+	// Make sure the retention policy exists.
+	if _, ok := db.policies[m.RetentionPolicy]; !ok {
+		return fmt.Errorf("retention policy does not exist: %s.%s", m.Database, m.RetentionPolicy)
 	}
 
-	nm := &influxql.Measurement{
-		Name:  influxql.QuoteIdent(segments[:n]),
-		Regex: m.Regex,
-	}
-
-	return nm, nil
+	return nil
 }
 
 // DiagnosticsAsRows returns diagnostic information about the server, as a slice of
@@ -3596,13 +3571,15 @@ func HashPassword(password string) ([]byte, error) {
 type ContinuousQuery struct {
 	Query string `json:"query"`
 
-	mu              sync.Mutex
-	cq              *influxql.CreateContinuousQueryStatement
-	lastRun         time.Time
-	intoDB          string
-	intoRP          string
-	intoMeasurement string
+	mu      sync.Mutex
+	cq      *influxql.CreateContinuousQueryStatement
+	lastRun time.Time
 }
+
+func (cq *ContinuousQuery) intoDB() string          { return cq.cq.Source.Target.Measurement.Database }
+func (cq *ContinuousQuery) intoRP() string          { return cq.cq.Source.Target.Measurement.RetentionPolicy }
+func (cq *ContinuousQuery) setIntoRP(rp string)     { cq.cq.Source.Target.Measurement.RetentionPolicy = rp }
+func (cq *ContinuousQuery) intoMeasurement() string { return cq.cq.Source.Target.Measurement.Name }
 
 // NewContinuousQuery returns a ContinuousQuery object with a parsed influxql.CreateContinuousQueryStatement
 func NewContinuousQuery(q string) (*ContinuousQuery, error) {
@@ -3619,26 +3596,6 @@ func NewContinuousQuery(q string) (*ContinuousQuery, error) {
 	cquery := &ContinuousQuery{
 		Query: q,
 		cq:    cq,
-	}
-
-	// set which database and retention policy, and measuremet a CQ is writing into
-	a, err := influxql.SplitIdent(cq.Source.Target.Measurement)
-	if err != nil {
-		return nil, err
-	}
-
-	// set the default into database to the same as the from database
-	cquery.intoDB = cq.Database
-
-	if len(a) == 1 { // into only set the measurement name. keep default db and rp
-		cquery.intoMeasurement = a[0]
-	} else if len(a) == 2 { // into set the rp and the measurement
-		cquery.intoRP = a[0]
-		cquery.intoMeasurement = a[1]
-	} else { // into set db, rp, and measurement
-		cquery.intoDB = a[0]
-		cquery.intoRP = a[1]
-		cquery.intoMeasurement = a[2]
 	}
 
 	return cquery, nil
@@ -3660,14 +3617,14 @@ func (s *Server) applyCreateContinuousQueryCommand(m *messaging.Message) error {
 	}
 
 	// ensure the into database exists
-	if s.databases[cq.intoDB] == nil {
-		return ErrDatabaseNotFound
+	if s.databases[cq.intoDB()] == nil {
+		return ErrDatabaseNotFound(cq.intoDB())
 	}
 
 	// Retrieve the database.
 	db := s.databases[cq.cq.Database]
 	if db == nil {
-		return ErrDatabaseNotFound
+		return ErrDatabaseNotFound(cq.cq.Database)
 	} else if db.continuousQueryByName(cq.cq.Name) != nil {
 		return ErrContinuousQueryExists
 	}
@@ -3692,7 +3649,7 @@ func (s *Server) applyDropContinuousQueryCommand(m *messaging.Message) error {
 	// retrieve the database and ensure that it exists
 	db := s.databases[c.Database]
 	if db == nil {
-		return ErrDatabaseNotFound
+		return ErrDatabaseNotFound(c.Database)
 	}
 
 	// loop through continuous queries and find the match
@@ -3731,8 +3688,8 @@ func (s *Server) RunContinuousQueries() error {
 		for _, c := range d.continuousQueries {
 			if s.shouldRunContinuousQuery(c) {
 				// set the into retention policy based on what is now the default
-				if c.intoRP == "" {
-					c.intoRP = d.defaultRetentionPolicy
+				if c.intoRP() == "" {
+					c.setIntoRP(d.defaultRetentionPolicy)
 				}
 				go func(cq *ContinuousQuery) {
 					s.runContinuousQuery(c)
@@ -3838,7 +3795,7 @@ func (s *Server) runContinuousQueryAndWriteResult(cq *ContinuousQuery) error {
 
 	// Read all rows from channel and write them in
 	for row := range ch {
-		points, err := s.convertRowToPoints(cq.intoMeasurement, row)
+		points, err := s.convertRowToPoints(cq.intoMeasurement(), row)
 		if err != nil {
 			log.Println(err)
 			continue
@@ -3854,7 +3811,7 @@ func (s *Server) runContinuousQueryAndWriteResult(cq *ContinuousQuery) error {
 					}
 				}
 			}
-			_, err = s.WriteSeries(cq.intoDB, cq.intoRP, points)
+			_, err = s.WriteSeries(cq.intoDB(), cq.intoRP(), points)
 			if err != nil {
 				log.Printf("[cq] err: %s", err)
 			}


### PR DESCRIPTION
The big change in this PR is how identifiers are scanned / parsed.  The scanner used to treat `"db"."rp".cpu` as one identifer.  It would be stored in a single string in the AST somewhere.  The scanner API exposed `SplitIdent` and it was up to clients consuming the AST to split identifiers into segments, strip quotes from the segments, and figure out what each segment was (db?, rp?, measurement?).  This PR simplifies things for client code by splitting identifiers and stripping quotes at the earliest stage (scanning) and changing the parser to store them in appropriate fields (db, rp, etc.) in the AST.

- Change `Scanner.scanIdent()` to scan `"db"."rp".cpu` as separate tokens: `IDENT`, `DOT`, `IDENT`, `DOT`, `IDENT` instead of scanning it as a single IDENT
- Add `Parser.parseSegmentedIdents()` to parse segmented (DOT separated) identifiers like `"db"."rp".cpu` and return them as an `[]string`
- Change AST types that held segmented identifiers in a string to have individual fields.  Note that `type VarRef` still, for now, holds a single string.  This may need to be changed.
- Add `type HasDefaultDatabase interface` to ast.go.  Types like `type CreateContinuousQueryStatement` that have a default database should implement this interface.
- Change parsing functions that work with segmented identifiers to use the new `parseSegmentedIdents()` function and store segments in the appropriate AST fields.
- Change `QuoteIdent` function to only quote segments that must be quoted.
- Add `IdentNeedsQuotes` func that returns `true` if an identifier would require quotes
- Change `Server.ExecuteQuery` to check for a default database passed by the caller.  If none was provided, see if the statement implements the `HasDefaultDB` interface and get the default database from there.  This fixes a bug in statement normalization.
- Remove uses of `influxql.SplitIdent` function outside of the parser
- Change `Server.expandSources` to always return expanded sources in sorted order
- Change `ErrDatabaseNotFound` and `ErrRetentionPolicyNotFound` to be functions that report the name of the "not found" object and the error locust