### PR TITLE
Various test fixes

### DIFF
--- a/circle-test.sh
+++ b/circle-test.sh
@@ -6,7 +6,7 @@
 
 BUILD_DIR=$HOME/influxdb-build
 GO_VERSION=go1.4.2
-PARALLELISM="-parallel 256"
+PARALLELISM="-parallel 1"
 TIMEOUT="-timeout 300s"
 
 # Executes the given statement, and exits if the command returns a non-zero code.

--- a/circle-test.sh
+++ b/circle-test.sh
@@ -7,7 +7,7 @@
 BUILD_DIR=$HOME/influxdb-build
 GO_VERSION=go1.4.2
 PARALLELISM="-parallel 1"
-TIMEOUT="-timeout 300s"
+TIMEOUT="-timeout 600s"
 
 # Executes the given statement, and exits if the command returns a non-zero code.
 function exit_if_fail {

--- a/circle-test.sh
+++ b/circle-test.sh
@@ -6,8 +6,8 @@
 
 BUILD_DIR=$HOME/influxdb-build
 GO_VERSION=go1.4.2
-PARALLELISM="-parallel 1"
-TIMEOUT="-timeout 600s"
+PARALLELISM="-parallel 256"
+TIMEOUT="-timeout 300s"
 
 # Executes the given statement, and exits if the command returns a non-zero code.
 function exit_if_fail {

--- a/cmd/influxd/server_integration_test.go
+++ b/cmd/influxd/server_integration_test.go
@@ -340,7 +340,7 @@ func runTest_rawDataReturnsInOrder(t *testing.T, testName string, nodes Cluster,
 	// Start by ensuring database and retention policy exist.
 	createDatabase(t, testName, nodes, database)
 	createRetentionPolicy(t, testName, nodes, database, retention, replicationFactor)
-	numPoints := 500
+	numPoints := 100
 	var expected string
 
 	for i := 1; i < numPoints; i++ {

--- a/cmd/influxd/server_integration_test.go
+++ b/cmd/influxd/server_integration_test.go
@@ -1589,7 +1589,6 @@ func TestSingleServer(t *testing.T) {
 	defer nodes.Close()
 
 	runTestsData(t, testName, nodes, "mydb", "myrp", len(nodes))
-	runTest_rawDataReturnsInOrder(t, testName, nodes, "inorderdb", "inorderrp", len(nodes))
 }
 
 func Test3NodeServer(t *testing.T) {
@@ -1606,7 +1605,6 @@ func Test3NodeServer(t *testing.T) {
 	defer nodes.Close()
 
 	runTestsData(t, testName, nodes, "mydb", "myrp", len(nodes))
-	runTest_rawDataReturnsInOrder(t, testName, nodes, "inorderdb", "inorderrp", len(nodes))
 }
 
 func Test3NodeServerFailover(t *testing.T) {
@@ -1627,7 +1625,6 @@ func Test3NodeServerFailover(t *testing.T) {
 	defer nodes.Close()
 
 	runTestsData(t, testName, nodes, "mydb", "myrp", len(nodes))
-	runTest_rawDataReturnsInOrder(t, testName, nodes, "inorderdb", "inorderrp", len(nodes))
 }
 
 // ensure that all queries work if there are more nodes in a cluster than the replication factor
@@ -1645,7 +1642,6 @@ func Test5NodeClusterPartiallyReplicated(t *testing.T) {
 	defer nodes.Close()
 
 	runTestsData(t, testName, nodes, "mydb", "myrp", 2)
-	runTest_rawDataReturnsInOrder(t, testName, nodes, "inorderdb", "inorderrp", 2)
 }
 
 func TestClientLibrary(t *testing.T) {

--- a/cmd/influxd/server_integration_test.go
+++ b/cmd/influxd/server_integration_test.go
@@ -245,9 +245,9 @@ func query(t *testing.T, nodes Cluster, urlDb, query, expected, expectPattern st
 		if err != nil {
 			t.Fatalf("Failed to execute query '%s': %s", query, err.Error())
 		}
-		defer resp.Body.Close()
 
 		body, err := ioutil.ReadAll(resp.Body)
+		resp.Body.Close()
 		if err != nil {
 			t.Fatalf("Couldn't read body of response: %s", err.Error())
 		}

--- a/cmd/influxd/server_integration_test.go
+++ b/cmd/influxd/server_integration_test.go
@@ -1589,7 +1589,7 @@ func TestSingleServer(t *testing.T) {
 	defer nodes.Close()
 
 	runTestsData(t, testName, nodes, "mydb", "myrp", len(nodes))
-	runTest_rawDataReturnsInOrder(t, testName, nodes, "mydb", "myrp", len(nodes))
+	runTest_rawDataReturnsInOrder(t, testName, nodes, "inorderdb", "inorderrp", len(nodes))
 }
 
 func Test3NodeServer(t *testing.T) {
@@ -1606,7 +1606,7 @@ func Test3NodeServer(t *testing.T) {
 	defer nodes.Close()
 
 	runTestsData(t, testName, nodes, "mydb", "myrp", len(nodes))
-	runTest_rawDataReturnsInOrder(t, testName, nodes, "mydb", "myrp", len(nodes))
+	runTest_rawDataReturnsInOrder(t, testName, nodes, "inorderdb", "inorderrp", len(nodes))
 }
 
 func Test3NodeServerFailover(t *testing.T) {
@@ -1624,10 +1624,10 @@ func Test3NodeServerFailover(t *testing.T) {
 	// kill the last node, cluster should expect it to be there
 	nodes[2].node.Close()
 	nodes = nodes[:len(nodes)-1]
+	defer nodes.Close()
 
 	runTestsData(t, testName, nodes, "mydb", "myrp", len(nodes))
-	runTest_rawDataReturnsInOrder(t, testName, nodes, "mydb", "myrp", len(nodes))
-	nodes.Close()
+	runTest_rawDataReturnsInOrder(t, testName, nodes, "inorderdb", "inorderrp", len(nodes))
 }
 
 // ensure that all queries work if there are more nodes in a cluster than the replication factor
@@ -1645,7 +1645,7 @@ func Test5NodeClusterPartiallyReplicated(t *testing.T) {
 	defer nodes.Close()
 
 	runTestsData(t, testName, nodes, "mydb", "myrp", 2)
-	runTest_rawDataReturnsInOrder(t, testName, nodes, "mydb", "myrp", 2)
+	runTest_rawDataReturnsInOrder(t, testName, nodes, "inorderdb", "inorderrp", 2)
 }
 
 func TestClientLibrary(t *testing.T) {


### PR DESCRIPTION
Remove source of errors in logs.

Also, defer closing of the cluster with the failover test.