### PR TITLE
Fix panic when reporting shard diagnostics

### DIFF
--- a/cmd/influxd/server_integration_test.go
+++ b/cmd/influxd/server_integration_test.go
@@ -1462,9 +1462,13 @@ func TestSingleServerDiags(t *testing.T) {
 	config.Monitoring.Enabled = true
 	config.Monitoring.WriteInterval = main.Duration(100 * time.Millisecond)
 	nodes := createCombinedNodeCluster(t, testName, dir, 1, config)
+	createDatabase(t, testName, nodes, "mydb")
+	createRetentionPolicy(t, testName, nodes, "mydb", "myrp", len(nodes))
 	defer nodes.Close()
 
-	time.Sleep(1 * time.Second)
+	// Write some data to create shards
+	mergeMany(t, nodes[0], "mydb", "myrp")
+
 }
 
 func TestSingleServer(t *testing.T) {

--- a/server.go
+++ b/server.go
@@ -3335,6 +3335,7 @@ func (s *Server) DiagnosticsAsRows() []*influxql.Row {
 	shardsRow.Name = "shards_diag"
 	shardsRow.Columns = append(shardsRow.Columns, "time", "id", "dataNodes", "index")
 	shardsRow.Tags = tags
+	var hasPath bool
 	for _, sh := range s.shards {
 		var nodes []string
 		for _, n := range sh.DataNodeIDs {
@@ -3345,9 +3346,14 @@ func (s *Server) DiagnosticsAsRows() []*influxql.Row {
 
 		// Shard may not be local to this node.
 		if sh.store != nil {
-			shardsRow.Columns = append(shardsRow.Columns, "path")
-			shardsRow.Values[0] = append(shardsRow.Values[0], sh.store.Path())
+			if !hasPath {
+				shardsRow.Columns = append(shardsRow.Columns, "path")
+				hasPath = true
+			}
+			index := len(shardsRow.Values) - 1 // Current shardsRow.Values index
+			shardsRow.Values[index] = append(shardsRow.Values[index], sh.store.Path())
 		}
+
 	}
 
 	return []*influxql.Row{


### PR DESCRIPTION
Shard diagnostics wasn't been populated correctly and it made influx panic when reporting shards.
I also changed the TestSingleServerDiags test to reproduce the error
Fixes #2421