### PR TITLE
Kayhman/update

### DIFF
--- a/server.go
+++ b/server.go
@@ -1811,6 +1811,19 @@ func (s *Server) WriteSeries(database, retentionPolicy string, points []Point) (
 				codec = NewFieldCodec(measurement)
 				codecs[measurement.Name] = codec
 			}
+			
+			values, err := s.ReadSeries(database, retentionPolicy, p.Name, p.Tags, p.Timestamp)
+			if err != nil {
+				s.Logger.Printf("database or series not found: dbname=%s, dbname=%s, tags=%#v", database, p.Name, p.Tags)
+				return err
+			}
+			//keep old values
+			for k, _ := range codec.fieldsByName {
+				if _, ok := p.Fields[k] ; !ok {
+					p.Fields[k] = values[k]
+				}
+			}
+			
 
 			// Convert string-key/values to encoded fields.
 			encodedFields, err := codec.EncodeFields(p.Fields)

--- a/server.go
+++ b/server.go
@@ -1820,7 +1820,10 @@ func (s *Server) WriteSeries(database, retentionPolicy string, points []Point) (
 			//keep old values
 			for k, _ := range codec.fieldsByName {
 				if _, ok := p.Fields[k] ; !ok {
-					p.Fields[k] = values[k]
+					v, ok := values[k]
+					if ok {
+						p.Fields[k] = v
+					}
 				}
 			}
 			

--- a/server_test.go
+++ b/server_test.go
@@ -1024,7 +1024,7 @@ func TestServer_UpdateSeries(t *testing.T) {
 
 	// Write series with one point to the database.
 	tags := map[string]string{"host": "serverA", "region": "uswest"}
-	index, err := s.WriteSeries("foo", "raw", []influxdb.Point{{Name: "cpu", Tags: tags, Timestamp: mustParseTime("2000-01-01T00:00:00Z"), Fields: map[string]interface{}{"value": float64(23.2), "value2": float64(23.3)}}})
+	index, err := s.UpdateSeries("foo", "raw", []influxdb.Point{{Name: "cpu", Tags: tags, Timestamp: mustParseTime("2000-01-01T00:00:00Z"), Fields: map[string]interface{}{"value": float64(23.2), "value2": float64(23.3)}}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1034,7 +1034,7 @@ func TestServer_UpdateSeries(t *testing.T) {
 	<- timer.C
 
 	//owerwrite measurement with new info
-	index, err = s.WriteSeries("foo", "raw", []influxdb.Point{{Name: "cpu", Tags: tags, Timestamp: mustParseTime("2000-01-01T00:00:00Z"), Fields: map[string]interface{}{"value2": float64(23.666)}}})
+	index, err = s.UpdateSeries("foo", "raw", []influxdb.Point{{Name: "cpu", Tags: tags, Timestamp: mustParseTime("2000-01-01T00:00:00Z"), Fields: map[string]interface{}{"value2": float64(23.666)}}})
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Currently, it is not possible to add new fields to a measurement at a given time step. For instance, if you run : 

```shell
curl -XPOST 'http://localhost:8086/write' -d '
{
    "database": "mydb",
    "retentionPolicy": "mypolicy",
    "points": [
        {
            "name": "realtime",
            "tags": {
                "host": "server01",
                "region": "us-west"
            },
            "timestamp": "2009-11-10T23:00:00Z",
            "fields": {
		"value" : 0.445
		}
        }
    ]
}
'
```

and then try do add another value : 
```shell
curl -XPOST 'http://localhost:8086/write' -d '
{
    "database": "hyseo",
    "retentionPolicy": "mypolicy",
    "points": [
        {
            "name": "realtime",
            "tags": {
                "host": "server01",
                "region": "us-west"
            },
            "timestamp": "2009-11-10T23:00:00Z",
            "fields": {
		"value2" : 0.556
		}
        }
    ]
}
'
```
You will lose the first value, as show this request : 

```shell
curl -G 'http://localhost:8086/query' --data-urlencode "db=mydb" --data-urlencode "q=SELECT * FROM realtime"

{"results":[{"series":[{"name":"realtime","columns":["time","value","value2"],"values":[["2009-11-10T23:00:00Z",null,0.556]]}]}]}
```

With my modification, the second request add the new field, and does not nullify the first one.

```shell
curl -G 'http://localhost:8086/query' --data-urlencode "db=mydb" --data-urlencode "q=SELECT * FROM realtime"

{"results":[{"series":[{"name":"realtime","columns":["time","value","value2"],"values":[["2009-11-10T23:00:00Z",0.445,0.556]]}]}]}
```

I've added a unit test that ensure that it's working.