### PR TITLE
Peer shard replication -- broker side

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## v0.9.0-rc29 [unreleased]
 
 ### Features
+- [#2410](https://github.com/influxdb/influxdb/pull/2410): If needed, brokers respond with data nodes for peer shard replication.
 
 ### Bugfixes
 - [#2446] (https://github.com/influxdb/influxdb/pull/2446): Correctly count number of queries executed. Thanks @neonstalwart

--- a/messaging/broker.go
+++ b/messaging/broker.go
@@ -1260,7 +1260,7 @@ func (r *TopicReader) Read(p []byte) (int, error) {
 		if err == ErrReaderClosed {
 			return 0, io.EOF
 		} else if err != nil {
-			return 0, fmt.Errorf("file: %s", err)
+			return 0, err
 		} else if f == nil {
 			if r.streaming {
 				time.Sleep(r.PollInterval)
@@ -1306,6 +1306,8 @@ func (r *TopicReader) File() (*os.File, error) {
 		segment, err := ReadSegmentByIndex(r.path, r.index)
 		if os.IsNotExist(err) {
 			return nil, nil
+		} else if err == ErrTopicTruncated {
+			return nil, err
 		} else if err != nil {
 			return nil, fmt.Errorf("segment by index: %s", err)
 		} else if segment == nil {
@@ -1551,7 +1553,7 @@ func (dec *MessageDecoder) Decode(m *Message) error {
 		warnf("unexpected eof(0): len=%d, n=%d, err=%s", len(b[:]), n, err)
 		return err
 	} else if err != nil {
-		return fmt.Errorf("read header: %s", err)
+		return err
 	}
 
 	// Read checksum.

--- a/messaging/broker.go
+++ b/messaging/broker.go
@@ -756,10 +756,7 @@ func (t *Topic) TombstonePath() string { return filepath.Join(t.path, "tombstone
 
 // Truncated returns whether the topic has even been truncated.
 func (t *Topic) Truncated() bool {
-	if _, err := os.Stat(t.TombstonePath()); os.IsNotExist(err) {
-		return false
-	}
-	return true
+	return tombstoneExists(t.path)
 }
 
 // Index returns the highest replicated index for the topic.
@@ -1138,10 +1135,7 @@ func ReadSegmentByIndex(path string, index uint64) (*Segment, error) {
 	}
 
 	// Determine if this topic has been truncated.
-	var truncated bool
-	if _, err := os.Stat(filepath.Join(path, "tombstone")); !os.IsNotExist(err) {
-		truncated = true
-	}
+	truncated := tombstoneExists(path)
 
 	// If the requested index is less than that available, one of two things will
 	// happen. If the topic has been truncated it means that topic data may exist
@@ -1585,6 +1579,14 @@ func (dec *MessageDecoder) Decode(m *Message) error {
 	}
 
 	return nil
+}
+
+// tombstoneExists returns whether the given directory contains a tombstone
+func tombstoneExists(path string) bool {
+	if _, err := os.Stat(filepath.Join(path, "tombstone")); os.IsNotExist(err) {
+		return false
+	}
+	return true
 }
 
 // UnmarshalMessage decodes a byte slice into a message.

--- a/messaging/handler.go
+++ b/messaging/handler.go
@@ -107,6 +107,13 @@ func (h *Handler) getMessages(w http.ResponseWriter, req *http.Request) {
 		if urls == nil {
 			h.error(w, ErrTopicNodesNotFound, http.StatusInternalServerError)
 		}
+
+		// Send back a list of URLs where the topic data can be fetched.
+		var redirects []string
+		for _, u := range urls {
+			redirects = append(redirects, u.String())
+		}
+		w.Header().Set("X-Broker-Truncated", strings.Join(redirects, ","))
 		http.Redirect(w, req, urls[0].String(), http.StatusTemporaryRedirect)
 	} else if err != nil {
 		log.Printf("message stream error: %s", err)

--- a/messaging/handler.go
+++ b/messaging/handler.go
@@ -106,6 +106,7 @@ func (h *Handler) getMessages(w http.ResponseWriter, req *http.Request) {
 		urls := h.Broker.DataURLsForTopic(topicID, index)
 		if urls == nil {
 			h.error(w, ErrTopicNodesNotFound, http.StatusInternalServerError)
+			return
 		}
 
 		// Send back a list of URLs where the topic data can be fetched.
@@ -113,7 +114,7 @@ func (h *Handler) getMessages(w http.ResponseWriter, req *http.Request) {
 		for _, u := range urls {
 			redirects = append(redirects, u.String())
 		}
-		w.Header().Set("X-Broker-Truncated", strings.Join(redirects, ","))
+		w.Header().Set("X-Broker-DataURLs", strings.Join(redirects, ","))
 		http.Redirect(w, req, urls[0].String(), http.StatusTemporaryRedirect)
 	} else if err != nil {
 		log.Printf("message stream error: %s", err)

--- a/messaging/handler_test.go
+++ b/messaging/handler_test.go
@@ -296,6 +296,9 @@ func (b *HandlerBroker) TopicReader(topicID, index uint64, streaming bool) inter
 func (b *HandlerBroker) SetTopicMaxIndex(topicID, index uint64, dataURL url.URL) error {
 	return b.SetTopicMaxIndexFunc(topicID, index, dataURL)
 }
+func (b *HandlerBroker) DataURLsForTopic(id, index uint64) []url.URL {
+	return nil
+}
 
 // MustParseURL parses a string into a URL. Panic on error.
 func MustParseURL(s string) *url.URL {


### PR DESCRIPTION
WIP.

This change is so far made up for two commits. The earlier commit simply adds some functions to the topic and broker types, such that each can provide (data node) URLs where data for that topic is available (through the already-implemented "serve-shard" endpoint).

The later commit then modifies the topic reader such that if during reading ErrTopicTruncated is returned by the reader, the handler serving the topic data can instead provide a URL where the client should instead request the data.

What remains at this point is to get this code working, and then have the client (a new data coming online for example) correctly respond to the redirect. In that case it will retrieve the data from that endpoint and return to this code, but requesting a later index.