### PR TITLE
Refactor Results to Response (#2050)

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -148,11 +148,11 @@ func queryDB(con *client.Client, cmd string) (res []client.Result, err error) {
 		Command:  cmd,
 		Database: MyDB,
 	}
-	if results, err := con.Query(q); err == nil {
-		if results.Error() != nil {
-			return res, results.Error()
+	if response, err := con.Query(q); err == nil {
+		if response.Error() != nil {
+			return res, response.Error()
 		}
-		res = results.Results
+		res = response.Results
 	}
 	return
 }

--- a/client/example_test.go
+++ b/client/example_test.go
@@ -63,8 +63,8 @@ func ExampleClient_Query() {
 		Command:  "select count(value) from shapes",
 		Database: "square_holes",
 	}
-	if results, err := con.Query(q); err == nil && results.Error() == nil {
-		log.Println(results.Results)
+	if response, err := con.Query(q); err == nil && response.Error() == nil {
+		log.Println(response.Results)
 	}
 }
 

--- a/client/influxdb_test.go
+++ b/client/influxdb_test.go
@@ -46,7 +46,7 @@ func TestClient_Ping(t *testing.T) {
 
 func TestClient_Query(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		var data influxdb.Results
+		var data influxdb.Response
 		w.WriteHeader(http.StatusOK)
 		_ = json.NewEncoder(w).Encode(data)
 	}))
@@ -99,7 +99,7 @@ func TestClient_BasicAuth(t *testing.T) {
 
 func TestClient_Write(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		var data influxdb.Results
+		var data influxdb.Response
 		w.WriteHeader(http.StatusOK)
 		_ = json.NewEncoder(w).Encode(data)
 	}))
@@ -124,7 +124,7 @@ func TestClient_UserAgent(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		receivedUserAgent = r.UserAgent()
 
-		var data influxdb.Results
+		var data influxdb.Response
 		w.WriteHeader(http.StatusOK)
 		_ = json.NewEncoder(w).Encode(data)
 	}))

--- a/cmd/influxd/server_integration_test.go
+++ b/cmd/influxd/server_integration_test.go
@@ -1442,11 +1442,11 @@ func TestClientLibrary(t *testing.T) {
 		for _, q := range test.queries {
 			if q.query.Command != "" {
 				time.Sleep(500 * time.Millisecond)
-				queryResult, err := c.Query(q.query)
+				queryResponse, err := c.Query(q.query)
 				if q.err != errToString(err) {
 					t.Errorf("unexpected error. expected: %s, got %v", q.err, err)
 				}
-				jsonResult := mustMarshalJSON(queryResult)
+				jsonResult := mustMarshalJSON(queryResponse)
 				if q.expected != jsonResult {
 					t.Logf("query expected result: %s\n", q.expected)
 					t.Logf("query got result:      %s\n", jsonResult)

--- a/httpd/handler.go
+++ b/httpd/handler.go
@@ -202,7 +202,7 @@ func (h *Handler) serveQuery(w http.ResponseWriter, r *http.Request, user *influ
 	}
 
 	// if we're not chunking, this will be the in memory buffer for all results before sending to client
-	res := influxdb.Results{Results: make([]*influxdb.Result, 0)}
+	res := influxdb.Response{Results: make([]*influxdb.Result, 0)}
 	statusWritten := false
 
 	// pull all results from the channel
@@ -320,7 +320,7 @@ func (h *Handler) showMeasurements(db string, user *influxdb.User) ([]string, er
 	if err != nil {
 		return measurements, err
 	}
-	results := influxdb.Results{}
+	results := influxdb.Response{}
 
 	for r := range c {
 		results.Results = append(results.Results, r)
@@ -691,12 +691,12 @@ func httpError(w http.ResponseWriter, error string, pretty bool, code int) {
 	w.Header().Add("content-type", "application/json")
 	w.WriteHeader(code)
 
-	results := influxdb.Results{Err: errors.New(error)}
+	response := influxdb.Response{Err: errors.New(error)}
 	var b []byte
 	if pretty {
-		b, _ = json.MarshalIndent(results, "", "    ")
+		b, _ = json.MarshalIndent(response, "", "    ")
 	} else {
-		b, _ = json.Marshal(results)
+		b, _ = json.Marshal(response)
 	}
 	w.Write(b)
 }

--- a/httpd/handler_test.go
+++ b/httpd/handler_test.go
@@ -1354,7 +1354,7 @@ func TestHandler_serveWriteSeriesNonZeroTime(t *testing.T) {
 		t.Errorf("unexpected status: %d", status)
 	}
 
-	r := &influxdb.Results{}
+	r := &influxdb.Response{}
 	if err := json.Unmarshal([]byte(body), r); err != nil {
 		t.Logf("query : %s\n", query)
 		t.Log(body)
@@ -1401,7 +1401,7 @@ func TestHandler_serveWriteSeriesZeroTime(t *testing.T) {
 		t.Errorf("unexpected status: %d", status)
 	}
 
-	r := &influxdb.Results{}
+	r := &influxdb.Response{}
 	if err := json.Unmarshal([]byte(body), r); err != nil {
 		t.Logf("query : %s\n", query)
 		t.Log(body)
@@ -1489,7 +1489,7 @@ func TestHandler_serveWriteSeriesBatch(t *testing.T) {
 		t.Errorf("unexpected status: %d", status)
 	}
 
-	r := &influxdb.Results{}
+	r := &influxdb.Response{}
 	if err := json.Unmarshal([]byte(body), r); err != nil {
 		t.Logf("query : %s\n", query)
 		t.Log(body)
@@ -1531,7 +1531,7 @@ func TestHandler_serveWriteSeriesFieldTypeConflict(t *testing.T) {
 		t.Errorf("unexpected status: %d", status)
 	}
 
-	r := &influxdb.Results{}
+	r := &influxdb.Response{}
 	if err := json.Unmarshal([]byte(body), r); err != nil {
 		t.Log(body)
 		t.Error(err)
@@ -1646,16 +1646,16 @@ func TestHandler_ChunkedResponses(t *testing.T) {
 		if err != nil {
 			t.Fatalf("error reading response: %s", err.Error())
 		}
-		results := &influxdb.Results{}
-		err = json.Unmarshal(chunk[0:n], results)
+		response := &influxdb.Response{}
+		err = json.Unmarshal(chunk[0:n], response)
 		if err != nil {
 			t.Fatalf("error unmarshaling resultsz: %s", err.Error())
 		}
-		if len(results.Results) != 1 {
-			t.Fatalf("didn't get 1 result: %s\n", mustMarshalJSON(results))
+		if len(response.Results) != 1 {
+			t.Fatalf("didn't get 1 result: %s\n", mustMarshalJSON(response))
 		}
-		if len(results.Results[0].Series) != 1 {
-			t.Fatalf("didn't get 1 series: %s\n", mustMarshalJSON(results))
+		if len(response.Results[0].Series) != 1 {
+			t.Fatalf("didn't get 1 series: %s\n", mustMarshalJSON(response))
 		}
 		var vals [][]interface{}
 		if i == 0 {
@@ -1663,8 +1663,8 @@ func TestHandler_ChunkedResponses(t *testing.T) {
 		} else {
 			vals = [][]interface{}{{"2009-11-10T23:30:00Z", 25}}
 		}
-		if mustMarshalJSON(vals) != mustMarshalJSON(results.Results[0].Series[0].Values) {
-			t.Fatalf("values weren't what was expected:\n  exp: %s\n  got: %s", mustMarshalJSON(vals), mustMarshalJSON(results.Results[0].Series[0].Values))
+		if mustMarshalJSON(vals) != mustMarshalJSON(response.Results[0].Series[0].Values) {
+			t.Fatalf("values weren't what was expected:\n  exp: %s\n  got: %s", mustMarshalJSON(vals), mustMarshalJSON(response.Results[0].Series[0].Values))
 		}
 	}
 }

--- a/server.go
+++ b/server.go
@@ -3318,14 +3318,14 @@ func (r *Result) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-// Results represents a list of statement results.
-type Results struct {
+// Response represents a list of statement results.
+type Response struct {
 	Results []*Result
 	Err     error
 }
 
-// MarshalJSON encodes a Results struct into JSON.
-func (r Results) MarshalJSON() ([]byte, error) {
+// MarshalJSON encodes a Response struct into JSON.
+func (r Response) MarshalJSON() ([]byte, error) {
 	// Define a struct that outputs "error" as a string.
 	var o struct {
 		Results []*Result `json:"results,omitempty"`
@@ -3341,8 +3341,8 @@ func (r Results) MarshalJSON() ([]byte, error) {
 	return json.Marshal(&o)
 }
 
-// UnmarshalJSON decodes the data into the Results struct
-func (r *Results) UnmarshalJSON(b []byte) error {
+// UnmarshalJSON decodes the data into the Response struct
+func (r *Response) UnmarshalJSON(b []byte) error {
 	var o struct {
 		Results []*Result `json:"results,omitempty"`
 		Err     string    `json:"error,omitempty"`
@@ -3361,7 +3361,7 @@ func (r *Results) UnmarshalJSON(b []byte) error {
 
 // Error returns the first error from any statement.
 // Returns nil if no errors occurred on any statements.
-func (r *Results) Error() error {
+func (r *Response) Error() error {
 	if r.Err != nil {
 		return r.Err
 	}

--- a/server_test.go
+++ b/server_test.go
@@ -1945,12 +1945,12 @@ func (s *Server) MustWriteSeries(database, retentionPolicy string, points []infl
 	return index
 }
 
-func (s *Server) executeQuery(q *influxql.Query, db string, user *influxdb.User) influxdb.Results {
+func (s *Server) executeQuery(q *influxql.Query, db string, user *influxdb.User) influxdb.Response {
 	results, err := s.ExecuteQuery(q, db, user, 10000)
 	if err != nil {
-		return influxdb.Results{Err: err}
+		return influxdb.Response{Err: err}
 	}
-	res := influxdb.Results{}
+	res := influxdb.Response{}
 	for r := range results {
 		l := len(res.Results)
 		if l == 0 {


### PR DESCRIPTION
As described by @pauldix in #2050, refactor client.Results and influxdb.Results struct to client.Response and influxdb.Response, respectively. This is purely change in the name of those two structs plus minor changes in comments + variable names in order to be in line with the type name change.

Testing performed:

    $ go test ./...
    ok  	github.com/influxdb/influxdb	3.990s
    ok  	github.com/influxdb/influxdb/admin	0.018s
    ok  	github.com/influxdb/influxdb/client	0.013s
    ok  	github.com/influxdb/influxdb/cmd/influx	0.012s
    ok  	github.com/influxdb/influxdb/cmd/influxd	72.731s
    ok  	github.com/influxdb/influxdb/collectd	0.016s
    ok  	github.com/influxdb/influxdb/graphite	0.009s
    ok  	github.com/influxdb/influxdb/httpd	1.380s
    ok  	github.com/influxdb/influxdb/influxql	0.019s
    ok  	github.com/influxdb/influxdb/messaging	5.602s
    ok  	github.com/influxdb/influxdb/raft	7.339s
    ?   	github.com/influxdb/influxdb/statik	[no test files]
    ?   	github.com/influxdb/influxdb/test	[no test files]
    ?   	github.com/influxdb/influxdb/tests/urlgen	[no test files]
    ?   	github.com/influxdb/influxdb/udp	[no test files]
    ?   	github.com/influxdb/influxdb/uuid	[no test files]