### PR TITLE
Broker truncation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 - [#2282](https://github.com/influxdb/influxdb/pull/2282): Use "value" as field name for OpenTSDB input.
 - [#2283](https://github.com/influxdb/influxdb/pull/2283): Fix bug when restarting an entire existing cluster.
 
+## Features
+- [#2276](https://github.com/influxdb/influxdb/pull/2276): Broker topic truncation.
+
 ## v0.9.0-rc24 [2015-04-13]
 
 ### Bugfixes

--- a/cmd/influxd/config.go
+++ b/cmd/influxd/config.go
@@ -46,6 +46,9 @@ const (
 	// shard groups need to be created in advance for writing
 	DefaultRetentionCreatePeriod = 45 * time.Minute
 
+	// DefaultBrokerTruncationInterval is the default period between truncating topics.
+	DefaultBrokerTruncationInterval = 10 * time.Minute
+
 	// DefaultMaxTopicSize is the default maximum size in bytes a topic can consume on disk of a broker.
 	DefaultBrokerMaxTopicSize = 1024 * 1024 * 1024
 
@@ -65,7 +68,7 @@ const (
 	DefaultRetentionCheckEnabled = true
 
 	// DefaultRetentionCheckPeriod is the period of time between retention policy checks are run
-	DefaultRetentionCheckPeriod = 10 * time.Minute
+	DefaultRetentionCheckPeriod = 30 * time.Minute
 
 	// DefaultRecomputePreviousN is ???
 	DefaultContinuousQueryRecomputePreviousN = 2
@@ -99,11 +102,12 @@ var DefaultSnapshotURL = url.URL{
 
 // Broker represents the configuration for a broker node
 type Broker struct {
-	Dir            string   `toml:"dir"`
-	Enabled        bool     `toml:"enabled"`
-	Timeout        Duration `toml:"election-timeout"`
-	MaxTopicSize   int64    `toml:"max-topic-size"`
-	MaxSegmentSize int64    `toml:"max-segment-size"`
+	Dir                string   `toml:"dir"`
+	Enabled            bool     `toml:"enabled"`
+	Timeout            Duration `toml:"election-timeout"`
+	TruncationInterval Duration `toml:"truncation-interval"`
+	MaxTopicSize       int64    `toml:"max-topic-size"`
+	MaxSegmentSize     int64    `toml:"max-segment-size"`
 }
 
 // Snapshot represents the configuration for a snapshot service. Snapshot configuration
@@ -241,6 +245,7 @@ func NewConfig() *Config {
 	c.ContinuousQuery.ComputeRunsPerInterval = DefaultContinuousQueryComputeRunsPerInterval
 	c.ContinuousQuery.ComputeNoMoreThan = Duration(DefaultContinousQueryComputeNoMoreThan)
 
+	c.Broker.TruncationInterval = Duration(DefaultBrokerTruncationInterval)
 	c.Broker.MaxTopicSize = DefaultBrokerMaxTopicSize
 	c.Broker.MaxSegmentSize = DefaultBrokerMaxSegmentSize
 

--- a/cmd/influxd/config.go
+++ b/cmd/influxd/config.go
@@ -46,6 +46,12 @@ const (
 	// shard groups need to be created in advance for writing
 	DefaultRetentionCreatePeriod = 45 * time.Minute
 
+	// DefaultMaxTopicSize is the default maximum size in bytes a topic can consume on disk of a broker.
+	DefaultBrokerMaxTopicSize = 1024 * 1024 * 1024
+
+	// DefaultMaxTopicSize is the default maximum size in bytes a segment can consume on disk of a broker.
+	DefaultBrokerMaxSegmentSize = 10 * 1024 * 1024
+
 	// DefaultGraphiteDatabaseName is the default Graphite database if none is specified
 	DefaultGraphiteDatabaseName = "graphite"
 
@@ -93,9 +99,11 @@ var DefaultSnapshotURL = url.URL{
 
 // Broker represents the configuration for a broker node
 type Broker struct {
-	Dir     string   `toml:"dir"`
-	Enabled bool     `toml:"enabled"`
-	Timeout Duration `toml:"election-timeout"`
+	Dir            string   `toml:"dir"`
+	Enabled        bool     `toml:"enabled"`
+	Timeout        Duration `toml:"election-timeout"`
+	MaxTopicSize   int64    `toml:"max-topic-size"`
+	MaxSegmentSize int64    `toml:"max-segment-size"`
 }
 
 // Snapshot represents the configuration for a snapshot service. Snapshot configuration
@@ -232,6 +240,9 @@ func NewConfig() *Config {
 	c.ContinuousQuery.RecomputeNoOlderThan = Duration(DefaultContinuousQueryRecomputeNoOlderThan)
 	c.ContinuousQuery.ComputeRunsPerInterval = DefaultContinuousQueryComputeRunsPerInterval
 	c.ContinuousQuery.ComputeNoMoreThan = Duration(DefaultContinousQueryComputeNoMoreThan)
+
+	c.Broker.MaxTopicSize = DefaultBrokerMaxTopicSize
+	c.Broker.MaxSegmentSize = DefaultBrokerMaxSegmentSize
 
 	// Detect hostname (or set to localhost).
 	if c.Hostname, _ = os.Hostname(); c.Hostname == "" {

--- a/cmd/influxd/config.go
+++ b/cmd/influxd/config.go
@@ -68,7 +68,7 @@ const (
 	DefaultRetentionCheckEnabled = true
 
 	// DefaultRetentionCheckPeriod is the period of time between retention policy checks are run
-	DefaultRetentionCheckPeriod = 30 * time.Minute
+	DefaultRetentionCheckPeriod = 10 * time.Minute
 
 	// DefaultRecomputePreviousN is ???
 	DefaultContinuousQueryRecomputePreviousN = 2

--- a/cmd/influxd/run.go
+++ b/cmd/influxd/run.go
@@ -476,6 +476,8 @@ func (cmd *RunCommand) openBroker(brokerURLs []url.URL) {
 
 	// Create broker
 	b := influxdb.NewBroker()
+	b.MaxTopicSize = cmd.config.Broker.MaxTopicSize
+	b.MaxSegmentSize = cmd.config.Broker.MaxSegmentSize
 	cmd.node.Broker = b
 
 	// Create raft log.

--- a/cmd/influxd/run.go
+++ b/cmd/influxd/run.go
@@ -476,6 +476,7 @@ func (cmd *RunCommand) openBroker(brokerURLs []url.URL) {
 
 	// Create broker
 	b := influxdb.NewBroker()
+	b.TruncationInterval = time.Duration(cmd.config.Broker.TruncationInterval)
 	b.MaxTopicSize = cmd.config.Broker.MaxTopicSize
 	b.MaxSegmentSize = cmd.config.Broker.MaxSegmentSize
 	cmd.node.Broker = b

--- a/etc/config.sample.toml
+++ b/etc/config.sample.toml
@@ -76,6 +76,9 @@ enabled = false
 enabled = true
 # Where the Raft logs are stored. The user running InfluxDB will need read/write access.
 dir  = "/var/opt/influxdb/raft"
+truncation-interval = "10m"
+max-topic-size = 1073741824
+max-segment-size = 10485760
 
 # Data node configuration. Data nodes are where the time-series data, in the form of
 # shards, is stored.

--- a/messaging/broker.go
+++ b/messaging/broker.go
@@ -492,7 +492,7 @@ func (b *Broker) TopicReader(topicID, index uint64, streaming bool) interface {
 // SetTopicMaxIndex updates the highest replicated index for a topic and data URL.
 // If a higher index is already set on the topic then the call is ignored.
 // This index is only held in memory and is used for topic segment reclamation.
-// The higheset replciated index per data URL is tracked separately from the current index
+// The higheset replicated index per data URL is tracked separately from the current index
 func (b *Broker) SetTopicMaxIndex(topicID, index uint64, u url.URL) error {
 	_, err := b.Publish(&Message{
 		Type: SetTopicMaxIndexMessageType,

--- a/messaging/broker.go
+++ b/messaging/broker.go
@@ -895,8 +895,7 @@ func (t *Topic) Truncate(maxSize int64) (int64, error) {
 		return 0, err
 	}
 
-	var totalSize int64
-	totalSize, err = segments.Size()
+	totalSize, err := segments.Size()
 	if err != nil {
 		return 0, err
 	}

--- a/messaging/broker.go
+++ b/messaging/broker.go
@@ -190,9 +190,14 @@ func (b *Broker) Open(path string) error {
 		go func() {
 			defer b.wg.Done()
 			tick := time.NewTicker(b.TruncationInterval)
+			defer tick.Stop()
 			for {
-				<-tick.C
-				b.TruncateTopics()
+				select {
+				case <-tick.C:
+					b.TruncateTopics()
+				case <-b.done:
+					return
+				}
 			}
 		}()
 
@@ -274,7 +279,7 @@ func (b *Broker) closeTopics() {
 
 // truncateTopics forces topics to truncate such that they are equal to
 // or less than the requested size, if possible.
-func (b *Broker) TruncateTopics() error {
+func (b *Broker) TruncateTopics() {
 	for _, t := range b.topics {
 		if n, err := t.Truncate(b.MaxTopicSize); err != nil {
 			b.Logger.Printf("error truncating topic %s: %s", t.Path(), err.Error())
@@ -282,7 +287,7 @@ func (b *Broker) TruncateTopics() error {
 			b.Logger.Printf("topic %s, %d bytes deleted", t.Path(), n)
 		}
 	}
-	return nil
+	return
 }
 
 // SetMaxIndex sets the highest index applied by the broker.

--- a/messaging/broker.go
+++ b/messaging/broker.go
@@ -542,12 +542,11 @@ func (b *Broker) SetTopicMaxIndex(topicID, index uint64, u url.URL) error {
 func (b *Broker) applySetTopicMaxIndex(m *Message) {
 	topicID, index, u := unmarshalTopicIndex(m.Data)
 
-	// Set index if it's not already set higher.
+	// Track the highest replicated index for the topic, per data node URL.
 	if t := b.topics[topicID]; t != nil {
 		t.mu.Lock()
 		defer t.mu.Unlock()
 
-		// Track the highest replicated index per data node URL
 		t.indexByURL[u] = index
 	}
 }

--- a/messaging/broker_test.go
+++ b/messaging/broker_test.go
@@ -466,7 +466,7 @@ func TestTopic_Truncate(t *testing.T) {
 	topic.Truncate(5) // always leave 2 segments around, regardless of truncation size and replication.
 	segments = MustReadSegments(topic.Path())
 	if len(MustReadSegments(topic.Path())) != 2 {
-		t.Fatalf("topic does not have correct number of segments, expected 1, got %d", len(segments))
+		t.Fatalf("topic does not have correct number of segments, expected 2, got %d", len(segments))
 	}
 
 	// Test that adding a segment still works.


### PR DESCRIPTION
This change implements basic topic truncation on Brokers. It does this by periodically checking each topic for its size, and if greater than a certain threshold and the topic data has been replicated, deleting segments until the required size is reached. 

The change also exposes maximum topic and segment sizes via configuration, as I believe some people may want to change these numbers.

I decided to implement this via a go-routine, so that the function to check the topic sizes could simply walk the filesystem, and not have to worry too much about efficiency vis a vis caching sizes in RAM. I think a design whereby truncation is performed every few minutes is fine (it's how Apache Kafka works), and this approach seems simpler and more robust.

Remaining:
- letting data nodes know when they must redirect to other nodes for topic data.

