### PR TITLE
Fixing time limits aggregate queries and interval buckets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,14 @@
-## v0.9.0-rc20 [unreleased]
+## v0.9.0-rc20 [2015-04-04]
 
 ### Features
 - [#2128](https://github.com/influxdb/influxdb/pull/2128): Data node discovery from brokers
 - [#2142](https://github.com/influxdb/influxdb/pull/2142): Support chunked queries
 - [#2154](https://github.com/influxdb/influxdb/pull/2154): Node redirection
+- [#2168](https://github.com/influxdb/influxdb/pull/2168): Return raft term from vote, add term logging
 
 ### Bugfixes
 - [#2147](https://github.com/influxdb/influxdb/pull/2147): Set Go Max procs in a better location
+- [#2137](https://github.com/influxdb/influxdb/pull/2137): Refactor `results` to `response`. Breaking Go Client change.
 - [#2151](https://github.com/influxdb/influxdb/pull/2151): Ignore replay commands on the metastore.
 - [#2152](https://github.com/influxdb/influxdb/issues/2152): Influxd process with stats enabled crashing with 'Unsuported protocol scheme for ""'
 - [#2156](https://github.com/influxdb/influxdb/pull/2156): Propagate error when resolving UDP address in Graphite UDP server.
@@ -15,8 +17,9 @@
 - [#2165](https://github.com/influxdb/influxdb/pull/2165): Better name for config section for stats and diags.
 - [#2165](https://github.com/influxdb/influxdb/pull/2165): Monitoring database and retention policy are not configurable.
 - [#2167](https://github.com/influxdb/influxdb/pull/2167): Add broker log recovery.
-- [#2050](https://github.com/influxdb/influxdb/issues/2050): Refactor `results` to `response`. Breaking Go Client change.
 - [#2166](https://github.com/influxdb/influxdb/pull/2166): Don't panic if presented with a field of unknown type.
+- [#2149](https://github.com/influxdb/influxdb/pull/2149): Fix unit tests for win32 when directory doesn't exist.
+- [#2150](https://github.com/influxdb/influxdb/pull/2150): Fix unit tests for win32 when a connection is refused.
 
 ## v0.9.0-rc19 [2015-04-01]
 

--- a/influxql/engine.go
+++ b/influxql/engine.go
@@ -124,8 +124,15 @@ func (m *MapReduceJob) Execute(out chan *Row, filterEmptyResults bool) {
 	// initialize the times of the aggregate points
 	resultValues := make([][]interface{}, pointCountInResult)
 
-	// ensure that the start time for the results is on the start of the window
-	startTimeBucket := m.TMin / m.interval * m.interval
+	var startTimeBucket int64
+
+	// If we have a group by query, specify the start times using normalization.  If we have a different,
+	// aggregate query with no buckets, set the start time as the TMin called out.
+	if m.stmt.groupByInterval > 0 {
+		startTimeBucket = m.TMin / m.interval * m.interval
+	} else {
+		startTimeBucket = m.TMin
+	}
 
 	for i, _ := range resultValues {
 		var t int64
@@ -604,9 +611,13 @@ func (m *MapReduceJob) processAggregate(c *Call, reduceFunc ReduceFunc, resultVa
 		}
 	}
 
+	firstInterval := m.interval
+
 	// the first interval in a query with a group by may be smaller than the others. This happens when they have a
 	// where time > clause that is in the middle of the bucket that the group by time creates
-	firstInterval := (m.TMin/m.interval*m.interval + m.interval) - m.TMin
+	if !m.stmt.IsRawQuery && m.stmt.groupByInterval > 0 {
+		firstInterval = (m.TMin/m.interval*m.interval + m.interval) - m.TMin
+	}
 
 	// populate the result values for each interval of time
 	for i, _ := range resultValues {


### PR DESCRIPTION
## History & Purpose

This pull request relates to two previous PR: #2016 and #2067.

#2016 was a PR I submitted to fix a bucket alignment issue.  Unfortunately, I introduced a different bug that broke raw queries with a time range specified.

#2067 was created by @corylanou to fix my bug, but created another issue reported in #2120 and #2027.

In fixing this, I found another few issues (described below).  IMO, they are less severe, so I will leave it up to the owners whether they should be fixed now with this PR or if new issues should be pulled and they should be fixed after.

Also, there is a definite need for more test cases around this.

## Testing

There seems to be 3 types of queries that need to be tested:

1. Raw queries with a time range specified like: `SELECT value FROM my_series WHERE time >= '2015-03-31T00:30:00Z' AND time < '2015-03-31T00:30:10Z'` (with or without both time bounds)

2. Aggregate queries without a group by interval: `SELECT count(value) FROM my_series WHERE time >= '2015-03-31T00:30:00Z' AND time < '2015-03-31T00:30:10Z'`

3. Aggregate queries with a group by interval: `SELECT count(value) FROM my_series WHERE time >= '2015-03-31T00:30:00Z' GROUP BY time(1h)`

To verify these are now correct, I created a database with data points spaced every 2 seconds for a few days.

Here are my findings case-by-case:

### Case 1

Query: `SELECT value FROM my_series WHERE time >= '2015-03-31T00:30:00Z' AND time <= '2015-03-31T00:30:10Z'`

Results (same on master vs this PR):
````json
{
    "results": [
        {
            "series": [
                {
                    "name": "my_series",
                    "columns": [
                        "time",
                        "value"
                    ],
                    "values": [
                        [
                            "2015-03-31T00:30:00Z",
                            79154
                        ],
                        [
                            "2015-03-31T00:30:02Z",
                            79156
                        ],
                        [
                            "2015-03-31T00:30:04Z",
                            79158
                        ],
                        [
                            "2015-03-31T00:30:06Z",
                            79160
                        ],
                        [
                            "2015-03-31T00:30:08Z",
                            79162
                        ]
                    ]
                }
            ]
        }
    ]
}
````

**New Issue 1:** The results are missing the last point at `2015-03-31T00:30:10Z`.  If we run the query with `time < '2015-03-31T00:30:10Z'` (getting rid of equal), we get the same result.  If we add a second (`time < '2015-03-31T00:30:11Z'`), then we get the point back.  The top bound is probably off by a nanosecond.

### Case 2

Query1: `SELECT count(value) FROM my_series WHERE time >= '2015-03-31T00:30:00Z' AND time < '2015-03-31T00:30:10Z'`

Results (same for master and PR):
````json
{
    "results": [
        {
            "series": [
                {
                    "name": "my_series",
                    "columns": [
                        "time",
                        "count"
                    ],
                    "values": [
                        [
                            "2015-03-31T00:30:00Z",
                            5
                        ]
                    ]
                }
            ]
        }
    ]
}
````

Query 2: `SELECT count(value) FROM my_series WHERE time >= '2015-03-31T00:30:00Z'`

This query is where the bug fix comes in.  In master we get inconsistent values (0, 2760, 17392, 37953, etc).  Timestamps varied as well.  With this PR, we get:
````json
{
    "results": [
        {
            "series": [
                {
                    "name": "my_series",
                    "columns": [
                        "time",
                        "count"
                    ],
                    "values": [
                        [
                            "2015-03-31T00:30:00Z",
                            37953
                        ]
                    ]
                }
            ]
        }
    ]
}
````

As expected, the PR fixes this issue.

### Case 3

Query: `SELECT count(value) FROM my_series WHERE time >= '2015-03-31T00:30:00Z' AND time < '2015-03-31T4:30:00Z' GROUP BY time(1h)`

Results (same in master and PR):
````json
{
    "results": [
        {
            "series": [
                {
                    "name": "my_series",
                    "columns": [
                        "time",
                        "count"
                    ],
                    "values": [
                        [
                            "2015-03-31T00:00:00Z",
                            900
                        ],
                        [
                            "2015-03-31T01:00:00Z",
                            1800
                        ],
                        [
                            "2015-03-31T02:00:00Z",
                            1800
                        ],
                        [
                            "2015-03-31T03:00:00Z",
                            1800
                        ],
                        [
                            "2015-03-31T04:00:00Z",
                            1800
                        ]
                    ]
                }
            ]
        }
    ]
}
````

**New Issue 2:** In the last time interval we get all the results back, when we should only be getting half, as we specified `2015-03-31T4:30:00Z` as the end time.  We can vary this from `2015-03-31T4:01:00Z` to `2015-03-31T5:00:00Z` and get the same results.

Please let me know your thoughts on this (and review my changes carefully :) )
