### PR TITLE
Fix issues when using config files

### DIFF
--- a/cmd/influxd/config.go
+++ b/cmd/influxd/config.go
@@ -36,6 +36,12 @@ const (
 	// DefaultClusterPort represents the default port the cluster runs ons.
 	DefaultClusterPort = 8086
 
+	// DefaultBrokerEnabled is the default for starting a node as a broker
+	DefaultBrokerEnabled = true
+
+	// DefaultDataEnabled is the default for starting a node as a data node
+	DefaultDataEnabled = true
+
 	// DefaultSnapshotBindAddress is the default bind address to serve snapshots from.
 	DefaultSnapshotBindAddress = "127.0.0.1"
 
@@ -207,6 +213,9 @@ func NewConfig() *Config {
 	c.Port = DefaultClusterPort
 
 	c.HTTPAPI.Port = DefaultClusterPort
+
+	c.Data.Enabled = DefaultDataEnabled
+	c.Broker.Enabled = DefaultBrokerEnabled
 
 	c.Data.RetentionAutoCreate = DefaultRetentionAutoCreate
 	c.Data.RetentionCheckEnabled = DefaultRetentionCheckEnabled

--- a/cmd/influxd/run.go
+++ b/cmd/influxd/run.go
@@ -114,11 +114,27 @@ func (cmd *RunCommand) Run(args ...string) error {
 		cmd.Logger.Println("No config provided, using default settings")
 	}
 
+	cmd.CheckConfig()
 	cmd.Open(cmd.config, join)
 
 	// Wait indefinitely.
 	<-(chan struct{})(nil)
 	return nil
+}
+
+// CheckConfig validates the configuration
+func (cmd *RunCommand) CheckConfig() {
+	if !(cmd.config.Data.Enabled || cmd.config.Broker.Enabled) {
+		cmd.Logger.Fatal("Node must be configured as a broker node, data node, or as both.  Run `influxd config` to generate a valid configuration.")
+	}
+
+	if cmd.config.Broker.Enabled && cmd.config.Broker.Dir == "" {
+		cmd.Logger.Fatal("Broker.Dir must be specified.  Run `influxd config` to generate a valid configuration.")
+	}
+
+	if cmd.config.Data.Enabled && cmd.config.Data.Dir == "" {
+		cmd.Logger.Fatal("Data.Dir must be specified.  Run `influxd config` to generate a valid configuration.")
+	}
 }
 
 func (cmd *RunCommand) Open(config *Config, join string) (*messaging.Broker, *influxdb.Server, *raft.Log) {

--- a/cmd/influxd/server_integration_test.go
+++ b/cmd/influxd/server_integration_test.go
@@ -1847,13 +1847,13 @@ func TestSeparateBrokerDataNode(t *testing.T) {
 	_ = os.RemoveAll(tmpDataDir)
 
 	brokerConfig := main.NewConfig()
-	brokerConfig.Broker.Enabled = true
+	brokerConfig.Data.Enabled = false
 	brokerConfig.Port = 9000
 	brokerConfig.Broker.Dir = filepath.Join(tmpBrokerDir, strconv.Itoa(brokerConfig.Port))
 	brokerConfig.ReportingDisabled = true
 
 	dataConfig := main.NewConfig()
-	dataConfig.Data.Enabled = true
+	dataConfig.Broker.Enabled = false
 	dataConfig.Data.Dir = filepath.Join(tmpDataDir, strconv.Itoa(dataConfig.Port))
 	dataConfig.ReportingDisabled = true
 
@@ -1893,7 +1893,7 @@ func TestSeparateBrokerTwoDataNodes(t *testing.T) {
 
 	// Start a single broker node
 	brokerConfig := main.NewConfig()
-	brokerConfig.Broker.Enabled = true
+	brokerConfig.Data.Enabled = false
 	brokerConfig.Port = 9010
 	brokerConfig.Broker.Dir = filepath.Join(tmpBrokerDir, strconv.Itoa(brokerConfig.Port))
 	brokerConfig.ReportingDisabled = true
@@ -1910,7 +1910,7 @@ func TestSeparateBrokerTwoDataNodes(t *testing.T) {
 	// Star the first data node and join the broker
 	dataConfig1 := main.NewConfig()
 	dataConfig1.Port = 9011
-	dataConfig1.Data.Enabled = true
+	dataConfig1.Broker.Enabled = false
 	dataConfig1.Data.Dir = filepath.Join(tmpDataDir, strconv.Itoa(dataConfig1.Port))
 	dataConfig1.ReportingDisabled = true
 
@@ -1924,7 +1924,7 @@ func TestSeparateBrokerTwoDataNodes(t *testing.T) {
 	// Join data node 2 to single broker and first data node
 	dataConfig2 := main.NewConfig()
 	dataConfig2.Port = 9012
-	dataConfig2.Data.Enabled = true
+	dataConfig2.Broker.Enabled = false
 	dataConfig2.Data.Dir = filepath.Join(tmpDataDir, strconv.Itoa(dataConfig2.Port))
 	dataConfig2.ReportingDisabled = true
 


### PR DESCRIPTION
This fixes two issues when starting `influxd` with a config file:
* If both data and broker were disabled, the server would start but not be functional
* By default, broker and data were disabled when using a config file and needed to be explicitly enabled.  This is counterintuitive since running w/o a config file has them both enabled by default.  It also meant that existing config files would break when upgrading to the next release.  

With this change, starting the server with both broker and data disabled reports an error and exit.  In addition, broker and data are enabled with a config file (by default) and must be disabled.