### PR TITLE
Fix all "golint" warnings in top-level package.

### DIFF
--- a/database.go
+++ b/database.go
@@ -313,7 +313,7 @@ func (m *Measurement) tagSets(stmt *influxql.SelectStatement, dimensions []strin
 	filters := m.filters(stmt)
 
 	// build the tag sets
-	tagStrings := make([]string, 0)
+	var tagStrings []string
 	tagSets := make(map[string]*influxql.TagSet)
 	for id, filter := range filters {
 		// get the series and set the tag values for the dimensions we care about
@@ -1074,6 +1074,7 @@ type RetentionPolicy struct {
 	shardGroups []*ShardGroup
 }
 
+// RetentionPolicies represents a list of retention policies.
 type RetentionPolicies []*RetentionPolicy
 
 func (a RetentionPolicies) Len() int           { return len(a) }

--- a/tx.go
+++ b/tx.go
@@ -130,7 +130,7 @@ func (tx *tx) CreateMapReduceJobs(stmt *influxql.SelectStatement, tagKeys []stri
 			}
 
 			// make a mapper for each shard that must be hit. We may need to hit multiple shards within a shard group
-			mappers := make([]influxql.Mapper, 0)
+			var mappers []influxql.Mapper
 
 			// create mappers for each shard we need to hit
 			for _, sg := range shardGroups {
@@ -228,6 +228,7 @@ type LocalMapper struct {
 	isRaw           bool                   // if the query is a non-aggregate query
 }
 
+// Open opens the LocalMapper.
 func (l *LocalMapper) Open() error {
 	// Open the data store
 	txn, err := l.db.Begin(false)
@@ -251,6 +252,7 @@ func (l *LocalMapper) Open() error {
 	return nil
 }
 
+// Close closes the LocalMapper.
 func (l *LocalMapper) Close() {
 	_ = l.txn.Rollback()
 }
@@ -345,6 +347,7 @@ func (l *LocalMapper) NextInterval(interval int64) (interface{}, error) {
 	return val, nil
 }
 
+// Next returns the next matching timestamped value for the LocalMapper.
 func (l *LocalMapper) Next() (seriesID uint32, timestamp int64, value interface{}) {
 	for {
 		// find the minimum timestamp


### PR DESCRIPTION
This fixes all [golint](https://github.com/golang/lint) warnings in the top-level "influxdb" package:

    database.go:316:2: can probably use "var tagStrings []string" instead
    database.go:1077:6: exported type RetentionPolicies should have comment or be unexported
    server.go:337:1: exported method Server.StartSelfMonitoring should have comment or be unexported
    server.go:345:3: can probably use "var points []Point" instead
    server.go:433:2: can probably use "var groups []group" instead
    server.go:498:2: can probably use "var groups []group" instead
    server.go:1417:1: comment on exported method Server.CreateRetentionPolicyIfNotExists should be of the form "CreateRetentionPolicyIfNotExists ..."
    server.go:1899:1: exported method Server.DropMeasurement should have comment or be unexported
    server.go:2153:10: if block ends with a return statement, so drop this else and outdent its block
    server.go:2695:2: can probably use "var rows []*influxql.Row" instead
    server.go:2876:11: if block ends with a return statement, so drop this else and outdent its block
    server.go:3804:1: exported method Server.StartReportingLoop should have comment or be unexported
    tx.go:133:4: can probably use "var mappers []influxql.Mapper" instead
    tx.go:231:1: exported method LocalMapper.Open should have comment or be unexported
    tx.go:254:1: exported method LocalMapper.Close should have comment or be unexported
    tx.go:348:1: exported method LocalMapper.Next should have comment or be unexported

I don't know if there is any aspiration of getting the entire codebase lint-clean eventually, so feel free to ignore this if it causes more noise than benefit.