### PR TITLE
Start cluster before broker.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Bugfixes
 - [#2282](https://github.com/influxdb/influxdb/pull/2282): Use "value" as field name for OpenTSDB input.
 - [#2283](https://github.com/influxdb/influxdb/pull/2283): Fix bug when restarting an entire existing cluster.
+- [#2293](https://github.com/influxdb/influxdb/pull/2293): Open cluster listener before starting broker.
 
 ## v0.9.0-rc24 [2015-04-13]
 

--- a/cmd/influxd/run.go
+++ b/cmd/influxd/run.go
@@ -493,7 +493,7 @@ func (cmd *RunCommand) openBroker(brokerURLs []url.URL, h *Handler) {
 		log.Fatalf("raft: %s", err)
 	}
 
-	// Attached broker and log to handler.
+	// Attach broker and log to handler.
 	h.Broker = b
 	h.Log = l
 

--- a/cmd/influxd/run.go
+++ b/cmd/influxd/run.go
@@ -254,26 +254,20 @@ func (cmd *RunCommand) Open(config *Config, join string) *Node {
 	// Parse join urls from the --join flag.
 	joinURLs := parseURLs(join)
 
+	// Start the broker handler.
+	h := &Handler{Config: config}
+	if err := cmd.node.openClusterListener(cmd.config.ClusterAddr(), h); err != nil {
+		log.Fatalf("Cluster server failed to listen on %s. %s ", cmd.config.ClusterAddr(), err)
+	}
+	log.Printf("Cluster server listening on %s", cmd.config.ClusterAddr())
+
 	// Open broker & raft log, initialize or join as necessary.
 	if cmd.config.Broker.Enabled {
-		cmd.openBroker(joinURLs)
+		cmd.openBroker(joinURLs, h)
 		// If were running as a broker locally, always connect to it since it must
 		// be ready before we can start the data node.
 		joinURLs = []url.URL{cmd.node.Broker.URL()}
 	}
-
-	// Start the broker handler.
-	h := &Handler{
-		Config: config,
-		Broker: cmd.node.Broker,
-		Log:    cmd.node.raftLog,
-	}
-
-	err := cmd.node.openClusterListener(cmd.config.ClusterAddr(), h)
-	if err != nil {
-		log.Fatalf("Cluster server failed to listen on %s. %s ", cmd.config.ClusterAddr(), err)
-	}
-	log.Printf("Cluster server listening on %s", cmd.config.ClusterAddr())
 
 	var s *influxdb.Server
 	// Open server, initialize or join as necessary.
@@ -469,7 +463,7 @@ func writePIDFile(path string) {
 }
 
 // creates and initializes a broker.
-func (cmd *RunCommand) openBroker(brokerURLs []url.URL) {
+func (cmd *RunCommand) openBroker(brokerURLs []url.URL, h *Handler) {
 	path := cmd.config.BrokerDir()
 	u := cmd.config.ClusterURL()
 	raftTracing := cmd.config.Logging.RaftTracing
@@ -498,6 +492,10 @@ func (cmd *RunCommand) openBroker(brokerURLs []url.URL) {
 	if err := l.Open(filepath.Join(path, "raft")); err != nil {
 		log.Fatalf("raft: %s", err)
 	}
+
+	// Attached broker and log to handler.
+	h.Broker = b
+	h.Log = l
 
 	// Checks to see if the raft index is 0.  If it's 0, it might be the first
 	// node in the cluster and must initialize or join


### PR DESCRIPTION
## Overview

This commit fixes an issue where the second node joins but the first node cannot commit because it doesn't have the HTTP endpoint running yet. This is a side effect of streaming raft since we don't synchronize the quorum set with the heartbeats. We should cache the config per term in the future.