### PR TITLE
Fix swallowed error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Bugfixes
 - [#2147](https://github.com/influxdb/influxdb/pull/2147): Set Go Max procs in a better location
 - [#2151](https://github.com/influxdb/influxdb/pull/2151): Ignore replay commands on the metastore.
+- [#2156](https://github.com/influxdb/influxdb/pull/2156): Propagate error when resolving UDP address in Graphite UDP server.
 
 ## v0.9.0-rc19 [2015-04-01]
 

--- a/graphite/graphite_udp.go
+++ b/graphite/graphite_udp.go
@@ -42,7 +42,7 @@ func (u *UDPServer) ListenAndServe(iface string) error {
 
 	addr, err := net.ResolveUDPAddr("udp", iface)
 	if err != nil {
-		return nil
+		return err
 	}
 
 	conn, err := net.ListenUDP("udp", addr)


### PR DESCRIPTION
Looks like the `return nil` that was there before was probably a typo.