### PR TITLE
count each executed query in queriesExecuted stat

### DIFF
--- a/server.go
+++ b/server.go
@@ -2257,6 +2257,8 @@ func (s *Server) ExecuteQuery(q *influxql.Query, database string, user *User, ch
 					break
 				}
 			}
+
+			s.stats.Inc("queriesExecuted")
 		}
 
 		// if there was an error send results that the remaining statements weren't executed
@@ -2264,7 +2266,6 @@ func (s *Server) ExecuteQuery(q *influxql.Query, database string, user *User, ch
 			results <- &Result{Err: ErrNotExecuted}
 		}
 
-		s.stats.Inc("queriesExecuted")
 		close(results)
 	}()
 


### PR DESCRIPTION
during 332c4275 the stats counter moved outside the loop.  this puts the counter back inside the loop so that each statement in `q.Statements` counts towards the stat if it succeeds