### PR TITLE
Fix shard group creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - [#2558](https://github.com/influxdb/influxdb/pull/2558): Fix client response check - thanks @vladlopes!
 - [#2566](https://github.com/influxdb/influxdb/pull/2566): Wait until each data write has been commited by the Raft cluster.
 - [#2602](https://github.com/influxdb/influxdb/pull/2602): CLI execute command exits without cleaning up liner package.
+- [#2610](https://github.com/influxdb/influxdb/pull/2610): Fix shard group creation
 
 ## PRs
 - [#2569](https://github.com/influxdb/influxdb/pull/2569): Add derivative functions

--- a/database.go
+++ b/database.go
@@ -1160,7 +1160,7 @@ func NewRetentionPolicy(name string) *RetentionPolicy {
 // Returns nil group does not exist.
 func (rp *RetentionPolicy) shardGroupByTimestamp(timestamp time.Time) *ShardGroup {
 	for _, g := range rp.shardGroups {
-		if timeBetweenInclusive(timestamp, g.StartTime, g.EndTime) {
+		if (g.StartTime.Before(timestamp) || g.StartTime.Equal(timestamp)) && g.EndTime.After(timestamp) {
 			return g
 		}
 	}

--- a/database.go
+++ b/database.go
@@ -1160,7 +1160,7 @@ func NewRetentionPolicy(name string) *RetentionPolicy {
 // Returns nil group does not exist.
 func (rp *RetentionPolicy) shardGroupByTimestamp(timestamp time.Time) *ShardGroup {
 	for _, g := range rp.shardGroups {
-		if (g.StartTime.Before(timestamp) || g.StartTime.Equal(timestamp)) && g.EndTime.After(timestamp) {
+		if g.Contains(timestamp) {
 			return g
 		}
 	}
@@ -1405,11 +1405,6 @@ func marshalTags(tags map[string]string) []byte {
 		}
 	}
 	return b
-}
-
-// timeBetweenInclusive returns true if t is between min and max, inclusive.
-func timeBetweenInclusive(t, min, max time.Time) bool {
-	return (t.Equal(min) || t.After(min)) && (t.Equal(max) || t.Before(max))
 }
 
 // measurementsByExpr takes and expression containing only tags and returns

--- a/internal_test.go
+++ b/internal_test.go
@@ -269,46 +269,55 @@ func Test_seriesIDs_reject(t *testing.T) {
 }
 
 // Test shard group selection.
-func TestShardGroup_Contains(t *testing.T) {
+func TestShardGroup_Overlaps(t *testing.T) {
 	// Make a shard group 1 hour in duration
 	tm, _ := time.Parse(time.RFC3339, "2000-01-01T00:00:00Z")
 	g := newShardGroup(tm, time.Hour)
 
-	if !g.Contains(g.StartTime.Add(-time.Minute), g.EndTime) {
+	if !g.Overlaps(g.StartTime.Add(-time.Minute), g.EndTime) {
 		t.Fatal("shard group not selected when min before start time")
 	}
 
-	if !g.Contains(g.StartTime, g.EndTime.Add(time.Minute)) {
+	if !g.Overlaps(g.StartTime.Add(-time.Minute), g.StartTime) {
+		t.Fatal("shard group not selected when min before start time and max equals start time")
+	}
+
+	if !g.Overlaps(g.StartTime, g.EndTime.Add(time.Minute)) {
 		t.Fatal("shard group not selected when max after after end time")
 	}
 
-	if !g.Contains(g.StartTime.Add(-time.Minute), g.EndTime.Add(time.Minute)) {
+	if !g.Overlaps(g.StartTime.Add(-time.Minute), g.EndTime.Add(time.Minute)) {
 		t.Fatal("shard group not selected when min before start time and when max after end time")
 	}
 
-	if !g.Contains(g.StartTime.Add(time.Minute), g.EndTime.Add(-time.Minute)) {
+	if !g.Overlaps(g.StartTime.Add(time.Minute), g.EndTime.Add(-time.Minute)) {
 		t.Fatal("shard group not selected when min after start time and when max before end time")
 	}
 
-	if !g.Contains(g.StartTime, g.EndTime) {
+	if !g.Overlaps(g.StartTime, g.EndTime) {
 		t.Fatal("shard group not selected when min at start time and when max at end time")
 	}
 
-	if !g.Contains(g.StartTime, g.StartTime) {
+	if !g.Overlaps(g.StartTime, g.StartTime) {
 		t.Fatal("shard group not selected when min and max set to start time")
 	}
 
-	if !g.Contains(g.EndTime, g.EndTime) {
-		t.Fatal("shard group not selected when min and max set to end time")
+	if !g.Overlaps(g.StartTime.Add(1*time.Minute), g.EndTime.Add(24*time.Hour)) {
+		t.Fatal("shard group selected when both min in range")
 	}
 
-	if g.Contains(g.StartTime.Add(-10*time.Hour), g.EndTime.Add(-9*time.Hour)) {
+	if g.Overlaps(g.EndTime, g.EndTime) {
+		t.Fatal("shard group selected when min and max set to end time")
+	}
+
+	if g.Overlaps(g.StartTime.Add(-10*time.Hour), g.EndTime.Add(-9*time.Hour)) {
 		t.Fatal("shard group selected when both min and max before shard times")
 	}
 
-	if g.Contains(g.StartTime.Add(24*time.Hour), g.EndTime.Add(25*time.Hour)) {
+	if g.Overlaps(g.StartTime.Add(24*time.Hour), g.EndTime.Add(25*time.Hour)) {
 		t.Fatal("shard group selected when both min and max after shard times")
 	}
+
 }
 
 // Ensure tags can be marshaled into a byte slice.

--- a/shard.go
+++ b/shard.go
@@ -84,11 +84,14 @@ func (sg *ShardGroup) ShardBySeriesID(seriesID uint64) *Shard {
 // Duration returns the duration between the shard group's start and end time.
 func (sg *ShardGroup) Duration() time.Duration { return sg.EndTime.Sub(sg.StartTime) }
 
-// Contains return whether the shard group contains data for the time between min and max
-func (sg *ShardGroup) Contains(min, max time.Time) bool {
-	return timeBetweenInclusive(sg.StartTime, min, max) ||
-		timeBetweenInclusive(sg.EndTime, min, max) ||
-		(sg.StartTime.Before(min) && sg.EndTime.After(max))
+// Contains return whether the shard group contains data for the timestamp
+func (sg *ShardGroup) Contains(timestamp time.Time) bool {
+	return !sg.StartTime.After(timestamp) && sg.EndTime.After(timestamp)
+}
+
+// Overlaps return whether the shard group contains data for the time range between min and max
+func (sg *ShardGroup) Overlaps(min, max time.Time) bool {
+	return !sg.StartTime.After(max) && sg.EndTime.After(min)
 }
 
 // dropSeries will delete all data with the seriesID

--- a/tx.go
+++ b/tx.go
@@ -127,7 +127,7 @@ func (tx *tx) CreateMapReduceJobs(stmt *influxql.SelectStatement, tagKeys []stri
 		// Find shard groups within time range.
 		var shardGroups []*ShardGroup
 		for _, group := range rp.shardGroups {
-			if group.Contains(tmin, tmax) {
+			if group.Overlaps(tmin, tmax) {
 				shardGroups = append(shardGroups, group)
 			}
 		}


### PR DESCRIPTION
This PR fixes two issues with shard group creation.

The first is that a shard group creating request was sent for every point which can cause large pauses when a new shard group needs to be created and sending large batches.

The second is that the shard group end time was being include in the point calculation which allow a point to be included in two shard group ranges if it matched the end time of a shard group.