### PR TITLE
Reduce maximum topic size to 50MB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Features
 - [#2410](https://github.com/influxdb/influxdb/pull/2410): If needed, brokers respond with data nodes for peer shard replication.
+- [#2469](https://github.com/influxdb/influxdb/pull/2469): Reduce default max topic size from 1GB to 50MB.
 
 ### Bugfixes
 - [#2446] (https://github.com/influxdb/influxdb/pull/2446): Correctly count number of queries executed. Thanks @neonstalwart

--- a/cmd/influxd/config.go
+++ b/cmd/influxd/config.go
@@ -53,11 +53,11 @@ const (
 	// DefaultBrokerTruncationInterval is the default period between truncating topics.
 	DefaultBrokerTruncationInterval = 10 * time.Minute
 
-	// DefaultMaxTopicSize is the default maximum size in bytes a topic can consume on disk of a broker.
-	DefaultBrokerMaxTopicSize = 1024 * 1024 * 1024
-
 	// DefaultMaxTopicSize is the default maximum size in bytes a segment can consume on disk of a broker.
 	DefaultBrokerMaxSegmentSize = 10 * 1024 * 1024
+
+	// DefaultMaxTopicSize is the default maximum size in bytes a topic can consume on disk of a broker.
+	DefaultBrokerMaxTopicSize = 5 * DefaultBrokerMaxSegmentSize
 
 	// DefaultRaftApplyInterval is the period between applying commited Raft log entries.
 	DefaultRaftApplyInterval = 10 * time.Millisecond

--- a/etc/config.sample.toml
+++ b/etc/config.sample.toml
@@ -77,7 +77,7 @@ enabled = true
 # Where the Raft logs are stored. The user running InfluxDB will need read/write access.
 dir  = "/var/opt/influxdb/raft"
 truncation-interval = "10m"
-max-topic-size = 1073741824
+max-topic-size = 52428800
 max-segment-size = 10485760
 
 # Raft configuration. Controls the distributed consensus system.


### PR DESCRIPTION
1GB per topic seems way too large. Instead make it 50MB. Topic data will
never be deleted until at least 1 data node has replicated the data, regardless of size.