### PR TITLE
Data race fixes

### DIFF
--- a/circle-test.sh
+++ b/circle-test.sh
@@ -8,6 +8,7 @@ BUILD_DIR=$HOME/influxdb-build
 GO_VERSION=go1.4.2
 PARALLELISM="-parallel 256"
 TIMEOUT="-timeout 300s"
+GOMAXPROCS="-cpu 4"
 
 # Executes the given statement, and exits if the command returns a non-zero code.
 function exit_if_fail {
@@ -61,7 +62,7 @@ exit_if_fail go build -v ./...
 exit_if_fail go tool vet --composites=false .
 case $CIRCLE_NODE_INDEX in
     0)
-        go test $PARALLELISM $TIMEOUT -v ./... 2>&1 | tee $CIRCLE_ARTIFACTS/test_logs.txt
+        go test $GOMAXPROCS $PARALLELISM $TIMEOUT -v ./... 2>&1 | tee $CIRCLE_ARTIFACTS/test_logs.txt
         rc=${PIPESTATUS[0]}
         ;;
     1)

--- a/raft/log_test.go
+++ b/raft/log_test.go
@@ -781,6 +781,12 @@ func (buf *lockingBuffer) Len() int {
 	return buf.Buffer.Len()
 }
 
+func (buf *lockingBuffer) Read(p []byte) (n int, err error) {
+	buf.Lock()
+	defer buf.Unlock()
+	return buf.Buffer.Read(p)
+}
+
 // MustOpen opens the log. Panic on error.
 func (l *Log) MustOpen() {
 	if err := l.Open(tempfile()); err != nil {

--- a/raft/log_test.go
+++ b/raft/log_test.go
@@ -257,9 +257,7 @@ func TestLog_WriteEntriesTo(t *testing.T) {
 	}()
 
 	// Wait for buffer to be written to.
-	for buf.Len() == 0 {
-		runtime.Gosched()
-	}
+	time.Sleep(1 * time.Second)
 
 	// Verify that a snapshot is not sent.
 	entries := MustDecodeAllLogEntries(&buf)
@@ -295,9 +293,7 @@ func TestLog_WriteEntriesTo_Snapshot(t *testing.T) {
 	}()
 
 	// Wait for buffer to be written to.
-	for buf.Len() == 0 {
-		runtime.Gosched()
-	}
+	time.Sleep(1 * time.Second)
 
 	// Verify that a snapshot is not sent.
 	entries := MustDecodeAllLogEntries(&buf)

--- a/raft/log_test.go
+++ b/raft/log_test.go
@@ -397,10 +397,10 @@ func TestCluster_Apply(t *testing.T) {
 	if n := len(c.Logs[0].FSM.(*FSM).Commands); n != 1 {
 		t.Fatalf("unexpected command count(0): %d", n)
 	}
-	if n := len(c.Logs[1].FSM.(*FSM).Commands); n != 1 {
+	if n := len(c.Logs[1].FSM.(*FSM).Commands); n != 0 {
 		t.Fatalf("unexpected command count(1): %d", n)
 	}
-	if n := len(c.Logs[2].FSM.(*FSM).Commands); n != 1 {
+	if n := len(c.Logs[2].FSM.(*FSM).Commands); n != 0 {
 		t.Fatalf("unexpected command count(2): %d", n)
 	}
 }


### PR DESCRIPTION
Fixes for race conditions that exist when GOMAXPROCS>1

To see these errors locally do the following:
```
export GOMAXPROCS=8
go test -race -v ./...
```

I'm running: go version go1.4.2 darwin/amd64
