### PR TITLE
init.sh: double start considers success

### DIFF
--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -117,7 +117,7 @@ case $1 in
             # If the status is SUCCESS then don't need to start again.
             if [ "x$status" = "x0" ]; then
                 log_failure_msg "$name process is running"
-                exit 1 # Exit
+                exit 0 # Exit
             fi
         fi
 


### PR DESCRIPTION
according to lsb spec http://refspecs.linuxbase.org/LSB_3.1.0/LSB-Core-generic/LSB-Core-generic/iniscrptact.html

"... In addition to straightforward success, the following situations are also to be considered successful:
running start on a service already running"
