### PR TITLE
Implemented Flush() for httpd.responseLogger

### DIFF
--- a/httpd/response_logger.go
+++ b/httpd/response_logger.go
@@ -27,6 +27,10 @@ func (l *responseLogger) Header() http.Header {
 	return l.w.Header()
 }
 
+func (l *responseLogger) Flush() {
+	l.w.(http.Flusher).Flush()
+}
+
 func (l *responseLogger) Write(b []byte) (int, error) {
 	if l.status == 0 {
 		// Set status if WriteHeader has not been called


### PR DESCRIPTION
This pull request is a solution to issue "Empty respones from server when using chunked responses" that I have reported myself. It is a simple implementation of a missing method in httpd.responseLogger.