### PR TITLE
Fix raft node getting stuck in candidate state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [#2404](https://github.com/influxdb/influxdb/pull/2404): Mean and percentile function fixes
 - [#2408](https://github.com/influxdb/influxdb/pull/2408): Fix snapshot 500 error
 - [#1896](https://github.com/influxdb/influxdb/issues/1896): Excessive heartbeater logging of "connection refused" on cluster node stop
+- [#2418](https://github.com/influxdb/influxdb/pull/2418): Fix raft node getting stuck in candidate state
 
 ### Features
 - [#2410](https://github.com/influxdb/influxdb/pull/2410) Allow configuration of Raft timers

--- a/cmd/influxd/server_integration_test.go
+++ b/cmd/influxd/server_integration_test.go
@@ -1524,7 +1524,6 @@ func Test3NodeServerFailover(t *testing.T) {
 // ensure that all queries work if there are more nodes in a cluster than the replication factor
 // and there is more than 1 shards
 func Test5NodeClusterPartiallyReplicated(t *testing.T) {
-	t.Skip("unstable, skipping for now")
 	t.Parallel()
 	testName := "5-node server integration partial replication"
 	if testing.Short() {

--- a/cmd/influxd/server_integration_test.go
+++ b/cmd/influxd/server_integration_test.go
@@ -350,7 +350,7 @@ func runTest_rawDataReturnsInOrder(t *testing.T, testName string, nodes Cluster,
 	expected = fmt.Sprintf(`{"results":[{"series":[{"name":"cpu","columns":["time","count"],"values":[["1970-01-01T00:00:00Z",%d]]}]}]}`, numPoints-1)
 	got, ok, nOK := queryAndWait(t, nodes, database, `SELECT count(value) FROM cpu`, expected, "", 120*time.Second)
 	if !ok {
-		t.Errorf("test %s:rawDataReturnsInOrder failed, SELECT count() query returned unexpected data\nexp: %s\n, got: %s\n%d nodes responded correctly", testName, expected, got, nOK)
+		t.Errorf("test %s:rawDataReturnsInOrder failed, SELECT count() query returned unexpected data\nexp: %s\ngot: %s\n%d nodes responded correctly", testName, expected, got, nOK)
 		dumpClusterDiags(t, testName, nodes)
 		dumpClusterStats(t, testName, nodes)
 	}

--- a/raft/log.go
+++ b/raft/log.go
@@ -1028,6 +1028,8 @@ func (l *Log) candidateLoop(closing <-chan struct{}) State {
 			if hb.term >= l.term {
 				l.tracef("candidateLoop: new leader: old=%d new=%d", l.leaderID, hb.leaderID)
 				l.leaderID = hb.leaderID
+				l.unlock()
+				return Follower
 			}
 			l.unlock()
 		case <-l.terms:


### PR DESCRIPTION
This PR fixes an issue where a raft peer gets stuck in candidate state and never increments it's index.  This happens after an election and somewhat sporadically.  The root issue appears to be that the node in candidate state should return to follower state if it starts receiving heartbeats from a new leader.  The node was not returning to follower state causing it to become inconsistent w/ the cluster.

In addition to this fix, when running multiple nodes locally w/ raft tracing, it's very difficult
to determine which node is logging.  This adds the nodes state(leader,follower,candidate) and
id to all the log messages so we can trace the nodes states more easily.

Also fixes test output alignment when there is a failure in an integration test.