### PR TITLE
make nowValuer public / exported

### DIFF
--- a/influxql/ast.go
+++ b/influxql/ast.go
@@ -2558,11 +2558,11 @@ type Valuer interface {
 }
 
 // nowValuer returns only the value for "now()".
-type nowValuer struct {
+type NowValuer struct {
 	Now time.Time
 }
 
-func (v *nowValuer) Value(key string) (interface{}, bool) {
+func (v *NowValuer) Value(key string) (interface{}, bool) {
 	if key == "now()" {
 		return v.Now, true
 	}

--- a/influxql/engine.go
+++ b/influxql/engine.go
@@ -692,7 +692,7 @@ func (p *Planner) Plan(stmt *SelectStatement, chunkSize int) (*Executor, error) 
 	now := p.Now().UTC()
 
 	// Replace instances of "now()" with the current time.
-	stmt.Condition = Reduce(stmt.Condition, &nowValuer{Now: now})
+	stmt.Condition = Reduce(stmt.Condition, &NowValuer{Now: now})
 
 	// Begin an unopened transaction.
 	tx, err := p.DB.Begin()


### PR DESCRIPTION
So apps using the `influxql` library can use `NowValuer` when calling `influxql.Reduce`.