### PR TITLE
Fix client response check after PR #2298

### DIFF
--- a/client/influxdb.go
+++ b/client/influxdb.go
@@ -140,7 +140,7 @@ func (c *Client) Write(bp BatchPoints) (*Response, error) {
 		return nil, err
 	}
 
-	if resp.StatusCode != http.StatusOK {
+	if resp.StatusCode != http.StatusNoContent {
 		return &response, response.Error()
 	}
 

--- a/client/influxdb_test.go
+++ b/client/influxdb_test.go
@@ -100,7 +100,7 @@ func TestClient_BasicAuth(t *testing.T) {
 func TestClient_Write(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var data influxdb.Response
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusNoContent)
 		_ = json.NewEncoder(w).Encode(data)
 	}))
 	defer ts.Close()

--- a/client/influxdb_test.go
+++ b/client/influxdb_test.go
@@ -113,9 +113,12 @@ func TestClient_Write(t *testing.T) {
 	}
 
 	bp := client.BatchPoints{}
-	_, err = c.Write(bp)
+	r, err := c.Write(bp)
 	if err != nil {
 		t.Fatalf("unexpected error.  expected %v, actual %v", nil, err)
+	}
+	if r != nil {
+		t.Fatalf("unexpected response. expected %v, actual %v", nil, r)
 	}
 }
 

--- a/cmd/influxd/server_integration_test.go
+++ b/cmd/influxd/server_integration_test.go
@@ -1692,7 +1692,7 @@ func TestClientLibrary(t *testing.T) {
 			name: "no points",
 			writes: []write{
 				{
-					expected: `{}`,
+					expected: `null`,
 					bp:       client.BatchPoints{Database: "mydb"},
 				},
 			},
@@ -1707,7 +1707,7 @@ func TestClientLibrary(t *testing.T) {
 							{Name: "cpu", Fields: map[string]interface{}{"value": 1.1}, Time: now},
 						},
 					},
-					expected: `{}`,
+					expected: `null`,
 				},
 			},
 			queries: []query{
@@ -1720,9 +1720,9 @@ func TestClientLibrary(t *testing.T) {
 		{
 			name: "mulitple points, multiple values",
 			writes: []write{
-				{bp: client.BatchPoints{Database: "mydb", Points: []client.Point{{Name: "network", Fields: map[string]interface{}{"rx": 1.1, "tx": 2.1}, Time: now}}}, expected: `{}`},
-				{bp: client.BatchPoints{Database: "mydb", Points: []client.Point{{Name: "network", Fields: map[string]interface{}{"rx": 1.2, "tx": 2.2}, Time: now.Add(time.Nanosecond)}}}, expected: `{}`},
-				{bp: client.BatchPoints{Database: "mydb", Points: []client.Point{{Name: "network", Fields: map[string]interface{}{"rx": 1.3, "tx": 2.3}, Time: now.Add(2 * time.Nanosecond)}}}, expected: `{}`},
+				{bp: client.BatchPoints{Database: "mydb", Points: []client.Point{{Name: "network", Fields: map[string]interface{}{"rx": 1.1, "tx": 2.1}, Time: now}}}, expected: `null`},
+				{bp: client.BatchPoints{Database: "mydb", Points: []client.Point{{Name: "network", Fields: map[string]interface{}{"rx": 1.2, "tx": 2.2}, Time: now.Add(time.Nanosecond)}}}, expected: `null`},
+				{bp: client.BatchPoints{Database: "mydb", Points: []client.Point{{Name: "network", Fields: map[string]interface{}{"rx": 1.3, "tx": 2.3}, Time: now.Add(2 * time.Nanosecond)}}}, expected: `null`},
 			},
 			queries: []query{
 				{


### PR DESCRIPTION
The write endpoint is returning `StatusNoContent` instead of `StatusOK` when the write is successful. 
This will be important only for clients that check for returning `*Response` being nil, as in both cases the `err` returned will be nil.