### PR TITLE
Data node retrieves replicated shard data from peer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 - [#2410](https://github.com/influxdb/influxdb/pull/2410): If needed, brokers respond with data nodes for peer shard replication.
 - [#2469](https://github.com/influxdb/influxdb/pull/2469): Reduce default max topic size from 1GB to 50MB.
+- [#2470](https://github.com/influxdb/influxdb/pull/2470): Data node retrieves replicated shard data from peer.
 
 ### Bugfixes
 - [#2446] (https://github.com/influxdb/influxdb/pull/2446): Correctly count number of queries executed. Thanks @neonstalwart

--- a/messaging/broker.go
+++ b/messaging/broker.go
@@ -1429,6 +1429,7 @@ const BrokerMessageType = 0x8000
 
 const (
 	SetTopicMaxIndexMessageType = BrokerMessageType | MessageType(0x00)
+	FetchPeerShardMessageType   = BrokerMessageType | MessageType(0x10)
 )
 
 const (

--- a/messaging/handler.go
+++ b/messaging/handler.go
@@ -115,7 +115,6 @@ func (h *Handler) getMessages(w http.ResponseWriter, req *http.Request) {
 			redirects = append(redirects, u.String())
 		}
 		w.Header().Set("X-Broker-DataURLs", strings.Join(redirects, ","))
-		http.Redirect(w, req, urls[0].String(), http.StatusTemporaryRedirect)
 	} else if err != nil {
 		log.Printf("message stream error: %s", err)
 	}

--- a/server.go
+++ b/server.go
@@ -3610,6 +3610,7 @@ func (c *messagingClient) Conn(topicID uint64) MessagingConn { return c.Client.C
 // MessagingConn represents a streaming connection to a single broker topic.
 type MessagingConn interface {
 	Open(index uint64, streaming bool) error
+	Close() error
 	C() <-chan *messaging.Message
 }
 

--- a/server_test.go
+++ b/server_test.go
@@ -1426,6 +1426,14 @@ func TestServer_CopyShard(t *testing.T) {
 	}
 }
 
+func TestServer_ShardReplication(t *testing.T) {
+	c := test.NewDefaultMessagingClient()
+	defer c.Close()
+	s := OpenServer(c)
+	defer s.Close()
+
+}
+
 /* TODO(benbjohnson): Change test to not expose underlying series ids directly.
 func TestServer_Measurements(t *testing.T) {
 	c := test.NewDefaultMessagingClient()


### PR DESCRIPTION
When a broker responds to a topic-stream request with list of data node
URLs, the requesting data node should instead fetch the shard for that
topic from one the URLs. When this fetch completes the data node writes
the shard to disk, and then restarts streaming from the broker at a
later index, which should be serviceable by the broker.