### PR TITLE
Set leader ID on log open if only 1 node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - [2535](https://github.com/influxdb/influxdb/pull/2535): Return exit status 0 if influxd already running. Thanks @haim0n.
 - [#2521](https://github.com/influxdb/influxdb/pull/2521): Don't truncate topic data until fully replicated.
 - [#2509](https://github.com/influxdb/influxdb/pull/2509): Parse config file correctly during restore. Thanks @neonstalwart
+- [#2536](https://github.com/influxdb/influxdb/pull/2536): Set leader ID on restart of single-ndoe cluster.
 
 ## v0.9.0-rc29 [2015-05-05]
 

--- a/raft/log.go
+++ b/raft/log.go
@@ -381,6 +381,11 @@ func (l *Log) Open(path string) error {
 		}
 		l.config = c
 
+		// If only node in cluster, then promote to leader immediately.
+		if l.config == nil || len(l.config.Nodes) == 1 {
+			l.leaderID = l.id
+		}
+
 		// Determine last applied index from FSM.
 		index := l.FSM.Index()
 		l.tracef("Open: fsm: index=%d", index)
@@ -461,6 +466,7 @@ func (l *Log) close() error {
 	l.lastLogIndex, l.lastLogTerm = 0, 0
 	l.entries = nil
 	l.term, l.votedFor = 0, 0
+	l.leaderID = 0
 	l.config = nil
 
 	l.tracef("closed")

--- a/raft/log_test.go
+++ b/raft/log_test.go
@@ -169,7 +169,7 @@ func TestLog_Opened(t *testing.T) {
 	}
 }
 
-// Ensure that reopening an existing log will restore its ID.
+// Ensure that reopening an existing log will restore its ID and leader ID.
 func TestLog_Reopen(t *testing.T) {
 	l := NewInitializedLog(url.URL{Host: "log0"})
 	if l.ID() != 1 {
@@ -177,10 +177,18 @@ func TestLog_Reopen(t *testing.T) {
 	}
 	path := l.Path()
 
-	// Close log and make sure id is cleared.
+	if l.IsLeader() != true {
+		t.Fatalf("expected log to be leader")
+	}
+
+	// Close log and make sure id is cleared and it is no longer leader.
 	l.Log.Close()
 	if l.ID() != 0 {
 		t.Fatalf("expected id == 0")
+	}
+
+	if l.IsLeader() != false {
+		t.Fatalf("expected log not to be leader")
 	}
 
 	// Re-open and ensure id is restored.
@@ -190,6 +198,12 @@ func TestLog_Reopen(t *testing.T) {
 	if id := l.ID(); id != 1 {
 		t.Fatalf("unexpected id: %d", id)
 	}
+
+	// Ensure node is leader again.
+	if l.IsLeader() != true {
+		t.Fatalf("expected log to be leader")
+	}
+
 	l.Close()
 }
 


### PR DESCRIPTION
Without this change a restart of a single-node cluster would result in
no Raft leader.