### PR TITLE
implement remove peer methods 

### DIFF
--- a/raft/handler_test.go
+++ b/raft/handler_test.go
@@ -86,7 +86,7 @@ func TestHandler_HandleLeave(t *testing.T) {
 	s := httptest.NewServer(h)
 	defer s.Close()
 
-	// Send request to join cluster.
+	// Send request to leave cluster.
 	resp, err := http.Get(s.URL + "/leave?id=1")
 	defer resp.Body.Close()
 	if err != nil {


### PR DESCRIPTION
RemovePeer adds a peer removal log entry and waits for it to be applied by mustApplyRemovePeer, which does the actual removal of a node from the cluster configuration.

compare:
mustApplyRemovePeer <-> mustApplyAddPeer(already implemented)
RemovePeer <-> AddPeer(already implemented)

more specifics are in @benbjohnson's TODO comments that this overwrites