### PR TITLE
ensure directory of pidfile exists after a restart

### DIFF
--- a/package.sh
+++ b/package.sh
@@ -33,7 +33,6 @@
 AWS_FILE=~/aws.conf
 
 INSTALL_ROOT_DIR=/opt/influxdb
-INFLUXDB_RUN_DIR=/var/run/influxdb
 INFLUXDB_LOG_DIR=/var/log/influxdb
 INFLUXDB_DATA_DIR=/var/opt/influxdb
 CONFIG_ROOT_DIR=/etc/opt/influxdb
@@ -187,8 +186,6 @@ fi
 chown -R -L influxdb:influxdb $INSTALL_ROOT_DIR
 chmod -R a+rX $INSTALL_ROOT_DIR
 
-mkdir -p $INFLUXDB_RUN_DIR
-chown -R -L influxdb:influxdb $INFLUXDB_RUN_DIR
 mkdir -p $INFLUXDB_LOG_DIR
 chown -R -L influxdb:influxdb $INFLUXDB_LOG_DIR
 mkdir -p $INFLUXDB_DATA_DIR

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -21,6 +21,9 @@
 # any config file values. Example: "-join http://1.2.3.4:8086"
 INFLUXD_OPTS=
 
+USER=influxdb
+GROUP=influxdb
+
 if [ -r /lib/lsb/init-functions ]; then
     source /lib/lsb/init-functions
 fi
@@ -93,6 +96,12 @@ daemon=/opt/influxdb/influxd
 
 # pid file for the daemon
 pidfile=/var/run/influxdb/influxd.pid
+piddir=`dirname $pidfile`
+
+if [ ! -d "$piddir" ]; then
+    mkdir -p $piddir
+    chown $GROUP:$USER $piddir
+fi
 
 # Configuration file
 config=/etc/opt/influxdb/influxdb.conf
@@ -121,7 +130,7 @@ case $1 in
 
         log_success_msg "Starting the process" "$name"
         if which start-stop-daemon > /dev/null 2>&1; then
-            start-stop-daemon --chuid influxdb:influxdb --start --quiet --pidfile $pidfile --exec $daemon -- -pidfile $pidfile -config $config $INFLUXD_OPTS >>$STDOUT 2>>$STDERR &
+            start-stop-daemon --chuid $GROUP:$USER --start --quiet --pidfile $pidfile --exec $daemon -- -pidfile $pidfile -config $config $INFLUXD_OPTS >>$STDOUT 2>>$STDERR &
         else
             nohup $daemon -pidfile $pidfile -config $config $INFLUXD_OPTS >>$STDOUT 2>>$STDERR &
         fi


### PR DESCRIPTION
/var/run on ubuntu is a tmpfs so /var/run/influxdb is lost after a reboot and the influxdb user does not have permission to create that directory.  this ensures that the directory exists by creating it in the init script

fixes #2273