### PR TITLE
Handle int and int32 types correctly.

### DIFF
--- a/database.go
+++ b/database.go
@@ -811,9 +811,19 @@ func (f *FieldCodec) EncodeFields(values map[string]interface{}) ([]byte, error)
 			buf = make([]byte, 9)
 			binary.BigEndian.PutUint64(buf[1:9], math.Float64bits(value))
 		case influxql.Integer:
-			value := v.(int64)
+			var value uint64
+			switch v.(type) {
+			case int:
+				value = uint64(v.(int))
+			case int32:
+				value = uint64(v.(int32))
+			case int64:
+				value = uint64(v.(int64))
+			default:
+				panic(fmt.Sprintf("invalid integer type: %T", v))
+			}
 			buf = make([]byte, 9)
-			binary.BigEndian.PutUint64(buf[1:9], uint64(value))
+			binary.BigEndian.PutUint64(buf[1:9], value)
 		case influxql.Boolean:
 			value := v.(bool)
 


### PR DESCRIPTION
Self monitoring enabled results in a panic since #2261 was introduced. I first tried to cast everything to int64 in server.go (eg. GoMaxProcs, PID, NumCPU, etc.), but then realized that in influxql/ast.go that Number types are permitted to be int, int32, and int64; so I added this type switch which I believe solves the problem.

    goroutine 238 [running]:
    github.com/influxdb/influxdb.(*FieldCodec).EncodeFields(0xc2080cf9c0, 0xc2081a53e0, 0x0, 0x0, 0x0, 0x0, 0x0)
    	/Users/jari/go/src/github.com/influxdb/influxdb/database.go:816 +0xb55
    github.com/influxdb/influxdb.func·035(0x0, 0x0)
    	/Users/jari/go/src/github.com/influxdb/influxdb/server.go:1818 +0x75d
    github.com/influxdb/influxdb.(*Server).WriteSeries(0xc20805ea00, 0x9c3bf0, 0x9, 0x9a0dd0, 0x7, 0xc2081c4000, 0x7, 0x8, 0x0, 0x0, ...)
    	/Users/jari/go/src/github.com/influxdb/influxdb/server.go:1836 +0xa80
    github.com/influxdb/influxdb.func·011()
    	/Users/jari/go/src/github.com/influxdb/influxdb/server.go:410 +0x7fe
    created by github.com/influxdb/influxdb.(*Server).StartSelfMonitoring
    	/Users/jari/go/src/github.com/influxdb/influxdb/server.go:412 +0x241