### PR TITLE
Update messaging client connection index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This release has a breaking API change for writes -- the field previously called
 - [#2448](https://github.com/influxdb/influxdb/pull/2448): Fix inconsistent data type - thanks @cannium!
 - [#2108](https://github.com/influxdb/influxdb/issues/2108): Change `timestamp` to `time` - thanks @neonstalwart!
 - [#2539](https://github.com/influxdb/influxdb/issues/2539): Add additional vote request logging.
+- [#2541](https://github.com/influxdb/influxdb/issues/2541): Update messaging client connection index with every message.
 
 ## v0.9.0-rc29 [2015-05-05]
 

--- a/server.go
+++ b/server.go
@@ -3476,6 +3476,9 @@ func (s *Server) processor(conn MessagingConn, done chan struct{}) {
 			if err != nil {
 				s.errors[m.Index] = err
 			}
+
+			// Update the connection with high water mark.
+			conn.SetIndex(s.index)
 		}()
 	}
 }
@@ -3611,6 +3614,7 @@ func (c *messagingClient) Conn(topicID uint64) MessagingConn { return c.Client.C
 type MessagingConn interface {
 	Open(index uint64, streaming bool) error
 	C() <-chan *messaging.Message
+	SetIndex(index uint64)
 }
 
 // DataNode represents a data node in the cluster.

--- a/shard.go
+++ b/shard.go
@@ -382,6 +382,9 @@ func (s *Shard) processor(conn MessagingConn, closing <-chan struct{}) {
 		s.mu.Lock()
 		s.index = m.Index
 		s.mu.Unlock()
+
+		// Update the connection with the high index.
+		conn.SetIndex(m.Index)
 	}
 }
 

--- a/test/messaging.go
+++ b/test/messaging.go
@@ -171,6 +171,10 @@ func (c *MessagingConn) Close() error {
 // C returns a channel for streaming message.
 func (c *MessagingConn) C() <-chan *messaging.Message { return c.c }
 
+// SetIndex sets the most-recently replicated index on the connection.
+func (c *MessagingConn) SetIndex(index uint64) {
+}
+
 func (c *MessagingConn) Send(m *messaging.Message) {
 	// Ignore any old messages.
 	c.mu.Lock()


### PR DESCRIPTION
With this change heartbeating to the brokers will always communicate the
index of the most recently replicated message. This will allow broker
truncation and broker diagnostics to operate correctly.