### PR TITLE
Encode all integer types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - [#2371](https://github.com/influxdb/influxdb/pull/2371): Don't set client to nil when closing broker Fixes #2352
 - [#2372](https://github.com/influxdb/influxdb/pull/2372): Fix data race in graphite endpoint.
 - [#2373](https://github.com/influxdb/influxdb/pull/2373): Actually allow HTTP logging to be controlled.
+- [#2376](https://github.com/influxdb/influxdb/pull/2376): Encode all types of integers. Thanks @jtakkala.
+- [#2376](https://github.com/influxdb/influxdb/pull/2376): Add shard path to existing diags value. Fix issue #2369.
 
 ## v0.9.0-rc26 [04-21-2015]
 

--- a/cmd/influxd/server_integration_test.go
+++ b/cmd/influxd/server_integration_test.go
@@ -466,6 +466,16 @@ func runTestsData(t *testing.T, testName string, nodes Cluster, database, retent
 			expected: `{"results":[{"series":[{"name":"cpu","columns":["time","value"],"values":[["2015-02-28T01:03:36.703820946Z",100],["2015-02-28T01:04:36.703820946Z",100]]}]}]}`,
 		},
 
+		{
+			reset: true,
+			name:  "two points with negative values",
+			write: `{"database" : "%DB%", "retentionPolicy" : "%RP%", "points": [{"name": "cpu", "timestamp": "2015-02-28T01:04:36.703820946Z", "fields": {"value": -200}},
+                                                                                 {"name": "cpu", "timestamp": "2015-02-28T01:03:36.703820946Z", "fields": {"value": -100}}
+                                                                                ]}`,
+			query:    `SELECT * FROM "%DB%"."%RP%".cpu`,
+			expected: `{"results":[{"series":[{"name":"cpu","columns":["time","value"],"values":[["2015-02-28T01:03:36.703820946Z",-100],["2015-02-28T01:04:36.703820946Z",-200]]}]}]}`,
+		},
+
 		// Data read and write tests using relative time
 		{
 			reset:    true,

--- a/cmd/influxd/server_integration_test.go
+++ b/cmd/influxd/server_integration_test.go
@@ -1402,6 +1402,27 @@ func runTestsData(t *testing.T, testName string, nodes Cluster, database, retent
 	}
 }
 
+// Ensures that diagnostics can be written to the internal database.
+func TestSingleServerDiags(t *testing.T) {
+	t.Parallel()
+	testName := "single server integration diagnostics"
+	if testing.Short() {
+		t.Skip(fmt.Sprintf("skipping '%s'", testName))
+	}
+	dir := tempfile()
+	defer func() {
+		os.RemoveAll(dir)
+	}()
+
+	config := main.NewConfig()
+	config.Monitoring.Enabled = true
+	config.Monitoring.WriteInterval = main.Duration(100 * time.Millisecond)
+	nodes := createCombinedNodeCluster(t, testName, dir, 1, config)
+	defer nodes.Close()
+
+	time.Sleep(1 * time.Second)
+}
+
 func TestSingleServer(t *testing.T) {
 	t.Parallel()
 	testName := "single server integration"

--- a/database.go
+++ b/database.go
@@ -811,9 +811,19 @@ func (f *FieldCodec) EncodeFields(values map[string]interface{}) ([]byte, error)
 			buf = make([]byte, 9)
 			binary.BigEndian.PutUint64(buf[1:9], math.Float64bits(value))
 		case influxql.Integer:
-			value := v.(int64)
+			var value uint64
+			switch v.(type) {
+			case int:
+				value = uint64(v.(int))
+			case int32:
+				value = uint64(v.(int32))
+			case int64:
+				value = uint64(v.(int64))
+			default:
+				panic(fmt.Sprintf("invalid integer type: %T", v))
+			}
 			buf = make([]byte, 9)
-			binary.BigEndian.PutUint64(buf[1:9], uint64(value))
+			binary.BigEndian.PutUint64(buf[1:9], value)
 		case influxql.Boolean:
 			value := v.(bool)
 

--- a/server.go
+++ b/server.go
@@ -3338,7 +3338,7 @@ func (s *Server) DiagnosticsAsRows() []*influxql.Row {
 		// Shard may not be local to this node.
 		if sh.store != nil {
 			shardsRow.Columns = append(shardsRow.Columns, "path")
-			shardsRow.Values = append(shardsRow.Values, []interface{}{sh.store.Path()})
+			shardsRow.Values[0] = append(shardsRow.Values[0], sh.store.Path())
 		}
 	}
 


### PR DESCRIPTION
This changes address two issues.

- When encoding integers, `int` and `int32` are encoded as `int64`. 
- When adding the path information for a shard to the diagnostics, a distinct array was added to the existing array. Instead the existing array should have had a new element appended to it.
- An integration test was added, which simply checks that when self-monitoring is enabled and occurs, that the database stays up. Also added explicit checks for negative values.