### PR TITLE
Broker log recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - [#2156](https://github.com/influxdb/influxdb/pull/2156): Propagate error when resolving UDP address in Graphite UDP server.
 - [#2163](https://github.com/influxdb/influxdb/pull/2163): Fix up paths for default data and run storage.
 - [#2164](https://github.com/influxdb/influxdb/pull/2164): Append STDOUT/STDERR in initscript.
+- [#2167](https://github.com/influxdb/influxdb/pull/2167): Add broker log recovery.
 
 ## v0.9.0-rc19 [2015-04-01]
 

--- a/messaging/client.go
+++ b/messaging/client.go
@@ -665,7 +665,7 @@ func (c *Conn) stream(req *http.Request, closing <-chan struct{}) error {
 	c.Logger.Printf("connected to broker: %s", req.URL.String())
 
 	// Continuously decode messages from request body in a separate goroutine.
-	dec := NewMessageDecoder(resp.Body)
+	dec := NewMessageDecoder(&nopSeeker{resp.Body})
 	for {
 		// Decode message from the stream.
 		m := &Message{}
@@ -703,3 +703,9 @@ func urlsEqual(a, b []url.URL) bool {
 	}
 	return true
 }
+
+type nopSeeker struct {
+	io.Reader
+}
+
+func (*nopSeeker) Seek(offset int64, whence int) (int64, error) { return 0, nil }

--- a/messaging/handler.go
+++ b/messaging/handler.go
@@ -19,7 +19,10 @@ type Handler struct {
 		URLs() []url.URL
 		IsLeader() bool
 		LeaderURL() url.URL
-		TopicReader(topicID, index uint64, streaming bool) io.ReadCloser
+		TopicReader(topicID, index uint64, streaming bool) interface {
+			io.ReadCloser
+			io.Seeker
+		}
 		Publish(m *Message) (uint64, error)
 		SetTopicMaxIndex(topicID, index uint64, u url.URL) error
 	}


### PR DESCRIPTION
## Overview

This pull request adds recovery to the messaging.Topic when opening. If any partial messages are found then the file is truncated at that point and started from there. This can occur when ungracefully shutting down a server. It can leave half written messages at the end of segments.