### PR TITLE
fix fmt error

### DIFF
--- a/influxql/parser_test.go
+++ b/influxql/parser_test.go
@@ -653,8 +653,8 @@ func TestParser_ParseStatement(t *testing.T) {
 		{
 			s: `SET PASSWORD FOR testuser = 'pwd1337'`,
 			stmt: &influxql.SetPasswordUserStatement{
-				Name:      "testuser",
-				Password:  "pwd1337",
+				Name:     "testuser",
+				Password: "pwd1337",
 			},
 		},
 


### PR DESCRIPTION
Master is failing `go fmt`.  I think this happens when we accept external pull requests.  Not sure why circleCI doesn't fail the master branch at that point.  Merging on green.