### PR TITLE
Re-enable Continuous Queries

### DIFF
--- a/broker.go
+++ b/broker.go
@@ -51,9 +51,7 @@ func NewBroker() *Broker {
 
 // RunContinuousQueryLoop starts running continuous queries on a background goroutine.
 func (b *Broker) RunContinuousQueryLoop() {
-	log.Println("and...")
 	b.done = make(chan struct{})
-	log.Println("boom!")
 	go b.continuousQueryLoop(b.done)
 }
 

--- a/broker.go
+++ b/broker.go
@@ -88,12 +88,12 @@ func (b *Broker) runContinuousQueries() {
 			topic := b.Broker.Topic(BroadcastTopicID)
 			if topic == nil {
 				log.Println("broker cq: no topics currently available.")
-				return // don't have any nodes to try, give it up
+				return // don't have any topics to get data urls from, give it up
 			}
 			dataURLs := topic.DataURLs()
 			if len(dataURLs) == 0 {
 				log.Println("broker cq: no data nodes currently available.")
-				return // don't have any nodes to try, give it up
+				return // don't have any data urls to try, give it up
 			}
 			next = next % len(dataURLs)
 			u := dataURLs[next]

--- a/broker.go
+++ b/broker.go
@@ -81,7 +81,7 @@ func (b *Broker) continuousQueryLoop(done chan struct{}) {
 func (b *Broker) runContinuousQueries() {
 	topic := b.Broker.Topic(BroadcastTopicID)
 	if topic == nil {
-		log.Println("broker cq: no topics currently available.")
+		log.Println("broker cq: no broadcast topic currently available.")
 		return // don't have any topics to get data urls from, give it up
 	}
 	dataURLs := topic.DataURLs()

--- a/cmd/influxd/run.go
+++ b/cmd/influxd/run.go
@@ -173,13 +173,6 @@ func (cmd *RunCommand) Open(config *Config, join string) (*messaging.Broker, *in
 	}()
 	log.Printf("TCP server listening on %s", cmd.config.ClusterAddr())
 
-	// have it occasionally tell a data node in the cluster to run continuous queries
-	if cmd.config.ContinuousQuery.Disabled {
-		log.Printf("Not running continuous queries. [continuous_queries].disabled is set to true.")
-	} else if cmd.node.broker != nil {
-		cmd.node.broker.RunContinuousQueryLoop()
-	}
-
 	var s *influxdb.Server
 	// Open server, initialize or join as necessary.
 	if cmd.config.Data.Enabled {
@@ -343,7 +336,15 @@ func (cmd *RunCommand) Open(config *Config, join string) (*messaging.Broker, *in
 	var b *messaging.Broker
 	if cmd.node.broker != nil {
 		b = cmd.node.broker.Broker
+
+		// have it occasionally tell a data node in the cluster to run continuous queries
+		if cmd.config.ContinuousQuery.Disabled {
+			log.Printf("Not running continuous queries. [continuous_queries].disabled is set to true.")
+		} else {
+			cmd.node.broker.RunContinuousQueryLoop()
+		}
 	}
+
 	return b, s, cmd.node.raftLog
 }
 

--- a/cmd/influxd/run.go
+++ b/cmd/influxd/run.go
@@ -176,7 +176,7 @@ func (cmd *RunCommand) Open(config *Config, join string) (*messaging.Broker, *in
 	// have it occasionally tell a data node in the cluster to run continuous queries
 	if cmd.config.ContinuousQuery.Disabled {
 		log.Printf("Not running continuous queries. [continuous_queries].disabled is set to true.")
-	} else {
+	} else if cmd.node.broker != nil {
 		cmd.node.broker.RunContinuousQueryLoop()
 	}
 

--- a/database.go
+++ b/database.go
@@ -813,7 +813,7 @@ func (f *FieldCodec) EncodeFields(values map[string]interface{}) ([]byte, error)
 				buf[i+3] = byte(c)
 			}
 		default:
-			panic(fmt.Sprintf("unsupported value type: %T", v))
+			panic(fmt.Sprintf("unsupported value type during encode fields: %T", v))
 		}
 
 		// Always set the field ID as the leading byte.
@@ -868,7 +868,7 @@ func (f *FieldCodec) DecodeByID(targetID uint8, b []byte) (interface{}, error) {
 			// Move bytes forward.
 			b = b[size+3:]
 		default:
-			panic(fmt.Sprintf("unsupported value type: %T", field.Type))
+			panic(fmt.Sprintf("unsupported value type during decode by id: %T", field.Type))
 		}
 
 		if field.ID == targetID {
@@ -922,7 +922,7 @@ func (f *FieldCodec) DecodeFields(b []byte) (map[uint8]interface{}, error) {
 			// Move bytes forward.
 			b = b[size+3:]
 		default:
-			panic(fmt.Sprintf("unsupported value type: %T", f.fieldsByID[fieldID]))
+			panic(fmt.Sprintf("unsupported value type during decode fields: %T", f.fieldsByID[fieldID]))
 		}
 
 		values[fieldID] = value

--- a/server_test.go
+++ b/server_test.go
@@ -1692,7 +1692,6 @@ func TestServer_DropContinuousQuery(t *testing.T) {
 
 // Ensure
 func TestServer_RunContinuousQueries(t *testing.T) {
-	t.Skip()
 	c := test.NewDefaultMessagingClient()
 	defer c.Close()
 	s := OpenServer(c)

--- a/server_test.go
+++ b/server_test.go
@@ -1690,7 +1690,7 @@ func TestServer_DropContinuousQuery(t *testing.T) {
 	}
 }
 
-// Ensure
+// Ensure continuous queries run
 func TestServer_RunContinuousQueries(t *testing.T) {
 	c := test.NewDefaultMessagingClient()
 	defer c.Close()


### PR DESCRIPTION
This was previously removed due to the stateless broker refactoring.  Now that brokers know about data nodes again, this was added back in.

Fixes #1666 