### PR TITLE
Separate broker and data nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Features
 - [#870](https://github.com/influxdb/influxdb/pull/870): Add support for OpenTSDB telnet input protocol. Thanks @tcolgate
+- [#2175](https://github.com/influxdb/influxdb/pull/2175): Separate broker and data nodes
 
 ## v0.9.0-rc20 [2015-04-04]
 

--- a/cmd/influxd/config.go
+++ b/cmd/influxd/config.go
@@ -42,9 +42,6 @@ const (
 	// DefaultSnapshotPort is the default port to serve snapshots from.
 	DefaultSnapshotPort = 8087
 
-	// DefaultJoinURLs represents the default URLs for joining a cluster.
-	DefaultJoinURLs = ""
-
 	// DefaultRetentionCreatePeriod represents how often the server will check to see if new
 	// shard groups need to be created in advance for writing
 	DefaultRetentionCreatePeriod = 45 * time.Minute
@@ -116,7 +113,6 @@ type Data struct {
 	RetentionCheckEnabled bool     `toml:"retention-check-enabled"`
 	RetentionCheckPeriod  Duration `toml:"retention-check-period"`
 	RetentionCreatePeriod Duration `toml:"retention-create-period"`
-	JoinURLs              string   `toml:"join-urls"`
 }
 
 // Config represents the configuration format for the influxd binary.
@@ -127,10 +123,6 @@ type Config struct {
 	ReportingDisabled bool   `toml:"reporting-disabled"`
 	Version           string `toml:"-"`
 	InfluxDBVersion   string `toml:"-"`
-
-	Initialization struct {
-		JoinURLs string `toml:"join-urls"`
-	} `toml:"initialization"`
 
 	Authentication struct {
 		Enabled bool `toml:"enabled"`
@@ -319,14 +311,6 @@ func (c *Config) DataDir() string {
 		log.Fatalf("Unable to get absolute path for Data Directory: %q", c.Data.Dir)
 	}
 	return p
-}
-
-func (c *Config) JoinURLs() string {
-	if c.Initialization.JoinURLs == "" {
-		return DefaultJoinURLs
-	} else {
-		return c.Initialization.JoinURLs
-	}
 }
 
 // ShardGroupPreCreateCheckPeriod returns the check interval to pre-create shard groups.

--- a/cmd/influxd/config.go
+++ b/cmd/influxd/config.go
@@ -280,8 +280,8 @@ func (c *Config) APIAddr() string {
 	return net.JoinHostPort(ba, strconv.Itoa(c.HTTPAPI.Port))
 }
 
-// DataAddrUDP returns the UDP address for the series listener.
-func (c *Config) DataAddrUDP() string {
+// APIAddrUDP returns the UDP address for the series listener.
+func (c *Config) APIAddrUDP() string {
 	return net.JoinHostPort(c.UDP.BindAddress, strconv.Itoa(c.UDP.Port))
 }
 

--- a/cmd/influxd/config.go
+++ b/cmd/influxd/config.go
@@ -57,6 +57,39 @@ const (
 
 	// DefaultOpenTSDBDatabaseName is the default OpenTSDB database if none is specified
 	DefaultOpenTSDBDatabaseName = "opentsdb"
+
+	// DefaultRetentionAutoCreate is the default for auto-creating retention policies
+	DefaultRetentionAutoCreate = true
+
+	// DefaultRetentionCheckEnabled is the default for checking for retention policy enforcement
+	DefaultRetentionCheckEnabled = true
+
+	// DefaultRetentionCheckPeriod is the period of time between retention policy checks are run
+	DefaultRetentionCheckPeriod = 10 * time.Minute
+
+	// DefaultRecomputePreviousN is ???
+	DefaultContinuousQueryRecomputePreviousN = 2
+
+	// DefaultContinuousQueryRecomputeNoOlderThan is ???
+	DefaultContinuousQueryRecomputeNoOlderThan = 10 * time.Minute
+
+	// DefaultContinuousQueryComputeRunsPerInterval is ???
+	DefaultContinuousQueryComputeRunsPerInterval = 10
+
+	// DefaultContinousQueryComputeNoMoreThan is ???
+	DefaultContinousQueryComputeNoMoreThan = 2 * time.Minute
+
+	// DefaultStatisticsEnabled is the default setting for whether internal statistics are collected
+	DefaultStatisticsEnabled = false
+
+	// DefaultStatisticsDatabase is the default database internal statistics are written
+	DefaultStatisticsDatabase = "_internal"
+
+	// DefaultStatisticsRetentionPolicy is he default internal statistics rentention policy name
+	DefaultStatisticsRetentionPolicy = "default"
+
+	// DefaultStatisticsWriteInterval is the interval of time between internal stats are written
+	DefaultStatisticsWriteInterval = 1 * time.Minute
 )
 
 var DefaultSnapshotURL = url.URL{
@@ -182,38 +215,27 @@ type Config struct {
 }
 
 // NewConfig returns an instance of Config with reasonable defaults.
-func NewConfig() (*Config, error) {
-	u, err := user.Current()
-	if err != nil {
-		return nil, fmt.Errorf("failed to determine current user for storage")
-	}
-
+func NewConfig() *Config {
 	c := &Config{}
-	c.Broker.Enabled = true
-	c.Broker.Dir = filepath.Join(u.HomeDir, ".influxdb/broker")
-	c.Broker.Port = DefaultBrokerPort
 	c.Broker.Timeout = Duration(1 * time.Second)
-	c.Data.Enabled = true
-	c.Data.Dir = filepath.Join(u.HomeDir, ".influxdb/data")
+	c.Broker.Port = DefaultBrokerPort
+
 	c.Data.Port = DefaultDataPort
-	c.Data.RetentionAutoCreate = true
-	c.Data.RetentionCheckEnabled = true
-	c.Data.RetentionCheckPeriod = Duration(10 * time.Minute)
+
+	c.Data.RetentionAutoCreate = DefaultRetentionAutoCreate
+	c.Data.RetentionCheckEnabled = DefaultRetentionCheckEnabled
+	c.Data.RetentionCheckPeriod = Duration(DefaultRetentionCheckPeriod)
 	c.Data.RetentionCreatePeriod = Duration(DefaultRetentionCreatePeriod)
-	c.Snapshot.Enabled = true
+
 	c.Snapshot.BindAddress = DefaultSnapshotBindAddress
 	c.Snapshot.Port = DefaultSnapshotPort
-	c.Admin.Enabled = true
-	c.Admin.Port = 8083
-	c.ContinuousQuery.RecomputePreviousN = 2
-	c.ContinuousQuery.RecomputeNoOlderThan = Duration(10 * time.Minute)
-	c.ContinuousQuery.ComputeRunsPerInterval = 10
-	c.ContinuousQuery.ComputeNoMoreThan = Duration(2 * time.Minute)
-	c.ContinuousQuery.Disabled = false
-	c.ReportingDisabled = false
 
 	c.Monitoring.Enabled = false
-	c.Monitoring.WriteInterval = Duration(1 * time.Minute)
+	c.Monitoring.WriteInterval = Duration(DefaultStatisticsWriteInterval)
+	c.ContinuousQuery.RecomputePreviousN = DefaultContinuousQueryRecomputePreviousN
+	c.ContinuousQuery.RecomputeNoOlderThan = Duration(DefaultContinuousQueryRecomputeNoOlderThan)
+	c.ContinuousQuery.ComputeRunsPerInterval = DefaultContinuousQueryComputeRunsPerInterval
+	c.ContinuousQuery.ComputeNoMoreThan = Duration(DefaultContinousQueryComputeNoMoreThan)
 
 	// Detect hostname (or set to localhost).
 	if c.Hostname, _ = os.Hostname(); c.Hostname == "" {
@@ -226,6 +248,32 @@ func NewConfig() (*Config, error) {
 	// 	Database: tomlConfiguration.InputPlugins.UDPInput.Database,
 	// 	Port:     tomlConfiguration.InputPlugins.UDPInput.Port,
 	// })
+
+	return c
+}
+
+// NewTestConfig returns an instance of Config with reasonable defaults suitable
+// for testing a local server w/ broker and data nodes active
+func NewTestConfig() (*Config, error) {
+	c := NewConfig()
+
+	// By default, store broker and data files in current users home directory
+	u, err := user.Current()
+	if err != nil {
+		return nil, fmt.Errorf("failed to determine current user for storage")
+	}
+
+	c.Broker.Enabled = true
+	c.Broker.Dir = filepath.Join(u.HomeDir, ".influxdb/broker")
+
+	c.Data.Enabled = true
+	c.Data.Dir = filepath.Join(u.HomeDir, ".influxdb/data")
+
+	c.Admin.Enabled = true
+	c.Admin.Port = 8083
+
+	c.Monitoring.Enabled = false
+	c.Snapshot.Enabled = true
 
 	return c, nil
 }
@@ -370,10 +418,8 @@ func (d Duration) MarshalText() (text []byte, err error) {
 
 // ParseConfigFile parses a configuration file at a given path.
 func ParseConfigFile(path string) (*Config, error) {
-	c, err := NewConfig()
-	if err != nil {
-		return nil, err
-	}
+	c := NewConfig()
+
 	if _, err := toml.DecodeFile(path, &c); err != nil {
 		return nil, err
 	}
@@ -382,10 +428,8 @@ func ParseConfigFile(path string) (*Config, error) {
 
 // ParseConfig parses a configuration string into a config object.
 func ParseConfig(s string) (*Config, error) {
-	c, err := NewConfig()
-	if err != nil {
-		return nil, err
-	}
+	c := NewConfig()
+
 	if _, err := toml.Decode(s, &c); err != nil {
 		return nil, err
 	}

--- a/cmd/influxd/config.go
+++ b/cmd/influxd/config.go
@@ -64,6 +64,30 @@ var DefaultSnapshotURL = url.URL{
 	Host:   net.JoinHostPort(DefaultSnapshotBindAddress, strconv.Itoa(DefaultSnapshotPort)),
 }
 
+// Broker represents the configuration for a broker node
+type Broker struct {
+	Port    int      `toml:"port"`
+	Dir     string   `toml:"dir"`
+	Timeout Duration `toml:"election-timeout"`
+}
+
+// Snapshot represents the configuration for a snapshot service
+type Snapshot struct {
+	Enabled     bool   `toml:"enabled"`
+	BindAddress string `toml:"bind-address"`
+	Port        int    `toml:"port"`
+}
+
+// Data represents the configuration for a data node
+type Data struct {
+	Dir                   string   `toml:"dir"`
+	Port                  int      `toml:"port"`
+	RetentionAutoCreate   bool     `toml:"retention-auto-create"`
+	RetentionCheckEnabled bool     `toml:"retention-check-enabled"`
+	RetentionCheckPeriod  Duration `toml:"retention-check-period"`
+	RetentionCreatePeriod Duration `toml:"retention-create-period"`
+}
+
 // Config represents the configuration format for the influxd binary.
 type Config struct {
 	Hostname          string `toml:"hostname"`
@@ -102,26 +126,12 @@ type Config struct {
 		Port        int    `toml:"port"`
 	} `toml:"udp"`
 
-	Broker struct {
-		Port    int      `toml:"port"`
-		Dir     string   `toml:"dir"`
-		Timeout Duration `toml:"election-timeout"`
-	} `toml:"broker"`
+	Broker Broker `toml:"broker"`
 
-	Data struct {
-		Dir                   string   `toml:"dir"`
-		Port                  int      `toml:"port"`
-		RetentionAutoCreate   bool     `toml:"retention-auto-create"`
-		RetentionCheckEnabled bool     `toml:"retention-check-enabled"`
-		RetentionCheckPeriod  Duration `toml:"retention-check-period"`
-		RetentionCreatePeriod Duration `toml:"retention-create-period"`
-	} `toml:"data"`
+	Data Data `toml:"data"`
 
-	Snapshot struct {
-		Enabled     bool   `toml:"enabled"`
-		BindAddress string `toml:"bind-address"`
-		Port        int    `toml:"port"`
-	}
+	Snapshot Snapshot `toml:"snapshot"`
+
 	Cluster struct {
 		Dir string `toml:"dir"`
 	} `toml:"cluster"`

--- a/cmd/influxd/config.go
+++ b/cmd/influxd/config.go
@@ -217,7 +217,6 @@ type Config struct {
 // NewConfig returns an instance of Config with reasonable defaults.
 func NewConfig() *Config {
 	c := &Config{}
-	c.Broker.Timeout = Duration(1 * time.Second)
 	c.Broker.Port = DefaultBrokerPort
 
 	c.Data.Port = DefaultDataPort

--- a/cmd/influxd/config.go
+++ b/cmd/influxd/config.go
@@ -33,6 +33,9 @@ const (
 	// DefaultAPIReadTimeout represents the duration before an API request times out.
 	DefaultAPIReadTimeout = 5 * time.Second
 
+	// DefaultClusterPort represents the default port the cluster runs ons.
+	DefaultClusterPort = 8086
+
 	// DefaultBrokerPort represents the default port the broker runs on.
 	DefaultBrokerPort = 8086
 
@@ -128,6 +131,7 @@ type Data struct {
 type Config struct {
 	Hostname          string `toml:"hostname"`
 	BindAddress       string `toml:"bind-address"`
+	Port              int    `toml:"port"`
 	ReportingDisabled bool   `toml:"reporting-disabled"`
 	Version           string `toml:"-"`
 	InfluxDBVersion   string `toml:"-"`
@@ -214,8 +218,8 @@ type Config struct {
 // NewConfig returns an instance of Config with reasonable defaults.
 func NewConfig() *Config {
 	c := &Config{}
+	c.Port = DefaultClusterPort
 	c.Broker.Port = DefaultBrokerPort
-
 	c.Data.Port = DefaultDataPort
 
 	c.Data.RetentionAutoCreate = DefaultRetentionAutoCreate

--- a/cmd/influxd/config.go
+++ b/cmd/influxd/config.go
@@ -393,8 +393,8 @@ func ParseConfig(s string) (*Config, error) {
 }
 
 type Collectd struct {
-	Addr string `toml:"address"`
-	Port uint16 `toml:"port"`
+	BindAddress string `toml:"bind-address"`
+	Port        uint16 `toml:"port"`
 
 	Database string `toml:"database"`
 	Enabled  bool   `toml:"enabled"`
@@ -403,7 +403,7 @@ type Collectd struct {
 
 // ConnnectionString returns the connection string for this collectd config in the form host:port.
 func (c *Collectd) ConnectionString(defaultBindAddr string) string {
-	addr := c.Addr
+	addr := c.BindAddress
 	// If no address specified, use default.
 	if addr == "" {
 		addr = defaultBindAddr
@@ -419,8 +419,8 @@ func (c *Collectd) ConnectionString(defaultBindAddr string) string {
 }
 
 type Graphite struct {
-	Addr string `toml:"address"`
-	Port uint16 `toml:"port"`
+	BindAddress string `toml:"bind-address"`
+	Port        uint16 `toml:"port"`
 
 	Database      string `toml:"database"`
 	Enabled       bool   `toml:"enabled"`
@@ -432,7 +432,7 @@ type Graphite struct {
 // ConnnectionString returns the connection string for this Graphite config in the form host:port.
 func (g *Graphite) ConnectionString(defaultBindAddr string) string {
 
-	addr := g.Addr
+	addr := g.BindAddress
 	// If no address specified, use default.
 	if addr == "" {
 		addr = defaultBindAddr

--- a/cmd/influxd/config.go
+++ b/cmd/influxd/config.go
@@ -68,6 +68,7 @@ var DefaultSnapshotURL = url.URL{
 type Broker struct {
 	Port    int      `toml:"port"`
 	Dir     string   `toml:"dir"`
+	Enabled bool     `toml:"enabled"`
 	Timeout Duration `toml:"election-timeout"`
 }
 
@@ -81,6 +82,7 @@ type Snapshot struct {
 // Data represents the configuration for a data node
 type Data struct {
 	Dir                   string   `toml:"dir"`
+	Enabled               bool     `toml:"enabled"`
 	Port                  int      `toml:"port"`
 	RetentionAutoCreate   bool     `toml:"retention-auto-create"`
 	RetentionCheckEnabled bool     `toml:"retention-check-enabled"`
@@ -187,9 +189,11 @@ func NewConfig() (*Config, error) {
 	}
 
 	c := &Config{}
+	c.Broker.Enabled = true
 	c.Broker.Dir = filepath.Join(u.HomeDir, ".influxdb/broker")
 	c.Broker.Port = DefaultBrokerPort
 	c.Broker.Timeout = Duration(1 * time.Second)
+	c.Data.Enabled = true
 	c.Data.Dir = filepath.Join(u.HomeDir, ".influxdb/data")
 	c.Data.Port = DefaultDataPort
 	c.Data.RetentionAutoCreate = true

--- a/cmd/influxd/config.go
+++ b/cmd/influxd/config.go
@@ -303,14 +303,6 @@ func (c *Config) ClusterURL() url.URL {
 	}
 }
 
-// BrokerURL returns the URL required to contact the Broker server.
-func (c *Config) BrokerURL() url.URL {
-	return url.URL{
-		Scheme: "http",
-		Host:   net.JoinHostPort(c.Hostname, strconv.Itoa(c.Port)),
-	}
-}
-
 // BrokerDir returns the data directory to start up in and does home directory expansion if necessary.
 func (c *Config) BrokerDir() string {
 	p, e := filepath.Abs(c.Broker.Dir)

--- a/cmd/influxd/config.go
+++ b/cmd/influxd/config.go
@@ -98,7 +98,8 @@ type Broker struct {
 	Timeout Duration `toml:"election-timeout"`
 }
 
-// Snapshot represents the configuration for a snapshot service
+// Snapshot represents the configuration for a snapshot service. Snapshot configuration
+// is only valid for data nodes.
 type Snapshot struct {
 	Enabled     bool   `toml:"enabled"`
 	BindAddress string `toml:"bind-address"`

--- a/cmd/influxd/config.go
+++ b/cmd/influxd/config.go
@@ -36,9 +36,6 @@ const (
 	// DefaultClusterPort represents the default port the cluster runs ons.
 	DefaultClusterPort = 8086
 
-	// DefaultBrokerPort represents the default port the broker runs on.
-	DefaultBrokerPort = 8086
-
 	// DefaultDataPort represents the default port the data server runs on.
 	DefaultDataPort = 8086
 
@@ -102,7 +99,6 @@ var DefaultSnapshotURL = url.URL{
 
 // Broker represents the configuration for a broker node
 type Broker struct {
-	Port    int      `toml:"port"`
 	Dir     string   `toml:"dir"`
 	Enabled bool     `toml:"enabled"`
 	Timeout Duration `toml:"election-timeout"`
@@ -219,7 +215,6 @@ type Config struct {
 func NewConfig() *Config {
 	c := &Config{}
 	c.Port = DefaultClusterPort
-	c.Broker.Port = DefaultBrokerPort
 	c.Data.Port = DefaultDataPort
 
 	c.Data.RetentionAutoCreate = DefaultRetentionAutoCreate
@@ -301,16 +296,16 @@ func (c *Config) SnapshotAddr() string {
 	return net.JoinHostPort(c.Snapshot.BindAddress, strconv.Itoa(c.Snapshot.Port))
 }
 
-// BrokerAddr returns the binding address the Broker server
-func (c *Config) BrokerAddr() string {
-	return fmt.Sprintf("%s:%d", c.BindAddress, c.Broker.Port)
+// ClusterAddr returns the binding address for the cluster
+func (c *Config) ClusterAddr() string {
+	return net.JoinHostPort(c.BindAddress, strconv.Itoa(c.Port))
 }
 
 // BrokerURL returns the URL required to contact the Broker server.
 func (c *Config) BrokerURL() url.URL {
 	return url.URL{
 		Scheme: "http",
-		Host:   net.JoinHostPort(c.Hostname, strconv.Itoa(c.Broker.Port)),
+		Host:   net.JoinHostPort(c.Hostname, strconv.Itoa(c.Port)),
 	}
 }
 

--- a/cmd/influxd/config.go
+++ b/cmd/influxd/config.go
@@ -121,6 +121,7 @@ type Data struct {
 	RetentionCheckEnabled bool     `toml:"retention-check-enabled"`
 	RetentionCheckPeriod  Duration `toml:"retention-check-period"`
 	RetentionCreatePeriod Duration `toml:"retention-create-period"`
+	JoinURLs              string   `toml:"join-urls"`
 }
 
 // Config represents the configuration format for the influxd binary.

--- a/cmd/influxd/config.go
+++ b/cmd/influxd/config.go
@@ -168,10 +168,6 @@ type Config struct {
 
 	Snapshot Snapshot `toml:"snapshot"`
 
-	Cluster struct {
-		Dir string `toml:"dir"`
-	} `toml:"cluster"`
-
 	Logging struct {
 		WriteTracing bool `toml:"write-tracing"`
 		RaftTracing  bool `toml:"raft-tracing"`

--- a/cmd/influxd/config.go
+++ b/cmd/influxd/config.go
@@ -177,7 +177,7 @@ type Config struct {
 		ComputeNoMoreThan Duration `toml:"compute-no-more-than"`
 
 		// If this flag is set to true, both the brokers and data nodes should ignore any CQ processing.
-		Disable bool `toml:"disable"`
+		Disabled bool `toml:"disabled"`
 	} `toml:"continuous_queries"`
 }
 
@@ -209,7 +209,7 @@ func NewConfig() (*Config, error) {
 	c.ContinuousQuery.RecomputeNoOlderThan = Duration(10 * time.Minute)
 	c.ContinuousQuery.ComputeRunsPerInterval = 10
 	c.ContinuousQuery.ComputeNoMoreThan = Duration(2 * time.Minute)
-	c.ContinuousQuery.Disable = false
+	c.ContinuousQuery.Disabled = false
 	c.ReportingDisabled = false
 
 	c.Monitoring.Enabled = false

--- a/cmd/influxd/config_test.go
+++ b/cmd/influxd/config_test.go
@@ -11,6 +11,116 @@ import (
 	main "github.com/influxdb/influxdb/cmd/influxd"
 )
 
+// Testing configuration file.
+const testFile = `
+# Welcome to the InfluxDB configuration file.
+
+# If hostname (on the OS) doesn't return a name that can be resolved by the other
+# systems in the cluster, you'll have to set the hostname to an IP or something
+# that can be resolved here.
+hostname = "myserver.com"
+
+# Controls certain parameters that only take effect until an initial successful
+# start-up has occurred.
+[initialization]
+join-urls = "http://127.0.0.1:8086"
+
+# Control authentication
+[authentication]
+enabled = true
+
+[logging]
+write-tracing = true
+raft-tracing = true
+
+[monitoring]
+enabled = true
+write-interval = "1m"
+
+# Configure the admin server
+[admin]
+enabled = true
+port = 8083
+
+# Configure the http api
+[api]
+ssl-port = 8087    # Ssl support is enabled if you set a port and cert
+ssl-cert = "../cert.pem"
+
+# connections will timeout after this amount of time. Ensures that clients that misbehave
+# and keep alive connections they don't use won't end up connection a million times.
+# However, if a request is taking longer than this to complete, could be a problem.
+read-timeout = "5s"
+
+[input_plugins]
+
+  [input_plugins.udp]
+  enabled = true
+  port = 4444
+  database = "test"
+
+# Configure the Graphite servers
+[[graphite]]
+protocol = "TCP"
+enabled = true
+address = "192.168.0.1"
+port = 2003
+database = "graphite_tcp"  # store graphite data in this database
+name-position = "last"
+name-separator = "-"
+
+[[graphite]]
+protocol = "udP"
+enabled = true
+address = "192.168.0.2"
+port = 2005
+
+# Configure collectd server
+[collectd]
+enabled = true
+address = "192.168.0.3"
+port = 25827
+database = "collectd_database"
+typesdb = "foo-db-type"
+
+# Configure OpenTSDB server
+[opentsdb]
+enabled = true
+address = "192.168.0.3"
+port = 4242
+database = "opentsdb_database"
+retention-policy = "raw"
+
+# Broker configuration
+[broker]
+# The broker port should be open between all servers in a cluster.
+# However, this port shouldn't be accessible from the internet.
+port = 8086
+enabled = false
+
+# Where the broker logs are stored. The user running InfluxDB will need read/write access.
+dir  = "/tmp/influxdb/development/broker"
+
+# election-timeout = "2s"
+
+[data]
+dir = "/tmp/influxdb/development/db"
+retention-auto-create = false
+retention-check-enabled = true
+retention-check-period = "5m"
+enabled = false
+
+[continuous_queries]
+disabled = true
+
+[cluster]
+dir = "/tmp/influxdb/development/cluster"
+
+[snapshot]
+bind-address = "1.2.3.4"
+port = 9999
+`
+
 // Ensure that megabyte sizes can be parsed.
 func TestSize_UnmarshalText_MB(t *testing.T) {
 	var s main.Size
@@ -166,6 +276,13 @@ func TestParseConfig(t *testing.T) {
 		t.Fatalf("Monitoring.WriteInterval mismatch: %v", c.Monitoring.WriteInterval)
 	}
 
+	if exp := "1.2.3.4"; c.Snapshot.BindAddress != exp {
+		t.Fatalf("snapshot bind-address mismatch: %v, got %v", exp, c.Snapshot.BindAddress)
+	}
+
+	if exp := 9999; c.Snapshot.Port != exp {
+		t.Fatalf("snapshot port mismatch: %v, got %v", exp, c.Snapshot.Port)
+	}
 	// TODO: UDP Servers testing.
 	/*
 		c.Assert(config.UdpServers, HasLen, 1)
@@ -187,112 +304,6 @@ func TestEncodeConfig(t *testing.T) {
 		t.Fatalf("Encoding config failed.\nfailed to find %s in:\n%s\n", search, got)
 	}
 }
-
-// Testing configuration file.
-const testFile = `
-# Welcome to the InfluxDB configuration file.
-
-# If hostname (on the OS) doesn't return a name that can be resolved by the other
-# systems in the cluster, you'll have to set the hostname to an IP or something
-# that can be resolved here.
-hostname = "myserver.com"
-
-# Controls certain parameters that only take effect until an initial successful
-# start-up has occurred.
-[initialization]
-join-urls = "http://127.0.0.1:8086"
-
-# Control authentication
-[authentication]
-enabled = true
-
-[logging]
-write-tracing = true
-raft-tracing = true
-
-[monitoring]
-enabled = true
-write-interval = "1m"
-
-# Configure the admin server
-[admin]
-enabled = true
-port = 8083
-
-# Configure the http api
-[api]
-ssl-port = 8087    # Ssl support is enabled if you set a port and cert
-ssl-cert = "../cert.pem"
-
-# connections will timeout after this amount of time. Ensures that clients that misbehave
-# and keep alive connections they don't use won't end up connection a million times.
-# However, if a request is taking longer than this to complete, could be a problem.
-read-timeout = "5s"
-
-[input_plugins]
-
-  [input_plugins.udp]
-  enabled = true
-  port = 4444
-  database = "test"
-
-# Configure the Graphite servers
-[[graphite]]
-protocol = "TCP"
-enabled = true
-address = "192.168.0.1"
-port = 2003
-database = "graphite_tcp"  # store graphite data in this database
-name-position = "last"
-name-separator = "-"
-
-[[graphite]]
-protocol = "udP"
-enabled = true
-address = "192.168.0.2"
-port = 2005
-
-# Configure collectd server
-[collectd]
-enabled = true
-address = "192.168.0.3"
-port = 25827
-database = "collectd_database"
-typesdb = "foo-db-type"
-
-# Configure OpenTSDB server
-[opentsdb]
-enabled = true
-address = "192.168.0.3"
-port = 4242
-database = "opentsdb_database"
-retention-policy = "raw"
-
-# Broker configuration
-[broker]
-# The broker port should be open between all servers in a cluster.
-# However, this port shouldn't be accessible from the internet.
-port = 8086
-enabled = false
-
-# Where the broker logs are stored. The user running InfluxDB will need read/write access.
-dir  = "/tmp/influxdb/development/broker"
-
-# election-timeout = "2s"
-
-[data]
-dir = "/tmp/influxdb/development/db"
-retention-auto-create = false
-retention-check-enabled = true
-retention-check-period = "5m"
-enabled = false
-
-[continuous_queries]
-disabled = true
-
-[cluster]
-dir = "/tmp/influxdb/development/cluster"
-`
 
 func TestCollectd_ConnectionString(t *testing.T) {
 	var tests = []struct {

--- a/cmd/influxd/config_test.go
+++ b/cmd/influxd/config_test.go
@@ -140,6 +140,10 @@ func TestParseConfig(t *testing.T) {
 		t.Fatalf("broker duration mismatch: %v", c.Broker.Timeout)
 	}
 
+	if c.Broker.Enabled != false {
+		t.Fatalf("broker disabled mismatch: %v, got: %v", false, c.Broker.Enabled)
+	}
+
 	if c.Data.Dir != "/tmp/influxdb/development/db" {
 		t.Fatalf("data dir mismatch: %v", c.Data.Dir)
 	}
@@ -148,6 +152,10 @@ func TestParseConfig(t *testing.T) {
 	}
 	if c.Data.RetentionCheckPeriod != main.Duration(5*time.Minute) {
 		t.Fatalf("Retention check period mismatch: %v", c.Data.RetentionCheckPeriod)
+	}
+
+	if c.Data.Enabled != false {
+		t.Fatalf("data disabled mismatch: %v, got: %v", false, c.Data.Enabled)
 	}
 
 	if c.Cluster.Dir != "/tmp/influxdb/development/cluster" {
@@ -265,6 +273,7 @@ retention-policy = "raw"
 # The broker port should be open between all servers in a cluster.
 # However, this port shouldn't be accessible from the internet.
 port = 8086
+enabled = false
 
 # Where the broker logs are stored. The user running InfluxDB will need read/write access.
 dir  = "/tmp/influxdb/development/broker"
@@ -276,6 +285,7 @@ dir = "/tmp/influxdb/development/db"
 retention-auto-create = false
 retention-check-enabled = true
 retention-check-period = "5m"
+enabled = false
 
 [continuous_queries]
 disabled = true

--- a/cmd/influxd/config_test.go
+++ b/cmd/influxd/config_test.go
@@ -19,6 +19,7 @@ const testFile = `
 # systems in the cluster, you'll have to set the hostname to an IP or something
 # that can be resolved here.
 hostname = "myserver.com"
+port = 8086
 
 # Controls certain parameters that only take effect until an initial successful
 # start-up has occurred.
@@ -150,6 +151,10 @@ func TestParseConfig(t *testing.T) {
 		t.Fatalf("unexpected error: %s", err)
 	} else if c.Hostname != "myserver.com" {
 		t.Fatalf("hostname mismatch: %v", c.Hostname)
+	}
+
+	if exp := 8086; c.Port != exp {
+		t.Fatalf("port mismatch. got %v, exp %v", c.Port, exp)
 	}
 
 	if c.JoinURLs() != "http://127.0.0.1:8086" {

--- a/cmd/influxd/config_test.go
+++ b/cmd/influxd/config_test.go
@@ -21,10 +21,6 @@ const testFile = `
 hostname = "myserver.com"
 port = 8086
 
-# Controls certain parameters that only take effect until an initial successful
-# start-up has occurred.
-[initialization]
-join-urls = "http://127.0.0.1:8086"
 
 # Control authentication
 [authentication]
@@ -110,7 +106,6 @@ retention-auto-create = false
 retention-check-enabled = true
 retention-check-period = "5m"
 enabled = false
-join-urls = "http://127.0.0.1:8087"
 
 [continuous_queries]
 disabled = true
@@ -155,10 +150,6 @@ func TestParseConfig(t *testing.T) {
 
 	if exp := 8086; c.Port != exp {
 		t.Fatalf("port mismatch. got %v, exp %v", c.Port, exp)
-	}
-
-	if c.JoinURLs() != "http://127.0.0.1:8086" {
-		t.Fatalf("JoinURLs mistmatch: %v", c.JoinURLs())
 	}
 
 	if !c.Authentication.Enabled {
@@ -265,10 +256,6 @@ func TestParseConfig(t *testing.T) {
 
 	if c.Data.Enabled != false {
 		t.Fatalf("data disabled mismatch: %v, got: %v", false, c.Data.Enabled)
-	}
-
-	if exp := "http://127.0.0.1:8087"; c.Data.JoinURLs != exp {
-		t.Fatalf("data join urls mismatch: %v, got: %v", exp, c.Data.JoinURLs)
 	}
 
 	if c.Monitoring.WriteInterval.String() != "1m0s" {

--- a/cmd/influxd/config_test.go
+++ b/cmd/influxd/config_test.go
@@ -64,8 +64,8 @@ func TestParseConfig(t *testing.T) {
 		t.Fatalf("admin port mismatch: %v", c.Admin.Port)
 	}
 
-	if c.ContinuousQuery.Disable == true {
-		t.Fatalf("continuous query disable mismatch: %v", c.ContinuousQuery.Disable)
+	if c.ContinuousQuery.Disabled != true {
+		t.Fatalf("continuous query disable mismatch: %v", c.ContinuousQuery.Disabled)
 	}
 
 	if c.Data.Port != main.DefaultBrokerPort {
@@ -278,7 +278,7 @@ retention-check-enabled = true
 retention-check-period = "5m"
 
 [continuous_queries]
-disable = false
+disabled = true
 
 [cluster]
 dir = "/tmp/influxdb/development/cluster"

--- a/cmd/influxd/config_test.go
+++ b/cmd/influxd/config_test.go
@@ -96,7 +96,6 @@ retention-policy = "raw"
 [broker]
 # The broker port should be open between all servers in a cluster.
 # However, this port shouldn't be accessible from the internet.
-port = 8086
 enabled = false
 
 # Where the broker logs are stored. The user running InfluxDB will need read/write access.
@@ -181,7 +180,7 @@ func TestParseConfig(t *testing.T) {
 		t.Fatalf("continuous query disable mismatch: %v", c.ContinuousQuery.Disabled)
 	}
 
-	if c.Data.Port != main.DefaultBrokerPort {
+	if c.Data.Port != main.DefaultDataPort {
 		t.Fatalf("data port mismatch: %v", c.Data.Port)
 	}
 
@@ -245,9 +244,7 @@ func TestParseConfig(t *testing.T) {
 		t.Errorf("collectd retention-policy mismatch: expected %v, got %v", "foo-db-type", c.OpenTSDB.RetentionPolicy)
 	}
 
-	if c.Broker.Port != 8086 {
-		t.Fatalf("broker port mismatch: %v", c.Broker.Port)
-	} else if c.Broker.Dir != "/tmp/influxdb/development/broker" {
+	if c.Broker.Dir != "/tmp/influxdb/development/broker" {
 		t.Fatalf("broker dir mismatch: %v", c.Broker.Dir)
 	}
 

--- a/cmd/influxd/config_test.go
+++ b/cmd/influxd/config_test.go
@@ -246,8 +246,6 @@ func TestParseConfig(t *testing.T) {
 		t.Fatalf("broker port mismatch: %v", c.Broker.Port)
 	} else if c.Broker.Dir != "/tmp/influxdb/development/broker" {
 		t.Fatalf("broker dir mismatch: %v", c.Broker.Dir)
-	} else if time.Duration(c.Broker.Timeout) != time.Second {
-		t.Fatalf("broker duration mismatch: %v", c.Broker.Timeout)
 	}
 
 	if c.Broker.Enabled != false {

--- a/cmd/influxd/config_test.go
+++ b/cmd/influxd/config_test.go
@@ -109,6 +109,7 @@ retention-auto-create = false
 retention-check-enabled = true
 retention-check-period = "5m"
 enabled = false
+join-urls = "http://127.0.0.1:8087"
 
 [continuous_queries]
 disabled = true
@@ -264,6 +265,10 @@ func TestParseConfig(t *testing.T) {
 
 	if c.Data.Enabled != false {
 		t.Fatalf("data disabled mismatch: %v, got: %v", false, c.Data.Enabled)
+	}
+
+	if exp := "http://127.0.0.1:8087"; c.Data.JoinURLs != exp {
+		t.Fatalf("data join urls mismatch: %v, got: %v", exp, c.Data.JoinURLs)
 	}
 
 	if c.Cluster.Dir != "/tmp/influxdb/development/cluster" {

--- a/cmd/influxd/config_test.go
+++ b/cmd/influxd/config_test.go
@@ -114,9 +114,6 @@ join-urls = "http://127.0.0.1:8087"
 [continuous_queries]
 disabled = true
 
-[cluster]
-dir = "/tmp/influxdb/development/cluster"
-
 [snapshot]
 bind-address = "1.2.3.4"
 port = 9999
@@ -269,10 +266,6 @@ func TestParseConfig(t *testing.T) {
 
 	if exp := "http://127.0.0.1:8087"; c.Data.JoinURLs != exp {
 		t.Fatalf("data join urls mismatch: %v, got: %v", exp, c.Data.JoinURLs)
-	}
-
-	if c.Cluster.Dir != "/tmp/influxdb/development/cluster" {
-		t.Fatalf("cluster dir mismatch: %v", c.Cluster.Dir)
 	}
 
 	if c.Monitoring.WriteInterval.String() != "1m0s" {

--- a/cmd/influxd/config_test.go
+++ b/cmd/influxd/config_test.go
@@ -45,6 +45,7 @@ port = 8083
 
 # Configure the http api
 [api]
+bind-address = "10.1.2.3"
 ssl-port = 8087    # Ssl support is enabled if you set a port and cert
 ssl-cert = "../cert.pem"
 
@@ -164,6 +165,10 @@ func TestParseConfig(t *testing.T) {
 		t.Fatalf("authentication enabled mismatch: %v", c.Authentication.Enabled)
 	}
 
+	if exp := "10.1.2.3"; c.HTTPAPI.BindAddress != exp {
+		t.Fatalf("http api bind-address mismatch: got %v, exp %v", c.HTTPAPI.BindAddress, exp)
+	}
+
 	if c.UDP.Enabled {
 		t.Fatalf("udp enabled mismatch: %v", c.UDP.Enabled)
 	}
@@ -178,10 +183,6 @@ func TestParseConfig(t *testing.T) {
 
 	if c.ContinuousQuery.Disabled != true {
 		t.Fatalf("continuous query disable mismatch: %v", c.ContinuousQuery.Disabled)
-	}
-
-	if c.Data.Port != main.DefaultDataPort {
-		t.Fatalf("data port mismatch: %v", c.Data.Port)
 	}
 
 	if len(c.Graphites) != 2 {

--- a/cmd/influxd/config_test.go
+++ b/cmd/influxd/config_test.go
@@ -63,7 +63,7 @@ read-timeout = "5s"
 [[graphite]]
 protocol = "TCP"
 enabled = true
-address = "192.168.0.1"
+bind-address = "192.168.0.1"
 port = 2003
 database = "graphite_tcp"  # store graphite data in this database
 name-position = "last"
@@ -72,13 +72,13 @@ name-separator = "-"
 [[graphite]]
 protocol = "udP"
 enabled = true
-address = "192.168.0.2"
+bind-address = "192.168.0.2"
 port = 2005
 
 # Configure collectd server
 [collectd]
 enabled = true
-address = "192.168.0.3"
+bind-address = "192.168.0.3"
 port = 25827
 database = "collectd_database"
 typesdb = "foo-db-type"
@@ -190,8 +190,8 @@ func TestParseConfig(t *testing.T) {
 	switch {
 	case tcpGraphite.Enabled != true:
 		t.Fatalf("graphite tcp enabled mismatch: expected: %v, got %v", true, tcpGraphite.Enabled)
-	case tcpGraphite.Addr != "192.168.0.1":
-		t.Fatalf("graphite tcp address mismatch: expected %v, got  %v", "192.168.0.1", tcpGraphite.Addr)
+	case tcpGraphite.BindAddress != "192.168.0.1":
+		t.Fatalf("graphite tcp address mismatch: expected %v, got  %v", "192.168.0.1", tcpGraphite.BindAddress)
 	case tcpGraphite.Port != 2003:
 		t.Fatalf("graphite tcp port mismatch: expected %v, got %v", 2003, tcpGraphite.Port)
 	case tcpGraphite.Database != "graphite_tcp":
@@ -208,8 +208,8 @@ func TestParseConfig(t *testing.T) {
 	switch {
 	case udpGraphite.Enabled != true:
 		t.Fatalf("graphite udp enabled mismatch: expected: %v, got %v", true, udpGraphite.Enabled)
-	case udpGraphite.Addr != "192.168.0.2":
-		t.Fatalf("graphite udp address mismatch: expected %v, got  %v", "192.168.0.2", udpGraphite.Addr)
+	case udpGraphite.BindAddress != "192.168.0.2":
+		t.Fatalf("graphite udp address mismatch: expected %v, got  %v", "192.168.0.2", udpGraphite.BindAddress)
 	case udpGraphite.Port != 2005:
 		t.Fatalf("graphite udp port mismatch: expected %v, got %v", 2005, udpGraphite.Port)
 	case udpGraphite.DatabaseString() != "graphite":
@@ -221,8 +221,8 @@ func TestParseConfig(t *testing.T) {
 	switch {
 	case c.Collectd.Enabled != true:
 		t.Errorf("collectd enabled mismatch: expected: %v, got %v", true, c.Collectd.Enabled)
-	case c.Collectd.Addr != "192.168.0.3":
-		t.Errorf("collectd address mismatch: expected %v, got  %v", "192.168.0.3", c.Collectd.Addr)
+	case c.Collectd.BindAddress != "192.168.0.3":
+		t.Errorf("collectd address mismatch: expected %v, got  %v", "192.168.0.3", c.Collectd.BindAddress)
 	case c.Collectd.Port != 25827:
 		t.Errorf("collectd port mismatch: expected %v, got %v", 2005, c.Collectd.Port)
 	case c.Collectd.Database != "collectd_database":
@@ -322,7 +322,7 @@ func TestCollectd_ConnectionString(t *testing.T) {
 			name:             "address provided, no port provided from config",
 			defaultBindAddr:  "192.168.0.1",
 			connectionString: "192.168.0.2:25826",
-			config:           main.Collectd{Addr: "192.168.0.2"},
+			config:           main.Collectd{BindAddress: "192.168.0.2"},
 		},
 		{
 			name:             "no address provided, port provided from config",
@@ -334,7 +334,7 @@ func TestCollectd_ConnectionString(t *testing.T) {
 			name:             "both address and port provided from config",
 			defaultBindAddr:  "192.168.0.1",
 			connectionString: "192.168.0.2:25827",
-			config:           main.Collectd{Addr: "192.168.0.2", Port: 25827},
+			config:           main.Collectd{BindAddress: "192.168.0.2", Port: 25827},
 		},
 	}
 

--- a/cmd/influxd/handler.go
+++ b/cmd/influxd/handler.go
@@ -28,15 +28,23 @@ func NewHandler() *Handler {
 
 // ServeHTTP responds to HTTP request to the handler.
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// FIXME: This is very brittle.  Refactor to have common path prefix
 	if strings.HasPrefix(r.URL.Path, "/raft") {
 		h.serveRaft(w, r)
 		return
 	}
+
 	if strings.HasPrefix(r.URL.Path, "/messaging") {
 		h.serveMessaging(w, r)
 		return
 	}
 
+	if strings.HasPrefix(r.URL.Path, "/data_nodes") ||
+		strings.HasPrefix(r.URL.Path, "/process_continuous_queries") ||
+		strings.HasPrefix(r.URL.Path, "/metastore") {
+		h.serveMetadata(w, r)
+		return
+	}
 	h.serveData(w, r)
 }
 
@@ -60,6 +68,31 @@ func (h *Handler) serveMessaging(w http.ResponseWriter, r *http.Request) {
 
 	// Redirect to a valid broker to handle the request
 	h.redirect(h.Server.BrokerURLs(), w, r)
+}
+
+// serverMetadata responds to broker requests
+func (h *Handler) serveMetadata(w http.ResponseWriter, r *http.Request) {
+	if h.Broker == nil && h.Server == nil {
+		log.Println("no broker or server configured to handle messaging endpoints")
+		http.Error(w, "server unavailable", http.StatusServiceUnavailable)
+		return
+	}
+
+	if h.Server != nil {
+		sh := httpd.NewClusterHandler(h.Server, h.Config.Authentication.Enabled, version)
+		sh.WriteTrace = h.Config.Logging.WriteTracing
+		sh.ServeHTTP(w, r)
+		return
+	}
+
+	t := h.Broker.Topic(influxdb.BroadcastTopicID)
+	if t == nil {
+		http.Error(w, "not found", http.StatusNotFound)
+		return
+	}
+
+	// Redirect to a valid data URL to handle the request
+	h.redirect(h.Broker.Topic(influxdb.BroadcastTopicID).DataURLs(), w, r)
 }
 
 // serveRaft responds to raft requests.
@@ -89,7 +122,7 @@ func (h *Handler) serveData(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if h.Server != nil {
-		sh := httpd.NewHandler(h.Server, h.Config.Authentication.Enabled, version)
+		sh := httpd.NewAPIHandler(h.Server, h.Config.Authentication.Enabled, version)
 		sh.WriteTrace = h.Config.Logging.WriteTracing
 		sh.ServeHTTP(w, r)
 		return
@@ -112,5 +145,5 @@ func (h *Handler) redirect(u []url.URL, w http.ResponseWriter, r *http.Request) 
 	// this is happening frequently, the clients are using a suboptimal endpoint
 
 	// Redirect the client to a valid data node that can handle the request
-	http.Redirect(w, r, u[0].String()+r.RequestURI, http.StatusTemporaryRedirect)
+	http.Redirect(w, r, u[0].String()+r.RequestURI, http.StatusSeeOther)
 }

--- a/cmd/influxd/handler.go
+++ b/cmd/influxd/handler.go
@@ -70,7 +70,7 @@ func (h *Handler) serveMessaging(w http.ResponseWriter, r *http.Request) {
 	h.redirect(h.Server.BrokerURLs(), w, r)
 }
 
-// serverMetadata responds to broker requests
+// serveMetadata responds to broker requests
 func (h *Handler) serveMetadata(w http.ResponseWriter, r *http.Request) {
 	if h.Broker == nil && h.Server == nil {
 		log.Println("no broker or server configured to handle messaging endpoints")
@@ -128,6 +128,12 @@ func (h *Handler) serveData(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	t := h.Broker.Topic(influxdb.BroadcastTopicID)
+	if t == nil {
+		http.Error(w, "not found", http.StatusNotFound)
+		return
+	}
+
 	// Redirect to a valid data URL to handle the request
 	h.redirect(h.Broker.Topic(influxdb.BroadcastTopicID).DataURLs(), w, r)
 }
@@ -145,5 +151,5 @@ func (h *Handler) redirect(u []url.URL, w http.ResponseWriter, r *http.Request) 
 	// this is happening frequently, the clients are using a suboptimal endpoint
 
 	// Redirect the client to a valid data node that can handle the request
-	http.Redirect(w, r, u[0].String()+r.RequestURI, http.StatusSeeOther)
+	http.Redirect(w, r, u[0].String()+r.RequestURI, http.StatusTemporaryRedirect)
 }

--- a/cmd/influxd/help.go
+++ b/cmd/influxd/help.go
@@ -1,0 +1,35 @@
+package main
+
+import "fmt"
+
+// HelpCommand displays help for command-line sub-commands.
+type HelpCommand struct {
+}
+
+// NewHelpCommand returns a new instance of HelpCommand.
+func NewHelpCommand() *HelpCommand {
+	return &HelpCommand{}
+}
+
+// Run executes the command.
+func (cmd *HelpCommand) Run(args ...string) error {
+	fmt.Println(`
+Configure and start an InfluxDB server.
+
+Usage:
+
+	influxd [[command] [arguments]]
+
+The commands are:
+
+    config               display the default configuration
+    join-cluster         create a new node that will join an existing cluster
+    run                  run node with existing configuration
+    version              displays the InfluxDB version
+
+"run" is the default command.
+
+Use "influxd help [command]" for more information about a command.
+`)
+	return nil
+}

--- a/cmd/influxd/main.go
+++ b/cmd/influxd/main.go
@@ -90,7 +90,10 @@ func main() {
 	case "config":
 		execConfig(args[1:])
 	case "help":
-		execHelp(args[1:])
+		cmd := NewHelpCommand()
+		if err := cmd.Run(args[1:]...); err != nil {
+			log.Fatalf("help: %s", err)
+		}
 	default:
 		log.Fatalf(`influxd: unknown command "%s"`+"\n"+`Run 'influxd help' for usage`+"\n\n", cmd)
 	}
@@ -179,28 +182,6 @@ func execConfig(args []string) {
 	}
 
 	config.Write(os.Stdout)
-}
-
-// execHelp runs the "help" command.
-func execHelp(args []string) {
-	fmt.Println(`
-Configure and start an InfluxDB server.
-
-Usage:
-
-	influxd [[command] [arguments]]
-
-The commands are:
-
-    config               display the default configuration
-    join-cluster         create a new node that will join an existing cluster
-    run                  run node with existing configuration
-    version              displays the InfluxDB version
-
-"run" is the default command.
-
-Use "influxd help [command]" for more information about a command.
-`)
 }
 
 type Stopper interface {

--- a/cmd/influxd/restore.go
+++ b/cmd/influxd/restore.go
@@ -29,23 +29,29 @@ type RestoreCommand struct {
 
 // NewRestoreCommand returns a new instance of RestoreCommand with default settings.
 func NewRestoreCommand() *RestoreCommand {
-	return &RestoreCommand{
+	cmd := RestoreCommand{
 		Stderr: os.Stderr,
 	}
+
+	// Set up logger.
+	cmd.Logger = log.New(cmd.Stderr, "", log.LstdFlags)
+	return &cmd
 }
 
 // Run excutes the program.
 func (cmd *RestoreCommand) Run(args ...string) error {
-	// Set up logger.
-	cmd.Logger = log.New(cmd.Stderr, "", log.LstdFlags)
-	cmd.Logger.Printf("influxdb restore, version %s, commit %s", version, commit)
 
+	cmd.Logger.Printf("influxdb restore, version %s, commit %s", version, commit)
 	// Parse command line arguments.
 	config, path, err := cmd.parseFlags(args)
 	if err != nil {
 		return err
 	}
 
+	return cmd.Restore(config, path)
+}
+
+func (cmd *RestoreCommand) Restore(config *Config, path string) error {
 	// Remove broker & data directories.
 	if err := os.RemoveAll(config.BrokerDir()); err != nil {
 		return fmt.Errorf("remove broker dir: %s", err)
@@ -78,7 +84,6 @@ func (cmd *RestoreCommand) Run(args ...string) error {
 
 	// Notify user of completion.
 	cmd.Logger.Printf("restore complete using %s", path)
-
 	return nil
 }
 

--- a/cmd/influxd/restore.go
+++ b/cmd/influxd/restore.go
@@ -78,7 +78,7 @@ func (cmd *RestoreCommand) Restore(config *Config, path string) error {
 	}
 
 	// Generate broker & raft directories from manifest.
-	if err := cmd.materialize(config.BrokerDir(), ss, config.BrokerURL()); err != nil {
+	if err := cmd.materialize(config.BrokerDir(), ss, config.ClusterURL()); err != nil {
 		return fmt.Errorf("materialize: %s", err)
 	}
 

--- a/cmd/influxd/restore_test.go
+++ b/cmd/influxd/restore_test.go
@@ -10,24 +10,17 @@ import (
 	"time"
 
 	"github.com/influxdb/influxdb"
-	"github.com/influxdb/influxdb/cmd/influxd"
+	main "github.com/influxdb/influxdb/cmd/influxd"
 )
 
 func newConfig(path string, brokerPort, dataPort, snapshotPort int) main.Config {
-	return main.Config{
-		Broker: main.Broker{
-			Port: brokerPort,
-			Dir:  filepath.Join(path, "broker"),
-		},
-		Data: main.Data{
-			Port:                dataPort,
-			Dir:                 filepath.Join(path, "data"),
-			RetentionAutoCreate: true,
-		},
-		Snapshot: main.Snapshot{
-			Port: snapshotPort,
-		},
-	}
+	config := main.NewConfig()
+	config.Broker.Port = brokerPort
+	config.Broker.Dir = filepath.Join(path, "broker")
+	config.Data.Port = dataPort
+	config.Data.Dir = filepath.Join(path, "data")
+	config.Snapshot.Port = snapshotPort
+	return *config
 }
 
 // Ensure the restore command can expand a snapshot and bootstrap a broker.

--- a/cmd/influxd/restore_test.go
+++ b/cmd/influxd/restore_test.go
@@ -2,7 +2,6 @@ package main_test
 
 import (
 	"bytes"
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -13,6 +12,23 @@ import (
 	"github.com/influxdb/influxdb"
 	"github.com/influxdb/influxdb/cmd/influxd"
 )
+
+func newConfig(path string, brokerPort, dataPort, snapshotPort int) main.Config {
+	return main.Config{
+		Broker: main.Broker{
+			Port: brokerPort,
+			Dir:  filepath.Join(path, "broker"),
+		},
+		Data: main.Data{
+			Port:                dataPort,
+			Dir:                 filepath.Join(path, "data"),
+			RetentionAutoCreate: true,
+		},
+		Snapshot: main.Snapshot{
+			Port: snapshotPort,
+		},
+	}
+}
 
 // Ensure the restore command can expand a snapshot and bootstrap a broker.
 func TestRestoreCommand(t *testing.T) {
@@ -26,36 +42,12 @@ func TestRestoreCommand(t *testing.T) {
 	path := tempfile()
 	defer os.Remove(path)
 
-	// Create a config template that can use different ports.
-	var configString = fmt.Sprintf(`
-		[broker]
-		port=%%d
-		dir=%q
-
-		[data]
-		port=%%d
-		dir = %q
-
-		[snapshot]
-		port=%%d
-		`,
-		filepath.Join(path, "broker"),
-		filepath.Join(path, "data"),
-	)
-
-	// Create configuration file.
-	configPath := tempfile()
-	defer os.Remove(configPath)
-
 	// Parse configuration.
-	MustWriteFile(configPath, []byte(fmt.Sprintf(configString, 8900, 8900, 8901)))
-	c, err := main.ParseConfigFile(configPath)
-	if err != nil {
-		t.Fatalf("parse config: %s", err)
-	}
+	config := newConfig(path, 8900, 8900, 8901)
 
 	// Start server.
-	b, s, l := main.Run(c, "", "x.x")
+	cmd := main.NewRunCommand()
+	b, s, l := cmd.Open(&config, "")
 	if b == nil {
 		t.Fatal("cannot run broker")
 	} else if s == nil {
@@ -97,20 +89,17 @@ func TestRestoreCommand(t *testing.T) {
 		t.Fatalf("remove: %s", err)
 	}
 
-	// Rewrite config to a new port and re-parse.
-	MustWriteFile(configPath, []byte(fmt.Sprintf(configString, 8910, 8910, 8911)))
-	c, err = main.ParseConfigFile(configPath)
-	if err != nil {
-		t.Fatalf("parse config: %s", err)
-	}
-
 	// Execute the restore.
-	if err := NewRestoreCommand().Run("-config", configPath, sspath); err != nil {
+	if err := NewRestoreCommand().Restore(&config, sspath); err != nil {
 		t.Fatal(err)
 	}
 
+	// Rewrite config to a new port and re-parse.
+	config = newConfig(path, 8910, 8910, 8911)
+
 	// Restart server.
-	b, s, l = main.Run(c, "", "x.x")
+	cmd = main.NewRunCommand()
+	b, s, l = cmd.Open(&config, "")
 	if b == nil {
 		t.Fatal("cannot run broker")
 	} else if s == nil {
@@ -167,14 +156,4 @@ func MustReadFile(filename string) []byte {
 		panic(err.Error())
 	}
 	return b
-}
-
-// MustWriteFile writes data to a file. Panic on error.
-func MustWriteFile(filename string, data []byte) {
-	if err := os.MkdirAll(filepath.Dir(filename), 0777); err != nil {
-		panic(err.Error())
-	}
-	if err := ioutil.WriteFile(filename, data, 0666); err != nil {
-		panic(err.Error())
-	}
 }

--- a/cmd/influxd/restore_test.go
+++ b/cmd/influxd/restore_test.go
@@ -15,8 +15,11 @@ import (
 
 func newConfig(path string, brokerPort, dataPort, snapshotPort int) main.Config {
 	config := main.NewConfig()
+	config.Broker.Enabled = true
 	config.Broker.Port = brokerPort
 	config.Broker.Dir = filepath.Join(path, "broker")
+
+	config.Data.Enabled = true
 	config.Data.Port = dataPort
 	config.Data.Dir = filepath.Join(path, "data")
 	config.Snapshot.Port = snapshotPort

--- a/cmd/influxd/restore_test.go
+++ b/cmd/influxd/restore_test.go
@@ -15,8 +15,8 @@ import (
 
 func newConfig(path string, brokerPort, dataPort, snapshotPort int) main.Config {
 	config := main.NewConfig()
+	config.Port = brokerPort
 	config.Broker.Enabled = true
-	config.Broker.Port = brokerPort
 	config.Broker.Dir = filepath.Join(path, "broker")
 
 	config.Data.Enabled = true

--- a/cmd/influxd/restore_test.go
+++ b/cmd/influxd/restore_test.go
@@ -13,14 +13,13 @@ import (
 	main "github.com/influxdb/influxdb/cmd/influxd"
 )
 
-func newConfig(path string, brokerPort, dataPort, snapshotPort int) main.Config {
+func newConfig(path string, port, snapshotPort int) main.Config {
 	config := main.NewConfig()
-	config.Port = brokerPort
+	config.Port = port
 	config.Broker.Enabled = true
 	config.Broker.Dir = filepath.Join(path, "broker")
 
 	config.Data.Enabled = true
-	config.Data.Port = dataPort
 	config.Data.Dir = filepath.Join(path, "data")
 	config.Snapshot.Port = snapshotPort
 	return *config
@@ -39,7 +38,7 @@ func TestRestoreCommand(t *testing.T) {
 	defer os.Remove(path)
 
 	// Parse configuration.
-	config := newConfig(path, 8900, 8900, 8901)
+	config := newConfig(path, 8900, 8901)
 
 	// Start server.
 	cmd := main.NewRunCommand()
@@ -91,7 +90,7 @@ func TestRestoreCommand(t *testing.T) {
 	}
 
 	// Rewrite config to a new port and re-parse.
-	config = newConfig(path, 8910, 8910, 8911)
+	config = newConfig(path, 8910, 8911)
 
 	// Restart server.
 	cmd = main.NewRunCommand()

--- a/cmd/influxd/run.go
+++ b/cmd/influxd/run.go
@@ -70,8 +70,14 @@ func (cmd *RunCommand) Run(args ...string) error {
 	log.Printf("GOMAXPROCS set to %d", runtime.GOMAXPROCS(0))
 
 	var err error
+
 	// Parse configuration file from disk.
-	cmd.config, err = parseConfig(configPath, hostname)
+	if configPath != "" {
+		cmd.config, err = parseConfig(configPath, hostname)
+	} else {
+		cmd.config, err = NewTestConfig()
+	}
+
 	if err != nil {
 		cmd.Logger.Fatal(err)
 	} else if configPath == "" {
@@ -317,11 +323,7 @@ func writePIDFile(path string) {
 // parseConfig parses the configuration from a given path. Sets overrides as needed.
 func parseConfig(path, hostname string) (*Config, error) {
 	if path == "" {
-		c, err := NewConfig()
-		if err != nil {
-			return nil, fmt.Errorf("failed to generate default config: %s. Please supply an explicit configuration file", err.Error())
-		}
-		return c, nil
+		return NewConfig(), nil
 	}
 
 	// Parse configuration.

--- a/cmd/influxd/run.go
+++ b/cmd/influxd/run.go
@@ -448,7 +448,7 @@ func joinLog(l *raft.Log, brokerURLs []url.URL) {
 func (cmd *RunCommand) openServer(brokerURLs []url.URL, dataURLs []url.URL) *influxdb.Server {
 
 	// Create messaging client to the brokers.
-	c := influxdb.NewMessagingClient(cmd.config.DataURL())
+	c := influxdb.NewMessagingClient(cmd.config.ClusterURL())
 	// If join URLs were passed in then use them to override the client's URLs.
 	if len(brokerURLs) > 0 {
 		c.SetURLs(brokerURLs)
@@ -485,16 +485,16 @@ func (cmd *RunCommand) openServer(brokerURLs []url.URL, dataURLs []url.URL) *inf
 	log.Printf("data server opened at %s", cmd.config.Data.Dir)
 
 	if len(dataURLs) > 0 {
-		joinServer(s, cmd.config.DataURL(), dataURLs)
+		joinServer(s, cmd.config.ClusterURL(), dataURLs)
 		return s
 	}
 
 	dataNodeIndex := s.Index()
 	if dataNodeIndex == 0 && len(dataURLs) == 0 {
-		if err := s.Initialize(cmd.config.DataURL()); err != nil {
+		if err := s.Initialize(cmd.config.ClusterURL()); err != nil {
 			log.Fatalf("server initialization error: %s", err)
 		}
-		u := cmd.config.DataURL()
+		u := cmd.config.ClusterURL()
 		log.Printf("initialized data node: %s\n", (&u).String())
 		return s
 	}

--- a/cmd/influxd/run.go
+++ b/cmd/influxd/run.go
@@ -385,7 +385,7 @@ func parseConfig(path, hostname string) (*Config, error) {
 // creates and initializes a broker.
 func (cmd *RunCommand) openBroker(brokerURLs []url.URL) {
 	path := cmd.config.BrokerDir()
-	u := cmd.config.BrokerURL()
+	u := cmd.config.ClusterURL()
 	raftTracing := cmd.config.Logging.RaftTracing
 
 	// Create broker

--- a/cmd/influxd/run.go
+++ b/cmd/influxd/run.go
@@ -135,8 +135,8 @@ func (cmd *RunCommand) Open(config *Config, join string) (*messaging.Broker, *in
 	log.Printf("TCP server listening on %s", cmd.config.BrokerAddr())
 
 	// have it occasionally tell a data node in the cluster to run continuous queries
-	if cmd.config.ContinuousQuery.Disable {
-		log.Printf("Not running continuous queries. [continuous_queries].disable is set to true.")
+	if cmd.config.ContinuousQuery.Disabled {
+		log.Printf("Not running continuous queries. [continuous_queries].disabled is set to true.")
 	} else {
 		b.RunContinuousQueryLoop()
 	}

--- a/cmd/influxd/run.go
+++ b/cmd/influxd/run.go
@@ -27,13 +27,18 @@ import (
 )
 
 type RunCommand struct {
+	// The logger passed to the ticker during execution.
+	Logger *log.Logger
 }
 
 func NewRunCommand() *RunCommand {
 	return &RunCommand{}
 }
 
-func (r *RunCommand) Run(args ...string) error {
+func (cmd *RunCommand) Run(args ...string) error {
+	// Set up logger.
+	cmd.Logger = log.New(os.Stderr, "", log.LstdFlags)
+
 	// Parse command flags.
 	fs := flag.NewFlagSet("", flag.ExitOnError)
 	var (
@@ -62,9 +67,9 @@ func (r *RunCommand) Run(args ...string) error {
 	// Parse configuration file from disk.
 	config, err := parseConfig(*configPath, *hostname)
 	if err != nil {
-		log.Fatal(err)
+		cmd.Logger.Fatal(err)
 	} else if *configPath == "" {
-		log.Println("No config provided, using default settings")
+		cmd.Logger.Println("No config provided, using default settings")
 	}
 
 	Run(config, *join, version)

--- a/cmd/influxd/run.go
+++ b/cmd/influxd/run.go
@@ -44,25 +44,26 @@ func (cmd *RunCommand) Run(args ...string) error {
 
 	// Parse command flags.
 	fs := flag.NewFlagSet("", flag.ExitOnError)
-	var (
-		configPath = fs.String("config", "", "")
-		pidPath    = fs.String("pidfile", "", "")
-		hostname   = fs.String("hostname", "", "")
-		join       = fs.String("join", "", "")
-		cpuprofile = fs.String("cpuprofile", "", "")
-		memprofile = fs.String("memprofile", "", "")
-	)
+	var configPath, pidfile, hostname, join, cpuprofile, memprofile string
+
+	fs.StringVar(&configPath, "config", "", "")
+	fs.StringVar(&pidfile, "pidfile", "", "")
+	fs.StringVar(&hostname, "hostname", "", "")
+	fs.StringVar(&join, "join", "", "")
+	fs.StringVar(&cpuprofile, "cpuprofile", "", "")
+	fs.StringVar(&memprofile, "memprofile", "", "")
+
 	fs.Usage = printRunUsage
 	fs.Parse(args)
-	cmd.hostname = *hostname
+	cmd.hostname = hostname
 
 	// Start profiling, if set.
-	startProfiling(*cpuprofile, *memprofile)
+	startProfiling(cpuprofile, memprofile)
 	defer stopProfiling()
 
 	// Print sweet InfluxDB logo and write the process id to file.
 	fmt.Print(logo)
-	writePIDFile(*pidPath)
+	writePIDFile(pidfile)
 
 	// Set parallelism.
 	runtime.GOMAXPROCS(runtime.NumCPU())
@@ -70,14 +71,14 @@ func (cmd *RunCommand) Run(args ...string) error {
 
 	var err error
 	// Parse configuration file from disk.
-	cmd.config, err = parseConfig(*configPath, *hostname)
+	cmd.config, err = parseConfig(configPath, hostname)
 	if err != nil {
 		cmd.Logger.Fatal(err)
-	} else if *configPath == "" {
+	} else if configPath == "" {
 		cmd.Logger.Println("No config provided, using default settings")
 	}
 
-	cmd.Open(cmd.config, *join)
+	cmd.Open(cmd.config, join)
 
 	// Wait indefinitely.
 	<-(chan struct{})(nil)

--- a/cmd/influxd/run.go
+++ b/cmd/influxd/run.go
@@ -236,10 +236,10 @@ func (cmd *RunCommand) Open(config *Config, join string) (*messaging.Broker, *in
 
 		// Start the server bound to a UDP listener
 		if cmd.config.UDP.Enabled {
-			log.Printf("Starting UDP listener on %s", cmd.config.DataAddrUDP())
+			log.Printf("Starting UDP listener on %s", cmd.config.APIAddrUDP())
 			u := udp.NewUDPServer(s)
-			if err := u.ListenAndServe(cmd.config.DataAddrUDP()); err != nil {
-				log.Printf("Failed to start UDP listener on %s: %s", cmd.config.DataAddrUDP(), err)
+			if err := u.ListenAndServe(cmd.config.APIAddrUDP()); err != nil {
+				log.Printf("Failed to start UDP listener on %s: %s", cmd.config.APIAddrUDP(), err)
 			}
 
 		}

--- a/cmd/influxd/run.go
+++ b/cmd/influxd/run.go
@@ -43,8 +43,29 @@ func NewRunCommand() *RunCommand {
 
 type Server struct {
 	broker   *influxdb.Broker
-	dataNode *influxdb.DataNode
+	dataNode *influxdb.Server
 	raftLog  *raft.Log
+}
+
+func (s *Server) Close() {
+	if s.broker != nil {
+		if err := s.broker.Close(); err != nil {
+			log.Fatalf("error closing broker: %s", err)
+		}
+	}
+
+	if s.raftLog != nil {
+		if err := s.raftLog.Close(); err != nil {
+			log.Fatalf("error closing raft log: %s", err)
+		}
+	}
+
+	if s.dataNode != nil {
+		if err := s.dataNode.Close(); err != nil {
+			log.Fatalf("error data broker: %s", err)
+		}
+	}
+
 }
 
 func (cmd *RunCommand) Run(args ...string) error {
@@ -109,15 +130,17 @@ func (cmd *RunCommand) Open(config *Config, join string) (*messaging.Broker, *in
 	log.Printf("influxdb started, version %s, commit %s", version, commit)
 
 	// Parse join urls from the --join flag.
-	var joinURLs []url.URL
+	var brokerURLs []url.URL
 	if join == "" {
-		joinURLs = parseURLs(cmd.config.JoinURLs())
+		brokerURLs = parseURLs(cmd.config.JoinURLs())
 	} else {
-		joinURLs = parseURLs(join)
+		brokerURLs = parseURLs(join)
 	}
 
 	// Open broker & raft log, initialize or join as necessary.
-	cmd.openBroker(joinURLs)
+	if cmd.config.Broker.Enabled {
+		cmd.openBroker(brokerURLs)
+	}
 
 	// Start the broker handler.
 	h := &Handler{
@@ -146,25 +169,29 @@ func (cmd *RunCommand) Open(config *Config, join string) (*messaging.Broker, *in
 		cmd.server.broker.RunContinuousQueryLoop()
 	}
 
+	var s *influxdb.Server
 	// Open server, initialize or join as necessary.
-	s := cmd.openServer(joinURLs)
-	s.SetAuthenticationEnabled(cmd.config.Authentication.Enabled)
+	if cmd.config.Data.Enabled {
+		//FIXME: Need to also pass in dataURLs to bootstrap a data node
+		s = cmd.openServer(brokerURLs, []url.URL{})
+		s.SetAuthenticationEnabled(cmd.config.Authentication.Enabled)
 
-	// Enable retention policy enforcement if requested.
-	if cmd.config.Data.RetentionCheckEnabled {
-		interval := time.Duration(cmd.config.Data.RetentionCheckPeriod)
-		if err := s.StartRetentionPolicyEnforcement(interval); err != nil {
-			log.Fatalf("retention policy enforcement failed: %s", err.Error())
+		// Enable retention policy enforcement if requested.
+		if cmd.config.Data.RetentionCheckEnabled {
+			interval := time.Duration(cmd.config.Data.RetentionCheckPeriod)
+			if err := s.StartRetentionPolicyEnforcement(interval); err != nil {
+				log.Fatalf("retention policy enforcement failed: %s", err.Error())
+			}
+			log.Printf("broker enforcing retention policies with check interval of %s", interval)
 		}
-		log.Printf("broker enforcing retention policies with check interval of %s", interval)
-	}
 
-	// Start shard group pre-create
-	interval := cmd.config.ShardGroupPreCreateCheckPeriod()
-	if err := s.StartShardGroupsPreCreate(interval); err != nil {
-		log.Fatalf("shard group pre-create failed: %s", err.Error())
+		// Start shard group pre-create
+		interval := cmd.config.ShardGroupPreCreateCheckPeriod()
+		if err := s.StartShardGroupsPreCreate(interval); err != nil {
+			log.Fatalf("shard group pre-create failed: %s", err.Error())
+		}
+		log.Printf("shard group pre-create with check interval of %s", interval)
 	}
-	log.Printf("shard group pre-create with check interval of %s", interval)
 
 	// Start the server handler. Attach to broker if listening on the same port.
 	if s != nil {
@@ -291,13 +318,26 @@ func (cmd *RunCommand) Open(config *Config, join string) (*messaging.Broker, *in
 
 	// unless disabled, start the loop to report anonymous usage stats every 24h
 	if !cmd.config.ReportingDisabled {
-		// Make sure we have a config object b4 we try to use it.
-		if clusterID := cmd.server.broker.Broker.ClusterID(); clusterID != 0 {
-			go s.StartReportingLoop(clusterID)
+
+		if cmd.config.Broker.Enabled && cmd.config.Data.Enabled {
+			// Make sure we have a config object b4 we try to use it.
+			if clusterID := cmd.server.broker.Broker.ClusterID(); clusterID != 0 {
+				go s.StartReportingLoop(clusterID)
+			}
+		} else {
+			log.Fatalln("failed to start reporting because not running as a broker and a data node")
 		}
 	}
 
-	return cmd.server.broker.Broker, s, cmd.server.raftLog
+	var b *messaging.Broker
+	if cmd.server.broker != nil {
+		b = cmd.server.broker.Broker
+	}
+	return b, s, cmd.server.raftLog
+}
+
+func (cmd *RunCommand) Close() {
+	cmd.server.Close()
 }
 
 // write the current process id to a file specified by path.
@@ -340,7 +380,7 @@ func parseConfig(path, hostname string) (*Config, error) {
 }
 
 // creates and initializes a broker.
-func (cmd *RunCommand) openBroker(joinURLs []url.URL) {
+func (cmd *RunCommand) openBroker(brokerURLs []url.URL) {
 	path := cmd.config.BrokerDir()
 	u := cmd.config.BrokerURL()
 	raftTracing := cmd.config.Logging.RaftTracing
@@ -382,15 +422,15 @@ func (cmd *RunCommand) openBroker(joinURLs []url.URL) {
 	}
 
 	// If we have join URLs, attemp to join an existing cluster
-	if len(joinURLs) > 0 {
-		joinLog(l, joinURLs)
+	if len(brokerURLs) > 0 {
+		joinLog(l, brokerURLs)
 	}
 }
 
 // joins a raft log to an existing cluster.
-func joinLog(l *raft.Log, joinURLs []url.URL) {
+func joinLog(l *raft.Log, brokerURLs []url.URL) {
 	// Attempts to join each server until successful.
-	for _, u := range joinURLs {
+	for _, u := range brokerURLs {
 		if err := l.Join(u); err != nil {
 			log.Printf("join: failed to connect to raft cluster: %s: %s", u, err)
 		} else {
@@ -402,14 +442,15 @@ func joinLog(l *raft.Log, joinURLs []url.URL) {
 }
 
 // creates and initializes a server.
-func (cmd *RunCommand) openServer(joinURLs []url.URL) *influxdb.Server {
+func (cmd *RunCommand) openServer(brokerURLs []url.URL, dataURLs []url.URL) *influxdb.Server {
 
 	// Create messaging client to the brokers.
 	c := influxdb.NewMessagingClient(cmd.config.DataURL())
-	if len(joinURLs) == 0 {
+	// If join URLs were passed in then use them to override the client's URLs.
+	if len(brokerURLs) > 0 {
+		c.SetURLs(brokerURLs)
+	} else if cmd.server.broker != nil {
 		c.SetURLs([]url.URL{cmd.server.broker.URL()})
-	} else {
-		c.SetURLs(joinURLs)
 	}
 
 	if err := c.Open(filepath.Join(cmd.config.Data.Dir, messagingClientFile)); err != nil {
@@ -432,6 +473,7 @@ func (cmd *RunCommand) openServer(joinURLs []url.URL) *influxdb.Server {
 	s.ComputeNoMoreThan = time.Duration(cmd.config.ContinuousQuery.ComputeNoMoreThan)
 	s.Version = version
 	s.CommitHash = commit
+	cmd.server.dataNode = s
 
 	// Open server with data directory and broker client.
 	if err := s.Open(cmd.config.Data.Dir, c); err != nil {
@@ -440,7 +482,7 @@ func (cmd *RunCommand) openServer(joinURLs []url.URL) *influxdb.Server {
 	log.Printf("data server opened at %s", cmd.config.Data.Dir)
 
 	dataNodeIndex := s.Index()
-	if dataNodeIndex == 0 && len(joinURLs) == 0 && cmd.server.broker != nil {
+	if dataNodeIndex == 0 && len(dataURLs) == 0 && cmd.server.broker != nil {
 		if err := s.Initialize(cmd.server.broker.URL()); err != nil {
 			log.Fatalf("server initialization error: %s", err)
 		}
@@ -449,8 +491,8 @@ func (cmd *RunCommand) openServer(joinURLs []url.URL) *influxdb.Server {
 		return s
 	}
 
-	if len(joinURLs) > 0 {
-		joinServer(s, cmd.config.DataURL(), joinURLs)
+	if len(dataURLs) > 0 {
+		joinServer(s, cmd.config.DataURL(), dataURLs)
 		return s
 	}
 

--- a/cmd/influxd/run.go
+++ b/cmd/influxd/run.go
@@ -152,17 +152,17 @@ func (cmd *RunCommand) Open(config *Config, join string) (*messaging.Broker, *in
 	}
 
 	// We want to make sure we are spun up before we exit this function, so we manually listen and serve
-	listener, err := net.Listen("tcp", cmd.config.BrokerAddr())
+	listener, err := net.Listen("tcp", cmd.config.ClusterAddr())
 	if err != nil {
-		log.Fatalf("TCP server failed to listen on %s. %s ", cmd.config.BrokerAddr(), err)
+		log.Fatalf("TCP server failed to listen on %s. %s ", cmd.config.ClusterAddr(), err)
 	}
 	go func() {
 		err := http.Serve(listener, h)
 		if err != nil {
-			log.Fatalf("TCP server failed to server on %s: %s", cmd.config.BrokerAddr(), err)
+			log.Fatalf("TCP server failed to server on %s: %s", cmd.config.ClusterAddr(), err)
 		}
 	}()
-	log.Printf("TCP server listening on %s", cmd.config.BrokerAddr())
+	log.Printf("TCP server listening on %s", cmd.config.ClusterAddr())
 
 	// have it occasionally tell a data node in the cluster to run continuous queries
 	if cmd.config.ContinuousQuery.Disabled {

--- a/cmd/influxd/run.go
+++ b/cmd/influxd/run.go
@@ -314,7 +314,6 @@ func (cmd *RunCommand) Open(config *Config, join string) (*messaging.Broker, *in
 
 	// unless disabled, start the loop to report anonymous usage stats every 24h
 	if !cmd.config.ReportingDisabled {
-
 		if cmd.config.Broker.Enabled && cmd.config.Data.Enabled {
 			// Make sure we have a config object b4 we try to use it.
 			if clusterID := cmd.node.broker.Broker.ClusterID(); clusterID != 0 {
@@ -398,7 +397,7 @@ func (cmd *RunCommand) openBroker(brokerURLs []url.URL) {
 	}
 	log.Printf("broker opened at %s", path)
 
-	// Attach the broker as the f	inite state machine of the raft log.
+	// Attach the broker as the finite state machine of the raft log.
 	l.FSM = &messaging.RaftFSM{Broker: b}
 
 	// Open raft log inside broker directory.

--- a/cmd/influxd/server_integration_test.go
+++ b/cmd/influxd/server_integration_test.go
@@ -124,7 +124,8 @@ func createCombinedNodeCluster(t *testing.T, testName, tmpDir string, nNodes, ba
 	c.ReportingDisabled = true
 	c.Snapshot.Enabled = false
 
-	b, s, l := main.Run(c, "", "x.x")
+	cmd := main.NewRunCommand()
+	b, s, l := cmd.Open(c, "")
 	if b == nil {
 		t.Fatalf("Test %s: failed to create broker on port %d", testName, basePort)
 	}
@@ -147,7 +148,8 @@ func createCombinedNodeCluster(t *testing.T, testName, tmpDir string, nNodes, ba
 		c.Broker.Port = nextPort
 		c.Data.Port = nextPort
 
-		b, s, l := main.Run(c, "http://localhost:"+strconv.Itoa(basePort), "x.x")
+		cmd := main.NewRunCommand()
+		b, s, l := cmd.Open(c, "http://localhost:"+strconv.Itoa(basePort))
 		if b == nil {
 			t.Fatalf("Test %s: failed to create following broker on port %d", testName, basePort)
 		}

--- a/cmd/influxd/server_integration_test.go
+++ b/cmd/influxd/server_integration_test.go
@@ -118,7 +118,7 @@ func createCombinedNodeCluster(t *testing.T, testName, tmpDir string, nNodes, ba
 	}
 	c.Broker.Dir = filepath.Join(tmpBrokerDir, strconv.Itoa(basePort))
 	c.Data.Dir = filepath.Join(tmpDataDir, strconv.Itoa(basePort))
-	c.Broker.Port = basePort
+	c.Port = basePort
 	c.Data.Port = basePort
 	c.Admin.Enabled = false
 	c.ReportingDisabled = true
@@ -145,7 +145,7 @@ func createCombinedNodeCluster(t *testing.T, testName, tmpDir string, nNodes, ba
 		nextPort := basePort + i
 		c.Broker.Dir = filepath.Join(tmpBrokerDir, strconv.Itoa(nextPort))
 		c.Data.Dir = filepath.Join(tmpDataDir, strconv.Itoa(nextPort))
-		c.Broker.Port = nextPort
+		c.Port = nextPort
 		c.Data.Port = nextPort
 
 		cmd := main.NewRunCommand()
@@ -1850,12 +1850,12 @@ func TestSeparateBrokerDataNode(t *testing.T) {
 
 	brokerConfig := main.NewConfig()
 	brokerConfig.Broker.Enabled = true
-	brokerConfig.Broker.Port = 9000
-	brokerConfig.Broker.Dir = filepath.Join(tmpBrokerDir, strconv.Itoa(brokerConfig.Broker.Port))
+	brokerConfig.Port = 9000
+	brokerConfig.Broker.Dir = filepath.Join(tmpBrokerDir, strconv.Itoa(brokerConfig.Port))
 	brokerConfig.ReportingDisabled = true
 
 	dataConfig := main.NewConfig()
-	dataConfig.Broker.Port = 9001
+	dataConfig.Port = 9001
 	dataConfig.Data.Enabled = true
 	dataConfig.Data.Port = 9001
 	dataConfig.Data.Dir = filepath.Join(tmpDataDir, strconv.Itoa(dataConfig.Data.Port))
@@ -1864,7 +1864,7 @@ func TestSeparateBrokerDataNode(t *testing.T) {
 	brokerCmd := main.NewRunCommand()
 	b, _, _ := brokerCmd.Open(brokerConfig, "")
 	if b == nil {
-		t.Fatalf("Test %s: failed to create broker on port %d", testName, brokerConfig.Broker.Port)
+		t.Fatalf("Test %s: failed to create broker on port %d", testName, brokerConfig.Port)
 	}
 
 	u := b.URL()
@@ -1895,14 +1895,14 @@ func TestSeparateBrokerTwoDataNodes(t *testing.T) {
 	// Start a single broker node
 	brokerConfig := main.NewConfig()
 	brokerConfig.Broker.Enabled = true
-	brokerConfig.Broker.Port = 9010
-	brokerConfig.Broker.Dir = filepath.Join(tmpBrokerDir, strconv.Itoa(brokerConfig.Broker.Port))
+	brokerConfig.Port = 9010
+	brokerConfig.Broker.Dir = filepath.Join(tmpBrokerDir, strconv.Itoa(brokerConfig.Port))
 	brokerConfig.ReportingDisabled = true
 
 	brokerCmd := main.NewRunCommand()
 	b, _, _ := brokerCmd.Open(brokerConfig, "")
 	if b == nil {
-		t.Fatalf("Test %s: failed to create broker on port %d", testName, brokerConfig.Broker.Port)
+		t.Fatalf("Test %s: failed to create broker on port %d", testName, brokerConfig.Port)
 	}
 
 	u := b.URL()
@@ -1910,7 +1910,7 @@ func TestSeparateBrokerTwoDataNodes(t *testing.T) {
 
 	// Star the first data node and join the broker
 	dataConfig1 := main.NewConfig()
-	dataConfig1.Broker.Port = 9011
+	dataConfig1.Port = 9011
 	dataConfig1.Data.Enabled = true
 	dataConfig1.Data.Port = 9011
 	dataConfig1.Data.Dir = filepath.Join(tmpDataDir, strconv.Itoa(dataConfig1.Data.Port))
@@ -1926,7 +1926,7 @@ func TestSeparateBrokerTwoDataNodes(t *testing.T) {
 
 	// Join data node 2 to single broker and first data node
 	dataConfig2 := main.NewConfig()
-	dataConfig2.Broker.Port = 9012
+	dataConfig2.Port = 9012
 	dataConfig2.Data.Enabled = true
 	dataConfig2.Data.Port = 9012
 	dataConfig2.Data.Dir = filepath.Join(tmpDataDir, strconv.Itoa(dataConfig2.Data.Port))

--- a/cmd/influxd/server_integration_test.go
+++ b/cmd/influxd/server_integration_test.go
@@ -114,7 +114,7 @@ func createCombinedNodeCluster(t *testing.T, testName, tmpDir string, nNodes, ba
 	// Create the first node, special case.
 	c := baseConfig
 	if c == nil {
-		c, _ = main.NewConfig()
+		c, _ = main.NewTestConfig()
 	}
 	c.Broker.Dir = filepath.Join(tmpBrokerDir, strconv.Itoa(basePort))
 	c.Data.Dir = filepath.Join(tmpDataDir, strconv.Itoa(basePort))
@@ -1469,7 +1469,7 @@ func Test_ServerSingleGraphiteIntegration(t *testing.T) {
 	testName := "graphite integration"
 	dir := tempfile()
 	now := time.Now().UTC().Round(time.Second)
-	c, _ := main.NewConfig()
+	c, _ := main.NewTestConfig()
 	g := main.Graphite{
 		Enabled:  true,
 		Database: "graphite",
@@ -1519,7 +1519,7 @@ func Test_ServerSingleGraphiteIntegration_FractionalTime(t *testing.T) {
 	testName := "graphite integration fractional time"
 	dir := tempfile()
 	now := time.Now().UTC().Round(time.Second).Add(500 * time.Millisecond)
-	c, _ := main.NewConfig()
+	c, _ := main.NewTestConfig()
 	g := main.Graphite{
 		Enabled:  true,
 		Database: "graphite",
@@ -1571,7 +1571,7 @@ func Test_ServerSingleGraphiteIntegration_ZeroDataPoint(t *testing.T) {
 	testName := "graphite integration"
 	dir := tempfile()
 	now := time.Now().UTC().Round(time.Second)
-	c, _ := main.NewConfig()
+	c, _ := main.NewTestConfig()
 	g := main.Graphite{
 		Enabled:  true,
 		Database: "graphite",
@@ -1622,7 +1622,7 @@ func Test_ServerSingleGraphiteIntegration_NoDatabase(t *testing.T) {
 	testName := "graphite integration"
 	dir := tempfile()
 	now := time.Now().UTC().Round(time.Second)
-	c, _ := main.NewConfig()
+	c, _ := main.NewTestConfig()
 	g := main.Graphite{
 		Enabled:  true,
 		Port:     2303,
@@ -1630,7 +1630,6 @@ func Test_ServerSingleGraphiteIntegration_NoDatabase(t *testing.T) {
 	}
 	c.Graphites = append(c.Graphites, g)
 	c.Logging.WriteTracing = true
-
 	t.Logf("Graphite Connection String: %s\n", g.ConnectionString(c.BindAddress))
 	nodes := createCombinedNodeCluster(t, testName, dir, nNodes, basePort, c)
 
@@ -1683,7 +1682,7 @@ func Test_ServerOpenTSDBIntegration(t *testing.T) {
 	testName := "opentsdb integration"
 	dir := tempfile()
 	now := time.Now().UTC().Round(time.Second)
-	c, _ := main.NewConfig()
+	c, _ := main.NewTestConfig()
 	o := main.OpenTSDB{
 		Port:            4242,
 		Enabled:         true,
@@ -1734,7 +1733,7 @@ func Test_ServerOpenTSDBIntegration_WithTags(t *testing.T) {
 	testName := "opentsdb integration"
 	dir := tempfile()
 	now := time.Now().UTC().Round(time.Second)
-	c, _ := main.NewConfig()
+	c, _ := main.NewTestConfig()
 	o := main.OpenTSDB{
 		Port:            4243,
 		Enabled:         true,
@@ -1788,7 +1787,7 @@ func Test_ServerOpenTSDBIntegration_BadData(t *testing.T) {
 	testName := "opentsdb integration"
 	dir := tempfile()
 	now := time.Now().UTC().Round(time.Second)
-	c, _ := main.NewConfig()
+	c, _ := main.NewTestConfig()
 	o := main.OpenTSDB{
 		Port:            4244,
 		Enabled:         true,

--- a/cmd/influxd/server_integration_test.go
+++ b/cmd/influxd/server_integration_test.go
@@ -1922,10 +1922,6 @@ func TestSeparateBrokerTwoDataNodes(t *testing.T) {
 		t.Fatalf("Test %s: failed to create leader data node on port %d", testName, dataConfig1.Port)
 	}
 
-	// FIXME: This is needed for now because cmd.Open() will return before the server
-	// is actually ready to handle requests.
-	time.Sleep(1 * time.Second)
-
 	// Join data node 2 to single broker and first data node
 	dataConfig2 := main.NewConfig()
 	dataConfig2.Port = 9012

--- a/cmd/influxd/server_integration_test.go
+++ b/cmd/influxd/server_integration_test.go
@@ -1309,11 +1309,7 @@ func TestSingleServer(t *testing.T) {
 }
 
 func Test3NodeServer(t *testing.T) {
-	t.Skip("temporarily disabling while #1934 is in progress")
-
 	testName := "3-node server integration"
-
-	t.Skip("disabling until #1934 is complete")
 
 	if testing.Short() {
 		t.Skip(fmt.Sprintf("skipping '%s'", testName))

--- a/cmd/influxd/server_integration_test.go
+++ b/cmd/influxd/server_integration_test.go
@@ -1868,10 +1868,9 @@ func TestSeparateBrokerDataNode(t *testing.T) {
 	}
 
 	u := b.URL()
-	dataConfig.Initialization.JoinURLs = (&u).String()
 	dataCmd := main.NewRunCommand()
 
-	_, s, _ := dataCmd.Open(dataConfig, "")
+	_, s, _ := dataCmd.Open(dataConfig, (&u).String())
 	if s == nil {
 		t.Fatalf("Test %s: failed to create leader data node on port %d", testName, dataConfig.Port)
 	}
@@ -1920,13 +1919,16 @@ func TestSeparateBrokerTwoDataNodes(t *testing.T) {
 	dataConfig1.Data.Dir = filepath.Join(tmpDataDir, strconv.Itoa(dataConfig1.Port))
 	dataConfig1.ReportingDisabled = true
 
-	dataConfig1.Initialization.JoinURLs = brokerURL
 	dataCmd1 := main.NewRunCommand()
 
-	_, s1, _ := dataCmd1.Open(dataConfig1, "")
+	_, s1, _ := dataCmd1.Open(dataConfig1, brokerURL)
 	if s1 == nil {
 		t.Fatalf("Test %s: failed to create leader data node on port %d", testName, dataConfig1.Port)
 	}
+
+	// FIXME: This is needed for now because cmd.Open() will return before the server
+	// is actually ready to handle requests.
+	time.Sleep(1 * time.Second)
 
 	// Join data node 2 to single broker and first data node
 	dataConfig2 := main.NewConfig()
@@ -1935,12 +1937,9 @@ func TestSeparateBrokerTwoDataNodes(t *testing.T) {
 	dataConfig2.Data.Dir = filepath.Join(tmpDataDir, strconv.Itoa(dataConfig2.Port))
 	dataConfig2.ReportingDisabled = true
 
-	dataNode1Url := s1.URL()
-	dataConfig2.Data.JoinURLs = (&dataNode1Url).String()
-	dataConfig2.Initialization.JoinURLs = brokerURL
 	dataCmd2 := main.NewRunCommand()
 
-	_, s2, _ := dataCmd2.Open(dataConfig2, "")
+	_, s2, _ := dataCmd2.Open(dataConfig2, brokerURL)
 	if s2 == nil {
 		t.Fatalf("Test %s: failed to create leader data node on port %d", testName, dataConfig2.Port)
 	}

--- a/cmd/influxd/server_integration_test.go
+++ b/cmd/influxd/server_integration_test.go
@@ -1875,7 +1875,6 @@ func TestSeparateBrokerDataNode(t *testing.T) {
 }
 
 func TestSeparateBrokerTwoDataNodes(t *testing.T) {
-
 	testName := "TestSeparateBrokerTwoDataNodes"
 	if testing.Short() {
 		t.Skip("Skipping", testName)

--- a/cmd/influxd/server_integration_test.go
+++ b/cmd/influxd/server_integration_test.go
@@ -1311,6 +1311,8 @@ func TestSingleServer(t *testing.T) {
 }
 
 func Test3NodeServer(t *testing.T) {
+	t.Skip("temporarily disabling while #1934 is in progress")
+
 	testName := "3-node server integration"
 
 	t.Skip("disabling until #1934 is complete")

--- a/cmd/influxd/server_integration_test.go
+++ b/cmd/influxd/server_integration_test.go
@@ -1312,6 +1312,9 @@ func TestSingleServer(t *testing.T) {
 
 func Test3NodeServer(t *testing.T) {
 	testName := "3-node server integration"
+
+	t.Skip("disabling until #1934 is complete")
+
 	if testing.Short() {
 		t.Skip(fmt.Sprintf("skipping '%s'", testName))
 	}
@@ -1828,6 +1831,51 @@ func Test_ServerOpenTSDBIntegration_BadData(t *testing.T) {
 	if !ok {
 		t.Errorf(`Test "%s" failed, expected: %s, got: %s`, testName, expected, got)
 	}
+}
+
+func TestSeparateBrokerDataNode(t *testing.T) {
+
+	testName := "TestSeparateBrokerDataNode"
+	tmpDir := tempfile()
+	tmpBrokerDir := filepath.Join(tmpDir, "broker-integration-test")
+	tmpDataDir := filepath.Join(tmpDir, "data-integration-test")
+	t.Logf("Test %s: using tmp directory %q for brokers\n", testName, tmpBrokerDir)
+	t.Logf("Test %s: using tmp directory %q for data nodes\n", testName, tmpDataDir)
+	// Sometimes if a test fails, it's because of a log.Fatal() in the program.
+	// This prevents the defer from cleaning up directories.
+	// To be safe, nuke them always before starting
+	_ = os.RemoveAll(tmpBrokerDir)
+	_ = os.RemoveAll(tmpDataDir)
+
+	brokerConfig := main.NewConfig()
+	brokerConfig.Broker.Enabled = true
+	brokerConfig.Broker.Port = 9000
+	brokerConfig.Broker.Dir = filepath.Join(tmpBrokerDir, strconv.Itoa(brokerConfig.Broker.Port))
+	brokerConfig.ReportingDisabled = true
+
+	dataConfig := main.NewConfig()
+	dataConfig.Data.Enabled = true
+	dataConfig.Data.Port = 9001
+	dataConfig.Data.Dir = filepath.Join(tmpDataDir, strconv.Itoa(dataConfig.Data.Port))
+	dataConfig.ReportingDisabled = true
+
+	brokerCmd := main.NewRunCommand()
+	b, _, _ := brokerCmd.Open(brokerConfig, "")
+	if b == nil {
+		t.Fatalf("Test %s: failed to create broker on port %d", testName, brokerConfig.Broker.Port)
+	}
+
+	u := b.URL()
+	dataConfig.Initialization.JoinURLs = (&u).String()
+	dataCmd := main.NewRunCommand()
+
+	_, s, _ := dataCmd.Open(dataConfig, "")
+	if s == nil {
+		t.Fatalf("Test %s: failed to create leader data node on port %d", testName, dataConfig.Data.Port)
+	}
+	brokerCmd.Close()
+	dataCmd.Close()
+
 }
 
 // helper funcs

--- a/cmd/influxd/server_integration_test.go
+++ b/cmd/influxd/server_integration_test.go
@@ -119,7 +119,6 @@ func createCombinedNodeCluster(t *testing.T, testName, tmpDir string, nNodes, ba
 	c.Broker.Dir = filepath.Join(tmpBrokerDir, strconv.Itoa(basePort))
 	c.Data.Dir = filepath.Join(tmpDataDir, strconv.Itoa(basePort))
 	c.Port = basePort
-	c.Data.Port = basePort
 	c.Admin.Enabled = false
 	c.ReportingDisabled = true
 	c.Snapshot.Enabled = false
@@ -146,7 +145,6 @@ func createCombinedNodeCluster(t *testing.T, testName, tmpDir string, nNodes, ba
 		c.Broker.Dir = filepath.Join(tmpBrokerDir, strconv.Itoa(nextPort))
 		c.Data.Dir = filepath.Join(tmpDataDir, strconv.Itoa(nextPort))
 		c.Port = nextPort
-		c.Data.Port = nextPort
 
 		cmd := main.NewRunCommand()
 		b, s, l := cmd.Open(c, "http://localhost:"+strconv.Itoa(basePort))
@@ -1837,6 +1835,10 @@ func Test_ServerOpenTSDBIntegration_BadData(t *testing.T) {
 
 func TestSeparateBrokerDataNode(t *testing.T) {
 	testName := "TestSeparateBrokerDataNode"
+	if testing.Short() {
+		t.Skip("Skipping", testName)
+	}
+
 	tmpDir := tempfile()
 	tmpBrokerDir := filepath.Join(tmpDir, "broker-integration-test")
 	tmpDataDir := filepath.Join(tmpDir, "data-integration-test")
@@ -1855,10 +1857,8 @@ func TestSeparateBrokerDataNode(t *testing.T) {
 	brokerConfig.ReportingDisabled = true
 
 	dataConfig := main.NewConfig()
-	dataConfig.Port = 9001
 	dataConfig.Data.Enabled = true
-	dataConfig.Data.Port = 9001
-	dataConfig.Data.Dir = filepath.Join(tmpDataDir, strconv.Itoa(dataConfig.Data.Port))
+	dataConfig.Data.Dir = filepath.Join(tmpDataDir, strconv.Itoa(dataConfig.Port))
 	dataConfig.ReportingDisabled = true
 
 	brokerCmd := main.NewRunCommand()
@@ -1873,14 +1873,19 @@ func TestSeparateBrokerDataNode(t *testing.T) {
 
 	_, s, _ := dataCmd.Open(dataConfig, "")
 	if s == nil {
-		t.Fatalf("Test %s: failed to create leader data node on port %d", testName, dataConfig.Data.Port)
+		t.Fatalf("Test %s: failed to create leader data node on port %d", testName, dataConfig.Port)
 	}
 	brokerCmd.Close()
 	dataCmd.Close()
 }
 
 func TestSeparateBrokerTwoDataNodes(t *testing.T) {
+
 	testName := "TestSeparateBrokerTwoDataNodes"
+	if testing.Short() {
+		t.Skip("Skipping", testName)
+	}
+
 	tmpDir := tempfile()
 	tmpBrokerDir := filepath.Join(tmpDir, "broker-integration-test")
 	tmpDataDir := filepath.Join(tmpDir, "data-integration-test")
@@ -1912,8 +1917,7 @@ func TestSeparateBrokerTwoDataNodes(t *testing.T) {
 	dataConfig1 := main.NewConfig()
 	dataConfig1.Port = 9011
 	dataConfig1.Data.Enabled = true
-	dataConfig1.Data.Port = 9011
-	dataConfig1.Data.Dir = filepath.Join(tmpDataDir, strconv.Itoa(dataConfig1.Data.Port))
+	dataConfig1.Data.Dir = filepath.Join(tmpDataDir, strconv.Itoa(dataConfig1.Port))
 	dataConfig1.ReportingDisabled = true
 
 	dataConfig1.Initialization.JoinURLs = brokerURL
@@ -1921,15 +1925,14 @@ func TestSeparateBrokerTwoDataNodes(t *testing.T) {
 
 	_, s1, _ := dataCmd1.Open(dataConfig1, "")
 	if s1 == nil {
-		t.Fatalf("Test %s: failed to create leader data node on port %d", testName, dataConfig1.Data.Port)
+		t.Fatalf("Test %s: failed to create leader data node on port %d", testName, dataConfig1.Port)
 	}
 
 	// Join data node 2 to single broker and first data node
 	dataConfig2 := main.NewConfig()
 	dataConfig2.Port = 9012
 	dataConfig2.Data.Enabled = true
-	dataConfig2.Data.Port = 9012
-	dataConfig2.Data.Dir = filepath.Join(tmpDataDir, strconv.Itoa(dataConfig2.Data.Port))
+	dataConfig2.Data.Dir = filepath.Join(tmpDataDir, strconv.Itoa(dataConfig2.Port))
 	dataConfig2.ReportingDisabled = true
 
 	dataNode1Url := s1.URL()
@@ -1939,7 +1942,7 @@ func TestSeparateBrokerTwoDataNodes(t *testing.T) {
 
 	_, s2, _ := dataCmd2.Open(dataConfig2, "")
 	if s2 == nil {
-		t.Fatalf("Test %s: failed to create leader data node on port %d", testName, dataConfig2.Data.Port)
+		t.Fatalf("Test %s: failed to create leader data node on port %d", testName, dataConfig2.Port)
 	}
 
 	brokerCmd.Close()

--- a/cmd/influxd/server_integration_test.go
+++ b/cmd/influxd/server_integration_test.go
@@ -149,10 +149,10 @@ func createCombinedNodeCluster(t *testing.T, testName, tmpDir string, nNodes, ba
 		cmd := main.NewRunCommand()
 		b, s, l := cmd.Open(c, "http://localhost:"+strconv.Itoa(basePort))
 		if b == nil {
-			t.Fatalf("Test %s: failed to create following broker on port %d", testName, basePort)
+			t.Fatalf("Test %s: failed to create following broker on port %d", testName, nextPort)
 		}
 		if s == nil {
-			t.Fatalf("Test %s: failed to create following data node on port %d", testName, basePort)
+			t.Fatalf("Test %s: failed to create following data node on port %d", testName, nextPort)
 		}
 
 		nodes = append(nodes, &Node{

--- a/etc/config.sample.toml
+++ b/etc/config.sample.toml
@@ -5,6 +5,7 @@
 # that can be resolved here.
 # hostname = ""
 bind-address = "0.0.0.0"
+port = 8086
 
 # Once every 24 hours InfluxDB will report anonymous data to m.influxdb.com
 # The data includes raft id (random 8 bytes), os, arch and version
@@ -13,11 +14,6 @@ bind-address = "0.0.0.0"
 # is very helpful for us.
 # Change this option to true to disable reporting.
 reporting-disabled = false
-
-# Controls settings for initial start-up. Once a node a successfully started,
-# these settings are ignored.
-[initialization]
-join-urls = "" # Comma-delimited URLs, in the form http://host:port, for joining another cluster. 
 
 # Control authentication
 # If not set authetication is DISABLED. Be sure to explicitly set this flag to
@@ -69,15 +65,15 @@ enabled = false
 # Broker configuration. Brokers are nodes which participate in distributed
 # consensus.
 [broker]
+enabled = true
 # Where the Raft logs are stored. The user running InfluxDB will need read/write access.
 dir  = "/var/opt/influxdb/raft"
-port = 8086
 
 # Data node configuration. Data nodes are where the time-series data, in the form of
 # shards, is stored.
 [data]
+enabled = true
 dir = "/var/opt/influxdb/db"
-port = 8086
 
 # Auto-create a retention policy when a database is created. Defaults to true.
 retention-auto-create = true
@@ -86,10 +82,6 @@ retention-auto-create = true
 # enforcing those policies.
 retention-check-enabled = true
 retention-check-period = "10m"
-
-[cluster]
-# Location for cluster state storage. For storing state persistently across restarts.
-dir = "/var/opt/influxdb/state"
 
 # Configuration for snapshot endpoint.
 [snapshot]

--- a/httpd/handler_test.go
+++ b/httpd/handler_test.go
@@ -145,7 +145,7 @@ func TestHandler_ShowMeasurementsNotFound(t *testing.T) {
 	srvr.CreateDatabase("foo")
 	srvr.CreateRetentionPolicy("foo", influxdb.NewRetentionPolicy("bar"))
 	srvr.SetDefaultRetentionPolicy("foo", "bar")
-	s := NewHTTPServer(srvr)
+	s := NewAPIServer(srvr)
 	defer s.Close()
 
 	status, body := MustHTTP("GET", s.URL+`/query`, map[string]string{"q": "SHOW SERIES from bin", "db": "foo"}, nil, "")
@@ -166,7 +166,7 @@ func TestHandler_CreateDatabase(t *testing.T) {
 	c := test.NewDefaultMessagingClient()
 	defer c.Close()
 	srvr := OpenAuthlessServer(c)
-	s := NewHTTPServer(srvr)
+	s := NewAPIServer(srvr)
 	defer s.Close()
 
 	status, body := MustHTTP("GET", s.URL+`/query`, map[string]string{"q": "CREATE DATABASE foo"}, nil, "")
@@ -181,7 +181,7 @@ func TestHandler_CreateDatabase_BadRequest_NoName(t *testing.T) {
 	c := test.NewDefaultMessagingClient()
 	defer c.Close()
 	srvr := OpenAuthlessServer(c)
-	s := NewHTTPServer(srvr)
+	s := NewAPIServer(srvr)
 	defer s.Close()
 
 	status, _ := MustHTTP("GET", s.URL+`/query`, map[string]string{"q": "CREATE DATABASE"}, nil, "")
@@ -195,7 +195,7 @@ func TestHandler_CreateDatabase_Conflict(t *testing.T) {
 	defer c.Close()
 	srvr := OpenAuthlessServer(c)
 	srvr.CreateDatabase("foo")
-	s := NewHTTPServer(srvr)
+	s := NewAPIServer(srvr)
 	defer s.Close()
 
 	status, body := MustHTTP("GET", s.URL+`/query`, map[string]string{"q": "CREATE DATABASE foo"}, nil, "")
@@ -211,7 +211,7 @@ func TestHandler_DropDatabase(t *testing.T) {
 	defer c.Close()
 	srvr := OpenAuthlessServer(c)
 	srvr.CreateDatabase("foo")
-	s := NewHTTPServer(srvr)
+	s := NewAPIServer(srvr)
 	defer s.Close()
 
 	status, body := MustHTTP("GET", s.URL+`/query`, map[string]string{"q": "DROP DATABASE foo"}, nil, "")
@@ -226,7 +226,7 @@ func TestHandler_DropDatabase_NotFound(t *testing.T) {
 	c := test.NewDefaultMessagingClient()
 	defer c.Close()
 	srvr := OpenAuthlessServer(c)
-	s := NewHTTPServer(srvr)
+	s := NewAPIServer(srvr)
 	defer s.Close()
 
 	status, body := MustHTTP("GET", s.URL+`/query`, map[string]string{"q": "DROP DATABASE bar"}, nil, "")
@@ -243,7 +243,7 @@ func TestHandler_RetentionPolicies(t *testing.T) {
 	srvr := OpenAuthlessServer(c)
 	srvr.CreateDatabase("foo")
 	srvr.CreateRetentionPolicy("foo", influxdb.NewRetentionPolicy("bar"))
-	s := NewHTTPServer(srvr)
+	s := NewAPIServer(srvr)
 	defer s.Close()
 
 	status, body := MustHTTP("GET", s.URL+`/query`, map[string]string{"q": "SHOW RETENTION POLICIES foo"}, nil, "")
@@ -259,7 +259,7 @@ func TestHandler_RetentionPolicies_DatabaseNotFound(t *testing.T) {
 	c := test.NewDefaultMessagingClient()
 	defer c.Close()
 	srvr := OpenAuthlessServer(c)
-	s := NewHTTPServer(srvr)
+	s := NewAPIServer(srvr)
 	defer s.Close()
 
 	status, body := MustHTTP("GET", s.URL+`/query`, map[string]string{"q": "SHOW RETENTION POLICIES foo"}, nil, "")
@@ -276,7 +276,7 @@ func TestHandler_CreateRetentionPolicy(t *testing.T) {
 	defer c.Close()
 	srvr := OpenAuthlessServer(c)
 	srvr.CreateDatabase("foo")
-	s := NewHTTPServer(srvr)
+	s := NewAPIServer(srvr)
 	defer s.Close()
 
 	query := map[string]string{"q": "CREATE RETENTION POLICY bar ON foo DURATION 1h REPLICATION 1"}
@@ -294,7 +294,7 @@ func TestHandler_CreateRetentionPolicyAsDefault(t *testing.T) {
 	defer c.Close()
 	srvr := OpenAuthlessServer(c)
 	srvr.CreateDatabase("foo")
-	s := NewHTTPServer(srvr)
+	s := NewAPIServer(srvr)
 	defer s.Close()
 
 	query := map[string]string{"q": "CREATE RETENTION POLICY bar ON foo DURATION 1h REPLICATION 1 DEFAULT"}
@@ -318,7 +318,7 @@ func TestHandler_CreateRetentionPolicy_DatabaseNotFound(t *testing.T) {
 	c := test.NewDefaultMessagingClient()
 	defer c.Close()
 	srvr := OpenAuthlessServer(c)
-	s := NewHTTPServer(srvr)
+	s := NewAPIServer(srvr)
 	defer s.Close()
 
 	query := map[string]string{"q": "CREATE RETENTION POLICY bar ON foo DURATION 1h REPLICATION 1"}
@@ -334,7 +334,7 @@ func TestHandler_CreateRetentionPolicy_Conflict(t *testing.T) {
 	defer c.Close()
 	srvr := OpenAuthlessServer(c)
 	srvr.CreateDatabase("foo")
-	s := NewHTTPServer(srvr)
+	s := NewAPIServer(srvr)
 	defer s.Close()
 
 	query := map[string]string{"q": "CREATE RETENTION POLICY bar ON foo DURATION 1h REPLICATION 1"}
@@ -352,7 +352,7 @@ func TestHandler_CreateRetentionPolicy_BadRequest(t *testing.T) {
 	defer c.Close()
 	srvr := OpenAuthlessServer(c)
 	srvr.CreateDatabase("foo")
-	s := NewHTTPServer(srvr)
+	s := NewAPIServer(srvr)
 	defer s.Close()
 
 	query := map[string]string{"q": "CREATE RETENTION POLICY bar ON foo DURATION ***BAD*** REPLICATION 1"}
@@ -369,7 +369,7 @@ func TestHandler_UpdateRetentionPolicy(t *testing.T) {
 	srvr := OpenAuthlessServer(c)
 	srvr.CreateDatabase("foo")
 	srvr.CreateRetentionPolicy("foo", influxdb.NewRetentionPolicy("bar"))
-	s := NewHTTPServer(srvr)
+	s := NewAPIServer(srvr)
 	defer s.Close()
 
 	query := map[string]string{"q": "ALTER RETENTION POLICY bar ON foo REPLICATION 42 DURATION 2h DEFAULT"}
@@ -401,7 +401,7 @@ func TestHandler_UpdateRetentionPolicy_BadRequest(t *testing.T) {
 	srvr := OpenAuthlessServer(c)
 	srvr.CreateDatabase("foo")
 	srvr.CreateRetentionPolicy("foo", influxdb.NewRetentionPolicy("bar"))
-	s := NewHTTPServer(srvr)
+	s := NewAPIServer(srvr)
 	defer s.Close()
 
 	query := map[string]string{"q": "ALTER RETENTION POLICY bar ON foo DURATION ***BAD*** REPLICATION 1"}
@@ -417,7 +417,7 @@ func TestHandler_UpdateRetentionPolicy_DatabaseNotFound(t *testing.T) {
 	c := test.NewDefaultMessagingClient()
 	defer c.Close()
 	srvr := OpenAuthlessServer(c)
-	s := NewHTTPServer(srvr)
+	s := NewAPIServer(srvr)
 	defer s.Close()
 
 	query := map[string]string{"q": "ALTER RETENTION POLICY bar ON foo DURATION 1h REPLICATION 1"}
@@ -435,7 +435,7 @@ func TestHandler_UpdateRetentionPolicy_NotFound(t *testing.T) {
 	srvr := OpenAuthlessServer(c)
 	srvr.CreateDatabase("foo")
 	srvr.CreateRetentionPolicy("foo", influxdb.NewRetentionPolicy("bar"))
-	s := NewHTTPServer(srvr)
+	s := NewAPIServer(srvr)
 	defer s.Close()
 
 	query := map[string]string{"q": "ALTER RETENTION POLICY qux ON foo DURATION 1h REPLICATION 1"}
@@ -453,7 +453,7 @@ func TestHandler_DeleteRetentionPolicy(t *testing.T) {
 	srvr := OpenAuthlessServer(c)
 	srvr.CreateDatabase("foo")
 	srvr.CreateRetentionPolicy("foo", influxdb.NewRetentionPolicy("bar"))
-	s := NewHTTPServer(srvr)
+	s := NewAPIServer(srvr)
 	defer s.Close()
 
 	query := map[string]string{"q": "DROP RETENTION POLICY bar ON foo"}
@@ -470,7 +470,7 @@ func TestHandler_DeleteRetentionPolicy_DatabaseNotFound(t *testing.T) {
 	c := test.NewDefaultMessagingClient()
 	defer c.Close()
 	srvr := OpenAuthlessServer(c)
-	s := NewHTTPServer(srvr)
+	s := NewAPIServer(srvr)
 	defer s.Close()
 
 	query := map[string]string{"q": "DROP RETENTION POLICY bar ON qux"}
@@ -488,7 +488,7 @@ func TestHandler_DeleteRetentionPolicy_NotFound(t *testing.T) {
 	defer c.Close()
 	srvr := OpenAuthlessServer(c)
 	srvr.CreateDatabase("foo")
-	s := NewHTTPServer(srvr)
+	s := NewAPIServer(srvr)
 	defer s.Close()
 
 	query := map[string]string{"q": "DROP RETENTION POLICY bar ON foo"}
@@ -505,7 +505,7 @@ func TestHandler_GzipEnabled(t *testing.T) {
 	c := test.NewDefaultMessagingClient()
 	defer c.Close()
 	srvr := OpenAuthlessServer(c)
-	s := NewHTTPServer(srvr)
+	s := NewAPIServer(srvr)
 	defer s.Close()
 
 	req, err := http.NewRequest("GET", s.URL+`/ping`, bytes.NewBuffer([]byte{}))
@@ -531,7 +531,7 @@ func TestHandler_GzipDisabled(t *testing.T) {
 	c := test.NewDefaultMessagingClient()
 	defer c.Close()
 	srvr := OpenAuthlessServer(c)
-	s := NewHTTPServer(srvr)
+	s := NewAPIServer(srvr)
 	defer s.Close()
 
 	req, err := http.NewRequest("GET", s.URL+`/ping`, bytes.NewBuffer([]byte{}))
@@ -557,7 +557,7 @@ func TestHandler_Index(t *testing.T) {
 	c := test.NewDefaultMessagingClient()
 	defer c.Close()
 	srvr := OpenAuthlessServer(c)
-	s := NewHTTPServer(srvr)
+	s := NewClusterServer(srvr)
 	defer s.Close()
 
 	status, body := MustHTTP("GET", s.URL, nil, nil, "")
@@ -575,7 +575,7 @@ func TestHandler_Wait(t *testing.T) {
 	c := test.NewDefaultMessagingClient()
 	defer c.Close()
 	srvr := OpenAuthlessServer(c)
-	s := NewHTTPServer(srvr)
+	s := NewClusterServer(srvr)
 	defer s.Close()
 
 	status, body := MustHTTP("GET", s.URL+`/wait/1`, map[string]string{"timeout": "1"}, nil, "")
@@ -596,7 +596,7 @@ func TestHandler_WaitIncrement(t *testing.T) {
 	srvr.CreateDatabase("foo")
 	srvr.CreateRetentionPolicy("foo", influxdb.NewRetentionPolicy("bar"))
 
-	s := NewHTTPServer(srvr)
+	s := NewClusterServer(srvr)
 	defer s.Close()
 
 	status, _ := MustHTTP("GET", s.URL+`/wait/2`, map[string]string{"timeout": "200"}, nil, "")
@@ -613,7 +613,7 @@ func TestHandler_WaitNoIndexSpecified(t *testing.T) {
 	c := test.NewDefaultMessagingClient()
 	defer c.Close()
 	srvr := OpenAuthlessServer(c)
-	s := NewHTTPServer(srvr)
+	s := NewClusterServer(srvr)
 	defer s.Close()
 
 	status, _ := MustHTTP("GET", s.URL+`/wait`, nil, nil, "")
@@ -627,7 +627,7 @@ func TestHandler_WaitInvalidIndexSpecified(t *testing.T) {
 	c := test.NewDefaultMessagingClient()
 	defer c.Close()
 	srvr := OpenAuthlessServer(c)
-	s := NewHTTPServer(srvr)
+	s := NewClusterServer(srvr)
 	defer s.Close()
 
 	status, _ := MustHTTP("GET", s.URL+`/wait/foo`, nil, nil, "")
@@ -641,7 +641,7 @@ func TestHandler_WaitExpectTimeout(t *testing.T) {
 	c := test.NewDefaultMessagingClient()
 	defer c.Close()
 	srvr := OpenAuthlessServer(c)
-	s := NewHTTPServer(srvr)
+	s := NewClusterServer(srvr)
 	defer s.Close()
 
 	status, _ := MustHTTP("GET", s.URL+`/wait/2`, map[string]string{"timeout": "1"}, nil, "")
@@ -655,7 +655,7 @@ func TestHandler_Ping(t *testing.T) {
 	c := test.NewDefaultMessagingClient()
 	defer c.Close()
 	srvr := OpenAuthlessServer(c)
-	s := NewHTTPServer(srvr)
+	s := NewAPIServer(srvr)
 	defer s.Close()
 
 	status, _ := MustHTTP("GET", s.URL+`/ping`, nil, nil, "")
@@ -669,7 +669,7 @@ func TestHandler_PingHead(t *testing.T) {
 	c := test.NewDefaultMessagingClient()
 	defer c.Close()
 	srvr := OpenAuthlessServer(c)
-	s := NewHTTPServer(srvr)
+	s := NewAPIServer(srvr)
 	defer s.Close()
 
 	status, _ := MustHTTP("HEAD", s.URL+`/ping`, nil, nil, "")
@@ -686,7 +686,7 @@ func TestHandler_Users_MultipleUsers(t *testing.T) {
 	srvr.CreateUser("jdoe", "1337", false)
 	srvr.CreateUser("mclark", "1337", true)
 	srvr.CreateUser("csmith", "1337", false)
-	s := NewHTTPServer(srvr)
+	s := NewAPIServer(srvr)
 	defer s.Close()
 
 	query := map[string]string{"q": "SHOW USERS"}
@@ -704,7 +704,7 @@ func TestHandler_UpdateUser(t *testing.T) {
 	defer c.Close()
 	srvr := OpenAuthlessServer(c)
 	srvr.CreateUser("jdoe", "1337", false)
-	s := NewHTTPServer(srvr)
+	s := NewAPIServer(srvr)
 	defer s.Close()
 
 	// Save original password hash.
@@ -727,7 +727,7 @@ func TestHandler_UpdateUser_PasswordBadRequest(t *testing.T) {
 	defer c.Close()
 	srvr := OpenAuthlessServer(c)
 	srvr.CreateUser("jdoe", "1337", false)
-	s := NewHTTPServer(srvr)
+	s := NewAPIServer(srvr)
 	defer s.Close()
 
 	status, body := MustHTTP("PUT", s.URL+`/users/jdoe`, nil, nil, `{"password": 10}`)
@@ -746,7 +746,7 @@ func TestHandler_DataNodes(t *testing.T) {
 	srvr.CreateDataNode(MustParseURL("http://localhost:1000"))
 	srvr.CreateDataNode(MustParseURL("http://localhost:2000"))
 	srvr.CreateDataNode(MustParseURL("http://localhost:3000"))
-	s := NewHTTPServer(srvr)
+	s := NewAPIServer(srvr)
 	defer s.Close()
 
 	status, body := MustHTTP("GET", s.URL+`/data_nodes`, nil, nil, "")
@@ -762,7 +762,7 @@ func TestHandler_CreateDataNode(t *testing.T) {
 	c := test.NewDefaultMessagingClient()
 	defer c.Close()
 	srvr := OpenUninitializedServer(c)
-	s := NewHTTPServer(srvr)
+	s := NewAPIServer(srvr)
 	defer s.Close()
 
 	status, body := MustHTTP("POST", s.URL+`/data_nodes`, nil, nil, `{"url":"http://localhost:1000"}`)
@@ -778,7 +778,7 @@ func TestHandler_CreateDataNode_BadRequest(t *testing.T) {
 	c := test.NewDefaultMessagingClient()
 	defer c.Close()
 	srvr := OpenAuthlessServer(c)
-	s := NewHTTPServer(srvr)
+	s := NewAPIServer(srvr)
 	defer s.Close()
 
 	status, body := MustHTTP("POST", s.URL+`/data_nodes`, nil, nil, `{"name":`)
@@ -794,7 +794,7 @@ func TestHandler_CreateDataNode_InternalServerError(t *testing.T) {
 	c := test.NewDefaultMessagingClient()
 	defer c.Close()
 	srvr := OpenAuthlessServer(c)
-	s := NewHTTPServer(srvr)
+	s := NewAPIServer(srvr)
 	defer s.Close()
 
 	status, body := MustHTTP("POST", s.URL+`/data_nodes`, nil, nil, `{"url":""}`)
@@ -811,7 +811,7 @@ func TestHandler_DeleteDataNode(t *testing.T) {
 	defer c.Close()
 	srvr := OpenAuthlessServer(c)
 	srvr.CreateDataNode(MustParseURL("http://localhost:1000"))
-	s := NewHTTPServer(srvr)
+	s := NewAPIServer(srvr)
 	defer s.Close()
 
 	status, body := MustHTTP("DELETE", s.URL+`/data_nodes/1`, nil, nil, "")
@@ -827,7 +827,7 @@ func TestHandler_DeleteUser_DataNodeNotFound(t *testing.T) {
 	c := test.NewDefaultMessagingClient()
 	defer c.Close()
 	srvr := OpenAuthlessServer(c)
-	s := NewHTTPServer(srvr)
+	s := NewAPIServer(srvr)
 	defer s.Close()
 
 	status, body := MustHTTP("DELETE", s.URL+`/data_nodes/10000`, nil, nil, "")
@@ -844,7 +844,7 @@ func TestHandler_AuthenticatedCreateAdminUser(t *testing.T) {
 	c := test.NewDefaultMessagingClient()
 	defer c.Close()
 	srvr := OpenAuthenticatedServer(c)
-	s := NewAuthenticatedHTTPServer(srvr)
+	s := NewAuthenticatedAPIServer(srvr)
 	defer s.Close()
 
 	// Attempting to create a non-admin user should fail.
@@ -867,7 +867,7 @@ func TestHandler_AuthenticatedDatabases_Unauthorized(t *testing.T) {
 	c := test.NewDefaultMessagingClient()
 	defer c.Close()
 	srvr := OpenAuthenticatedServer(c)
-	s := NewAuthenticatedHTTPServer(srvr)
+	s := NewAuthenticatedAPIServer(srvr)
 	defer s.Close()
 
 	status, _ := MustHTTP("GET", s.URL+`/query`, map[string]string{"q": "SHOW DATABASES"}, nil, "")
@@ -880,7 +880,7 @@ func TestHandler_QueryParamenterMissing(t *testing.T) {
 	c := test.NewDefaultMessagingClient()
 	defer c.Close()
 	srvr := OpenAuthlessServer(c)
-	s := NewHTTPServer(srvr)
+	s := NewAPIServer(srvr)
 	defer s.Close()
 
 	status, body := MustHTTP("GET", s.URL+`/query`, nil, nil, "")
@@ -896,7 +896,7 @@ func TestHandler_AuthenticatedDatabases_AuthorizedQueryParams(t *testing.T) {
 	defer c.Close()
 	srvr := OpenAuthenticatedServer(c)
 	srvr.CreateUser("lisa", "password", true)
-	s := NewAuthenticatedHTTPServer(srvr)
+	s := NewAuthenticatedAPIServer(srvr)
 	defer s.Close()
 
 	query := map[string]string{"q": "SHOW DATABASES", "u": "lisa", "p": "password"}
@@ -911,7 +911,7 @@ func TestHandler_AuthenticatedDatabases_UnauthorizedQueryParams(t *testing.T) {
 	defer c.Close()
 	srvr := OpenAuthenticatedServer(c)
 	srvr.CreateUser("lisa", "password", true)
-	s := NewAuthenticatedHTTPServer(srvr)
+	s := NewAuthenticatedAPIServer(srvr)
 	defer s.Close()
 
 	query := map[string]string{"q": "SHOW DATABASES", "u": "lisa", "p": "wrong"}
@@ -926,7 +926,7 @@ func TestHandler_AuthenticatedDatabases_AuthorizedBasicAuth(t *testing.T) {
 	defer c.Close()
 	srvr := OpenAuthenticatedServer(c)
 	srvr.CreateUser("lisa", "password", true)
-	s := NewAuthenticatedHTTPServer(srvr)
+	s := NewAuthenticatedAPIServer(srvr)
 	defer s.Close()
 
 	auth := make(map[string]string)
@@ -943,7 +943,7 @@ func TestHandler_AuthenticatedDatabases_UnauthorizedBasicAuth(t *testing.T) {
 	defer c.Close()
 	srvr := OpenAuthenticatedServer(c)
 	srvr.CreateUser("lisa", "password", true)
-	s := NewAuthenticatedHTTPServer(srvr)
+	s := NewAuthenticatedAPIServer(srvr)
 	defer s.Close()
 
 	auth := make(map[string]string)
@@ -963,7 +963,7 @@ func TestHandler_GrantDBPrivilege(t *testing.T) {
 	srvr.CreateUser("lisa", "password", true)
 	// Create user that will be granted a privilege.
 	srvr.CreateUser("john", "password", false)
-	s := NewAuthenticatedHTTPServer(srvr)
+	s := NewAuthenticatedAPIServer(srvr)
 	defer s.Close()
 
 	auth := make(map[string]string)
@@ -1002,7 +1002,7 @@ func TestHandler_RevokeAdmin(t *testing.T) {
 	srvr.CreateUser("lisa", "password", true)
 	// Create user that will have cluster admin revoked.
 	srvr.CreateUser("john", "password", true)
-	s := NewAuthenticatedHTTPServer(srvr)
+	s := NewAuthenticatedAPIServer(srvr)
 	defer s.Close()
 
 	auth := make(map[string]string)
@@ -1038,7 +1038,7 @@ func TestHandler_RevokeDBPrivilege(t *testing.T) {
 	srvr.CreateUser("john", "password", false)
 	u := srvr.User("john")
 	u.Privileges["foo"] = influxql.ReadPrivilege
-	s := NewAuthenticatedHTTPServer(srvr)
+	s := NewAuthenticatedAPIServer(srvr)
 	defer s.Close()
 
 	auth := make(map[string]string)
@@ -1070,7 +1070,7 @@ func TestHandler_DropSeries(t *testing.T) {
 	srvr := OpenAuthlessServer(c)
 	srvr.CreateDatabase("foo")
 	srvr.CreateRetentionPolicy("foo", influxdb.NewRetentionPolicy("bar"))
-	s := NewHTTPServer(srvr)
+	s := NewAPIServer(srvr)
 	defer s.Close()
 
 	status, _ := MustHTTP("POST", s.URL+`/write`, nil, nil, `{"database" : "foo", "retentionPolicy" : "bar", "points": [{"name": "cpu", "tags": {"host": "server01"},"timestamp": "2009-11-10T23:00:00Z","fields": {"value": 100}}]}`)
@@ -1092,7 +1092,7 @@ func TestHandler_serveWriteSeries(t *testing.T) {
 	defer c.Close()
 	srvr := OpenAuthlessServer(c)
 	srvr.CreateDatabase("foo")
-	s := NewHTTPServer(srvr)
+	s := NewAPIServer(srvr)
 	defer s.Close()
 
 	status, _ := MustHTTP("POST", s.URL+`/write`, nil, nil, `{"database" : "foo", "retentionPolicy" : "default", "points": [{"name": "cpu", "tags": {"host": "server01"},"timestamp": "2009-11-10T23:00:00Z","fields": {"value": 100}}]}`)
@@ -1115,7 +1115,7 @@ func TestHandler_serveDump(t *testing.T) {
 	defer c.Close()
 	srvr := OpenAuthlessServer(c)
 	srvr.CreateDatabase("foo")
-	s := NewHTTPServer(srvr)
+	s := NewAPIServer(srvr)
 	defer s.Close()
 
 	status, _ := MustHTTP("POST", s.URL+`/write`, nil, nil, `{"database" : "foo", "retentionPolicy" : "default", "points": [{"name": "cpu", "tags": {"host": "server01"},"timestamp": "2009-11-10T23:00:00Z","fields": {"value": 100}}]}`)
@@ -1147,7 +1147,7 @@ func TestHandler_serveWriteSeriesWithNoFields(t *testing.T) {
 	srvr := OpenAuthenticatedServer(c)
 	srvr.CreateDatabase("foo")
 	srvr.CreateRetentionPolicy("foo", influxdb.NewRetentionPolicy("bar"))
-	s := NewHTTPServer(srvr)
+	s := NewAPIServer(srvr)
 	defer s.Close()
 
 	status, body := MustHTTP("POST", s.URL+`/write`, nil, nil, `{"database" : "foo", "retentionPolicy" : "bar", "points": [{"name": "cpu", "tags": {"host": "server01"},"timestamp": "2009-11-10T23:00:00Z"}]}`)
@@ -1167,7 +1167,7 @@ func TestHandler_serveWriteSeriesWithAuthNilUser(t *testing.T) {
 	srvr := OpenAuthenticatedServer(c)
 	srvr.CreateDatabase("foo")
 	srvr.CreateRetentionPolicy("foo", influxdb.NewRetentionPolicy("bar"))
-	s := NewAuthenticatedHTTPServer(srvr)
+	s := NewAuthenticatedAPIServer(srvr)
 	defer s.Close()
 
 	status, body := MustHTTP("POST", s.URL+`/write`, nil, nil, `{"database" : "foo", "retentionPolicy" : "bar", "points": [{"name": "cpu", "tags": {"host": "server01"},"timestamp": "2009-11-10T23:00:00Z","fields": {"value": 100}}]}`)
@@ -1186,7 +1186,7 @@ func TestHandler_serveWriteSeries_noDatabaseExists(t *testing.T) {
 	c := test.NewDefaultMessagingClient()
 	defer c.Close()
 	srvr := OpenAuthenticatedServer(c)
-	s := NewHTTPServer(srvr)
+	s := NewAPIServer(srvr)
 	defer s.Close()
 
 	status, body := MustHTTP("POST", s.URL+`/write`, nil, nil, `{"database" : "foo", "retentionPolicy" : "bar", "points": [{"name": "cpu", "tags": {"host": "server01"},"timestamp": "2009-11-10T23:00:00Z","fields": {"value": 100}}]}`)
@@ -1206,7 +1206,7 @@ func TestHandler_serveWriteSeries_errorHasJsonContentType(t *testing.T) {
 	c := test.NewDefaultMessagingClient()
 	defer c.Close()
 	srvr := OpenAuthlessServer(c)
-	s := NewHTTPServer(srvr)
+	s := NewAPIServer(srvr)
 	defer s.Close()
 
 	client := &http.Client{}
@@ -1237,7 +1237,7 @@ func TestHandler_serveWriteSeries_queryHasJsonContentType(t *testing.T) {
 	srvr.CreateRetentionPolicy("foo", influxdb.NewRetentionPolicy("bar"))
 	srvr.SetDefaultRetentionPolicy("foo", "bar")
 
-	s := NewHTTPServer(srvr)
+	s := NewAPIServer(srvr)
 	defer s.Close()
 
 	status, _ := MustHTTP("POST", s.URL+`/write`, nil, nil, `{"database" : "foo", "retentionPolicy" : "bar", "points": [{"name": "cpu", "tags": {"host": "server01"},"timestamp": "2009-11-10T23:00:00Z", "fields": {"value": 100}}]}`)
@@ -1293,7 +1293,7 @@ func TestHandler_serveWriteSeries_invalidJSON(t *testing.T) {
 	c := test.NewDefaultMessagingClient()
 	defer c.Close()
 	srvr := OpenAuthenticatedServer(c)
-	s := NewHTTPServer(srvr)
+	s := NewAPIServer(srvr)
 	defer s.Close()
 
 	status, body := MustHTTP("POST", s.URL+`/write`, nil, nil, `{"database" : foo", "retentionPolicy" : "bar", "points": [{"name": "cpu", "tags": {"host": "server01"},"timestamp": "2009-11-10T23:00:00Z","fields": {"value": 100}}]}`)
@@ -1312,7 +1312,7 @@ func TestHandler_serveWriteSeries_noDatabaseSpecified(t *testing.T) {
 	c := test.NewDefaultMessagingClient()
 	defer c.Close()
 	srvr := OpenAuthenticatedServer(c)
-	s := NewHTTPServer(srvr)
+	s := NewAPIServer(srvr)
 	defer s.Close()
 
 	status, body := MustHTTP("POST", s.URL+`/write`, nil, nil, `{}`)
@@ -1335,7 +1335,7 @@ func TestHandler_serveWriteSeriesNonZeroTime(t *testing.T) {
 	srvr.CreateRetentionPolicy("foo", influxdb.NewRetentionPolicy("bar"))
 	srvr.SetDefaultRetentionPolicy("foo", "bar")
 
-	s := NewHTTPServer(srvr)
+	s := NewAPIServer(srvr)
 	defer s.Close()
 
 	status, _ := MustHTTP("POST", s.URL+`/write`, nil, nil, `{"database" : "foo", "retentionPolicy" : "bar", "points": [{"name": "cpu", "tags": {"host": "server01"},"timestamp": "2009-11-10T23:00:00Z", "fields": {"value": 100}}]}`)
@@ -1378,7 +1378,7 @@ func TestHandler_serveWriteSeriesZeroTime(t *testing.T) {
 	srvr.CreateRetentionPolicy("foo", influxdb.NewRetentionPolicy("bar"))
 	srvr.SetDefaultRetentionPolicy("foo", "bar")
 
-	s := NewHTTPServer(srvr)
+	s := NewAPIServer(srvr)
 	defer s.Close()
 
 	now := time.Now()
@@ -1433,7 +1433,7 @@ func TestHandler_serveWriteSeriesBatch(t *testing.T) {
 	srvr.CreateRetentionPolicy("foo", influxdb.NewRetentionPolicy("bar"))
 	srvr.SetDefaultRetentionPolicy("foo", "bar")
 
-	s := NewHTTPServer(srvr)
+	s := NewAPIServer(srvr)
 	defer s.Close()
 
 	batch := `
@@ -1518,7 +1518,7 @@ func TestHandler_serveWriteSeriesFieldTypeConflict(t *testing.T) {
 	srvr.CreateRetentionPolicy("foo", influxdb.NewRetentionPolicy("bar"))
 	srvr.SetDefaultRetentionPolicy("foo", "bar")
 
-	s := NewHTTPServer(srvr)
+	s := NewAPIServer(srvr)
 	defer s.Close()
 
 	status, _ := MustHTTP("POST", s.URL+`/write`, nil, nil, `{"database" : "foo", "retentionPolicy" : "bar", "points": [{"name": "cpu", "tags": {"host": "server01"},"fields": {"value": 100}}]}`)
@@ -1556,8 +1556,8 @@ func str2iface(strs []string) []interface{} {
 func TestHandler_ProcessContinousQueries(t *testing.T) {
 	c := test.NewDefaultMessagingClient()
 	defer c.Close()
-	srvr := OpenAuthenticatedServer(c)
-	s := NewAuthenticatedHTTPServer(srvr)
+	srvr := OpenAuthlessServer(c)
+	s := NewClusterServer(srvr)
 	defer s.Close()
 
 	status, _ := MustHTTP("POST", s.URL+`/process_continuous_queries`, nil, nil, "")
@@ -1624,7 +1624,7 @@ func TestHandler_ChunkedResponses(t *testing.T) {
 	srvr.CreateRetentionPolicy("foo", influxdb.NewRetentionPolicy("bar"))
 	srvr.SetDefaultRetentionPolicy("foo", "bar")
 
-	s := NewHTTPServer(srvr)
+	s := NewAPIServer(srvr)
 	defer s.Close()
 
 	status, errString := MustHTTP("POST", s.URL+`/write`, nil, nil, `{"database" : "foo", "retentionPolicy" : "bar", "points": [
@@ -1728,13 +1728,23 @@ type HTTPServer struct {
 	Handler *httpd.Handler
 }
 
-func NewHTTPServer(s *Server) *HTTPServer {
-	h := httpd.NewHandler(s.Server, false, "X.X")
+func NewAPIServer(s *Server) *HTTPServer {
+	h := httpd.NewAPIHandler(s.Server, false, "X.X")
 	return &HTTPServer{httptest.NewServer(h), h}
 }
 
-func NewAuthenticatedHTTPServer(s *Server) *HTTPServer {
-	h := httpd.NewHandler(s.Server, true, "X.X")
+func NewClusterServer(s *Server) *HTTPServer {
+	h := httpd.NewClusterHandler(s.Server, false, "X.X")
+	return &HTTPServer{httptest.NewServer(h), h}
+}
+
+func NewAuthenticatedClusterServer(s *Server) *HTTPServer {
+	h := httpd.NewClusterHandler(s.Server, true, "X.X")
+	return &HTTPServer{httptest.NewServer(h), h}
+}
+
+func NewAuthenticatedAPIServer(s *Server) *HTTPServer {
+	h := httpd.NewAPIHandler(s.Server, true, "X.X")
 	return &HTTPServer{httptest.NewServer(h), h}
 }
 

--- a/influxdb.go
+++ b/influxdb.go
@@ -35,7 +35,8 @@ var (
 	// ErrDataNodeExists is returned when creating a duplicate data node.
 	ErrDataNodeExists = errors.New("data node exists")
 
-	// ErrDataNodeNotFound is returned when dropping a non-existent data node.
+	// ErrDataNodeNotFound is returned when dropping a non-existent data node or
+	// attempting to join another data node when no data nodes exist yet
 	ErrDataNodeNotFound = errors.New("data node not found")
 
 	// ErrDataNodeRequired is returned when using a blank data node id.

--- a/messaging/broker.go
+++ b/messaging/broker.go
@@ -492,6 +492,8 @@ func (b *Broker) applySetTopicMaxIndex(m *Message) {
 
 	// Set index if it's not already set higher.
 	if t := b.topics[topicID]; t != nil {
+		t.mu.Lock()
+		defer t.mu.Unlock()
 		// Track the highest replicated index per data node URL
 		t.indexByURL[u] = index
 

--- a/server.go
+++ b/server.go
@@ -623,6 +623,7 @@ func (s *Server) Initialize(u url.URL) error {
 	// the messaging client relies on the first server being assigned ID 1.
 	n := s.DataNodeByURL(&u)
 	assert(n != nil, "node not created: %s", u.String())
+	assert(n.ID > 0, "invalid node id: %d", n.ID)
 
 	// Set the ID on the metastore.
 	if err := s.meta.mustUpdate(0, func(tx *metatx) error {

--- a/server.go
+++ b/server.go
@@ -3876,11 +3876,11 @@ func (s *Server) CreateSnapshotWriter() (*SnapshotWriter, error) {
 	return createServerSnapshotWriter(s)
 }
 
-func (s *Server) URL() *url.URL {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+func (s *Server) URL() url.URL {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	if n := s.dataNodes[s.id]; n != nil {
-		return n.URL
+		return *n.URL
 	}
-	return &url.URL{}
+	return url.URL{}
 }

--- a/server.go
+++ b/server.go
@@ -611,18 +611,18 @@ func (s *Server) syncBroadcast(index uint64) error {
 	}
 }
 
-// Initialize creates a new data node and initializes the server's id to 1.
+// Initialize creates a new data node and initializes the server's id to the latest.
 func (s *Server) Initialize(u url.URL) error {
 	// Create a new data node.
 	if err := s.CreateDataNode(&u); err != nil {
 		return err
 	}
 
-	// Ensure the data node returns with an ID of 1.
+	// Ensure the data node returns with an ID.
 	// If it doesn't then something went really wrong. We have to panic because
 	// the messaging client relies on the first server being assigned ID 1.
 	n := s.DataNodeByURL(&u)
-	assert(n != nil && n.ID == 1, "invalid initial server id: %d", n.ID)
+	assert(n != nil, "node not created: %s", u.String())
 
 	// Set the ID on the metastore.
 	if err := s.meta.mustUpdate(0, func(tx *metatx) error {
@@ -632,7 +632,7 @@ func (s *Server) Initialize(u url.URL) error {
 	}
 
 	// Set the ID on the server.
-	s.id = 1
+	s.id = n.ID
 
 	return nil
 }
@@ -657,20 +657,58 @@ func (s *Server) Join(u *url.URL, joinURL *url.URL) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	// Encode data node request.
-	var buf bytes.Buffer
-	if err := json.NewEncoder(&buf).Encode(&dataNodeJSON{URL: u.String()}); err != nil {
-		return err
-	}
-
-	// Send request.
+	// Create the initial request. Might get a redirect though depending on
+	// the nodes role
 	joinURL = copyURL(joinURL)
 	joinURL.Path = "/data_nodes"
-	resp, err := http.Post(joinURL.String(), "application/octet-stream", &buf)
-	if err != nil {
-		return err
+
+	var retries int
+	var resp *http.Response
+	var err error
+
+	// When POSTing the to the join endoinpoint, we are manually following redirects
+	// and not relying on the Go http client redirect policy. The Go http client will convert
+	// POSTs to GETSs when following redirects which is not what we want when joining.
+	// (i.e. we want to join a node, not list the nodes) If we recieve a redirect response,
+	// the Location header is where we should resend the POST.  We also need to re-encode
+	// body since the buf was already read.
+	for {
+
+		// Should never get here but bail to avoid a infinite redirect loop to be safe
+		if retries >= 3 {
+			return ErrUnableToJoin
+		}
+
+		// Encode data node request.
+		var buf bytes.Buffer
+		if err := json.NewEncoder(&buf).Encode(&dataNodeJSON{URL: u.String()}); err != nil {
+			return err
+		}
+
+		resp, err = http.Post(joinURL.String(), "application/octet-stream", &buf)
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+
+		// We likely tried to join onto a broker which cannot handle this request.  It
+		// has given us the address of a known data node to join instead.
+		if resp.StatusCode == http.StatusTemporaryRedirect {
+			joinURL, err = url.Parse(resp.Header.Get("Location"))
+			if err != nil {
+				return err
+			}
+			retries += 1
+			resp.Body.Close()
+			continue
+		}
+
+		// If we are first data node, we can't join anyone and need to initialize
+		if resp.StatusCode == http.StatusNotFound {
+			return ErrDataNodeNotFound
+		}
+		break
 	}
-	defer resp.Body.Close()
 
 	// Check if created.
 	if resp.StatusCode != http.StatusCreated {

--- a/server.go
+++ b/server.go
@@ -691,6 +691,14 @@ func (s *Server) Join(u *url.URL, joinURL *url.URL) error {
 		}
 		defer resp.Body.Close()
 
+		// If we get a service unavailable, the other data nodes may still be booting
+		// so retry again
+		if resp.StatusCode == http.StatusServiceUnavailable {
+			retries += 1
+			time.Sleep(1 * time.Second)
+			continue
+		}
+
 		// We likely tried to join onto a broker which cannot handle this request.  It
 		// has given us the address of a known data node to join instead.
 		if resp.StatusCode == http.StatusTemporaryRedirect {

--- a/server.go
+++ b/server.go
@@ -667,10 +667,10 @@ func (s *Server) Join(u *url.URL, joinURL *url.URL) error {
 	var resp *http.Response
 	var err error
 
-	// When POSTing the to the join endoinpoint, we are manually following redirects
+	// When POSTing the to the join endpoint, we are manually following redirects
 	// and not relying on the Go http client redirect policy. The Go http client will convert
 	// POSTs to GETSs when following redirects which is not what we want when joining.
-	// (i.e. we want to join a node, not list the nodes) If we recieve a redirect response,
+	// (i.e. we want to join a node, not list the nodes) If we receive a redirect response,
 	// the Location header is where we should resend the POST.  We also need to re-encode
 	// body since the buf was already read.
 	for {


### PR DESCRIPTION
This PR adds the ability to start up a cluster with dedicated broker and data nodes.  It fixes #1934.  It also allows cluster communication to be separated from the public API via separate ports and/or interfaces.  By default they all share the same port and interface.

When starting separate data and broker nodes, you now must disable the role in the config.
```
# Broker only
[data]
enabled = false
```

and/or
```
# Data only
[broker]
enabled = false
```

By default, they are both false and must be explicitly enabled.  The sample config has an example w/ both enabled.  ~~This also means that starting `influxd` w/o a config file will currently exit w/ an error.  (_We may want to add additional flags to specify a role (e.g. `-enable-data`, `-enable-broker`)_)~~

To join a cluster, you start a node and join it to any other member w/ the `-join http://host:port[,http://host:port]...`.  The port should be the cluster port and the host can any node in the cluster.

There are several config level changes.  Some options have been removed or replaced:
* **Added** - `Port` - The cluster port is now the default port used for cluster endpoints and API endpoints.  The default is 8086.
* **Added** - `[api].Port` - The API port used for API endpoints.  If not specified, 8086 is used.
* **Added** - `[broker].Enabled` - Determines whether the node runs as a broker. Default false.
* **Added** - `[data].Enabled` - Determines whether the node runs as a data node. Default false.
* **Removed** - `[broker].Port` - This has been replaced w/ the cluster port
* **Removed** - `[data].Port` - This has been replaced w/ the cluster port
* **Removed** - `[cluster]` - This whole section was removed as it was not used.  The actual values are at the root of the config.
* **Removed** - `[Initialization].JoinURLs` - This section has been removed.  Join URLs are specified on the command line via the `-join` flag.  If a node was already joined to a cluster, then these flags are ignored (and logged as ignored) to help avoid confusion.

While this PR adds the ability to start a cluster w/ separate broker and data nodes, there are still several open issues and more extensive testing necessary:  
* https://github.com/influxdb/influxdb/issues/2173
* https://github.com/influxdb/influxdb/issues/1467
* https://github.com/influxdb/influxdb/issues/1471




  