### PR TITLE
Fix data race for openTSDB listener addr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.9.0-rc27 [unreleased]
+
+### Bugfixes
+- [#2370](https://github.com/influxdb/influxdb/pull/2370): Fix data race in openTSDB endpoint.
+
 ## v0.9.0-rc26 [04-21-2015]
 
 ### Features

--- a/cmd/influxd/server_integration_test.go
+++ b/cmd/influxd/server_integration_test.go
@@ -1877,7 +1877,7 @@ func Test_ServerOpenTSDBIntegration(t *testing.T) {
 	createDatabase(t, testName, nodes, "opentsdb")
 	createRetentionPolicy(t, testName, nodes, "opentsdb", "raw", len(nodes))
 
-	// Connect to the graphite endpoint we just spun up
+	// Connect to the openTSDB endpoint we just spun up
 	host := nodes[0].node.OpenTSDBServer.Addr().String()
 	conn, err := net.Dial("tcp", host)
 	if err != nil {
@@ -1933,7 +1933,7 @@ func Test_ServerOpenTSDBIntegration_WithTags(t *testing.T) {
 	createDatabase(t, testName, nodes, "opentsdb")
 	createRetentionPolicy(t, testName, nodes, "opentsdb", "raw", len(nodes))
 
-	// Connect to the graphite endpoint we just spun up
+	// Connect to the openTSDB endpoint we just spun up
 	host := nodes[0].node.OpenTSDBServer.Addr().String()
 	conn, err := net.Dial("tcp", host)
 	if err != nil {
@@ -1992,7 +1992,7 @@ func Test_ServerOpenTSDBIntegration_BadData(t *testing.T) {
 	createDatabase(t, testName, nodes, "opentsdb")
 	createRetentionPolicy(t, testName, nodes, "opentsdb", "raw", len(nodes))
 
-	// Connect to the graphite endpoint we just spun up
+	// Connect to the openTSDB endpoint we just spun up
 	host := nodes[0].node.OpenTSDBServer.Addr().String()
 	conn, err := net.Dial("tcp", host)
 	if err != nil {

--- a/opentsdb/opentsdb.go
+++ b/opentsdb/opentsdb.go
@@ -37,6 +37,8 @@ type Server struct {
 
 	listener *net.TCPListener
 	wg       sync.WaitGroup
+
+	addr net.Addr
 }
 
 func NewServer(w SeriesWriter, retpol string, db string) *Server {
@@ -50,7 +52,7 @@ func NewServer(w SeriesWriter, retpol string, db string) *Server {
 }
 
 func (s *Server) Addr() net.Addr {
-	return s.listener.Addr()
+	return s.addr
 }
 
 func (s *Server) ListenAndServe(listenAddress string) {
@@ -67,6 +69,8 @@ func (s *Server) ListenAndServe(listenAddress string) {
 		log.Println("TSDBServer: Listen: ", err)
 		return
 	}
+
+	s.addr = s.listener.Addr()
 
 	s.wg.Add(1)
 	go func() {


### PR DESCRIPTION
Fixes the race condition when asking for the endpoints address.


```
WARNING: DATA RACE
Read by goroutine 9:
  github.com/influxdb/influxdb/opentsdb.(*Server).Addr()
      /home/ubuntu/influxdb-build/src/github.com/influxdb/influxdb/opentsdb/opentsdb.go:53 +0x8c
  github.com/influxdb/influxdb/cmd/influxd_test.Test_ServerOpenTSDBIntegration_WithTags()
      /home/ubuntu/influxdb-build/src/github.com/influxdb/influxdb/cmd/influxd/server_integration_test.go:1937 +0x614
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:447 +0x133

Previous write by goroutine 333:
  [failed to restore the stack]

Goroutine 9 (running) created at:
  testing.RunTests()
      /usr/local/go/src/testing/testing.go:555 +0xd4e
  testing.(*M).Run()
      /usr/local/go/src/testing/testing.go:485 +0xe0
  main.main()
      github.com/influxdb/influxdb/cmd/influxd/_test/_testmain.go:104 +0x28c
==================
==================
WARNING: DATA RACE
Read by goroutine 9:
  net.(*TCPAddr).String()
      /usr/local/go/src/net/tcpsock.go:21 +0x71
  github.com/influxdb/influxdb/cmd/influxd_test.Test_ServerOpenTSDBIntegration_WithTags()
      /home/ubuntu/influxdb-build/src/github.com/influxdb/influxdb/cmd/influxd/server_integration_test.go:1937 +0x638
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:447 +0x133

Previous write by goroutine 333:
  [failed to restore the stack]

Goroutine 9 (running) created at:
  testing.RunTests()
      /usr/local/go/src/testing/testing.go:555 +0xd4e
  testing.(*M).Run()
      /usr/local/go/src/testing/testing.go:485 +0xe0
  main.main()
      github.com/influxdb/influxdb/cmd/influxd/_test/_testmain.go:104 +0x28c
==================
==================
WARNING: DATA RACE
Read by goroutine 9:
  net.IP.String()
      /usr/local/go/src/net/ip.go:270 +0x116
  net.ipEmptyString()
      /usr/local/go/src/net/ip.go:324 +0x7d
  net.(*TCPAddr).String()
      /usr/local/go/src/net/tcpsock.go:21 +0x94
  github.com/influxdb/influxdb/cmd/influxd_test.Test_ServerOpenTSDBIntegration_WithTags()
      /home/ubuntu/influxdb-build/src/github.com/influxdb/influxdb/cmd/influxd/server_integration_test.go:1937 +0x638
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:447 +0x133

Previous write by goroutine 333:
  [failed to restore the stack]

Goroutine 9 (running) created at:
  testing.RunTests()
      /usr/local/go/src/testing/testing.go:555 +0xd4e
  testing.(*M).Run()
      /usr/local/go/src/testing/testing.go:485 +0xe0
  main.main()
      github.com/influxdb/influxdb/cmd/influxd/_test/_testmain.go:104 +0x28c
==================
==================
WARNING: DATA RACE
Read by goroutine 9:
  net.IP.String()
      /usr/local/go/src/net/ip.go:271 +0x176
  net.ipEmptyString()
      /usr/local/go/src/net/ip.go:324 +0x7d
  net.(*TCPAddr).String()
      /usr/local/go/src/net/tcpsock.go:21 +0x94
  github.com/influxdb/influxdb/cmd/influxd_test.Test_ServerOpenTSDBIntegration_WithTags()
      /home/ubuntu/influxdb-build/src/github.com/influxdb/influxdb/cmd/influxd/server_integration_test.go:1937 +0x638
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:447 +0x133

Previous write by goroutine 333:
  [failed to restore the stack]

Goroutine 9 (running) created at:
  testing.RunTests()
      /usr/local/go/src/testing/testing.go:555 +0xd4e
  testing.(*M).Run()
      /usr/local/go/src/testing/testing.go:485 +0xe0
  main.main()
      github.com/influxdb/influxdb/cmd/influxd/_test/_testmain.go:104 +0x28c
==================
==================
WARNING: DATA RACE
Read by goroutine 9:
  net.IP.String()
      /usr/local/go/src/net/ip.go:272 +0x1da
  net.ipEmptyString()
      /usr/local/go/src/net/ip.go:324 +0x7d
  net.(*TCPAddr).String()
      /usr/local/go/src/net/tcpsock.go:21 +0x94
  github.com/influxdb/influxdb/cmd/influxd_test.Test_ServerOpenTSDBIntegration_WithTags()
      /home/ubuntu/influxdb-build/src/github.com/influxdb/influxdb/cmd/influxd/server_integration_test.go:1937 +0x638
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:447 +0x133

Previous write by goroutine 333:
  [failed to restore the stack]

Goroutine 9 (running) created at:
  testing.RunTests()
      /usr/local/go/src/testing/testing.go:555 +0xd4e
  testing.(*M).Run()
      /usr/local/go/src/testing/testing.go:485 +0xe0
  main.main()
      github.com/influxdb/influxdb/cmd/influxd/_test/_testmain.go:104 +0x28c
==================
==================
WARNING: DATA RACE
Read by goroutine 9:
  net.IP.String()
      /usr/local/go/src/net/ip.go:273 +0x23f
  net.ipEmptyString()
      /usr/local/go/src/net/ip.go:324 +0x7d
  net.(*TCPAddr).String()
      /usr/local/go/src/net/tcpsock.go:21 +0x94
  github.com/influxdb/influxdb/cmd/influxd_test.Test_ServerOpenTSDBIntegration_WithTags()
      /home/ubuntu/influxdb-build/src/github.com/influxdb/influxdb/cmd/influxd/server_integration_test.go:1937 +0x638
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:447 +0x133

Previous write by goroutine 333:
  [failed to restore the stack]

Goroutine 9 (running) created at:
  testing.RunTests()
      /usr/local/go/src/testing/testing.go:555 +0xd4e
  testing.(*M).Run()
      /usr/local/go/src/testing/testing.go:485 +0xe0
  main.main()
      github.com/influxdb/influxdb/cmd/influxd/_test/_testmain.go:104 +0x28c
==================
==================
WARNING: DATA RACE
Read by goroutine 9:
  net.(*TCPAddr).String()
      /usr/local/go/src/net/tcpsock.go:22 +0xbc
  github.com/influxdb/influxdb/cmd/influxd_test.Test_ServerOpenTSDBIntegration_WithTags()
      /home/ubuntu/influxdb-build/src/github.com/influxdb/influxdb/cmd/influxd/server_integration_test.go:1937 +0x638
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:447 +0x133

Previous write by goroutine 333:
  [failed to restore the stack]

Goroutine 9 (running) created at:
  testing.RunTests()
      /usr/local/go/src/testing/testing.go:555 +0xd4e
  testing.(*M).Run()
      /usr/local/go/src/testing/testing.go:485 +0xe0
  main.main()
      github.com/influxdb/influxdb/cmd/influxd/_test/_testmain.go:104 +0x28c
==================
==================
WARNING: DATA RACE
Read by goroutine 9:
  net.(*TCPAddr).String()
      /usr/local/go/src/net/tcpsock.go:25 +0x1c2
  github.com/influxdb/influxdb/cmd/influxd_test.Test_ServerOpenTSDBIntegration_WithTags()
      /home/ubuntu/influxdb-build/src/github.com/influxdb/influxdb/cmd/influxd/server_integration_test.go:1937 +0x638
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:447 +0x133

Previous write by goroutine 333:
  [failed to restore the stack]

Goroutine 9 (running) created at:
  testing.RunTests()
      /usr/local/go/src/testing/testing.go:555 +0xd4e
  testing.(*M).Run()
      /usr/local/go/src/testing/testing.go:485 +0xe0
  main.main()
      github.com/influxdb/influxdb/cmd/influxd/_test/_testmain.go:104 +0x28c
```