### PR TITLE
Allow HTTP logging to be controlled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - [#2292](https://github.com/influxdb/influxdb/pull/2292): Wire up drop CQ statement - thanks @neonstalwart!
 - [#2290](https://github.com/influxdb/influxdb/pull/2290): Allow hostname argument to override default config - thanks @neonstalwart!
 - [#2295](https://github.com/influxdb/influxdb/pull/2295): Use nil as default return value for MapCount - thanks @neonstalwart!
+- [#2246](https://github.com/influxdb/influxdb/pull/2246): Allow HTTP logging to be controlled.
 
 ## v0.9.0-rc24 [2015-04-13]
 

--- a/circle.yml
+++ b/circle.yml
@@ -7,5 +7,3 @@ test:
     override:
     # Put each test command on its own line.
         - go tool vet .
-        - case $CIRCLE_NODE_INDEX in 0) go test -p 1 -timeout 300s -v ./... ;; 1) GORACE="halt_on_error=1" go test -p 1 -race -timeout 300s -v ./... ;; esac:
-            parallel: true

--- a/circle.yml
+++ b/circle.yml
@@ -7,5 +7,5 @@ test:
     override:
     # Put each test command on its own line.
         - go tool vet .
-        - case $CIRCLE_NODE_INDEX in 0) go test -p 1 -timeout 300s -v ./... ;; 1) GORACE="halt_on_error=1" go test -p 1 -race -timeout 600s -v ./... ;; esac:
+        - case $CIRCLE_NODE_INDEX in 0) go test -p 1 -timeout 300s -v ./... ;; 1) GORACE="halt_on_error=1" go test -p 1 -race -timeout 300s -v ./... ;; esac:
             parallel: true

--- a/cmd/influxd/config.go
+++ b/cmd/influxd/config.go
@@ -179,6 +179,7 @@ type Config struct {
 	Snapshot Snapshot `toml:"snapshot"`
 
 	Logging struct {
+		HTTPAccess   bool `toml:"http-access"`
 		WriteTracing bool `toml:"write-tracing"`
 		RaftTracing  bool `toml:"raft-tracing"`
 	} `toml:"logging"`
@@ -237,6 +238,10 @@ func NewConfig() *Config {
 	c.Data.RetentionCheckEnabled = DefaultRetentionCheckEnabled
 	c.Data.RetentionCheckPeriod = Duration(DefaultRetentionCheckPeriod)
 	c.Data.RetentionCreatePeriod = Duration(DefaultRetentionCreatePeriod)
+
+	c.Logging.HTTPAccess = true
+	c.Logging.WriteTracing = false
+	c.Logging.RaftTracing = false
 
 	c.Monitoring.Enabled = false
 	c.Monitoring.WriteInterval = Duration(DefaultStatisticsWriteInterval)

--- a/cmd/influxd/handler.go
+++ b/cmd/influxd/handler.go
@@ -104,7 +104,7 @@ func (h *Handler) serveData(w http.ResponseWriter, r *http.Request) {
 		sh := httpd.NewClusterHandler(h.Server, h.Config.Authentication.Enabled,
 			h.Config.Snapshot.Enabled, version)
 		sh.WriteTrace = h.Config.Logging.WriteTracing
-		sh.HTTPAccessLogging = h.Config.Logging.HTTPAccess
+		sh.LoggingEnabled = h.Config.Logging.HTTPAccess
 		sh.ServeHTTP(w, r)
 		return
 	}

--- a/cmd/influxd/handler.go
+++ b/cmd/influxd/handler.go
@@ -104,6 +104,7 @@ func (h *Handler) serveData(w http.ResponseWriter, r *http.Request) {
 		sh := httpd.NewClusterHandler(h.Server, h.Config.Authentication.Enabled,
 			h.Config.Snapshot.Enabled, version)
 		sh.WriteTrace = h.Config.Logging.WriteTracing
+		sh.HTTPAccessLogging = h.Config.Logging.HTTPAccess
 		sh.ServeHTTP(w, r)
 		return
 	}

--- a/cmd/influxd/server_integration_test.go
+++ b/cmd/influxd/server_integration_test.go
@@ -76,7 +76,7 @@ func (c *Cluster) Close() {
 //
 // This function returns a slice of nodes, the first of which will be the leader.
 func createCombinedNodeCluster(t *testing.T, testName, tmpDir string, nNodes int, baseConfig *main.Config) Cluster {
-	basePort := 8086
+	basePort := 10000
 	t.Logf("Creating cluster of %d nodes for test %s", nNodes, testName)
 	if nNodes < 1 {
 		t.Fatalf("Test %s: asked to create nonsense cluster", testName)
@@ -232,7 +232,7 @@ func queryAndWait(t *testing.T, nodes Cluster, urlDb, q, expected, expectPattern
 		v.Set("db", urlDb)
 	}
 
-	sleep := 10 * time.Millisecond
+	sleep := 1 * time.Second
 	// Check to see if they set the env for duration sleep
 	if sleepRaw := os.Getenv("TEST_SLEEP"); sleepRaw != "" {
 		d, err := time.ParseDuration(sleepRaw)

--- a/cmd/influxd/server_integration_test.go
+++ b/cmd/influxd/server_integration_test.go
@@ -105,6 +105,7 @@ func createCombinedNodeCluster(t *testing.T, testName, tmpDir string, nNodes int
 	c.Admin.Enabled = false
 	c.ReportingDisabled = true
 	c.Snapshot.Enabled = false
+	c.Logging.HTTPAccess = false
 
 	cmd := main.NewRunCommand()
 	node := cmd.Open(c, "")
@@ -177,7 +178,9 @@ func write(t *testing.T, node *TestNode, data string) {
 		t.Fatalf("Couldn't write data: %s", err)
 	}
 	body, _ := ioutil.ReadAll(resp.Body)
-	fmt.Println("BODY: ", string(body))
+	if string(body) != "" {
+		t.Log("BODY: ", string(body))
+	}
 	if resp.StatusCode != http.StatusOK {
 		body, _ := ioutil.ReadAll(resp.Body)
 		t.Fatalf("Write to database failed.  Unexpected status code.  expected: %d, actual %d, %s", http.StatusOK, resp.StatusCode, string(body))

--- a/cmd/influxd/server_integration_test.go
+++ b/cmd/influxd/server_integration_test.go
@@ -1404,7 +1404,6 @@ func Test3NodeServer(t *testing.T) {
 
 // ensure that all queries work if there are more nodes in a cluster than the replication factor
 func Test3NodeClusterPartiallyReplicated(t *testing.T) {
-	t.Skip("Skipping due to instability")
 	testName := "3-node server integration partial replication"
 	if testing.Short() {
 		t.Skip(fmt.Sprintf("skipping '%s'", testName))

--- a/cmd/influxd/server_integration_test.go
+++ b/cmd/influxd/server_integration_test.go
@@ -1357,7 +1357,7 @@ func runTestsData(t *testing.T, testName string, nodes Cluster, database, retent
 				urlDb = tt.queryDb
 			}
 			qry := rewriteDbRp(tt.query, database, retention)
-			got, ok := queryAndWait(t, qNodes, rewriteDbRp(urlDb, database, retention), qry, rewriteDbRp(tt.expected, database, retention), rewriteDbRp(tt.expectPattern, database, retention), 60*time.Second)
+			got, ok := queryAndWait(t, qNodes, rewriteDbRp(urlDb, database, retention), qry, rewriteDbRp(tt.expected, database, retention), rewriteDbRp(tt.expectPattern, database, retention), 10*time.Second)
 			if !ok {
 				if tt.expected != "" {
 					t.Errorf("Test #%d: \"%s\" failed\n  query: %s\n  exp: %s\n  got: %s\n", i, name, qry, rewriteDbRp(tt.expected, database, retention), got)

--- a/httpd/handler.go
+++ b/httpd/handler.go
@@ -53,9 +53,9 @@ type Handler struct {
 	snapshotEnabled       bool
 	version               string
 
-	Logger            *log.Logger
-	HTTPAccessLogging bool // Log every HTTP access.
-	WriteTrace        bool // Detailed logging of write path
+	Logger         *log.Logger
+	LoggingEnabled bool // Log every HTTP access.
+	WriteTrace     bool // Detailed logging of write path
 }
 
 // NewClusterHandler is the http handler for cluster communication endpoints
@@ -170,7 +170,7 @@ func (h *Handler) SetRoutes(routes []route) {
 		handler = versionHeader(handler, h.version)
 		handler = cors(handler)
 		handler = requestID(handler)
-		if h.HTTPAccessLogging && r.log {
+		if h.LoggingEnabled && r.log {
 			handler = logging(handler, r.name, h.Logger)
 		}
 		handler = recovery(handler, r.name, h.Logger) // make sure recovery is always last

--- a/httpd/handler.go
+++ b/httpd/handler.go
@@ -53,8 +53,9 @@ type Handler struct {
 	snapshotEnabled       bool
 	version               string
 
-	Logger     *log.Logger
-	WriteTrace bool // Detailed logging of write path
+	Logger            *log.Logger
+	HTTPAccessLogging bool // Log every HTTP access.
+	WriteTrace        bool // Detailed logging of write path
 }
 
 // NewClusterHandler is the http handler for cluster communication endpoints
@@ -169,7 +170,7 @@ func (h *Handler) SetRoutes(routes []route) {
 		handler = versionHeader(handler, h.version)
 		handler = cors(handler)
 		handler = requestID(handler)
-		if r.log {
+		if h.HTTPAccessLogging && r.log {
 			handler = logging(handler, r.name, h.Logger)
 		}
 		handler = recovery(handler, r.name, h.Logger) // make sure recovery is always last

--- a/influxql/functions.go
+++ b/influxql/functions.go
@@ -121,7 +121,6 @@ func InitializeUnmarshaller(c *Call) (UnmarshalFunc, error) {
 	// if c is nil it's a raw data query
 	if c == nil {
 		return func(b []byte) (interface{}, error) {
-			warn("MARSHAL OUTPUT: ", string(b))
 			a := make([]*rawQueryMapOutput, 0)
 			err := json.Unmarshal(b, &a)
 			return a, err


### PR DESCRIPTION
This change also re-enables DQ testing, as well as remove a bogus `warn` statement.