### PR TITLE
Snapshot and API bind addresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [#2257](https://github.com/influxdb/influxdb/pull/2257): Add "snapshotting" pseudo state & log entry cache.
 - [#2261](https://github.com/influxdb/influxdb/pull/2261): Support int64 value types.
 - [#2191](https://github.com/influxdb/influxdb/pull/2191): Case-insensitive check for "fill"
+- [#2274](https://github.com/influxdb/influxdb/pull/2274): Snapshot and HTTP API endpoints
 
 ## v0.9.0-rc23 [2015-04-11]
 
@@ -17,7 +18,7 @@
 ### Bugfixes
 - [#2225](https://github.com/influxdb/influxdb/pull/2225): Make keywords completely case insensitive
 - [#2228](https://github.com/influxdb/influxdb/pull/2228): Accept keyword default unquoted in ALTER RETENTION POLICY statement
-- [#2236](https://github.com/influxdb/influxdb/pull/2236): Immediate term changes, fix stale write issue, net/http/pprof 
+- [#2236](https://github.com/influxdb/influxdb/pull/2236): Immediate term changes, fix stale write issue, net/http/pprof
 - [#2213](https://github.com/influxdb/influxdb/pull/2213): Seed random number generator for election timeout. Thanks @cannium.
 
 ## v0.9.0-rc22 [2015-04-09]

--- a/broker.go
+++ b/broker.go
@@ -109,7 +109,7 @@ func (b *Broker) runContinuousQueries() {
 
 func (b *Broker) requestContinuousQueryProcessing(cqURL url.URL) error {
 	// Send request.
-	cqURL.Path = "/process_continuous_queries"
+	cqURL.Path = "/data/process_continuous_queries"
 	cqURL.Scheme = "http"
 	client := &http.Client{
 		Timeout: DefaultDataNodeTimeout,

--- a/broker_test.go
+++ b/broker_test.go
@@ -83,7 +83,7 @@ func (h *BrokerTestHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
 	}
 	switch r.URL.Path {
-	case "/process_continuous_queries":
+	case "/data/process_continuous_queries":
 		if r.Method == "POST" {
 			h.processRequestCount++
 			w.WriteHeader(http.StatusAccepted)

--- a/cmd/influxd/backup.go
+++ b/cmd/influxd/backup.go
@@ -143,7 +143,7 @@ func (cmd *BackupCommand) download(u url.URL, ss *influxdb.Snapshot, path string
 	}
 
 	// Create request with existing snapshot as the body.
-	u.Path = "/snapshot"
+	u.Path = "/data/snapshot"
 	req, err := http.NewRequest("GET", u.String(), &buf)
 	if err != nil {
 		return fmt.Errorf("new request: %s", err)

--- a/cmd/influxd/backup_test.go
+++ b/cmd/influxd/backup_test.go
@@ -16,7 +16,7 @@ import (
 func TestBackupCommand(t *testing.T) {
 	// Mock the backup endpoint.
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/snapshot" {
+		if r.URL.Path != "/data/snapshot" {
 			t.Fatalf("unexpected url path: %s", r.URL.Path)
 		}
 

--- a/cmd/influxd/config.go
+++ b/cmd/influxd/config.go
@@ -42,12 +42,6 @@ const (
 	// DefaultDataEnabled is the default for starting a node as a data node
 	DefaultDataEnabled = true
 
-	// DefaultSnapshotBindAddress is the default bind address to serve snapshots from.
-	DefaultSnapshotBindAddress = "127.0.0.1"
-
-	// DefaultSnapshotPort is the default port to serve snapshots from.
-	DefaultSnapshotPort = 8087
-
 	// DefaultRetentionCreatePeriod represents how often the server will check to see if new
 	// shard groups need to be created in advance for writing
 	DefaultRetentionCreatePeriod = 45 * time.Minute
@@ -107,9 +101,7 @@ type Broker struct {
 // Snapshot represents the configuration for a snapshot service. Snapshot configuration
 // is only valid for data nodes.
 type Snapshot struct {
-	Enabled     bool   `toml:"enabled"`
-	BindAddress string `toml:"bind-address"`
-	Port        int    `toml:"port"`
+	Enabled bool `toml:"enabled"`
 }
 
 // Data represents the configuration for a data node
@@ -236,9 +228,6 @@ func NewConfig() *Config {
 	c.Data.RetentionCheckPeriod = Duration(DefaultRetentionCheckPeriod)
 	c.Data.RetentionCreatePeriod = Duration(DefaultRetentionCreatePeriod)
 
-	c.Snapshot.BindAddress = DefaultSnapshotBindAddress
-	c.Snapshot.Port = DefaultSnapshotPort
-
 	c.Monitoring.Enabled = false
 	c.Monitoring.WriteInterval = Duration(DefaultStatisticsWriteInterval)
 	c.ContinuousQuery.RecomputePreviousN = DefaultContinuousQueryRecomputePreviousN
@@ -299,11 +288,6 @@ func (c *Config) APIAddr() string {
 // APIAddrUDP returns the UDP address for the series listener.
 func (c *Config) APIAddrUDP() string {
 	return net.JoinHostPort(c.UDP.BindAddress, strconv.Itoa(c.UDP.Port))
-}
-
-// SnapshotAddr returns the TCP binding address for the snapshot handler.
-func (c *Config) SnapshotAddr() string {
-	return net.JoinHostPort(c.Snapshot.BindAddress, strconv.Itoa(c.Snapshot.Port))
 }
 
 // ClusterAddr returns the binding address for the cluster

--- a/cmd/influxd/config.go
+++ b/cmd/influxd/config.go
@@ -94,7 +94,7 @@ const (
 
 var DefaultSnapshotURL = url.URL{
 	Scheme: "http",
-	Host:   net.JoinHostPort(DefaultSnapshotBindAddress, strconv.Itoa(DefaultSnapshotPort)),
+	Host:   net.JoinHostPort("127.0.0.1", strconv.Itoa(DefaultClusterPort)),
 }
 
 // Broker represents the configuration for a broker node

--- a/cmd/influxd/config.go
+++ b/cmd/influxd/config.go
@@ -218,8 +218,6 @@ func NewConfig() *Config {
 	c := &Config{}
 	c.Port = DefaultClusterPort
 
-	c.HTTPAPI.Port = DefaultClusterPort
-
 	c.Data.Enabled = DefaultDataEnabled
 	c.Broker.Enabled = DefaultBrokerEnabled
 
@@ -278,11 +276,18 @@ func NewTestConfig() (*Config, error) {
 
 // APIAddr returns the TCP binding address for the API server.
 func (c *Config) APIAddr() string {
+	// Default to cluster bind address if not overriden
 	ba := c.BindAddress
 	if c.HTTPAPI.BindAddress != "" {
 		ba = c.HTTPAPI.BindAddress
 	}
-	return net.JoinHostPort(ba, strconv.Itoa(c.HTTPAPI.Port))
+
+	// Default to cluster port if not overridden
+	bp := c.Port
+	if c.HTTPAPI.Port != 0 {
+		bp = c.HTTPAPI.Port
+	}
+	return net.JoinHostPort(ba, strconv.Itoa(bp))
 }
 
 // APIAddrUDP returns the UDP address for the series listener.

--- a/cmd/influxd/config_test.go
+++ b/cmd/influxd/config_test.go
@@ -116,8 +116,7 @@ enabled = false
 disabled = true
 
 [snapshot]
-bind-address = "1.2.3.4"
-port = 9999
+enabled = true
 `
 
 // Ensure that megabyte sizes can be parsed.
@@ -271,13 +270,10 @@ func TestParseConfig(t *testing.T) {
 		t.Fatalf("Monitoring.WriteInterval mismatch: %v", c.Monitoring.WriteInterval)
 	}
 
-	if exp := "1.2.3.4"; c.Snapshot.BindAddress != exp {
-		t.Fatalf("snapshot bind-address mismatch: %v, got %v", exp, c.Snapshot.BindAddress)
+	if !c.Snapshot.Enabled {
+		t.Fatalf("snapshot enabled mismatch: %v, got %v", true, c.Snapshot.Enabled)
 	}
 
-	if exp := 9999; c.Snapshot.Port != exp {
-		t.Fatalf("snapshot port mismatch: %v, got %v", exp, c.Snapshot.Port)
-	}
 	// TODO: UDP Servers testing.
 	/*
 		c.Assert(config.UdpServers, HasLen, 1)

--- a/cmd/influxd/handler.go
+++ b/cmd/influxd/handler.go
@@ -67,7 +67,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// These are public API endpoints
-	h.serveData(w, r)
+	h.serveAPI(w, r)
 }
 
 // serveMessaging responds to broker requests
@@ -135,8 +135,8 @@ func (h *Handler) serveRaft(w http.ResponseWriter, r *http.Request) {
 	h.redirect(h.Server.BrokerURLs(), w, r)
 }
 
-// serveData responds to data requests
-func (h *Handler) serveData(w http.ResponseWriter, r *http.Request) {
+// serveAPI responds to data requests
+func (h *Handler) serveAPI(w http.ResponseWriter, r *http.Request) {
 	if h.Broker == nil && h.Server == nil {
 		log.Println("no broker or server configured to handle data endpoints")
 		http.Error(w, "server unavailable", http.StatusServiceUnavailable)

--- a/cmd/influxd/handler.go
+++ b/cmd/influxd/handler.go
@@ -101,7 +101,8 @@ func (h *Handler) serveData(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if h.Server != nil {
-		sh := httpd.NewClusterHandler(h.Server, h.Config.Authentication.Enabled, version)
+		sh := httpd.NewClusterHandler(h.Server, h.Config.Authentication.Enabled,
+			h.Config.Snapshot.Enabled, version)
 		sh.WriteTrace = h.Config.Logging.WriteTracing
 		sh.ServeHTTP(w, r)
 		return

--- a/cmd/influxd/handler.go
+++ b/cmd/influxd/handler.go
@@ -45,24 +45,28 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// FIXME: This is very brittle.  Refactor to have common path prefix
+	// Broker raft communication endpoints.  These are called and handled by brokers
+	// to coordinate changes to the raft log.
 	if strings.HasPrefix(r.URL.Path, "/raft") {
 		h.serveRaft(w, r)
 		return
 	}
 
+	// Broker messaging endpoints.  These are handled by brokers and called by data
+	// nodes to receive topic change and update replication status.
 	if strings.HasPrefix(r.URL.Path, "/messaging") {
 		h.serveMessaging(w, r)
 		return
 	}
 
-	if strings.HasPrefix(r.URL.Path, "/data_nodes") ||
-		strings.HasPrefix(r.URL.Path, "/process_continuous_queries") ||
-		strings.HasPrefix(r.URL.Path, "/run_mapper") ||
-		strings.HasPrefix(r.URL.Path, "/metastore") {
+	// Data node endpoints.  These are handled by data nodes and allow brokers and data
+	// nodes to transfer state, process queries, etc..
+	if strings.HasPrefix(r.URL.Path, "/data") {
 		h.serveMetadata(w, r)
 		return
 	}
+
+	// These are public API endpoints
 	h.serveData(w, r)
 }
 

--- a/cmd/influxd/handler.go
+++ b/cmd/influxd/handler.go
@@ -62,7 +62,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Data node endpoints.  These are handled by data nodes and allow brokers and data
 	// nodes to transfer state, process queries, etc..
 	if strings.HasPrefix(r.URL.Path, "/data") {
-		h.serveMetadata(w, r)
+		h.serveData(w, r)
 		return
 	}
 
@@ -92,8 +92,8 @@ func (h *Handler) serveMessaging(w http.ResponseWriter, r *http.Request) {
 	h.redirect(h.Server.BrokerURLs(), w, r)
 }
 
-// serveMetadata responds to broker requests
-func (h *Handler) serveMetadata(w http.ResponseWriter, r *http.Request) {
+// serveData responds to broker requests
+func (h *Handler) serveData(w http.ResponseWriter, r *http.Request) {
 	if h.Broker == nil && h.Server == nil {
 		log.Println("no broker or server configured to handle metadata endpoints")
 		http.Error(w, "server unavailable", http.StatusServiceUnavailable)

--- a/cmd/influxd/restore_test.go
+++ b/cmd/influxd/restore_test.go
@@ -13,7 +13,7 @@ import (
 	main "github.com/influxdb/influxdb/cmd/influxd"
 )
 
-func newConfig(path string, port, snapshotPort int) main.Config {
+func newConfig(path string, port int) main.Config {
 	config := main.NewConfig()
 	config.Port = port
 	config.Broker.Enabled = true
@@ -21,7 +21,6 @@ func newConfig(path string, port, snapshotPort int) main.Config {
 
 	config.Data.Enabled = true
 	config.Data.Dir = filepath.Join(path, "data")
-	config.Snapshot.Port = snapshotPort
 	return *config
 }
 
@@ -38,7 +37,7 @@ func TestRestoreCommand(t *testing.T) {
 	defer os.Remove(path)
 
 	// Parse configuration.
-	config := newConfig(path, 8900, 8901)
+	config := newConfig(path, 8900)
 
 	// Start server.
 	cmd := main.NewRunCommand()
@@ -90,7 +89,7 @@ func TestRestoreCommand(t *testing.T) {
 	}
 
 	// Rewrite config to a new port and re-parse.
-	config = newConfig(path, 8910, 8911)
+	config = newConfig(path, 8910)
 
 	// Restart server.
 	cmd = main.NewRunCommand()

--- a/httpd/handler.go
+++ b/httpd/handler.go
@@ -62,35 +62,35 @@ func NewClusterHandler(s *influxdb.Server, requireAuthentication bool, version s
 	h.SetRoutes([]route{
 		route{ // List data nodes
 			"data_nodes_index",
-			"GET", "/data_nodes", true, false, h.serveDataNodes,
+			"GET", "/data/data_nodes", true, false, h.serveDataNodes,
 		},
 		route{ // Create data node
 			"data_nodes_create",
-			"POST", "/data_nodes", true, false, h.serveCreateDataNode,
+			"POST", "/data/data_nodes", true, false, h.serveCreateDataNode,
 		},
 		route{ // Delete data node
 			"data_nodes_delete",
-			"DELETE", "/data_nodes/:id", true, false, h.serveDeleteDataNode,
+			"DELETE", "/data/data_nodes/:id", true, false, h.serveDeleteDataNode,
 		},
 		route{ // Metastore
 			"metastore",
-			"GET", "/metastore", false, false, h.serveMetastore,
+			"GET", "/data/metastore", false, false, h.serveMetastore,
 		},
 		route{ // Tell data node to run CQs that should be run
 			"process_continuous_queries",
-			"POST", "/process_continuous_queries", false, false, h.serveProcessContinuousQueries,
+			"POST", "/data/process_continuous_queries", false, false, h.serveProcessContinuousQueries,
 		},
 		route{
 			"index", // Index.
-			"GET", "/", true, true, h.serveIndex,
+			"GET", "/data", true, true, h.serveIndex,
 		},
 		route{
 			"wait", // Wait.
-			"GET", "/wait/:index", true, true, h.serveWait,
+			"GET", "/data/wait/:index", true, true, h.serveWait,
 		},
 		route{
 			"run_mapper",
-			"POST", "/run_mapper", true, true, h.serveRunMapper,
+			"POST", "/data/run_mapper", true, true, h.serveRunMapper,
 		},
 	})
 	return h

--- a/httpd/handler_test.go
+++ b/httpd/handler_test.go
@@ -1614,7 +1614,7 @@ func TestSnapshotHandler(t *testing.T) {
 	// The "shards/1" has a higher index in the diff so it won't be included in the snapshot.
 	w := httptest.NewRecorder()
 	r, _ := http.NewRequest(
-		"GET", "http://localhost/snapshot",
+		"GET", "http://localhost/data/snapshot",
 		strings.NewReader(`{"files":[{"name":"meta","index":10},{"name":"shards/1","index":20}]}`),
 	)
 	h.ServeHTTP(w, r)
@@ -1759,12 +1759,12 @@ func NewAPIServer(s *Server) *HTTPServer {
 }
 
 func NewClusterServer(s *Server) *HTTPServer {
-	h := httpd.NewClusterHandler(s.Server, false, "X.X")
+	h := httpd.NewClusterHandler(s.Server, false, true, "X.X")
 	return &HTTPServer{httptest.NewServer(h), h}
 }
 
 func NewAuthenticatedClusterServer(s *Server) *HTTPServer {
-	h := httpd.NewClusterHandler(s.Server, true, "X.X")
+	h := httpd.NewClusterHandler(s.Server, true, true, "X.X")
 	return &HTTPServer{httptest.NewServer(h), h}
 }
 

--- a/httpd/handler_test.go
+++ b/httpd/handler_test.go
@@ -585,7 +585,7 @@ func TestHandler_Index(t *testing.T) {
 	s := NewClusterServer(srvr)
 	defer s.Close()
 
-	status, body := MustHTTP("GET", s.URL, nil, nil, "")
+	status, body := MustHTTP("GET", s.URL+"/data", nil, nil, "")
 
 	if status != http.StatusOK {
 		t.Fatalf("unexpected status: %d", status)
@@ -603,7 +603,7 @@ func TestHandler_Wait(t *testing.T) {
 	s := NewClusterServer(srvr)
 	defer s.Close()
 
-	status, body := MustHTTP("GET", s.URL+`/wait/1`, map[string]string{"timeout": "1"}, nil, "")
+	status, body := MustHTTP("GET", s.URL+`/data/wait/1`, map[string]string{"timeout": "1"}, nil, "")
 
 	if status != http.StatusOK {
 		t.Fatalf("unexpected status: %d", status)
@@ -624,7 +624,7 @@ func TestHandler_WaitIncrement(t *testing.T) {
 	s := NewClusterServer(srvr)
 	defer s.Close()
 
-	status, _ := MustHTTP("GET", s.URL+`/wait/2`, map[string]string{"timeout": "200"}, nil, "")
+	status, _ := MustHTTP("GET", s.URL+`/data/wait/2`, map[string]string{"timeout": "200"}, nil, "")
 
 	// Write some data
 	_, _ = MustHTTP("POST", s.URL+`/write`, nil, nil, `{"database" : "foo", "retentionPolicy" : "bar", "points": [{"name": "cpu", "tags": {"host": "server01"},"timestamp": "2009-11-10T23:00:00Z","fields": {"value": 100}}]}`)
@@ -641,7 +641,7 @@ func TestHandler_WaitNoIndexSpecified(t *testing.T) {
 	s := NewClusterServer(srvr)
 	defer s.Close()
 
-	status, _ := MustHTTP("GET", s.URL+`/wait`, nil, nil, "")
+	status, _ := MustHTTP("GET", s.URL+`/data/wait`, nil, nil, "")
 
 	if status != http.StatusNotFound {
 		t.Fatalf("unexpected status, expected:  %d, actual: %d", http.StatusNotFound, status)
@@ -655,7 +655,7 @@ func TestHandler_WaitInvalidIndexSpecified(t *testing.T) {
 	s := NewClusterServer(srvr)
 	defer s.Close()
 
-	status, _ := MustHTTP("GET", s.URL+`/wait/foo`, nil, nil, "")
+	status, _ := MustHTTP("GET", s.URL+`/data/wait/foo`, nil, nil, "")
 
 	if status != http.StatusBadRequest {
 		t.Fatalf("unexpected status, expected:  %d, actual: %d", http.StatusBadRequest, status)
@@ -669,7 +669,7 @@ func TestHandler_WaitExpectTimeout(t *testing.T) {
 	s := NewClusterServer(srvr)
 	defer s.Close()
 
-	status, _ := MustHTTP("GET", s.URL+`/wait/2`, map[string]string{"timeout": "1"}, nil, "")
+	status, _ := MustHTTP("GET", s.URL+`/data/wait/2`, map[string]string{"timeout": "1"}, nil, "")
 
 	if status != http.StatusRequestTimeout {
 		t.Fatalf("unexpected status, expected:  %d, actual: %d", http.StatusRequestTimeout, status)
@@ -774,7 +774,7 @@ func TestHandler_DataNodes(t *testing.T) {
 	s := NewAPIServer(srvr)
 	defer s.Close()
 
-	status, body := MustHTTP("GET", s.URL+`/data_nodes`, nil, nil, "")
+	status, body := MustHTTP("GET", s.URL+`/data/data_nodes`, nil, nil, "")
 	if status != http.StatusOK {
 		t.Fatalf("unexpected status: %d", status)
 	} else if body != `[{"id":1,"url":"http://localhost:1000"},{"id":2,"url":"http://localhost:2000"},{"id":3,"url":"http://localhost:3000"}]` {
@@ -790,7 +790,7 @@ func TestHandler_CreateDataNode(t *testing.T) {
 	s := NewAPIServer(srvr)
 	defer s.Close()
 
-	status, body := MustHTTP("POST", s.URL+`/data_nodes`, nil, nil, `{"url":"http://localhost:1000"}`)
+	status, body := MustHTTP("POST", s.URL+`/data/data_nodes`, nil, nil, `{"url":"http://localhost:1000"}`)
 	if status != http.StatusOK {
 		t.Fatalf("unexpected status: %d", status)
 	} else if body != `{"id":1,"url":"http://localhost:1000"}` {
@@ -806,7 +806,7 @@ func TestHandler_CreateDataNode_BadRequest(t *testing.T) {
 	s := NewAPIServer(srvr)
 	defer s.Close()
 
-	status, body := MustHTTP("POST", s.URL+`/data_nodes`, nil, nil, `{"name":`)
+	status, body := MustHTTP("POST", s.URL+`/data/data_nodes`, nil, nil, `{"name":`)
 	if status != http.StatusBadRequest {
 		t.Fatalf("unexpected status: %d", status)
 	} else if body != `unexpected EOF` {
@@ -822,7 +822,7 @@ func TestHandler_CreateDataNode_InternalServerError(t *testing.T) {
 	s := NewAPIServer(srvr)
 	defer s.Close()
 
-	status, body := MustHTTP("POST", s.URL+`/data_nodes`, nil, nil, `{"url":""}`)
+	status, body := MustHTTP("POST", s.URL+`/data/data_nodes`, nil, nil, `{"url":""}`)
 	if status != http.StatusInternalServerError {
 		t.Fatalf("unexpected status: %d, %s", status, body)
 	} else if body != `data node url required` {
@@ -839,7 +839,7 @@ func TestHandler_DeleteDataNode(t *testing.T) {
 	s := NewAPIServer(srvr)
 	defer s.Close()
 
-	status, body := MustHTTP("DELETE", s.URL+`/data_nodes/1`, nil, nil, "")
+	status, body := MustHTTP("DELETE", s.URL+`/data/data_nodes/1`, nil, nil, "")
 	if status != http.StatusOK {
 		t.Fatalf("unexpected status: %d", status)
 	} else if body != `` {
@@ -855,7 +855,7 @@ func TestHandler_DeleteUser_DataNodeNotFound(t *testing.T) {
 	s := NewAPIServer(srvr)
 	defer s.Close()
 
-	status, body := MustHTTP("DELETE", s.URL+`/data_nodes/10000`, nil, nil, "")
+	status, body := MustHTTP("DELETE", s.URL+`/data/data_nodes/10000`, nil, nil, "")
 	if status != http.StatusNotFound {
 		t.Fatalf("unexpected status: %d", status)
 	} else if body != `data node not found` {
@@ -1585,7 +1585,7 @@ func TestHandler_ProcessContinousQueries(t *testing.T) {
 	s := NewClusterServer(srvr)
 	defer s.Close()
 
-	status, _ := MustHTTP("POST", s.URL+`/process_continuous_queries`, nil, nil, "")
+	status, _ := MustHTTP("POST", s.URL+`/data/process_continuous_queries`, nil, nil, "")
 	if status != http.StatusAccepted {
 		t.Fatalf("unexpected status: %d", status)
 	}

--- a/remote_mapper.go
+++ b/remote_mapper.go
@@ -78,7 +78,7 @@ func (m *RemoteMapper) Begin(c *influxql.Call, startingTime int64, chunkSize int
 	}
 
 	// request to start streaming results
-	resp, err := http.Post(m.dataNodes[0].URL.String()+"/run_mapper", "application/json", bytes.NewReader(b))
+	resp, err := http.Post(m.dataNodes[0].URL.String()+"/data/run_mapper", "application/json", bytes.NewReader(b))
 	if err != nil {
 		return err
 	}

--- a/server.go
+++ b/server.go
@@ -667,7 +667,7 @@ func (s *Server) Join(u *url.URL, joinURL *url.URL) error {
 	// Create the initial request. Might get a redirect though depending on
 	// the nodes role
 	joinURL = copyURL(joinURL)
-	joinURL.Path = "/data_nodes"
+	joinURL.Path = "/data/data_nodes"
 
 	var retries int
 	var resp *http.Response
@@ -745,7 +745,7 @@ func (s *Server) Join(u *url.URL, joinURL *url.URL) error {
 	assert(n.ID > 0, "invalid join node id returned: %d", n.ID)
 
 	// Download the metastore from joining server.
-	joinURL.Path = "/metastore"
+	joinURL.Path = "/data/metastore"
 	resp, err = http.Get(joinURL.String())
 	if err != nil {
 		return err


### PR DESCRIPTION
This PR does the following:

* Moves all the data node handlers under a `/data` prefix to make the top-level handler less brittle.
* Removes the separate snapshot listener and makes it an endpoint on the cluster server at `/data/snapshot`  
* Removes the `[snapshot].bind-address` and `[snapshot].port` config sections since it now uses the cluster bind address and port
* Fixes the HTTP API listener so that it can actually be run on a separate interface and port from the cluster addr.