### PR TITLE
add the most basics of systemd support:  influxdb.service

### DIFF
--- a/scripts/influxdb.service
+++ b/scripts/influxdb.service
@@ -1,0 +1,16 @@
+# If you modify this, please also make sure to edit init.sh
+
+[Unit]
+Description=InfluxDB is an open-source, distributed, time series database
+After=network.target
+
+[Service]
+User=influxdb
+Group=influxdb
+LimitNOFILE=65536
+EnvironmentFile=-/etc/default/influxdb
+ExecStart=/opt/influxdb/influxd -config /etc/opt/influxdb/influxdb.conf $INFLUXD_OPTS
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -9,6 +9,7 @@
 # Short-Description: Start influxd at boot time
 ### END INIT INFO
 
+# If you modify this, please make sure to also edit influxdb.service
 # this init script supports three different variations:
 #  1. New lsb that define start-stop-daemon
 #  2. Old lsb that don't have start-stop-daemon but define, log, pidofproc and killproc


### PR DESCRIPTION
The added influxdb.service is the direct functional equivalent of
the init.sh script where appropriate, some features are missing
like redirecting stdout/stderr to files, but that can be done by
the syslog daemon a layer up anyway.
For aditional support influxdb should support Type=notify for
notifying systemd about when it has finished starting up, and for
watchdog functionality.