### PR TITLE
Handle distributed queries when shards != data nodes

### DIFF
--- a/cmd/influxd/run.go
+++ b/cmd/influxd/run.go
@@ -105,14 +105,14 @@ func (s *Node) Close() error {
 		}
 	}
 
-	if s.Broker != nil {
-		if err := s.Broker.Close(); err != nil {
+	if s.raftLog != nil {
+		if err := s.raftLog.Close(); err != nil {
 			return err
 		}
 	}
 
-	if s.raftLog != nil {
-		if err := s.raftLog.Close(); err != nil {
+	if s.Broker != nil {
+		if err := s.Broker.Close(); err != nil {
 			return err
 		}
 	}

--- a/cmd/influxd/server_integration_test.go
+++ b/cmd/influxd/server_integration_test.go
@@ -1458,7 +1458,6 @@ func Test3NodeServerFailover(t *testing.T) {
 
 // ensure that all queries work if there are more nodes in a cluster than the replication factor
 func Test3NodeClusterPartiallyReplicated(t *testing.T) {
-	t.Skip("Skipping due to instability")
 	t.Parallel()
 	testName := "3-node server integration partial replication"
 	if testing.Short() {

--- a/cmd/influxd/server_integration_test.go
+++ b/cmd/influxd/server_integration_test.go
@@ -1435,7 +1435,8 @@ func Test3NodeServer(t *testing.T) {
 }
 
 func Test3NodeServerFailover(t *testing.T) {
-	testName := "3-node server integration"
+	t.Parallel()
+	testName := "3-node server failover integration"
 
 	if testing.Short() {
 		t.Skip(fmt.Sprintf("skipping '%s'", testName))


### PR DESCRIPTION
This PR has 3 changes:

1. There was previously a explict panic put in the query engine to prevent
queries where the number of shards was not equal to the number of data nodes
in the cluster.  This was waiting for the distributed queries branch to land
but was not removed when that landed.  This PR removes that panic.

2. Adds a change to prefer local shard data over remote data to prevent unnecessary network traffic when deciding whether to use local `LocalMapper` or a `RemoteMapper`

3. Changes the order of closing the broker and raft log to avoid a panic when closing the server.

Fixes #2272
