### PR TITLE
Bring back config join URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [#2180](https://github.com/influxdb/influxdb/pull/2180): Allow http write handler to decode gzipped body
 - [#2175](https://github.com/influxdb/influxdb/pull/2175): Separate broker and data nodes
 - [#2158](https://github.com/influxdb/influxdb/pull/2158): Allow user password to be changed. Thanks @n1tr0g
+- [#2201](https://github.com/influxdb/influxdb/pull/2201): Bring back config join URLs
 
 ### Bugfixes
 - [#2181](https://github.com/influxdb/influxdb/pull/2181): Fix panic on "SHOW DIAGNOSTICS".

--- a/cmd/influxd/config.go
+++ b/cmd/influxd/config.go
@@ -122,6 +122,14 @@ type Data struct {
 	RetentionCreatePeriod Duration `toml:"retention-create-period"`
 }
 
+// Initialization contains configuration options for the first time a node boots
+type Initialization struct {
+	// JoinURLs are cluster URLs to use when joining a node to a cluster the first time it boots.  After,
+	// a node is joined to a cluster, these URLS are ignored.  These will be overriden at runtime if
+	// the node is started with the `-join` flag.
+	JoinURLs string `toml:"join-urls"`
+}
+
 // Config represents the configuration format for the influxd binary.
 type Config struct {
 	Hostname          string `toml:"hostname"`
@@ -130,6 +138,8 @@ type Config struct {
 	ReportingDisabled bool   `toml:"reporting-disabled"`
 	Version           string `toml:"-"`
 	InfluxDBVersion   string `toml:"-"`
+
+	Initialization Initialization `toml:"initialization"`
 
 	Authentication struct {
 		Enabled bool `toml:"enabled"`

--- a/cmd/influxd/config_test.go
+++ b/cmd/influxd/config_test.go
@@ -39,6 +39,11 @@ write-interval = "1m"
 enabled = true
 port = 8083
 
+# Controls certain parameters that only take effect until an initial successful
+# start-up has occurred.
+[initialization]
+join-urls = "http://127.0.0.1:8086"
+
 # Configure the http api
 [api]
 bind-address = "10.1.2.3"
@@ -150,6 +155,10 @@ func TestParseConfig(t *testing.T) {
 
 	if exp := 8086; c.Port != exp {
 		t.Fatalf("port mismatch. got %v, exp %v", c.Port, exp)
+	}
+
+	if c.Initialization.JoinURLs != "http://127.0.0.1:8086" {
+		t.Fatalf("JoinURLs mistmatch: %v", c.Initialization.JoinURLs)
 	}
 
 	if !c.Authentication.Enabled {

--- a/cmd/influxd/handler.go
+++ b/cmd/influxd/handler.go
@@ -73,7 +73,7 @@ func (h *Handler) serveMessaging(w http.ResponseWriter, r *http.Request) {
 // serveMetadata responds to broker requests
 func (h *Handler) serveMetadata(w http.ResponseWriter, r *http.Request) {
 	if h.Broker == nil && h.Server == nil {
-		log.Println("no broker or server configured to handle messaging endpoints")
+		log.Println("no broker or server configured to handle metadata endpoints")
 		http.Error(w, "server unavailable", http.StatusServiceUnavailable)
 		return
 	}
@@ -98,7 +98,7 @@ func (h *Handler) serveMetadata(w http.ResponseWriter, r *http.Request) {
 // serveRaft responds to raft requests.
 func (h *Handler) serveRaft(w http.ResponseWriter, r *http.Request) {
 	if h.Log == nil && h.Server == nil {
-		log.Println("no broker or server configured to handle messaging endpoints")
+		log.Println("no broker or server configured to handle raft endpoints")
 		http.Error(w, "server unavailable", http.StatusServiceUnavailable)
 		return
 	}
@@ -116,7 +116,7 @@ func (h *Handler) serveRaft(w http.ResponseWriter, r *http.Request) {
 // serveData responds to data requests
 func (h *Handler) serveData(w http.ResponseWriter, r *http.Request) {
 	if h.Broker == nil && h.Server == nil {
-		log.Println("no broker or server configured to handle messaging endpoints")
+		log.Println("no broker or server configured to handle data endpoints")
 		http.Error(w, "server unavailable", http.StatusServiceUnavailable)
 		return
 	}

--- a/cmd/influxd/handler.go
+++ b/cmd/influxd/handler.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"log"
+	"math/rand"
 	"net/http"
 	"net/url"
 	"strings"
@@ -151,5 +152,5 @@ func (h *Handler) redirect(u []url.URL, w http.ResponseWriter, r *http.Request) 
 	// this is happening frequently, the clients are using a suboptimal endpoint
 
 	// Redirect the client to a valid data node that can handle the request
-	http.Redirect(w, r, u[0].String()+r.RequestURI, http.StatusTemporaryRedirect)
+	http.Redirect(w, r, u[rand.Intn(len(u))].String()+r.RequestURI, http.StatusTemporaryRedirect)
 }

--- a/cmd/influxd/run.go
+++ b/cmd/influxd/run.go
@@ -114,8 +114,15 @@ func (cmd *RunCommand) Run(args ...string) error {
 		cmd.Logger.Println("No config provided, using default settings")
 	}
 
+	// Use the config JoinURLs by default
+	joinURLs := cmd.config.Initialization.JoinURLs
+
+	// If a -join flag was passed, these should override the config
+	if join != "" {
+		joinURLs = join
+	}
 	cmd.CheckConfig()
-	cmd.Open(cmd.config, join)
+	cmd.Open(cmd.config, joinURLs)
 
 	// Wait indefinitely.
 	<-(chan struct{})(nil)

--- a/cmd/influxd/server_integration_test.go
+++ b/cmd/influxd/server_integration_test.go
@@ -1860,6 +1860,7 @@ func TestSeparateBrokerDataNode(t *testing.T) {
 	brokerConfig.ReportingDisabled = true
 
 	dataConfig := main.NewConfig()
+	dataConfig.Port = 9001
 	dataConfig.Broker.Enabled = false
 	dataConfig.Data.Dir = filepath.Join(tmpDataDir, strconv.Itoa(dataConfig.Port))
 	dataConfig.ReportingDisabled = true

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -17,6 +17,10 @@
 # In the third case we have to define our own functions which are very dumb
 # and expect the args to be positioned correctly.
 
+# Command-line options that can be set in /etc/default/influxdb.  These will override
+# any config file values. Example: "-join http://1.2.3.4:8086"
+INFLUXD_OPTS=
+
 if [ -r /lib/lsb/init-functions ]; then
     source /lib/lsb/init-functions
 fi
@@ -117,9 +121,9 @@ case $1 in
 
         log_success_msg "Starting the process" "$name"
         if which start-stop-daemon > /dev/null 2>&1; then
-            start-stop-daemon --chuid influxdb:influxdb --start --quiet --pidfile $pidfile --exec $daemon -- -pidfile $pidfile -config $config >>$STDOUT 2>>$STDERR &
+            start-stop-daemon --chuid influxdb:influxdb --start --quiet --pidfile $pidfile --exec $daemon -- -pidfile $pidfile -config $config $INFLUXD_OPTS >>$STDOUT 2>>$STDERR &
         else
-            nohup $daemon -pidfile $pidfile -config $config >>$STDOUT 2>>$STDERR &
+            nohup $daemon -pidfile $pidfile -config $config $INFLUXD_OPTS >>$STDOUT 2>>$STDERR &
         fi
         log_success_msg "$name process was started"
         ;;

--- a/server.go
+++ b/server.go
@@ -677,9 +677,8 @@ func (s *Server) Join(u *url.URL, joinURL *url.URL) error {
 	// the Location header is where we should resend the POST.  We also need to re-encode
 	// body since the buf was already read.
 	for {
-
 		// Should never get here but bail to avoid a infinite redirect loop to be safe
-		if retries >= 3 {
+		if retries >= 60 {
 			return ErrUnableToJoin
 		}
 


### PR DESCRIPTION
This PR does the following:

1. Brings back `[Initialization].join-urls` which were removed as part of #2175 
2. Updates the init script to allow passing options to via /etc/influxdb/defaults if desired.
3. Fixes `-join` flag so it will override the config file `join-urls` when passed but not when the node has already joined a cluster.
4. Add better logging in the server around what join URLs are used and not used
5. Increases the max join attempts a node will try before giving up