### PR TITLE
Fix hostname defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - [#2376](https://github.com/influxdb/influxdb/pull/2376): Encode all types of integers. Thanks @jtakkala.
 - [#2376](https://github.com/influxdb/influxdb/pull/2376): Add shard path to existing diags value. Fix issue #2369.
 - [#2386](https://github.com/influxdb/influxdb/pull/2386): Fix shard datanodes stats getting appended too many times
+- [#2393](https://github.com/influxdb/influxdb/pull/2393): Fix default hostname for connecting to cluster.
 
 ## v0.9.0-rc26 [04-21-2015]
 

--- a/cmd/influxd/config.go
+++ b/cmd/influxd/config.go
@@ -31,6 +31,12 @@ const (
 	// DefaultAPIReadTimeout represents the duration before an API request times out.
 	DefaultAPIReadTimeout = 5 * time.Second
 
+	// DefaultHostName represents the default host name to use if it is never provided
+	DefaultHostName = "localhost"
+
+	// DefaultBindAddress represents the bind address to use if none is specified
+	DefaultBindAddress = "0.0.0.0"
+
 	// DefaultClusterPort represents the default port the cluster runs ons.
 	DefaultClusterPort = 8086
 
@@ -227,6 +233,8 @@ type Config struct {
 // NewConfig returns an instance of Config with reasonable defaults.
 func NewConfig() *Config {
 	c := &Config{}
+	c.Hostname = DefaultHostName
+	c.BindAddress = DefaultBindAddress
 	c.Port = DefaultClusterPort
 
 	c.Data.Enabled = DefaultDataEnabled


### PR DESCRIPTION
This fixes the issue with hostnames being set incorrectly and not being able to attach to the cluster.

We also added explicit defaults for hostname and bind address.  These where already set to this, but by explicitly setting them, they will show up in the default config if you print it via `influxd config`.