### PR TITLE
Fix http logger to report status OK if never set

### DIFF
--- a/httpd/response_logger.go
+++ b/httpd/response_logger.go
@@ -43,6 +43,10 @@ func (l *responseLogger) WriteHeader(s int) {
 }
 
 func (l *responseLogger) Status() int {
+	if l.status == 0 {
+		// This can happen if we never actually write data, but only set response headers.
+		l.status = http.StatusOK
+	}
 	return l.status
 }
 


### PR DESCRIPTION
If we never actually wrote to the http.Response, the status is never set to http.StatusOk by default.  There are a few edge cases where we only set a response header and return, never writing data.  The Go library does the correct thing and sets the header to http.StatusOk, but our logger did not.