### PR TITLE
Distributed Query/Clustering Fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 - [#2301](https://github.com/influxdb/influxdb/pull/2301): Distributed query load balancing and failover
 - [#2336](https://github.com/influxdb/influxdb/pull/2336): Handle distributed queries when shards != data nodes
+- [#2353](https://github.com/influxdb/influxdb/pull/2353): Distributed Query/Clustering Fixes
 
 ### Bugfixes
 - [#2297](https://github.com/influxdb/influxdb/pull/2297): create /var/run during startup. Thanks @neonstalwart.
@@ -18,6 +19,10 @@
 - [#2338](https://github.com/influxdb/influxdb/pull/2338): Fix panic if tag key isn't double quoted when it should have been
 - [#2340](https://github.com/influxdb/influxdb/pull/2340): Fix SHOW DIAGNOSTICS panic if any shard was non-local.
 - [#2351](https://github.com/influxdb/influxdb/pull/2351): Fix data race by rlocking shard during diagnostics.
+- [#2348](https://github.com/influxdb/influxdb/pull/2348): Data node fail to join cluster in 0.9.0rc25
+- [#2343](https://github.com/influxdb/influxdb/pull/2343): Node falls behind Metastore updates
+- [#2334](https://github.com/influxdb/influxdb/pull/2334): Test Partial replication is very problematic
+- [#2272](https://github.com/influxdb/influxdb/pull/2272): clustering: influxdb 0.9.0-rc23 panics when doing a GET with merge_metrics in a
 
 ## v0.9.0-rc25 [2015-04-15]
 

--- a/client/influxdb.go
+++ b/client/influxdb.go
@@ -45,7 +45,7 @@ func NewClient(c Config) (*Client, error) {
 		url:        c.URL,
 		username:   c.Username,
 		password:   c.Password,
-		httpClient: &http.Client{},
+		httpClient: http.DefaultClient,
 		userAgent:  c.UserAgent,
 	}
 	if client.userAgent == "" {

--- a/cmd/influxd/run.go
+++ b/cmd/influxd/run.go
@@ -651,7 +651,8 @@ func (cmd *RunCommand) openServer(joinURLs []url.URL) *influxdb.Server {
 	return s
 }
 
-// joinOrInitializeServer a server to an existing cluster or initializes.
+// joinOrInitializeServer joins a new server to an existing cluster or initializes it as the first
+// member of the cluster
 func joinOrInitializeServer(s *influxdb.Server, u url.URL, joinURLs []url.URL) {
 	// Create data node on an existing data node.
 	for _, joinURL := range joinURLs {
@@ -663,6 +664,7 @@ func joinOrInitializeServer(s *influxdb.Server, u url.URL, joinURLs []url.URL) {
 			log.Printf("initialized data node: %s\n", (&u).String())
 			return
 		} else if err != nil {
+			// does not return so that the next joinURL can be tried
 			log.Printf("join: failed to connect data node: %s: %s", (&u).String(), err)
 		} else {
 			log.Printf("join: connected data node to %s", u)

--- a/cmd/influxd/server_integration_test.go
+++ b/cmd/influxd/server_integration_test.go
@@ -1458,9 +1458,10 @@ func Test3NodeServerFailover(t *testing.T) {
 }
 
 // ensure that all queries work if there are more nodes in a cluster than the replication factor
-func Test3NodeClusterPartiallyReplicated(t *testing.T) {
+// and there is more than 1 shards
+func Test6NodeClusterPartiallyReplicated(t *testing.T) {
 	t.Parallel()
-	testName := "3-node server integration partial replication"
+	testName := "6-node server integration partial replication"
 	if testing.Short() {
 		t.Skip(fmt.Sprintf("skipping '%s'", testName))
 	}
@@ -1469,11 +1470,11 @@ func Test3NodeClusterPartiallyReplicated(t *testing.T) {
 		os.RemoveAll(dir)
 	}()
 
-	nodes := createCombinedNodeCluster(t, testName, dir, 3, nil)
+	nodes := createCombinedNodeCluster(t, testName, dir, 6, nil)
 	defer nodes.Close()
 
-	runTestsData(t, testName, nodes, "mydb", "myrp", len(nodes)-1)
-	runTest_rawDataReturnsInOrder(t, testName, nodes, "mydb", "myrp", len(nodes)-1)
+	runTestsData(t, testName, nodes, "mydb", "myrp", 3)
+	runTest_rawDataReturnsInOrder(t, testName, nodes, "mydb", "myrp", 3)
 }
 
 func TestClientLibrary(t *testing.T) {

--- a/cmd/influxd/server_integration_test.go
+++ b/cmd/influxd/server_integration_test.go
@@ -1459,9 +1459,9 @@ func Test3NodeServerFailover(t *testing.T) {
 
 // ensure that all queries work if there are more nodes in a cluster than the replication factor
 // and there is more than 1 shards
-func Test6NodeClusterPartiallyReplicated(t *testing.T) {
+func Test5NodeClusterPartiallyReplicated(t *testing.T) {
 	t.Parallel()
-	testName := "6-node server integration partial replication"
+	testName := "5-node server integration partial replication"
 	if testing.Short() {
 		t.Skip(fmt.Sprintf("skipping '%s'", testName))
 	}
@@ -1470,11 +1470,11 @@ func Test6NodeClusterPartiallyReplicated(t *testing.T) {
 		os.RemoveAll(dir)
 	}()
 
-	nodes := createCombinedNodeCluster(t, testName, dir, 6, nil)
+	nodes := createCombinedNodeCluster(t, testName, dir, 5, nil)
 	defer nodes.Close()
 
-	runTestsData(t, testName, nodes, "mydb", "myrp", 3)
-	runTest_rawDataReturnsInOrder(t, testName, nodes, "mydb", "myrp", 3)
+	runTestsData(t, testName, nodes, "mydb", "myrp", 2)
+	runTest_rawDataReturnsInOrder(t, testName, nodes, "mydb", "myrp", 2)
 }
 
 func TestClientLibrary(t *testing.T) {

--- a/influxql/engine.go
+++ b/influxql/engine.go
@@ -276,8 +276,11 @@ func (m *MapReduceJob) processRawQuery(out chan *Row, filterEmptyResults bool) {
 			// add up to the index to the values
 			values = append(values, o[:ind]...)
 
+			// clear out previously send mapper output data
+			mapperOutputs[j] = mapperOutputs[j][ind:]
+
 			// if we emptied out all the values, set this output to nil so that the mapper will get run again on the next loop
-			if ind == len(o) {
+			if len(mapperOutputs[j]) == 0 {
 				mapperOutputs[j] = nil
 			}
 		}

--- a/influxql/engine.go
+++ b/influxql/engine.go
@@ -276,7 +276,7 @@ func (m *MapReduceJob) processRawQuery(out chan *Row, filterEmptyResults bool) {
 			// add up to the index to the values
 			values = append(values, o[:ind]...)
 
-			// clear out previously send mapper output data
+			// clear out previously sent mapper output data
 			mapperOutputs[j] = mapperOutputs[j][ind:]
 
 			// if we emptied out all the values, set this output to nil so that the mapper will get run again on the next loop

--- a/server.go
+++ b/server.go
@@ -3157,6 +3157,7 @@ func (s *Server) StartLocalMapper(rm *RemoteMapper) (*LocalMapper, error) {
 		selectFields: rm.SelectFields,
 		selectTags:   rm.SelectTags,
 		interval:     rm.Interval,
+		tmin:         rm.TMin,
 		tmax:         rm.TMax,
 		limit:        limit,
 	}

--- a/server.go
+++ b/server.go
@@ -1015,8 +1015,38 @@ func (s *Server) applyDropDatabase(m *messaging.Message) (err error) {
 	// Remove from metastore.
 	err = s.meta.mustUpdate(m.Index, func(tx *metatx) error { return tx.dropDatabase(c.Name) })
 
+	db := s.databases[c.Name]
+	for _, rp := range db.policies {
+		for _, sg := range rp.shardGroups {
+			for _, sh := range sg.Shards {
+
+				// if we have this shard locally, close and remove it
+				if sh.store != nil {
+					// close topic readers/heartbeaters/etc. connections
+					err := s.client.CloseConn(sh.ID)
+					if err != nil {
+						panic(err)
+					}
+
+					err = sh.close()
+					if err != nil {
+						panic(err)
+					}
+
+					err = os.Remove(s.shardPath(sh.ID))
+					if err != nil {
+						panic(err)
+					}
+				}
+
+				delete(s.shards, sh.ID)
+			}
+		}
+	}
+
 	// Delete the database entry.
 	delete(s.databases, c.Name)
+
 	return
 }
 
@@ -3518,6 +3548,7 @@ type MessagingClient interface {
 
 	// Conn returns an open, streaming connection to a topic.
 	Conn(topicID uint64) MessagingConn
+	CloseConn(topicID uint64) error
 }
 
 type messagingClient struct {

--- a/test/messaging.go
+++ b/test/messaging.go
@@ -90,6 +90,24 @@ func (c *MessagingClient) Conn(topicID uint64) influxdb.MessagingConn {
 	return c.ConnFunc(topicID)
 }
 
+func (c *MessagingClient) CloseConn(topicID uint64) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	conns := []*MessagingConn{}
+	for _, conn := range c.conns {
+		if conn.topicID == topicID {
+			if err := conn.Close(); err != nil {
+				return err
+			}
+			continue
+		}
+		conns = append(conns, conn)
+	}
+	c.conns = conns
+	return nil
+}
+
 // DefaultConnFunc returns a connection for a specific topic.
 func (c *MessagingClient) DefaultConnFunc(topicID uint64) influxdb.MessagingConn {
 	c.mu.Lock()

--- a/tx.go
+++ b/tx.go
@@ -187,6 +187,7 @@ func (tx *tx) CreateMapReduceJobs(stmt *influxql.SelectStatement, tagKeys []stri
 							whereFields:  whereFields,
 							selectFields: selectFields,
 							selectTags:   selectTags,
+							tmin:         tmin.UnixNano(),
 							tmax:         tmax.UnixNano(),
 							interval:     interval,
 							// multiple mappers may need to be merged together to get the results

--- a/tx.go
+++ b/tx.go
@@ -149,7 +149,7 @@ func (tx *tx) CreateMapReduceJobs(stmt *influxql.SelectStatement, tagKeys []stri
 					shards[shard] = append(shards[shard], sid)
 				}
 
-				for shard, _ := range shards {
+				for shard, sids := range shards {
 					var mapper influxql.Mapper
 
 					// create either a remote or local mapper for this shard
@@ -167,7 +167,7 @@ func (tx *tx) CreateMapReduceJobs(stmt *influxql.SelectStatement, tagKeys []stri
 							MeasurementName: m.Name,
 							TMin:            tmin.UnixNano(),
 							TMax:            tmax.UnixNano(),
-							SeriesIDs:       t.SeriesIDs,
+							SeriesIDs:       sids,
 							ShardID:         shard.ID,
 							WhereFields:     whereFields,
 							SelectFields:    selectFields,
@@ -179,7 +179,7 @@ func (tx *tx) CreateMapReduceJobs(stmt *influxql.SelectStatement, tagKeys []stri
 						mapper.(*RemoteMapper).SetFilters(t.Filters)
 					} else {
 						mapper = &LocalMapper{
-							seriesIDs:    t.SeriesIDs,
+							seriesIDs:    sids,
 							db:           shard.store,
 							job:          job,
 							decoder:      NewFieldCodec(m),


### PR DESCRIPTION
This PR fixes cluster joins and distributed queries.

New data nodes would never join an existing cluster properly.  They would start up but would not attempt to join the cluster so they all reported themselves as Server ID 1.

The distributed queries issue was that previously sent data was not being cleared out on each iteration of the mapper output processing.  Subsequent iterations would send out duplicate data causing incorrect results.
 
Fixes #2348 #2343 #2334 #2272