### PR TITLE
Fix all lint errors in "admin" and "collectd" packages.

### DIFF
--- a/admin/admin.go
+++ b/admin/admin.go
@@ -7,20 +7,25 @@ import (
 
 	"github.com/rakyll/statik/fs"
 
+	// Register static assets via statik.
 	_ "github.com/influxdb/influxdb/statik"
 )
 
+// Server manages InfluxDB's admin web server.
 type Server struct {
 	port     string
 	listener net.Listener
 	closed   bool
 }
 
-// port should be a string that looks like ":8083" or whatever port to serve on.
+// NewServer constructs a new admin web server. The "port" argument should be a
+// string that looks like ":8083" or whatever port to serve on.
 func NewServer(port string) *Server {
 	return &Server{port: port, closed: true}
 }
 
+// ListenAndServe starts the admin web server and serves requests until
+// s.Close() is called.
 func (s *Server) ListenAndServe() {
 	if s.port == "" {
 		return
@@ -41,6 +46,7 @@ func (s *Server) ListenAndServe() {
 	}
 }
 
+// Close stops the admin web server.
 func (s *Server) Close() {
 	if s.closed {
 		return


### PR DESCRIPTION
    admin/admin.go:10:2: a blank import should be only in a main or test package, or have a comment justifying it
    admin/admin.go:13:6: exported type Server should have comment or be unexported
    admin/admin.go:19:1: comment on exported function NewServer should be of the form "NewServer ..."
    admin/admin.go:24:1: exported method Server.ListenAndServe should have comment or be unexported
    admin/admin.go:44:1: exported method Server.Close should have comment or be unexported

    collectd/collectd.go:23:6: exported type Server should have comment or be unexported
    collectd/collectd.go:35:1: exported function NewServer should have comment or be unexported
    collectd/collectd.go:46:1: exported function ListenAndServe should have comment or be unexported
    collectd/collectd.go:145:1: exported function Unmarshal should have comment or be unexported