### PR TITLE
Fix excessive heartbeater logging of "connection refused" on cluster node stop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - [#2374](https://github.com/influxdb/influxdb/issues/2374): Two different panics during SELECT percentile
 - [#2404](https://github.com/influxdb/influxdb/pull/2404): Mean and percentile function fixes
 - [#2408](https://github.com/influxdb/influxdb/pull/2408): Fix snapshot 500 error
+- [#1896](https://github.com/influxdb/influxdb/issues/1896): Excessive heartbeater logging of "connection refused" on cluster node stop
 
 ### Features
 - [#2410](https://github.com/influxdb/influxdb/pull/2410) Allow configuration of Raft timers

--- a/raft/config.go
+++ b/raft/config.go
@@ -96,9 +96,10 @@ func (c *Config) Clone() *Config {
 
 // ConfigNode represents a single machine in the raft configuration.
 type ConfigNode struct {
-	ID                 uint64
-	URL                url.URL
-	LastHeartbeatError int64 // the time a heartbeat returned an error
+	ID                  uint64
+	URL                 url.URL
+	LastHeartbeatError  int64 // the time a heartbeat returned an error
+	HeartbeatErrorCount int64 // the number of times in a row that a heartbeat has failed
 }
 
 // clone returns a deep copy of the node.

--- a/raft/config.go
+++ b/raft/config.go
@@ -96,8 +96,9 @@ func (c *Config) Clone() *Config {
 
 // ConfigNode represents a single machine in the raft configuration.
 type ConfigNode struct {
-	ID  uint64
-	URL url.URL
+	ID                 uint64
+	URL                url.URL
+	LastHeartbeatError int64 // the time a heartbeat returned an error
 }
 
 // clone returns a deep copy of the node.

--- a/raft/log.go
+++ b/raft/log.go
@@ -1183,6 +1183,10 @@ func (l *Log) heartbeater(term uint64, committed chan uint64, wg *sync.WaitGroup
 				}
 				return
 			}
+			if atomic.LoadInt64(&n.LastHeartbeatError) != 0 {
+				l.Logger.Printf("send heartbeat: success url=%s", n.URL.String())
+				atomic.StoreInt64(&n.LastHeartbeatError, 0)
+			}
 			peerIndices <- peerIndex
 		}(n)
 	}

--- a/raft/log.go
+++ b/raft/log.go
@@ -41,6 +41,10 @@ type FSM interface {
 
 const logEntryHeaderSize = 8 + 8 + 8 // sz+index+term
 
+// heartbeartErrorLogThreshold is the number of seconds to wait before logging
+// another heartbeat error
+const heartbeartErrorLogThreshold = 15
+
 // WaitInterval represents the amount of time between checks to the applied index.
 // This is used by clients wanting to wait until a given index is processed.
 const WaitInterval = 1 * time.Millisecond
@@ -1178,7 +1182,7 @@ func (l *Log) heartbeater(term uint64, committed chan uint64, wg *sync.WaitGroup
 			if err != nil {
 				c := atomic.AddInt64(&n.HeartbeatErrorCount, 1)
 				// log heartbeat error once every 15 seconds to avoid flooding the logs
-				if time.Now().Unix()-atomic.LoadInt64(&n.LastHeartbeatError) > 15 {
+				if time.Now().Unix()-atomic.LoadInt64(&n.LastHeartbeatError) > heartbeartErrorLogThreshold {
 					l.Logger.Printf("send heartbeat: error: cnt=%d %s", c, err)
 					atomic.StoreInt64(&n.LastHeartbeatError, time.Now().Unix())
 				}


### PR DESCRIPTION
When a broker is down, the leader will log a heartbeat error every second until it re-joins.  This can fill up the logs fairly quickly.  This PR adds a timestamp to the raft config struct to track the last time a node had a heartbeat error.  It will only log the error once every 15s, per node, to cut down on the noise.

Fixes #1896