### PR TITLE
add test for merging precision from BatchPoints to Point

### DIFF
--- a/influxdb_test.go
+++ b/influxdb_test.go
@@ -14,6 +14,7 @@ func TestNormalizeBatchPoints(t *testing.T) {
 	tests := []struct {
 		name string
 		bp   client.BatchPoints
+		json []byte // if set, generate bp from json. overrides bp
 		p    []influxdb.Point
 		err  string
 	}{
@@ -54,11 +55,29 @@ func TestNormalizeBatchPoints(t *testing.T) {
 				{Name: "memory", Tags: map[string]string{"day": "monday"}, Timestamp: now, Fields: map[string]interface{}{"value": 2.0}},
 			},
 		},
+		{
+			name: "merge precision",
+			json: []byte(`{ "precision": "ms", "points": [
+			{"name": "cpu", "timestamp": 1422921600000, "fields": { "value": 1.0 }},
+			{"name": "memory", "timestamp": 1423008000000, "fields": { "value": 2.0 }}
+			] }`),
+			p: []influxdb.Point{
+				{Name: "cpu", Timestamp: time.Unix(1422921600, 0), Fields: map[string]interface{}{"value": 1.0}},
+				{Name: "memory", Timestamp: time.Unix(1423008000, 0), Fields: map[string]interface{}{"value": 2.0}},
+			},
+		},
 	}
 
 	for _, test := range tests {
 		t.Logf("running test %q", test.name)
-		p, e := influxdb.NormalizeBatchPoints(test.bp)
+		bp := test.bp
+		if test.json != nil {
+			e := bp.UnmarshalJSON(test.json)
+			if e != nil {
+				t.Errorf("error unmarshalling batchpoints %v\n json: %s", e, test.json)
+			}
+		}
+		p, e := influxdb.NormalizeBatchPoints(bp)
 		if test.err == "" && e != nil {
 			t.Errorf("unexpected error %v", e)
 		} else if test.err != "" && e == nil {


### PR DESCRIPTION
this adds a test case showing how merging `Precision` from `BatchPoints` to `Point` is failing.  unfortunately though there is a chicken and egg problem here.  when a `Point` is unmarshalled it has not yet "inherited" its precision form `BatchPoints` and so the default precision of `'s'` is used. this can cause an overflow (see https://play.golang.org/p/Lmv2xESOyX).  to fix this, either the default needs to become
nano or somehow the inherited precision needs to be known before unmarshalling the `Point` (chicken and egg).

~~even if we don't cause an overflow, the problem is then how do we get back the original `int64` to apply the inherited precision?  (this is probably just my inexperience with go - i bet there's a way).~~ there is a way (`t.Unix()` will give the original value), and it was the way i was trying but it doesn't work when the value used to generate the time is an `int64` that has overflowed - you get back the overflowed value and that's why i thought it didn't work.

anyone got some help on this one?  it looks like some non-trivial changes are needed.

* store the `int64` timestamp on the point so that either `BatchPoints.UnmarshalJson` or `NormalizeBatchPoints` can update `Point.Timestamp` based on the inherited precision?
* detect overflow in `EpochToTime`?
* make nano the default precision?
* ???

refs #1657

EDIT: changed the go playground link.  overflow is not as obvious in this one but that is the reason for the strange date and since overflow occurs we can't get back the original `int64` value for the timestamp.