### PR TITLE
Make InfluxDB win32 friendly, fix unit test is failed on the windows and it is for directory isn't exists.

### DIFF
--- a/messaging/broker_test.go
+++ b/messaging/broker_test.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
-	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -393,7 +392,7 @@ func TestReadSegments_ENOENT(t *testing.T) {
 	os.RemoveAll(path)
 
 	_, err := messaging.ReadSegments(path)
-	if err == nil || !strings.Contains(err.Error(), "no such file or directory") {
+	if err == nil || !os.IsNotExist(err) {
 		t.Fatal(err)
 	}
 }
@@ -454,7 +453,7 @@ func TestReadSegmentByIndex_ENOENT(t *testing.T) {
 	os.RemoveAll(path)
 
 	_, err := messaging.ReadSegmentByIndex(path, 0)
-	if err == nil || !strings.Contains(err.Error(), "no such file or directory") {
+	if err == nil || !os.IsNotExist(err) {
 		t.Fatalf("unexpected error: %s", err)
 	}
 }

--- a/messaging/client_test.go
+++ b/messaging/client_test.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"os"
 	"reflect"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -73,6 +74,9 @@ func TestClient_Open_WithInvalidConfig(t *testing.T) {
 
 // Ensure a client can return an error if the configuration file has non-readable permissions.
 func TestClient_Open_WithBadPermConfig(t *testing.T) {
+	if "windows" == runtime.GOOS {
+		t.Skip("skip it on the windows")
+	}
 	// Write inaccessible configuration file.
 	path := NewTempFile()
 	defer os.Remove(path)
@@ -82,7 +86,7 @@ func TestClient_Open_WithBadPermConfig(t *testing.T) {
 	// Open new client against path.
 	c := NewClient()
 	if err := c.Open(path); err == nil || !strings.Contains(err.Error(), `permission denied`) {
-		t.Fatalf("unexpected error: %s", err)
+		t.Fatalf("unexpected error: %v", err)
 	}
 	defer c.Close()
 }


### PR DESCRIPTION
Make InfluxDB win32 friendly, fix unit test is failed on the windows and it is for directory isn't exists.