### PR TITLE
Wait for first applied index on Log.Join().

### DIFF
--- a/raft/log.go
+++ b/raft/log.go
@@ -769,7 +769,8 @@ func (l *Log) Join(u url.URL) error {
 	// Change to a follower state.
 	l.Logger.Println("log join: entered 'follower' state for cluster at", u, " with log ID", l.id)
 
-	return nil
+	// Wait for anything to be applied.
+	return l.Wait(1)
 }
 
 // Leave removes the log from cluster membership and removes the log data.


### PR DESCRIPTION
## Overview

Previously the join method returned immediately after connecting. Now the join method will wait until the snapshot and/or log entry is replicated as well before returning.