### PR TITLE
Make InfluxDB win32 friendly, fix hostname of node is empty

### DIFF
--- a/cmd/influxd/run.go
+++ b/cmd/influxd/run.go
@@ -306,6 +306,14 @@ func (cmd *RunCommand) CheckConfig() {
 func (cmd *RunCommand) Open(config *Config, join string) *Node {
 	if config != nil {
 		cmd.config = config
+
+		// Override config properties.
+		if cmd.hostname != "" {
+			cmd.config.Hostname = cmd.hostname
+		}
+		cmd.node.hostname = cmd.config.Hostname
+	} else {
+		panic("repeated calls to RunCommand.Open()")
 	}
 
 	log.Printf("influxdb started, version %s, commit %s", version, commit)


### PR DESCRIPTION
I run TestRestoreCommand in the win32, and failed as follow:

=== RUN TestRestoreCommand
2015/04/26 14:52:36 influxdb started, version 0.9, commit
2015/04/26 14:52:36 Cluster server listening on [::]:8900
2015/04/26 14:52:36 broker opened at C:\Users\xxx\AppData\Local\Temp\influxdb-054464615\broker
[raft] 2015/04/26 14:52:36 stopped[0]: log pending: waiting for initialization or join
[raft] 2015/04/26 14:52:36 stopped[1]: changing term: 0 => 1
[raft] 2015/04/26 14:52:36 leader[1]: log initialize: promoted to 'leader' with cluster ID 8460512468382321822, log ID 1, term 1
2015/04/26 14:52:36 initialized broker: http://:8900
2015/04/26 14:52:36 data node(0) opened at C:\Users\xxx\AppData\Local\Temp\influxdb-054464615\data
[messaging] 2015/04/26 14:52:36 reconnecting to broker: url={http  <nil> :8900 /messaging/messages index=0&streaming=true&topicID=0 }, err=Get http://
:8900/messaging/messages?index=0&streaming=true&topicID=0: dial tcp :8900: ConnectEx tcp: The requested address is not valid in its context.
2015/04/26 14:52:37 join: failed to connect data node: http://:8900: Post http://:8900/data/data_nodes: dial tcp :8900: ConnectEx tcp: The requested a
ddress is not valid in its context.
2015/04/26 14:52:37 join: failed to connect data node to any specified server