### PR TITLE
Replace several pending tests in server

### DIFF
--- a/server_test.go
+++ b/server_test.go
@@ -35,10 +35,31 @@ func TestServer_Open(t *testing.T) {
 }
 
 // Ensure an error is returned when opening an already open server.
-func TestServer_Open_ErrServerOpen(t *testing.T) { t.Skip("pending") }
+func TestServer_Open_ErrServerOpen(t *testing.T) {
+	c := test.NewDefaultMessagingClient()
+	defer c.Close()
+	s := NewServer()
+	defer s.Close()
+
+	if err := s.Server.Open(tempfile(), c); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Server.Open(tempfile(), c); err != influxdb.ErrServerOpen {
+		t.Fatal(err)
+	}
+}
 
 // Ensure an error is returned when opening a server without a path.
-func TestServer_Open_ErrPathRequired(t *testing.T) { t.Skip("pending") }
+func TestServer_Open_ErrPathRequired(t *testing.T) {
+	c := test.NewDefaultMessagingClient()
+	defer c.Close()
+	s := NewServer()
+	defer s.Close()
+
+	if err := s.Server.Open("", c); err != influxdb.ErrPathRequired {
+		t.Fatal(err)
+	}
+}
 
 // Ensure the server can create a new data node.
 func TestServer_CreateDataNode(t *testing.T) {


### PR DESCRIPTION
### Test Server.Open
- test Open returns ErrServerOpen if the server is already open
- test Open returns ErrPathRequired if an empty path is supplied

### Test Server.CreateContinuousQuery
- test CreateContinuousQuery returns ErrContinuousQueryExists if continuous query already exists
- test CreateContinuousQuery returns ErrDatabaseNotFound if database specified does not exist
- test CreateContinuousQuery returns ErrRetentionPolicyNotFound if specified retention policy does not exist

### Notes
I'm sure there must be better approaches to test some of these errors and welcome your suggestions.
