### PR TITLE
Fix stream writer flushing to be thread safe.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [#2293](https://github.com/influxdb/influxdb/pull/2293): Open cluster listener before starting broker.
 - [#2287](https://github.com/influxdb/influxdb/pull/2287): Fix data race during SHOW RETENTION POLICIES.
 - [#2288](https://github.com/influxdb/influxdb/pull/2288): Fix expression parsing bug.
+- [#2294](https://github.com/influxdb/influxdb/pull/2294): Fix async response flushing (invalid chunked response error).
 
 ## Features
 - [#2276](https://github.com/influxdb/influxdb/pull/2276): Broker topic truncation.

--- a/messaging/handler.go
+++ b/messaging/handler.go
@@ -231,7 +231,9 @@ func CopyFlush(dst io.Writer, src io.Reader) (written int64, err error) {
 			}
 
 			// Flush after write.
-			if dst, ok := dst.(http.Flusher); ok {
+			if dst, ok := dst.(interface {
+				Flush()
+			}); ok {
 				dst.Flush()
 			}
 


### PR DESCRIPTION
## Overview

This change fixes the raft streams so that Flush() is not called asynchronously while the snapshot is being written. Previously the `logWriter` would call `Flush()` while the snapshot was being written. Now it will not call flush until the snapshot is complete.