### PR TITLE
RLock server when checking shard groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - [#2452](https://github.com/influxdb/influxdb/issues/2452): Fix panic with shard stats on multiple clusters
 - [#2460](https://github.com/influxdb/influxdb/issues/2460): Collectd input should use "value" for fields values. Fixes 2412. Thanks @josh-padnick
 - [#2465](https://github.com/influxdb/influxdb/pull/2465): HTTP response logging paniced with chunked requests. Thanks @Jackkoz
+- [#2475](https://github.com/influxdb/influxdb/pull/2475): RLock server when checking if shards groups are required during write.
 
 ## v0.9.0-rc28 [04-27-2015]
 


### PR DESCRIPTION
This fixes a race detected by the race detector. "Create shard groups"
commands must be broadcast across the cluster without holding the server
lock so the commands are created under lock, and then processed after
releasing the lock.