### PR TITLE
Allow http write handler to decode gzipped body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Features
 - [#870](https://github.com/influxdb/influxdb/pull/870): Add support for OpenTSDB telnet input protocol. Thanks @tcolgate
+- [#2180](https://github.com/influxdb/influxdb/pull/2180): Allow http write handler to decode gzipped body
 - [#2175](https://github.com/influxdb/influxdb/pull/2175): Separate broker and data nodes
 
 ## v0.9.0-rc20 [2015-04-04]

--- a/tests/read_write_gzip.sh
+++ b/tests/read_write_gzip.sh
@@ -4,12 +4,12 @@ curl -G http://localhost:8086/query --data-urlencode "q=CREATE DATABASE foo"
 echo "creating retention policy"
 curl -G http://localhost:8086/query --data-urlencode "q=CREATE RETENTION POLICY bar ON foo DURATION 1h REPLICATION 3 DEFAULT"
 
-echo '{"database" : "foo", "retentionPolicy" : "bar", "points": [{"name": "cpu", "tags": {"host": "server01"},"timestamp": "2015-01-26T22:01:11.703Z","fields": {"value": 123}}]}' | gzip > ./foo.zip
+echo '{"database" : "foo", "retentionPolicy" : "bar", "points": [{"name": "cpu", "tags": {"host": "server01"},"timestamp": "2015-01-26T22:01:11.703Z","fields": {"value": 123}}]}' | gzip > foo.json.gz
 
 echo "inserting data"
-curl -v -i --compressed -H "Content-encoding: gzip" -H "Content-Type: application/json" -X POST --data-binary ./foo.zip http://localhost:8086/write
+curl -v -i -H "Content-encoding: gzip" -H "Content-Type: application/json" -X POST -T foo.json.gz http://localhost:8086/write
 
-rm ./foo.zip
+rm foo.json.gz
 
 echo "querying data with gzip encoding"
 curl -v -G --compressed http://localhost:8086/query --data-urlencode "db=foo" --data-urlencode "q=SELECT sum(value) FROM \"foo\".\"bar\".cpu GROUP BY time(1h)"


### PR DESCRIPTION
Previously, we supported streaming out gzip'ed responses, but we had not implemented the ability to post gzipped json to our write endpoint.