### PR TITLE
SELECT on tag that doesn't exist should return 200

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Bugfixes
 - [#2181](https://github.com/influxdb/influxdb/pull/2181): Fix panic on "SHOW DIAGNOSTICS".
+- [#2170](https://github.com/influxdb/influxdb/pull/2170): Make sure queries on missing tags return 200 status.
 
 ## v0.9.0-rc20 [2015-04-04]
 

--- a/httpd/handler.go
+++ b/httpd/handler.go
@@ -230,6 +230,8 @@ func (h *Handler) serveQuery(w http.ResponseWriter, r *http.Request, user *influ
 					w.WriteHeader(http.StatusUnauthorized)
 				} else if isMeasurementNotFoundError(r.Err) {
 					w.WriteHeader(http.StatusOK)
+				} else if isTagNotFoundError(r.Err) {
+					w.WriteHeader(http.StatusOK)
 				} else if isFieldNotFoundError(r.Err) {
 					w.WriteHeader(http.StatusOK)
 				} else {
@@ -711,6 +713,10 @@ func isAuthorizationError(err error) bool {
 func isMeasurementNotFoundError(err error) bool {
 	s := err.Error()
 	return strings.HasPrefix(s, "measurement") && strings.HasSuffix(s, "not found") || strings.Contains(s, "measurement not found")
+}
+
+func isTagNotFoundError(err error) bool {
+	return (strings.HasPrefix(err.Error(), "unknown field or tag name"))
 }
 
 func isFieldNotFoundError(err error) bool {


### PR DESCRIPTION
If a query is issued against a measurement for a tag that doesn't exist, the response should be a 200 with the Err object filled in for that statement.