### PR TITLE
Ignore replayed commands on the metastore.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ### Bugfixes
 - [#2147](https://github.com/influxdb/influxdb/pull/2147): Set Go Max procs in a better location
-- 
+- [#2151](https://github.com/influxdb/influxdb/pull/2151): Ignore replay commands on the metastore.
+
 ## v0.9.0-rc19 [2015-04-01]
 
 ### Features

--- a/metastore.go
+++ b/metastore.go
@@ -76,8 +76,11 @@ func (m *metastore) mustView(fn func(*metatx) error) (err error) {
 // Panics if a disk or system error occurs. Return error from the fn for validation errors.
 func (m *metastore) mustUpdate(index uint64, fn func(*metatx) error) (err error) {
 	if e := m.update(func(tx *metatx) error {
+		// Ignore replayed commands.
 		curr := tx.index()
-		assert(index == 0 || index > curr, "metastore index replay: meta=%d, index=%d", curr, index)
+		if index > 0 && index <= curr {
+			return nil
+		}
 
 		// Execute function passed in.
 		err = fn(tx)


### PR DESCRIPTION
## Overview

This commit changes the `metastore` to ignore any commands that are replayed against it. This is typically handled by the `messaging.Conn` but there's no sense in panicing in the `metastore` if a replayed message comes through.