### PR TITLE
Cluster fix

### DIFF
--- a/messaging/client.go
+++ b/messaging/client.go
@@ -674,9 +674,9 @@ func (c *Conn) stream(req *http.Request, closing <-chan struct{}) error {
 			return fmt.Errorf("decode: %s", err)
 		}
 
-		// Panic if we received no data.
+		// Log if we received a message with no data.
 		if len(m.Data) == 0 {
-			panic("messaging conn no data recv")
+			c.Logger.Printf("conn recv message w/ no data: type=%x", m.Type)
 		}
 
 		// TODO: Write broker set updates, do not passthrough to channel.

--- a/raft/log.go
+++ b/raft/log.go
@@ -995,7 +995,7 @@ func (l *Log) candidateLoop(closing <-chan struct{}) State {
 
 			// Check against the current term since that may have changed.
 			l.mu.Lock()
-			if newTerm >= l.term {
+			if newTerm > l.term {
 				l.mustSetTerm(newTerm)
 				l.mu.Unlock()
 				return Follower


### PR DESCRIPTION
## Overview

This pull request provides two fixes:

1. There's a zero length message check that doesn't need to exist now that we have checksums.

2. We were overwriting votes in some cases which may be causing the stale term issue.