### PR TITLE
raft: fix leaderID error when state changed

### DIFF
--- a/raft/log.go
+++ b/raft/log.go
@@ -1023,6 +1023,9 @@ func (l *Log) candidateLoop(closing <-chan struct{}) State {
 		case <-l.terms:
 			return Follower
 		case <-elected:
+			l.lock()
+			l.leaderID = l.id
+			l.unlock()
 			return Leader
 		case ch := <-l.Clock.AfterElectionTimeout():
 			close(ch)


### PR DESCRIPTION
I'm try to use raft module in my project and found the bug:
after follower becoming leader, the `IsLeader()` api don't return correctly :sob: :cry: 