### PR TITLE
graphite: log the field name when we encounter a value parse failure

### DIFF
--- a/graphite/graphite.go
+++ b/graphite/graphite.go
@@ -83,7 +83,7 @@ func (p *Parser) Parse(line string) (influxdb.Point, error) {
 	// Parse value.
 	v, err := strconv.ParseFloat(fields[1], 64)
 	if err != nil {
-		return influxdb.Point{}, err
+		return influxdb.Point{}, fmt.Errorf("field \"%s\" value: %s", fields[0], err)
 	}
 
 	fieldValues := make(map[string]interface{})
@@ -92,7 +92,7 @@ func (p *Parser) Parse(line string) (influxdb.Point, error) {
 	// Parse timestamp.
 	unixTime, err := strconv.ParseFloat(fields[2], 64)
 	if err != nil {
-		return influxdb.Point{}, err
+		return influxdb.Point{}, fmt.Errorf("field \"%s\" timestamp: %s", fields[0], err)
 	}
 
 	// Check if we have fractional seconds

--- a/graphite/graphite_test.go
+++ b/graphite/graphite_test.go
@@ -174,17 +174,17 @@ func Test_DecodeMetric(t *testing.T) {
 		{
 			test: "should fail parsing invalid float",
 			line: `cpu 50.554z 1419972457825`,
-			err:  `strconv.ParseFloat: parsing "50.554z": invalid syntax`,
+			err:  `field "cpu" value: strconv.ParseFloat: parsing "50.554z": invalid syntax`,
 		},
 		{
 			test: "should fail parsing invalid int",
 			line: `cpu 50z 1419972457825`,
-			err:  `strconv.ParseFloat: parsing "50z": invalid syntax`,
+			err:  `field "cpu" value: strconv.ParseFloat: parsing "50z": invalid syntax`,
 		},
 		{
 			test: "should fail parsing invalid time",
 			line: `cpu 50.554 14199724z57825`,
-			err:  `strconv.ParseFloat: parsing "14199724z57825": invalid syntax`,
+			err:  `field "cpu" timestamp: strconv.ParseFloat: parsing "14199724z57825": invalid syntax`,
 		},
 	}
 


### PR DESCRIPTION
The java metrics library will dump anything and everything to graphite leading to many error messages like:

```
[graphite] 2015/04/19 10:11:46 unable to parse data: strconv.ParseFloat: parsing "[J@4deff1ac": invalid syntax
[graphite] 2015/04/19 10:11:46 unable to parse data: strconv.ParseFloat: parsing "[J@5b8c4bb5": invalid syntax
```

It makes sense to include the name field given that the graphite parsing code has already validated the name and tags by the time the value is parsed.
The field name can then be used to filter the offending field from the stats publish.

The ParseFloat related error messages have been modified such they include the field name and the value that was being parsed (value|timestamp).

The result should look something like:
```
[graphite] 2015/04/19 11:03:16 unable to parse data: field "host/cas-nyc1/.org.apache.cassandra.metrics.ColumnFamily.bitcrest.depth.EstimatedColumnCountHistogram.value" value: strconv.ParseFloat: parsing "[J@6d603059": invalid syntax
[graphite] 2015/04/19 11:03:16 unable to parse data: field "host/cas-nyc2/.org.apache.cassandra.metrics.ColumnFamily.bitcrest.depth.EstimatedRowSizeHistogram.value" value: strconv.ParseFloat: parsing "[J@593b8406": invalid syntax
```
Which provides enough information to fix the problem at it's source.