### PR TITLE
Node redirection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,12 @@
 ### Features
 - [#2128](https://github.com/influxdb/influxdb/pull/2128): Data node discovery from brokers
 - [#2142](https://github.com/influxdb/influxdb/pull/2142): Support chunked queries
+- [#2154](https://github.com/influxdb/influxdb/pull/2154): Node redirection
 
 ### Bugfixes
 - [#2147](https://github.com/influxdb/influxdb/pull/2147): Set Go Max procs in a better location
 - [#2151](https://github.com/influxdb/influxdb/pull/2151): Ignore replay commands on the metastore.
+- [#2152](https://github.com/influxdb/influxdb/issues/2152): Influxd process with stats enabled crashing with 'Unsuported protocol scheme for ""'
 - [#2156](https://github.com/influxdb/influxdb/pull/2156): Propagate error when resolving UDP address in Graphite UDP server.
 - [#2163](https://github.com/influxdb/influxdb/pull/2163): Fix up paths for default data and run storage.
 - [#2164](https://github.com/influxdb/influxdb/pull/2164): Append STDOUT/STDERR in init script.

--- a/cmd/influxd/handler.go
+++ b/cmd/influxd/handler.go
@@ -1,42 +1,116 @@
 package main
 
 import (
+	"log"
 	"net/http"
+	"net/url"
 	"strings"
+
+	"github.com/influxdb/influxdb"
+	"github.com/influxdb/influxdb/httpd"
+	"github.com/influxdb/influxdb/messaging"
+	"github.com/influxdb/influxdb/raft"
 )
 
 // Handler represents an HTTP handler for InfluxDB node.
 // Depending on its role, it will serve many different endpoints.
 type Handler struct {
-	brokerHandler http.Handler
-	serverHandler http.Handler
+	Log    *raft.Log
+	Broker *influxdb.Broker
+	Server *influxdb.Server
+	Config *Config
 }
 
 // NewHandler returns a new instance of Handler.
-func NewHandler(bh, sh http.Handler) *Handler {
-	return &Handler{
-		brokerHandler: bh,
-		serverHandler: sh,
-	}
+func NewHandler() *Handler {
+	return &Handler{}
 }
 
 // ServeHTTP responds to HTTP request to the handler.
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	// Route raft and messaging paths to the broker.
-	if strings.HasPrefix(r.URL.Path, "/raft") || strings.HasPrefix(r.URL.Path, "/messaging") {
-		if h.brokerHandler == nil {
-			http.NotFound(w, r)
-			return
+	if strings.HasPrefix(r.URL.Path, "/raft") {
+		h.serveRaft(w, r)
+		return
+	}
+	if strings.HasPrefix(r.URL.Path, "/messaging") {
+		h.serveMessaging(w, r)
+		return
+	}
+
+	h.serveData(w, r)
+}
+
+// serveMessaging responds to broker requests
+func (h *Handler) serveMessaging(w http.ResponseWriter, r *http.Request) {
+	if h.Broker == nil && h.Server == nil {
+		log.Println("no broker or server configured to handle messaging endpoints")
+		http.Error(w, "server unavailable", http.StatusServiceUnavailable)
+		return
+	}
+
+	// If we're running a broker, handle the broker endpoints
+	if h.Broker != nil {
+		mh := &messaging.Handler{
+			Broker:      h.Broker.Broker,
+			RaftHandler: &raft.Handler{Log: h.Log},
 		}
-
-		h.brokerHandler.ServeHTTP(w, r)
+		mh.ServeHTTP(w, r)
 		return
 	}
 
-	// Route all other paths to the server.
-	if h.serverHandler == nil {
-		http.NotFound(w, r)
+	// Redirect to a valid broker to handle the request
+	h.redirect(h.Server.BrokerURLs(), w, r)
+}
+
+// serveRaft responds to raft requests.
+func (h *Handler) serveRaft(w http.ResponseWriter, r *http.Request) {
+	if h.Log == nil && h.Server == nil {
+		log.Println("no broker or server configured to handle messaging endpoints")
+		http.Error(w, "server unavailable", http.StatusServiceUnavailable)
 		return
 	}
-	h.serverHandler.ServeHTTP(w, r)
+
+	if h.Log != nil {
+		rh := raft.Handler{Log: h.Log}
+		rh.ServeHTTP(w, r)
+		return
+	}
+
+	// Redirect to a valid broker to handle the request
+	h.redirect(h.Server.BrokerURLs(), w, r)
+}
+
+// serveData responds to data requests
+func (h *Handler) serveData(w http.ResponseWriter, r *http.Request) {
+	if h.Broker == nil && h.Server == nil {
+		log.Println("no broker or server configured to handle messaging endpoints")
+		http.Error(w, "server unavailable", http.StatusServiceUnavailable)
+		return
+	}
+
+	if h.Server != nil {
+		sh := httpd.NewHandler(h.Server, h.Config.Authentication.Enabled, version)
+		sh.WriteTrace = h.Config.Logging.WriteTracing
+		sh.ServeHTTP(w, r)
+		return
+	}
+
+	// Redirect to a valid data URL to handle the request
+	h.redirect(h.Broker.Topic(influxdb.BroadcastTopicID).DataURLs(), w, r)
+}
+
+// redirect redirects a request to URL in u.  If u is an empty slice,
+// a 503 is returned
+func (h *Handler) redirect(u []url.URL, w http.ResponseWriter, r *http.Request) {
+	// No valid URLs, return an error
+	if len(u) == 0 {
+		http.Error(w, "service unavailable", http.StatusServiceUnavailable)
+		return
+	}
+
+	// TODO: Log to internal stats to track how frequently this is happening. If
+	// this is happening frequently, the clients are using a suboptimal endpoint
+
+	// Redirect the client to a valid data node that can handle the request
+	http.Redirect(w, r, u[0].String()+r.RequestURI, http.StatusTemporaryRedirect)
 }

--- a/cmd/influxd/run.go
+++ b/cmd/influxd/run.go
@@ -310,13 +310,10 @@ func openServer(config *Config, b *influxdb.Broker, initServer, initBroker bool,
 
 	// Create messaging client to the brokers.
 	c := influxdb.NewMessagingClient(config.DataURL())
+	c.SetURLs(clientJoinURLs)
+
 	if err := c.Open(filepath.Join(config.Data.Dir, messagingClientFile)); err != nil {
 		log.Fatalf("messaging client error: %s", err)
-	}
-
-	// If join URLs were passed in then use them to override the client's URLs.
-	if len(clientJoinURLs) > 0 {
-		c.SetURLs(clientJoinURLs)
 	}
 
 	// If no URLs exist on the client the return an error since we cannot reach a broker.

--- a/messaging/broker.go
+++ b/messaging/broker.go
@@ -670,6 +670,17 @@ func (t *Topic) Index() uint64 {
 	return t.index
 }
 
+// DataURLs returns the data node URLs subscribed to this topic
+func (t *Topic) DataURLs() []url.URL {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	var urls []url.URL
+	for u, _ := range t.indexByURL {
+		urls = append(urls, u)
+	}
+	return urls
+}
+
 // IndexForURL returns the highest index replicated for a given data URL.
 func (t *Topic) IndexForURL(u url.URL) uint64 {
 	t.mu.Lock()

--- a/messaging/client.go
+++ b/messaging/client.go
@@ -197,7 +197,6 @@ func (c *Client) loadConfig() error {
 	// Open config file for reading.
 	f, err := os.Open(c.path)
 	if os.IsNotExist(err) {
-		c.urls = nil
 		return nil
 	} else if err != nil {
 		return fmt.Errorf("open config: %s", err)

--- a/messaging/client_test.go
+++ b/messaging/client_test.go
@@ -49,16 +49,21 @@ func TestClient_Open_WithConfig(t *testing.T) {
 func TestClient_Open_WithMissingConfig(t *testing.T) {
 	path := NewTempFile()
 	c := NewClient()
-	c.SetURLs([]url.URL{{Host: "//hostA"}})
+	c.SetURLs([]url.URL{{Host: "hostA"}})
 	if err := c.Open(path); err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
 	defer c.Close()
 
 	// Verify that urls were cleared.
-	if a := c.URLs(); len(a) != 0 {
-		t.Fatalf("unexpected urls: %#v", a)
+	if a := c.URLs(); len(a) != 1 {
+		t.Fatalf("unexpected urls: exp 1, got: %d", len(a))
 	}
+
+	if exp, got := "//hostA", c.URLs()[0].String(); exp != got {
+		t.Fatalf("unexpected urls: exp %q, got: %v", got, exp)
+	}
+
 }
 
 // Ensure a client can return an error if the configuration file is corrupt.

--- a/server.go
+++ b/server.go
@@ -122,6 +122,10 @@ func NewServer() *Server {
 	return &s
 }
 
+func (s *Server) BrokerURLs() []url.URL {
+	return s.client.URLs()
+}
+
 // SetAuthenticationEnabled turns on or off server authentication
 func (s *Server) SetAuthenticationEnabled(enabled bool) {
 	s.authenticationEnabled = enabled


### PR DESCRIPTION
This change allows a given node to handle broker  (`/raft`, `/messages`) and data (`/data_nodes_*`, etc..) endpoints even when they are not operating as that role.  The behavior works as follows:

For a broker only node, requests for broker endpoints are handled as before.  Requests for data node endpoints are returned with a HTTP redirect to the first data node URL that the broker knows about.  Brokers learn about data node URLs through the heartbeat for the topics they are subscribed.

For a data only node, requests for broker endpoints are handled as before.  Requests for broker node endpoints are returned with a HTTP redirect to the first broker node URL that the data node knows about.  Data nodes learn about brokers boot time through join URLs or through the config store in the metastore on a restart. 

When a node is running as both a broker and a data node, the all requests are handled by the node itself.