### PR TITLE
Add support for SET PASSWORD FOR user = 'PASSWORD'

### DIFF
--- a/influxql/ast.go
+++ b/influxql/ast.go
@@ -85,6 +85,7 @@ func (*ShowTagValuesStatement) node()         {}
 func (*ShowUsersStatement) node()             {}
 func (*RevokeStatement) node()                {}
 func (*SelectStatement) node()                {}
+func (*SetPasswordUserStatement) node()       {}
 
 func (*BinaryExpr) node()      {}
 func (*BooleanLiteral) node()  {}
@@ -179,6 +180,7 @@ func (*ShowTagValuesStatement) stmt()         {}
 func (*ShowUsersStatement) stmt()             {}
 func (*RevokeStatement) stmt()                {}
 func (*SelectStatement) stmt()                {}
+func (*SetPasswordUserStatement) stmt()       {}
 
 // Expr represents an expression that can be evaluated to a value.
 type Expr interface {
@@ -429,6 +431,30 @@ func (s *GrantStatement) String() string {
 
 // RequiredPrivileges returns the privilege required to execute a GrantStatement.
 func (s *GrantStatement) RequiredPrivileges() ExecutionPrivileges {
+	return ExecutionPrivileges{{Name: "", Privilege: AllPrivileges}}
+}
+
+// SetPasswordUserStatement represents a command for chaning user password.
+type SetPasswordUserStatement struct {
+	// Plain Password
+	Password string
+
+	// Who to grant the privilege to.
+	Name string
+}
+
+// String returns a string representation of the set password statement.
+func (s *SetPasswordUserStatement) String() string {
+	var buf bytes.Buffer
+	_, _ = buf.WriteString("SET PASSWORD FOR ")
+	_, _ = buf.WriteString(s.Name)
+	_, _ = buf.WriteString(" = ")
+	_, _ = buf.WriteString(s.Password)
+	return buf.String()
+}
+
+// RequiredPrivileges returns the privilege required to execute a GrantStatement.
+func (s *SetPasswordUserStatement) RequiredPrivileges() ExecutionPrivileges {
 	return ExecutionPrivileges{{Name: "", Privilege: AllPrivileges}}
 }
 

--- a/influxql/parser_test.go
+++ b/influxql/parser_test.go
@@ -649,6 +649,15 @@ func TestParser_ParseStatement(t *testing.T) {
 			},
 		},
 
+		// SET PASSWORD FOR USER
+		{
+			s: `SET PASSWORD FOR testuser = 'pwd1337'`,
+			stmt: &influxql.SetPasswordUserStatement{
+				Name:      "testuser",
+				Password:  "pwd1337",
+			},
+		},
+
 		// DROP CONTINUOUS QUERY statement
 		{
 			s:    `DROP CONTINUOUS QUERY myquery ON foo`,
@@ -877,9 +886,9 @@ func TestParser_ParseStatement(t *testing.T) {
 		},
 
 		// Errors
-		{s: ``, err: `found EOF, expected SELECT, DELETE, SHOW, CREATE, DROP, GRANT, REVOKE, ALTER at line 1, char 1`},
+		{s: ``, err: `found EOF, expected SELECT, DELETE, SHOW, CREATE, DROP, GRANT, REVOKE, ALTER, SET at line 1, char 1`},
 		{s: `SELECT`, err: `found EOF, expected identifier, string, number, bool at line 1, char 8`},
-		{s: `blah blah`, err: `found blah, expected SELECT, DELETE, SHOW, CREATE, DROP, GRANT, REVOKE, ALTER at line 1, char 1`},
+		{s: `blah blah`, err: `found blah, expected SELECT, DELETE, SHOW, CREATE, DROP, GRANT, REVOKE, ALTER, SET at line 1, char 1`},
 		{s: `SELECT field1 X`, err: `found X, expected FROM at line 1, char 15`},
 		{s: `SELECT field1 FROM "series" WHERE X +;`, err: `found ;, expected identifier, string, number, bool at line 1, char 38`},
 		{s: `SELECT field1 FROM myseries GROUP`, err: `found EOF, expected BY at line 1, char 35`},
@@ -955,6 +964,13 @@ func TestParser_ParseStatement(t *testing.T) {
 		{s: `ALTER RETENTION POLICY`, err: `found EOF, expected identifier at line 1, char 24`},
 		{s: `ALTER RETENTION POLICY policy1`, err: `found EOF, expected ON at line 1, char 32`}, {s: `ALTER RETENTION POLICY policy1 ON`, err: `found EOF, expected identifier at line 1, char 35`},
 		{s: `ALTER RETENTION POLICY policy1 ON testdb`, err: `found EOF, expected DURATION, RETENTION, DEFAULT at line 1, char 42`},
+		{s: `SET`, err: `found EOF, expected PASSWORD at line 1, char 5`},
+		{s: `SET PASSWORD`, err: `found EOF, expected FOR at line 1, char 14`},
+		{s: `SET PASSWORD something`, err: `found something, expected FOR at line 1, char 14`},
+		{s: `SET PASSWORD FOR`, err: `found EOF, expected identifier at line 1, char 18`},
+		{s: `SET PASSWORD FOR dejan`, err: `found EOF, expected = at line 1, char 24`},
+		{s: `SET PASSWORD FOR dejan =`, err: `found EOF, expected string at line 1, char 25`},
+		{s: `SET PASSWORD FOR dejan = bla`, err: `found bla, expected string at line 1, char 26`},
 	}
 
 	for i, tt := range tests {

--- a/influxql/token.go
+++ b/influxql/token.go
@@ -74,6 +74,7 @@ const (
 	EXISTS
 	EXPLAIN
 	FIELD
+	FOR
 	FROM
 	GRANT
 	GROUP
@@ -104,6 +105,7 @@ const (
 	SELECT
 	SERIES
 	SERVERS
+	SET
 	SHOW
 	SLIMIT
 	STATS
@@ -177,6 +179,7 @@ var tokens = [...]string{
 	EXISTS:       "EXISTS",
 	EXPLAIN:      "EXPLAIN",
 	FIELD:        "FIELD",
+	FOR:          "FOR",
 	FROM:         "FROM",
 	GRANT:        "GRANT",
 	GROUP:        "GROUP",
@@ -207,6 +210,7 @@ var tokens = [...]string{
 	SELECT:       "SELECT",
 	SERIES:       "SERIES",
 	SERVERS:      "SERVERS",
+	SET:          "SET",
 	SHOW:         "SHOW",
 	SLIMIT:       "SLIMIT",
 	SOFFSET:      "SOFFSET",

--- a/server.go
+++ b/server.go
@@ -2073,6 +2073,8 @@ func (s *Server) ExecuteQuery(q *influxql.Query, database string, user *User, ch
 				res = s.executeShowServersStatement(stmt, user)
 			case *influxql.CreateUserStatement:
 				res = s.executeCreateUserStatement(stmt, user)
+			case *influxql.SetPasswordUserStatement:
+				res = s.executeSetPasswordUserStatement(stmt, user)
 			case *influxql.DeleteStatement:
 				res = s.executeDeleteStatement()
 			case *influxql.DropUserStatement:
@@ -2350,6 +2352,10 @@ func (s *Server) executeCreateUserStatement(q *influxql.CreateUserStatement, use
 		isAdmin = *q.Privilege == influxql.AllPrivileges
 	}
 	return &Result{Err: s.CreateUser(q.Name, q.Password, isAdmin)}
+}
+
+func (s *Server) executeSetPasswordUserStatement(q *influxql.SetPasswordUserStatement, user *User) *Result {
+	return &Result{Err: s.UpdateUser(q.Name, q.Password)}
 }
 
 func (s *Server) executeDropUserStatement(q *influxql.DropUserStatement, user *User) *Result {


### PR DESCRIPTION
Added support for the set password for user, so we can update user password via the new server administration commands.

Example:

curl -s -G http://localhost:8086//query?db=&q=set+password+for+dejan+%3D+%golja%27