### PR TITLE
fix #2215: allow keyword default to be unquoted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Bugfixes
 - [#2225](https://github.com/influxdb/influxdb/pull/2225): Make keywords completely case insensitive
+- [#2228](https://github.com/influxdb/influxdb/pull/2228): Accept keyword default unquoted in ALTER RETENTION POLICY statement
 
 ### Features
 - [#2214](https://github.com/influxdb/influxdb/pull/2214): Added the option to influx CLI to execute single command and exit. Thanks @n1tr0g

--- a/influxql/parser.go
+++ b/influxql/parser.go
@@ -293,19 +293,22 @@ func (p *Parser) parseAlterRetentionPolicyStatement() (*AlterRetentionPolicyStat
 	stmt := &AlterRetentionPolicyStatement{}
 
 	// Parse the retention policy name.
-	ident, err := p.parseIdent()
-	if err != nil {
-		return nil, err
+	tok, pos, lit := p.scanIgnoreWhitespace()
+	if tok == DEFAULT {
+		stmt.Name = "default"
+	} else if tok == IDENT {
+		stmt.Name = lit
+	} else {
+		return nil, newParseError(tokstr(tok, lit), []string{"identifier"}, pos)
 	}
-	stmt.Name = ident
 
 	// Consume the required ON token.
-	if tok, pos, lit := p.scanIgnoreWhitespace(); tok != ON {
+	if tok, pos, lit = p.scanIgnoreWhitespace(); tok != ON {
 		return nil, newParseError(tokstr(tok, lit), []string{"ON"}, pos)
 	}
 
 	// Parse the database name.
-	ident, err = p.parseIdent()
+	ident, err := p.parseIdent()
 	if err != nil {
 		return nil, err
 	}

--- a/influxql/parser_test.go
+++ b/influxql/parser_test.go
@@ -895,6 +895,11 @@ func TestParser_ParseStatement(t *testing.T) {
 			s:    `ALTER RETENTION POLICY policy1 ON testdb REPLICATION 4`,
 			stmt: newAlterRetentionPolicyStatement("policy1", "testdb", -1, 4, false),
 		},
+		// ALTER default retention policy unquoted
+		{
+			s:    `ALTER RETENTION POLICY default ON testdb REPLICATION 4`,
+			stmt: newAlterRetentionPolicyStatement("default", "testdb", -1, 4, false),
+		},
 
 		// SHOW STATS
 		{


### PR DESCRIPTION
InfluxDB creates a default retention policy named "default".  DEFAULT is
also a keyword in the language.  This required double quoting "default"
in the ALTER RETENTION POLICY statement.  This commit makes the parser
accept it unquoted for that one statement.