### PR TITLE
Make InfluxDB win32 friendly, fix unit test is failed on the windows and it is for connection refused.

### DIFF
--- a/cmd/influxd/backup_test.go
+++ b/cmd/influxd/backup_test.go
@@ -88,7 +88,8 @@ func TestBackupCommand_ErrConnectionRefused(t *testing.T) {
 	// Execute the backup command.
 	path := tempfile()
 	defer os.Remove(path)
-	if err := NewBackupCommand().Run("-host", s.URL, path); err == nil || !strings.Contains(err.Error(), `connection refused`) {
+	if err := NewBackupCommand().Run("-host", s.URL, path); err == nil ||
+		!(strings.Contains(err.Error(), `connection refused`) || strings.Contains(err.Error(), `No connection could be made`)) {
 		t.Fatal(err)
 	}
 }

--- a/messaging/client_test.go
+++ b/messaging/client_test.go
@@ -20,6 +20,10 @@ func init() {
 	testDataURL, _ = url.Parse("http://localhost:1234/data")
 }
 
+func is_connection_refused(err error) bool {
+	return strings.Contains(err.Error(), `connection refused`) || strings.Contains(err.Error(), `No connection could be made`)
+}
+
 // Ensure a client can open the configuration file, if it exists.
 func TestClient_Open_WithConfig(t *testing.T) {
 	// Write configuration file.
@@ -260,7 +264,7 @@ func TestClient_Publish_ErrConnectionRefused(t *testing.T) {
 	defer c.Close()
 
 	// Publish message to server.
-	if _, err := c.Publish(&messaging.Message{}); err == nil || !strings.Contains(err.Error(), `connection refused`) {
+	if _, err := c.Publish(&messaging.Message{}); err == nil || !is_connection_refused(err) {
 		t.Fatal(err)
 	}
 }
@@ -361,7 +365,7 @@ func TestClient_Ping_ErrConnectionRefused(t *testing.T) {
 	defer c.Close()
 
 	// Ping server.
-	if err := c.Ping(); err == nil || !strings.Contains(err.Error(), `connection refused`) {
+	if err := c.Ping(); err == nil || !is_connection_refused(err) {
 		t.Fatal(err)
 	}
 }
@@ -619,7 +623,7 @@ func TestConn_Heartbeat_ErrConnectionRefused(t *testing.T) {
 	// Create connection and heartbeat.
 	c := messaging.NewConn(0, testDataURL)
 	c.SetURL(*MustParseURL(s.URL))
-	if err := c.Heartbeat(); err == nil || !strings.Contains(err.Error(), `connection refused`) {
+	if err := c.Heartbeat(); err == nil || !is_connection_refused(err) {
 		t.Fatalf("unexpected error: %s", err)
 	}
 }

--- a/raft/transport_test.go
+++ b/raft/transport_test.go
@@ -16,6 +16,10 @@ import (
 	"github.com/influxdb/influxdb/raft"
 )
 
+func is_connection_refused(err error) bool {
+	return strings.Contains(err.Error(), `connection refused`) || strings.Contains(err.Error(), `No connection could be made`)
+}
+
 // Ensure a join over HTTP can be read and responded to.
 func TestHTTPTransport_Join(t *testing.T) {
 	// Start mock HTTP server.
@@ -49,7 +53,7 @@ func TestHTTPTransport_Join(t *testing.T) {
 // Ensure that joining a server that doesn't exist returns an error.
 func TestHTTPTransport_Join_ErrConnectionRefused(t *testing.T) {
 	_, _, _, err := (&raft.HTTPTransport{}).Join(url.URL{Scheme: "http", Host: "localhost:27322"}, url.URL{Host: "local"})
-	if err == nil || !strings.Contains(err.Error(), "connection refused") {
+	if err == nil || !is_connection_refused(err) {
 		t.Fatalf("unexpected error: %s", err)
 	}
 }
@@ -144,7 +148,7 @@ func TestHTTPTransport_Leave(t *testing.T) {
 // Ensure that leaving a server that doesn't exist returns an error.
 func TestHTTPTransport_Leave_ErrConnectionRefused(t *testing.T) {
 	err := (&raft.HTTPTransport{}).Leave(url.URL{Scheme: "http", Host: "localhost:27322"}, 1)
-	if err == nil || !strings.Contains(err.Error(), "connection refused") {
+	if err == nil || !is_connection_refused(err) {
 		t.Fatalf("unexpected error: %s", err)
 	}
 }
@@ -231,7 +235,7 @@ func TestHTTPTransport_Heartbeat_ErrConnectionRefused(t *testing.T) {
 	_, err := (&raft.HTTPTransport{}).Heartbeat(*u, 0, 0, 0)
 	if err == nil {
 		t.Fatal("expected error")
-	} else if !strings.Contains(err.Error(), `connection refused`) {
+	} else if !is_connection_refused(err) {
 		t.Fatalf("unexpected error: %s", err)
 	}
 }
@@ -294,7 +298,7 @@ func TestHTTPTransport_ReadFrom_ErrConnectionRefused(t *testing.T) {
 	_, err := (&raft.HTTPTransport{}).ReadFrom(*u, 0, 0, 0)
 	if err == nil {
 		t.Fatal("expected error")
-	} else if !strings.Contains(err.Error(), `connection refused`) {
+	} else if !is_connection_refused(err) {
 		t.Fatalf("unexpected error: %s", err)
 	}
 }
@@ -351,7 +355,7 @@ func TestHTTPTransport_RequestVote_ErrConnectionRefused(t *testing.T) {
 	u, _ := url.Parse("http://localhost:41932")
 	if err := (&raft.HTTPTransport{}).RequestVote(*u, 0, 0, 0, 0); err == nil {
 		t.Fatal("expected error")
-	} else if !strings.Contains(err.Error(), `connection refused`) {
+	} else if !is_connection_refused(err) {
 		t.Fatalf("unexpected error: %s", err)
 	}
 }


### PR DESCRIPTION
Make InfluxDB win32 friendly, fix unit test is failed on the windows and it is for connection refused.