### PR TITLE
Set Go Max procs in a better location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.9.0-rc20 [unreleased]
+
+### Bugfixes
+- [#2147](https://github.com/influxdb/influxdb/pull/2147): Set Go Max procs in a better location
+- 
 ## v0.9.0-rc19 [2015-04-01]
 
 ### Features

--- a/cmd/influxd/main.go
+++ b/cmd/influxd/main.go
@@ -74,13 +74,11 @@ func main() {
 	case "":
 		execRun(args)
 	case "backup":
-		setGoMaxProcs()
 		cmd := NewBackupCommand()
 		if err := cmd.Run(args[1:]...); err != nil {
 			log.Fatalf("backup: %s", err)
 		}
 	case "restore":
-		setGoMaxProcs()
 		cmd := NewRestoreCommand()
 		if err := cmd.Run(args[1:]...); err != nil {
 			log.Fatalf("restore: %s", err)
@@ -94,12 +92,6 @@ func main() {
 	default:
 		log.Fatalf(`influxd: unknown command "%s"`+"\n"+`Run 'influxd help' for usage`+"\n\n", cmd)
 	}
-}
-
-func setGoMaxProcs() {
-	// Set parallelism.
-	runtime.GOMAXPROCS(runtime.NumCPU())
-	log.Printf("GOMAXPROCS set to %d", runtime.GOMAXPROCS(0))
 }
 
 // execRun runs the "run" command.
@@ -125,7 +117,9 @@ func execRun(args []string) {
 	fmt.Print(logo)
 	writePIDFile(*pidPath)
 
-	setGoMaxProcs()
+	// Set parallelism.
+	runtime.GOMAXPROCS(runtime.NumCPU())
+	log.Printf("GOMAXPROCS set to %d", runtime.GOMAXPROCS(0))
 
 	// Parse configuration file from disk.
 	config, err := parseConfig(*configPath, *hostname)

--- a/cmd/influxd/main.go
+++ b/cmd/influxd/main.go
@@ -47,10 +47,6 @@ func main() {
 		commit = "unknown"
 	}
 
-	// Set parallelism.
-	runtime.GOMAXPROCS(runtime.NumCPU())
-	log.Printf("GOMAXPROCS set to %d", runtime.GOMAXPROCS(0))
-
 	// Shift binary name off argument list.
 	args := os.Args[1:]
 
@@ -78,11 +74,13 @@ func main() {
 	case "":
 		execRun(args)
 	case "backup":
+		setGoMaxProcs()
 		cmd := NewBackupCommand()
 		if err := cmd.Run(args[1:]...); err != nil {
 			log.Fatalf("backup: %s", err)
 		}
 	case "restore":
+		setGoMaxProcs()
 		cmd := NewRestoreCommand()
 		if err := cmd.Run(args[1:]...); err != nil {
 			log.Fatalf("restore: %s", err)
@@ -96,6 +94,12 @@ func main() {
 	default:
 		log.Fatalf(`influxd: unknown command "%s"`+"\n"+`Run 'influxd help' for usage`+"\n\n", cmd)
 	}
+}
+
+func setGoMaxProcs() {
+	// Set parallelism.
+	runtime.GOMAXPROCS(runtime.NumCPU())
+	log.Printf("GOMAXPROCS set to %d", runtime.GOMAXPROCS(0))
 }
 
 // execRun runs the "run" command.
@@ -120,6 +124,8 @@ func execRun(args []string) {
 	// Print sweet InfluxDB logo and write the process id to file.
 	fmt.Print(logo)
 	writePIDFile(*pidPath)
+
+	setGoMaxProcs()
 
 	// Parse configuration file from disk.
 	config, err := parseConfig(*configPath, *hostname)


### PR DESCRIPTION
Go max procs doesn't always need to be set.  It doesn't really hurt anything, but the log statement had an undesired side affect.

1) It was printing above the logo, so it felt out of place when the server started up.
2) For thinks like printing usage, or config, it was being written out and again, felt out of place.