### PR TITLE
Wait for quorum write before returning from Log.Apply().

### DIFF
--- a/client/influxdb.go
+++ b/client/influxdb.go
@@ -167,6 +167,8 @@ func (c *Client) Ping() (time.Duration, string, error) {
 	if err != nil {
 		return 0, "", err
 	}
+	defer resp.Body.Close()
+
 	version := resp.Header.Get("X-Influxdb-Version")
 	return time.Since(now), version, nil
 }

--- a/cmd/influxd/server_integration_test.go
+++ b/cmd/influxd/server_integration_test.go
@@ -117,6 +117,8 @@ func createCombinedNodeCluster(t *testing.T, testName, tmpDir string, nNodes int
 	c.Snapshot.Enabled = false
 	c.Logging.HTTPAccess = false
 
+	// c.Raft.HeartbeatInterval = main.Duration(10 * time.Millisecond)
+
 	cmd := main.NewRunCommand()
 	baseNode := cmd.Open(c, "")
 	b := baseNode.Broker
@@ -2223,7 +2225,6 @@ func Test_ServerOpenTSDBIntegrationHTTPSingle(t *testing.T) {
 		t.Fatal(err)
 		return
 	}
-
 	resp.Body.Close()
 
 	expected := fmt.Sprintf(`{"results":[{"series":[{"name":"cpu","columns":["time","value"],"values":[["%s",10]]}]}]}`, now.Format(time.RFC3339Nano))

--- a/httpd/handler_test.go
+++ b/httpd/handler_test.go
@@ -545,6 +545,7 @@ func TestHandler_GzipEnabled(t *testing.T) {
 	if err != nil {
 		panic(err)
 	}
+	defer resp.Body.Close()
 
 	if ce := resp.Header.Get("Content-Encoding"); ce != "gzip" {
 		t.Fatalf("unexpected Content-Encoding.  expected %q, actual: %q", "gzip", ce)
@@ -570,6 +571,7 @@ func TestHandler_GzipDisabled(t *testing.T) {
 	if err != nil {
 		panic(err)
 	}
+	defer resp.Body.Close()
 
 	if ce := resp.Header.Get("Content-Encoding"); ce == "gzip" {
 		t.Fatalf("unexpected Content-Encoding.  expected %q, actual: %q", "", ce)
@@ -1264,6 +1266,7 @@ func TestHandler_serveWriteSeries_errorHasJsonContentType(t *testing.T) {
 	if err != nil {
 		panic(err)
 	}
+	defer resp.Body.Close()
 
 	if ct := resp.Header.Get("Content-Type"); ct != "application/json" {
 		t.Fatalf("unexpected Content-Type.  expected %q, actual: %q", "application/json", ct)
@@ -1303,6 +1306,7 @@ func TestHandler_serveWriteSeries_queryHasJsonContentType(t *testing.T) {
 	if err != nil {
 		panic(err)
 	}
+	defer resp.Body.Close()
 
 	if ct := resp.Header.Get("Content-Type"); ct != "application/json" {
 		t.Fatalf("unexpected Content-Type.  expected %q, actual: %q", "application/json", ct)
@@ -1679,6 +1683,7 @@ func TestHandler_ChunkedResponses(t *testing.T) {
 		t.Fatalf("error making request: %s", err.Error())
 	}
 	defer resp.Body.Close()
+
 	for i := 0; i < 2; i++ {
 		chunk := make([]byte, 2048, 2048)
 		n, err := resp.Body.Read(chunk)

--- a/messaging/client.go
+++ b/messaging/client.go
@@ -341,9 +341,10 @@ func (c *Client) do(method, path string, values url.Values, contentType string, 
 		// If a temporary redirect occurs then update the leader and retry.
 		// If a non-200 status is returned then an error occurred.
 		if resp.StatusCode == http.StatusTemporaryRedirect {
+			resp.Body.Close()
+
 			redirectURL, err := url.Parse(resp.Header.Get("Location"))
 			if err != nil {
-				resp.Body.Close()
 				return nil, fmt.Errorf("invalid redirect location: %s", resp.Header.Get("Location"))
 			}
 			c.SetURL(*redirectURL)

--- a/raft/clock.go
+++ b/raft/clock.go
@@ -37,33 +37,65 @@ func NewClock() *Clock {
 	}
 }
 
-// AfterApplyInterval returns a channel that fires after the apply interval.
-func (c *Clock) AfterApplyInterval() <-chan chan struct{} { return newClockChan(c.ApplyInterval) }
+// ApplyTimer returns a timer that fires after the apply interval.
+func (c *Clock) ApplyTimer() Timer { return NewTimer(c.ApplyInterval) }
 
 // AfterElectionTimeout returns a channel that fires after a duration that is
 // between the election timeout and double the election timeout.
-func (c *Clock) AfterElectionTimeout() <-chan chan struct{} {
+func (c *Clock) ElectionTimer() Timer {
 	rand.Seed(time.Now().UnixNano())
 	d := c.ElectionTimeout + time.Duration(rand.Intn(int(c.ElectionTimeout)))
-	return newClockChan(d)
+	return NewTimer(d)
 }
 
-// AfterHeartbeatInterval returns a channel that fires after the heartbeat interval.
-func (c *Clock) AfterHeartbeatInterval() <-chan chan struct{} {
-	return newClockChan(c.HeartbeatInterval)
+// HeartbeatTimer returns a timer that fires after the heartbeat interval.
+func (c *Clock) HeartbeatTimer() Timer {
+	return NewTimer(c.HeartbeatInterval)
 }
 
-// AfterReconnectTimeout returns a channel that fires after the reconnection timeout.
-func (c *Clock) AfterReconnectTimeout() <-chan chan struct{} { return newClockChan(c.ReconnectTimeout) }
+// ReconnectTimer returns a timer that fires after the reconnection timeout.
+func (c *Clock) ReconnectTimer() Timer { return NewTimer(c.ReconnectTimeout) }
 
 // Now returns the current wall clock time.
 func (c *Clock) Now() time.Time { return time.Now() }
 
-// newClockChan returns a channel that sends a channel after a given duration.
+type Timer interface {
+	C() <-chan chan struct{}
+	Stop()
+}
+
+// NewTimer returns a channel that sends a channel after a given duration.
 // The channel being sent, over the channel that is returned, can be used to
 // notify the sender when an action is done.
-func newClockChan(d time.Duration) <-chan chan struct{} {
-	ch := make(chan chan struct{}, 1)
-	go func() { time.Sleep(d); ch <- make(chan struct{}) }()
-	return ch
+func NewTimer(d time.Duration) Timer {
+	t := &timer{
+		Timer:   time.NewTimer(d),
+		closing: make(chan struct{}, 0),
+		c:       make(chan chan struct{}, 1),
+	}
+	go t.run()
+	return t
+}
+
+type timer struct {
+	*time.Timer
+	closing chan struct{}
+	c       chan chan struct{}
+}
+
+func (t *timer) C() <-chan chan struct{} {
+	return t.c
+}
+
+func (t *timer) Stop() {
+	t.Timer.Stop()
+	close(t.closing)
+}
+
+func (t *timer) run() {
+	select {
+	case <-t.closing:
+	case <-t.Timer.C:
+		t.c <- make(chan struct{})
+	}
 }

--- a/raft/clock_test.go
+++ b/raft/clock_test.go
@@ -21,7 +21,7 @@ func TestClock_AfterApplyInterval(t *testing.T) {
 	c := raft.NewClock()
 	c.ApplyInterval = 10 * time.Millisecond
 	t0 := time.Now()
-	<-c.AfterApplyInterval()
+	<-c.ApplyTimer().C()
 	if d := time.Since(t0); d < c.ApplyInterval {
 		t.Fatalf("channel fired too soon: %v", d)
 	}
@@ -32,7 +32,7 @@ func TestClock_AfterElectionTimeout(t *testing.T) {
 	c := raft.NewClock()
 	c.ElectionTimeout = 10 * time.Millisecond
 	t0 := time.Now()
-	<-c.AfterElectionTimeout()
+	<-c.ElectionTimer().C()
 	if d := time.Since(t0); d < c.ElectionTimeout {
 		t.Fatalf("channel fired too soon: %v", d)
 	}
@@ -43,7 +43,7 @@ func TestClock_AfterHeartbeatInterval(t *testing.T) {
 	c := raft.NewClock()
 	c.HeartbeatInterval = 10 * time.Millisecond
 	t0 := time.Now()
-	<-c.AfterHeartbeatInterval()
+	<-c.HeartbeatTimer().C()
 	if d := time.Since(t0); d < c.HeartbeatInterval {
 		t.Fatalf("channel fired too soon: %v", d)
 	}
@@ -54,7 +54,7 @@ func TestClock_AfterReconnectTimeout(t *testing.T) {
 	c := raft.NewClock()
 	c.ReconnectTimeout = 10 * time.Millisecond
 	t0 := time.Now()
-	<-c.AfterReconnectTimeout()
+	<-c.ReconnectTimer().C()
 	if d := time.Since(t0); d < c.ReconnectTimeout {
 		t.Fatalf("channel fired too soon: %v", d)
 	}
@@ -76,11 +76,11 @@ type Clock struct {
 	heartbeatChan chan chan struct{}
 	reconnectChan chan chan struct{}
 
-	NowFunc                    func() time.Time
-	AfterApplyIntervalFunc     func() <-chan chan struct{}
-	AfterElectionTimeoutFunc   func() <-chan chan struct{}
-	AfterHeartbeatIntervalFunc func() <-chan chan struct{}
-	AfterReconnectTimeoutFunc  func() <-chan chan struct{}
+	NowFunc            func() time.Time
+	ApplyTimerFunc     func() raft.Timer
+	ElectionTimerFunc  func() raft.Timer
+	HeartbeatTimerFunc func() raft.Timer
+	ReconnectTimerFunc func() raft.Timer
 }
 
 // NewClock returns an instance of Clock with default.
@@ -95,10 +95,10 @@ func NewClock() *Clock {
 
 	// Set default functions.
 	c.NowFunc = func() time.Time { return c.now }
-	c.AfterApplyIntervalFunc = func() <-chan chan struct{} { return c.applyChan }
-	c.AfterElectionTimeoutFunc = func() <-chan chan struct{} { return c.electionChan }
-	c.AfterHeartbeatIntervalFunc = func() <-chan chan struct{} { return c.heartbeatChan }
-	c.AfterReconnectTimeoutFunc = func() <-chan chan struct{} { return c.reconnectChan }
+	c.ApplyTimerFunc = func() raft.Timer { return &timer{c: c.applyChan} }
+	c.ElectionTimerFunc = func() raft.Timer { return &timer{c: c.electionChan} }
+	c.HeartbeatTimerFunc = func() raft.Timer { return &timer{c: c.heartbeatChan} }
+	c.ReconnectTimerFunc = func() raft.Timer { return &timer{c: c.reconnectChan} }
 	return c
 }
 
@@ -126,10 +126,20 @@ func (c *Clock) reconnect() {
 	<-ch
 }
 
-func (c *Clock) Now() time.Time                               { return c.NowFunc() }
-func (c *Clock) AfterApplyInterval() <-chan chan struct{}     { return c.AfterApplyIntervalFunc() }
-func (c *Clock) AfterElectionTimeout() <-chan chan struct{}   { return c.AfterElectionTimeoutFunc() }
-func (c *Clock) AfterHeartbeatInterval() <-chan chan struct{} { return c.AfterHeartbeatIntervalFunc() }
-func (c *Clock) AfterReconnectTimeout() <-chan chan struct{}  { return c.AfterReconnectTimeoutFunc() }
+func (c *Clock) Now() time.Time             { return c.NowFunc() }
+func (c *Clock) ApplyTimer() raft.Timer     { return c.ApplyTimerFunc() }
+func (c *Clock) ElectionTimer() raft.Timer  { return c.ElectionTimerFunc() }
+func (c *Clock) HeartbeatTimer() raft.Timer { return c.HeartbeatTimerFunc() }
+func (c *Clock) ReconnectTimer() raft.Timer { return c.ReconnectTimerFunc() }
+
+type timer struct {
+	c chan chan struct{}
+}
+
+func (t *timer) C() <-chan chan struct{} {
+	return t.c
+}
+
+func (t *timer) Stop() {}
 
 func gosched() { time.Sleep(*goschedTimeout) }

--- a/raft/transport.go
+++ b/raft/transport.go
@@ -77,7 +77,7 @@ func (t *HTTPTransport) Leave(uri url.URL, id uint64) error {
 }
 
 // Heartbeat checks the status of a follower.
-func (t *HTTPTransport) Heartbeat(uri url.URL, term, commitIndex, leaderID uint64) (uint64, error) {
+func (t *HTTPTransport) Heartbeat(uri url.URL, term, commitIndex, leaderID uint64, closing <-chan struct{}) (uint64, error) {
 	// Construct URL.
 	u := uri
 	u.Path = path.Join(u.Path, "raft/heartbeat")
@@ -89,8 +89,25 @@ func (t *HTTPTransport) Heartbeat(uri url.URL, term, commitIndex, leaderID uint6
 	v.Set("leaderID", strconv.FormatUint(leaderID, 10))
 	u.RawQuery = v.Encode()
 
+	// Create request.
+	req, err := http.NewRequest("GET", u.String(), nil)
+	if err != nil {
+		return 0, err
+	}
+
+	// Check for connection close request.
+	exiting := make(chan struct{})
+	defer close(exiting)
+	go func() {
+		select {
+		case <-exiting:
+		case <-closing:
+			http.DefaultTransport.(*http.Transport).CancelRequest(req)
+		}
+	}()
+
 	// Send HTTP request.
-	resp, err := http.Get(u.String())
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return 0, err
 	}

--- a/raft/transport_test.go
+++ b/raft/transport_test.go
@@ -192,7 +192,7 @@ func TestHTTPTransport_Heartbeat(t *testing.T) {
 
 	// Execute heartbeat against test server.
 	u, _ := url.Parse(s.URL)
-	newIndex, err := (&raft.HTTPTransport{}).Heartbeat(*u, 1, 2, 3)
+	newIndex, err := (&raft.HTTPTransport{}).Heartbeat(*u, 1, 2, 3, make(chan struct{}))
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	} else if newIndex != 4 {
@@ -219,7 +219,7 @@ func TestHTTPTransport_Heartbeat_Err(t *testing.T) {
 		}))
 
 		u, _ := url.Parse(s.URL)
-		_, err := (&raft.HTTPTransport{}).Heartbeat(*u, 1, 2, 3)
+		_, err := (&raft.HTTPTransport{}).Heartbeat(*u, 1, 2, 3, make(chan struct{}))
 		if err == nil {
 			t.Errorf("%d. expected error", i)
 		} else if tt.err != err.Error() {
@@ -232,7 +232,7 @@ func TestHTTPTransport_Heartbeat_Err(t *testing.T) {
 // Ensure an HTTP heartbeat to a stopped server returns an error.
 func TestHTTPTransport_Heartbeat_ErrConnectionRefused(t *testing.T) {
 	u, _ := url.Parse("http://localhost:41932")
-	_, err := (&raft.HTTPTransport{}).Heartbeat(*u, 0, 0, 0)
+	_, err := (&raft.HTTPTransport{}).Heartbeat(*u, 0, 0, 0, make(chan struct{}))
 	if err == nil {
 		t.Fatal("expected error")
 	} else if !is_connection_refused(err) {
@@ -406,7 +406,7 @@ func (t *Transport) Leave(u url.URL, id uint64) error {
 }
 
 // Heartbeat calls the Heartbeat method on the target log.
-func (t *Transport) Heartbeat(u url.URL, term, commitIndex, leaderID uint64) (lastIndex uint64, err error) {
+func (t *Transport) Heartbeat(u url.URL, term, commitIndex, leaderID uint64, closing <-chan struct{}) (lastIndex uint64, err error) {
 	l, err := t.log(u)
 	if err != nil {
 		return 0, err


### PR DESCRIPTION
## Overview

This pull request ensures a commit is written to a quorum before returning from `Log.Apply()`. It also fixes issues with the `raft.Clock` to ensure that channels are closed when they're not needed and it also fixes some `io.Closer` objects that need to be closed.