### PR TITLE
Don't continually re-request shard group creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [#2557](https://github.com/influxdb/influxdb/issues/2557): Fix false positive error with `GROUP BY time`
 
 ### Bugfixes
+- [#2545](https://github.com/influxdb/influxdb/pull/2545): Don't continually re-request shard group creation.
 - [#2545](https://github.com/influxdb/influxdb/pull/2545): Use "value" as the field name for graphite input. Thanks @cannium.
 - [#2558](https://github.com/influxdb/influxdb/pull/2558): Fix client response check - thanks @vladlopes!
 - [#2566](https://github.com/influxdb/influxdb/pull/2566): Wait until each data write has been commited by the Raft cluster.

--- a/server.go
+++ b/server.go
@@ -2067,6 +2067,11 @@ func (s *Server) createShardGroupsIfNotExists(database, retentionPolicy string, 
 		// Local function makes locking fool-proof.
 		s.mu.RLock()
 		defer s.mu.RUnlock()
+		rp, err := s.RetentionPolicy(database, retentionPolicy)
+		if err != nil {
+			return err
+		}
+
 		for _, p := range points {
 			// Check if shard group exists first.
 			g, err := s.shardGroupByTimestamp(database, retentionPolicy, p.Time)
@@ -2075,10 +2080,27 @@ func (s *Server) createShardGroupsIfNotExists(database, retentionPolicy string, 
 			} else if g != nil {
 				continue
 			}
+
+			// Only add the command if the equivalent command has not already been added. Point timestamp
+			// always result in shard groups with a starting time truncated to the nearest previous day.
+			sgRequested := false
+			for _, c := range commands {
+				if c.Database == database &&
+					c.Policy == retentionPolicy &&
+					c.Time == p.Time.Truncate(rp.Duration).UTC() {
+					sgRequested = true
+					break
+				}
+			}
+			if sgRequested {
+				continue
+			}
+
+			// Create shard-groups has not been already requested, so do it.
 			commands = append(commands, &createShardGroupIfNotExistsCommand{
 				Database: database,
 				Policy:   retentionPolicy,
-				Time:     p.Time,
+				Time:     p.Time.Truncate(rp.Duration).UTC(),
 			})
 		}
 		return nil


### PR DESCRIPTION
If a point in a batch triggers shard creation, many other points in that
batch may too. Don't continually re-request the same shard group to be
created.