### PR TITLE
Graphite name parser

### DIFF
--- a/etc/config.sample.toml
+++ b/etc/config.sample.toml
@@ -91,7 +91,26 @@ reporting-disabled = false
   # protocol = "tcp"
   # consistency-level = "one"
   # name-separator = "."
-  # name-position = "last"
+
+  ## "name-schema" configures tag names for parsing the metric name from graphite protocol;
+  ## separated by `name-separator`.
+  ## The "measurement" tag is special and the corresponding field will become
+  ## the name of the metric.
+  ## e.g. "type.host.measurement.device" will parse "server.localhost.cpu.cpu0" as
+  ## {
+  ##     measurement: "cpu",
+  ##     tags: {
+  ##         "type": "server",
+  ##         "host": "localhost,
+  ##         "device": "cpu0"
+  ##     }
+  ## }
+  # name-schema = "type.host.measurement.device"
+
+  ## If set to true, when the input metric name has more fields than `name-schema` specified,
+  ## the extra fields will be ignored.
+  ## Otherwise an error will be logged and the metric rejected.
+  # ignore-unnamed = true
 
 ###
 ### [collectd]

--- a/services/graphite/config.go
+++ b/services/graphite/config.go
@@ -1,8 +1,6 @@
 package graphite
 
 import (
-	"strings"
-
 	"github.com/influxdb/influxdb/toml"
 )
 
@@ -16,8 +14,11 @@ const (
 	// DefaultNameSeparator represents the default field separator.
 	DefaultNameSeparator = "."
 
-	// DefaultNamePosition represents the default location of the name.
-	DefaultNamePosition = "last"
+	// DefaultNameSchema represents the default schema of the name.
+	DefaultNameSchema = "measurement"
+
+	// By default unnamed fields from metrics will be ignored.
+	DefaultIgnoreUnnamed = true
 
 	// DefaultProtocol is the default IP protocol used by the Graphite input.
 	DefaultProtocol = "tcp"
@@ -33,7 +34,9 @@ type Config struct {
 	Enabled          bool          `toml:"enabled"`
 	Protocol         string        `toml:"protocol"`
 	NamePosition     string        `toml:"name-position"`
+	NameSchema       string        `toml:"name-schema"`
 	NameSeparator    string        `toml:"name-separator"`
+	IgnoreUnnamed    bool          `toml:"ignore-unnamed"`
 	BatchSize        int           `toml:"batch-size"`
 	BatchTimeout     toml.Duration `toml:"batch-timeout"`
 	ConsistencyLevel string        `toml:"consistency-level"`
@@ -45,15 +48,11 @@ func NewConfig() Config {
 		BindAddress:      DefaultBindAddress,
 		Database:         DefaultDatabase,
 		Protocol:         DefaultProtocol,
-		NamePosition:     DefaultNamePosition,
+		NameSchema:       DefaultNameSchema,
 		NameSeparator:    DefaultNameSeparator,
+		IgnoreUnnamed:    DefaultIgnoreUnnamed,
 		ConsistencyLevel: DefaultConsistencyLevel,
 	}
-}
-
-// LastEnabled returns whether the server should interpret the last field as "name".
-func (c *Config) LastEnabled() bool {
-	return c.NamePosition == strings.ToLower("last")
 }
 
 // WithDefaults takes the given config and returns a new config with any required
@@ -69,8 +68,8 @@ func (c *Config) WithDefaults() *Config {
 	if d.Protocol == "" {
 		d.Protocol = DefaultProtocol
 	}
-	if d.NamePosition == "" {
-		d.NamePosition = DefaultNamePosition
+	if d.NameSchema == "" {
+		d.NameSchema = DefaultNameSchema
 	}
 	if d.NameSeparator == "" {
 		d.NameSeparator = DefaultNameSeparator

--- a/services/graphite/config_test.go
+++ b/services/graphite/config_test.go
@@ -16,7 +16,8 @@ bind-address = ":8080"
 database = "mydb"
 enabled = true
 protocol = "tcp"
-name-position = "first"
+name-schema= "measurement"
+ignore-unnamed = true
 name-separator = "."
 batch-size=100
 batch-timeout="1s"
@@ -34,8 +35,10 @@ consistency-level="one"
 		t.Fatalf("unexpected graphite enabled: %v", c.Enabled)
 	} else if c.Protocol != "tcp" {
 		t.Fatalf("unexpected graphite protocol: %s", c.Protocol)
-	} else if c.NamePosition != "first" {
-		t.Fatalf("unexpected graphite name position: %s", c.NamePosition)
+	} else if c.NameSchema != "measurement" {
+		t.Fatalf("unexpected graphite name schema: %s", c.NameSchema)
+	} else if c.IgnoreUnnamed != true {
+		t.Fatalf("unexpected ignore-unnamed: %v", c.IgnoreUnnamed)
 	} else if c.NameSeparator != "." {
 		t.Fatalf("unexpected graphite name separator: %s", c.NameSeparator)
 	} else if c.BatchSize != 100 {


### PR DESCRIPTION
Related to the discussion of #2102.
Users could specify a `name-schema` for influxdb to parse graphite metric names into key-valued point.
e.g.
`prefix.host.name.measure.device` will parse `server.localhost.cpu.irq.cpu0` as
```
 {
     name: "cpu",
     tags: {
         "type": "server",
         "host": "localhost,
         "measure": "irq",
         "device": "cpu0"
     }
 }
```
