### PR TITLE
call ParseConfigFile with path from restore command

### DIFF
--- a/cmd/influxd/restore.go
+++ b/cmd/influxd/restore.go
@@ -104,7 +104,7 @@ func (cmd *RestoreCommand) parseFlags(args []string) (*Config, string, error) {
 		config, err = NewTestConfig()
 		log.Println("No config provided, using default settings")
 	} else {
-		config, err = ParseConfig(*configPath)
+		config, err = ParseConfigFile(*configPath)
 	}
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
fixes #2506

for some reason the restore command called `ParseConfig` with a path rather than calling `ParseConfigFile`