### PR TITLE
Update SELECT * to return tag values

### DIFF
--- a/cmd/influxd/server_integration_test.go
+++ b/cmd/influxd/server_integration_test.go
@@ -1639,7 +1639,7 @@ func runTestsData(t *testing.T, testName string, nodes Cluster, database, retent
 				urlDb = tt.queryDb
 			}
 			qry := rewriteDbRp(tt.query, database, retention)
-			got, ok, nOK := queryAndWait(t, qNodes, rewriteDbRp(urlDb, database, retention), qry, rewriteDbRp(tt.expected, database, retention), rewriteDbRp(tt.expectPattern, database, retention), 200*time.Millisecond)
+			got, ok, nOK := queryAndWait(t, qNodes, rewriteDbRp(urlDb, database, retention), qry, rewriteDbRp(tt.expected, database, retention), rewriteDbRp(tt.expectPattern, database, retention), 30*time.Second)
 			if !ok {
 				if tt.expected != "" {
 					t.Fatalf("Test #%d: \"%s:%s\" failed\n  query: %s\n  exp: %s\n  got: %s\n%d nodes responded correctly", i, testName, name, qry, rewriteDbRp(tt.expected, database, retention), got, nOK)

--- a/cmd/influxd/server_integration_test.go
+++ b/cmd/influxd/server_integration_test.go
@@ -436,7 +436,7 @@ func runTestsData(t *testing.T, testName string, nodes Cluster, database, retent
 			name:     "single point with time",
 			write:    `{"database" : "%DB%", "retentionPolicy" : "%RP%", "points": [{"name": "cpu", "time": "2015-02-28T01:03:36.703820946Z", "tags": {"host": "server01"}, "fields": {"value": 100}}]}`,
 			query:    `SELECT * FROM "%DB%"."%RP%".cpu`,
-			expected: `{"results":[{"series":[{"name":"cpu","columns":["time","value"],"values":[["2015-02-28T01:03:36.703820946Z",100]]}]}]}`,
+			expected: `{"results":[{"series":[{"name":"cpu","tags":{"host":"server01"},"columns":["time","value"],"values":[["2015-02-28T01:03:36.703820946Z",100]]}]}]}`,
 		},
 		{
 			name:     "single point count query with time",
@@ -447,18 +447,18 @@ func runTestsData(t *testing.T, testName string, nodes Cluster, database, retent
 			name:     "single string point with time",
 			write:    `{"database" : "%DB%", "retentionPolicy" : "%RP%", "points": [{"name": "logs", "time": "2015-02-28T01:03:36.703820946Z", "tags": {"host": "server01"}, "fields": {"value": "disk full"}}]}`,
 			query:    `SELECT * FROM "%DB%"."%RP%".logs`,
-			expected: `{"results":[{"series":[{"name":"logs","columns":["time","value"],"values":[["2015-02-28T01:03:36.703820946Z","disk full"]]}]}]}`,
+			expected: `{"results":[{"series":[{"name":"logs","tags":{"host":"server01"},"columns":["time","value"],"values":[["2015-02-28T01:03:36.703820946Z","disk full"]]}]}]}`,
 		},
 		{
 			name:     "single bool point with time",
 			write:    `{"database" : "%DB%", "retentionPolicy" : "%RP%", "points": [{"name": "status", "time": "2015-02-28T01:03:36.703820946Z", "tags": {"host": "server01"}, "fields": {"value": "true"}}]}`,
 			query:    `SELECT * FROM "%DB%"."%RP%".status`,
-			expected: `{"results":[{"series":[{"name":"status","columns":["time","value"],"values":[["2015-02-28T01:03:36.703820946Z","true"]]}]}]}`,
+			expected: `{"results":[{"series":[{"name":"status","tags":{"host":"server01"},"columns":["time","value"],"values":[["2015-02-28T01:03:36.703820946Z","true"]]}]}]}`,
 		},
 		{
 			name:     "single point, select with now()",
 			query:    `SELECT * FROM "%DB%"."%RP%".cpu WHERE time < NOW()`,
-			expected: `{"results":[{"series":[{"name":"cpu","columns":["time","value"],"values":[["2015-02-28T01:03:36.703820946Z",100]]}]}]}`,
+			expected: `{"results":[{"series":[{"name":"cpu","tags":{"host":"server01"},"columns":["time","value"],"values":[["2015-02-28T01:03:36.703820946Z",100]]}]}]}`,
 		},
 
 		// Selecting tags
@@ -477,6 +477,11 @@ func runTestsData(t *testing.T, testName string, nodes Cluster, database, retent
 			name:     "selecting a tag and two fields",
 			query:    `SELECT host, value, cores FROM "%DB%"."%RP%".gpu`,
 			expected: `{"results":[{"series":[{"name":"gpu","tags":{"host":"server01"},"columns":["time","value","cores"],"values":[["2015-02-28T01:03:36Z",100,4]]},{"name":"gpu","tags":{"host":"server02"},"columns":["time","value","cores"],"values":[["2015-02-28T01:03:37Z",50,2]]}]}]}`,
+		},
+		{
+			name:     "selecting * from a measurement with tags",
+			query:    `SELECT * FROM "%DB%"."%RP%".gpu`,
+			expected: `{"results":[{"series":[{"name":"gpu","tags":{"host":"server01"},"columns":["time","cores","value"],"values":[["2015-02-28T01:03:36Z",4,100]]},{"name":"gpu","tags":{"host":"server02"},"columns":["time","cores","value"],"values":[["2015-02-28T01:03:37Z",2,50]]}]}]}`,
 		},
 
 		{
@@ -522,14 +527,14 @@ func runTestsData(t *testing.T, testName string, nodes Cluster, database, retent
 			name:     "single point with time pre-calculated for past time queries yesterday",
 			write:    `{"database" : "%DB%", "retentionPolicy" : "%RP%", "points": [{"name": "cpu", "time": "` + yesterday.Format(time.RFC3339Nano) + `", "tags": {"host": "server01"}, "fields": {"value": 100}}]}`,
 			query:    `SELECT * FROM "%DB%"."%RP%".cpu where time >= '` + yesterday.Add(-1*time.Minute).Format(time.RFC3339Nano) + `'`,
-			expected: fmt.Sprintf(`{"results":[{"series":[{"name":"cpu","columns":["time","value"],"values":[["%s",100]]}]}]}`, yesterday.Format(time.RFC3339Nano)),
+			expected: fmt.Sprintf(`{"results":[{"series":[{"name":"cpu","tags":{"host":"server01"},"columns":["time","value"],"values":[["%s",100]]}]}]}`, yesterday.Format(time.RFC3339Nano)),
 		},
 		{
 			reset:    true,
 			name:     "single point with time pre-calculated for relative time queries now",
 			write:    `{"database" : "%DB%", "retentionPolicy" : "%RP%", "points": [{"name": "cpu", "time": "` + now.Format(time.RFC3339Nano) + `", "tags": {"host": "server01"}, "fields": {"value": 100}}]}`,
 			query:    `SELECT * FROM "%DB%"."%RP%".cpu where time >= now() - 1m`,
-			expected: fmt.Sprintf(`{"results":[{"series":[{"name":"cpu","columns":["time","value"],"values":[["%s",100]]}]}]}`, now.Format(time.RFC3339Nano)),
+			expected: fmt.Sprintf(`{"results":[{"series":[{"name":"cpu","tags":{"host":"server01"},"columns":["time","value"],"values":[["%s",100]]}]}]}`, now.Format(time.RFC3339Nano)),
 		},
 
 		// Merge tests.
@@ -599,25 +604,25 @@ func runTestsData(t *testing.T, testName string, nodes Cluster, database, retent
 			]}`,
 			query:    `SELECT * FROM /cpu[13]/`,
 			queryDb:  "%DB%",
-			expected: `{"results":[{"series":[{"name":"cpu1","columns":["time","value"],"values":[["2015-02-28T01:03:36.703820946Z",10]]},{"name":"cpu3","columns":["time","value"],"values":[["2015-02-28T01:03:36.703820946Z",30]]}]}]}`,
+			expected: `{"results":[{"series":[{"name":"cpu1","tags":{"host":"server01"},"columns":["time","value"],"values":[["2015-02-28T01:03:36.703820946Z",10]]},{"name":"cpu3","tags":{"host":"server01"},"columns":["time","value"],"values":[["2015-02-28T01:03:36.703820946Z",30]]}]}]}`,
 		},
 		{
 			name:     `FROM regex specifying db and rp`,
 			query:    `SELECT * FROM "%DB%"."%RP%"./cpu[13]/`,
 			queryDb:  "%DB%",
-			expected: `{"results":[{"series":[{"name":"cpu1","columns":["time","value"],"values":[["2015-02-28T01:03:36.703820946Z",10]]},{"name":"cpu3","columns":["time","value"],"values":[["2015-02-28T01:03:36.703820946Z",30]]}]}]}`,
+			expected: `{"results":[{"series":[{"name":"cpu1","tags":{"host":"server01"},"columns":["time","value"],"values":[["2015-02-28T01:03:36.703820946Z",10]]},{"name":"cpu3","tags":{"host":"server01"},"columns":["time","value"],"values":[["2015-02-28T01:03:36.703820946Z",30]]}]}]}`,
 		},
 		{
 			name:     `FROM regex using specified db and default rp`,
 			query:    `SELECT * FROM "%DB%"../cpu[13]/`,
 			queryDb:  "%DB%",
-			expected: `{"results":[{"series":[{"name":"cpu1","columns":["time","value"],"values":[["2015-02-28T01:03:36.703820946Z",10]]},{"name":"cpu3","columns":["time","value"],"values":[["2015-02-28T01:03:36.703820946Z",30]]}]}]}`,
+			expected: `{"results":[{"series":[{"name":"cpu1","tags":{"host":"server01"},"columns":["time","value"],"values":[["2015-02-28T01:03:36.703820946Z",10]]},{"name":"cpu3","tags":{"host":"server01"},"columns":["time","value"],"values":[["2015-02-28T01:03:36.703820946Z",30]]}]}]}`,
 		},
 		{
 			name:     `FROM regex using default db and specified rp`,
 			query:    `SELECT * FROM "%RP%"./cpu[13]/`,
 			queryDb:  "%DB%",
-			expected: `{"results":[{"series":[{"name":"cpu1","columns":["time","value"],"values":[["2015-02-28T01:03:36.703820946Z",10]]},{"name":"cpu3","columns":["time","value"],"values":[["2015-02-28T01:03:36.703820946Z",30]]}]}]}`,
+			expected: `{"results":[{"series":[{"name":"cpu1","tags":{"host":"server01"},"columns":["time","value"],"values":[["2015-02-28T01:03:36.703820946Z",10]]},{"name":"cpu3","tags":{"host":"server01"},"columns":["time","value"],"values":[["2015-02-28T01:03:36.703820946Z",30]]}]}]}`,
 		},
 
 		// Aggregations
@@ -885,7 +890,7 @@ func runTestsData(t *testing.T, testName string, nodes Cluster, database, retent
 			]}`,
 			query:    `SELECT * FROM cpu`,
 			queryDb:  "%DB%",
-			expected: `{"results":[{"series":[{"name":"cpu","columns":["time","val-x","value"],"values":[["2000-01-01T00:00:00Z",null,10],["2000-01-01T00:00:10Z",20,null],["2000-01-01T00:00:20Z",40,30]]}]}]}`,
+			expected: `{"results":[{"series":[{"name":"cpu","tags":{"region":"us-east"},"columns":["time","val-x","value"],"values":[["2000-01-01T00:00:00Z",null,10],["2000-01-01T00:00:10Z",20,null],["2000-01-01T00:00:20Z",40,30]]}]}]}`,
 		},
 		{
 			reset: true,
@@ -1634,7 +1639,7 @@ func runTestsData(t *testing.T, testName string, nodes Cluster, database, retent
 				urlDb = tt.queryDb
 			}
 			qry := rewriteDbRp(tt.query, database, retention)
-			got, ok, nOK := queryAndWait(t, qNodes, rewriteDbRp(urlDb, database, retention), qry, rewriteDbRp(tt.expected, database, retention), rewriteDbRp(tt.expectPattern, database, retention), 30*time.Second)
+			got, ok, nOK := queryAndWait(t, qNodes, rewriteDbRp(urlDb, database, retention), qry, rewriteDbRp(tt.expected, database, retention), rewriteDbRp(tt.expectPattern, database, retention), 200*time.Millisecond)
 			if !ok {
 				if tt.expected != "" {
 					t.Fatalf("Test #%d: \"%s:%s\" failed\n  query: %s\n  exp: %s\n  got: %s\n%d nodes responded correctly", i, testName, name, qry, rewriteDbRp(tt.expected, database, retention), got, nOK)

--- a/cmd/influxd/server_integration_test.go
+++ b/cmd/influxd/server_integration_test.go
@@ -2232,7 +2232,7 @@ func Test_ServerOpenTSDBIntegration_WithTags(t *testing.T) {
 		return
 	}
 
-	expected := fmt.Sprintf(`{"results":[{"series":[{"name":"cpu","columns":["time","value"],"values":[["%s",20]]}]}]}`, now.Format(time.RFC3339Nano))
+	expected := fmt.Sprintf(`{"results":[{"series":[{"name":"cpu","tags":{"tag1":"val3","tag2":"val4"},"columns":["time","value"],"values":[["%s",20]]}]}]}`, now.Format(time.RFC3339Nano))
 
 	// query and wait for results
 	got, ok, _ := queryAndWait(t, nodes, "opentsdb", `select * from "opentsdb"."raw".cpu where tag1='val3'`, expected, "", openTSDBTestTimeout)
@@ -2289,7 +2289,7 @@ func Test_ServerOpenTSDBIntegration_BadData(t *testing.T) {
 		return
 	}
 
-	expected := fmt.Sprintf(`{"results":[{"series":[{"name":"cpu","columns":["time","value"],"values":[["%s",10]]}]}]}`, now.Format(time.RFC3339Nano))
+	expected := fmt.Sprintf(`{"results":[{"series":[{"name":"cpu","tags":{"tag1":"val1","tag2":"val2"},"columns":["time","value"],"values":[["%s",10]]}]}]}`, now.Format(time.RFC3339Nano))
 
 	// query and wait for results
 	got, ok, _ := queryAndWait(t, nodes, "opentsdb", `select * from "opentsdb"."raw".cpu`, expected, "", openTSDBTestTimeout)
@@ -2335,7 +2335,7 @@ func Test_ServerOpenTSDBIntegrationHTTPSingle(t *testing.T) {
 	}
 	resp.Body.Close()
 
-	expected := fmt.Sprintf(`{"results":[{"series":[{"name":"cpu","columns":["time","value"],"values":[["%s",10]]}]}]}`, now.Format(time.RFC3339Nano))
+	expected := fmt.Sprintf(`{"results":[{"series":[{"name":"cpu","tags":{"tag1":"val1","tag2":"val2"},"columns":["time","value"],"values":[["%s",10]]}]}]}`, now.Format(time.RFC3339Nano))
 
 	// query and wait for results
 	got, ok, _ := queryAndWait(t, nodes, "opentsdb", `select * from "opentsdb"."raw".cpu`, expected, "", openTSDBTestTimeout)
@@ -2383,7 +2383,7 @@ func Test_ServerOpenTSDBIntegrationHTTPMulti(t *testing.T) {
 	resp.Body.Close()
 
 	expts := now.Format(time.RFC3339Nano)
-	expected := fmt.Sprintf(`{"results":[{"series":[{"name":"cpu","columns":["time","value"],"values":[["%s",10],["%s",20]]}]}]}`, expts, expts)
+	expected := fmt.Sprintf(`{"results":[{"series":[{"name":"cpu","tags":{"tag1":"val1","tag2":"val2"},"columns":["time","value"],"values":[["%s",10]]},{"name":"cpu","tags":{"tag1":"val3","tag2":"val4"},"columns":["time","value"],"values":[["%s",20]]}]}]}`, expts, expts)
 
 	// query and wait for results
 	got, ok, _ := queryAndWait(t, nodes, "opentsdb", `select * from "opentsdb"."raw".cpu`, expected, "", openTSDBTestTimeout)

--- a/httpd/handler_test.go
+++ b/httpd/handler_test.go
@@ -1542,14 +1542,14 @@ func TestHandler_serveWriteSeriesBatch(t *testing.T) {
 		t.Fatalf("unexpected results count")
 	}
 	result := r.Results[0]
-	if len(result.Series) != 1 {
-		t.Fatalf("unexpected row count, expected: %d, actual: %d", 1, len(result.Series))
+	if len(result.Series) != 2 {
+		t.Fatalf("unexpected row count, expected: %d, actual: %d", 2, len(result.Series))
 	}
 	if len(result.Series[0].Columns) != 3 {
 		t.Fatalf("unexpected column count, expected: %d, actual: %d", 3, len(result.Series[0].Columns))
 	}
-	if len(result.Series[0].Values) != 3 {
-		t.Fatalf("unexpected values count, expected: %d, actual: %d", 3, len(result.Series[0].Values))
+	if len(result.Series[0].Values) != 2 {
+		t.Fatalf("unexpected values count, expected: %d, actual: %d", 2, len(result.Series[0].Values))
 	}
 }
 

--- a/influxql/ast.go
+++ b/influxql/ast.go
@@ -737,6 +737,7 @@ func cloneSource(s Source) Source {
 // with the supplied dimensions.
 func (s *SelectStatement) RewriteWildcards(fields Fields, dimensions Dimensions) *SelectStatement {
 	other := s.Clone()
+	selectWildcard, groupWildcard := false, false
 
 	// Rewrite all wildcard query fields
 	rwFields := make(Fields, 0, len(s.Fields))
@@ -746,6 +747,7 @@ func (s *SelectStatement) RewriteWildcards(fields Fields, dimensions Dimensions)
 			// Sort wildcard fields for consistent output
 			sort.Sort(fields)
 			rwFields = append(rwFields, fields...)
+			selectWildcard = true
 		default:
 			rwFields = append(rwFields, f)
 		}
@@ -758,9 +760,14 @@ func (s *SelectStatement) RewriteWildcards(fields Fields, dimensions Dimensions)
 		switch d.Expr.(type) {
 		case *Wildcard:
 			rwDimensions = append(rwDimensions, dimensions...)
+			groupWildcard = true
 		default:
 			rwDimensions = append(rwDimensions, d)
 		}
+	}
+
+	if selectWildcard && !groupWildcard {
+		rwDimensions = append(rwDimensions, dimensions...)
 	}
 	other.Dimensions = rwDimensions
 

--- a/influxql/ast_test.go
+++ b/influxql/ast_test.go
@@ -333,7 +333,7 @@ func TestSelectStatement_RewriteWildcards(t *testing.T) {
 		// Query wildcard
 		{
 			stmt:    `SELECT * FROM cpu`,
-			rewrite: `SELECT value1, value2 FROM cpu`,
+			rewrite: `SELECT value1, value2 FROM cpu GROUP BY host, region`,
 		},
 
 		// Parser fundamentally prohibits multiple query sources

--- a/server_test.go
+++ b/server_test.go
@@ -1282,7 +1282,7 @@ func TestServer_DropSeriesTagsPreserved(t *testing.T) {
 		t.Fatalf("unexpected error: %s", res.Err)
 	} else if len(res.Series) != 1 {
 		t.Fatalf("unexpected row count: %d", len(res.Series))
-	} else if s := mustMarshalJSON(res); s != `{"series":[{"name":"cpu","columns":["time","value"],"values":[["2000-01-01T00:00:01Z",33.2]]}]}` {
+	} else if s := mustMarshalJSON(res); s != `{"series":[{"name":"cpu","tags":{"host":"serverB","region":"uswest"},"columns":["time","value"],"values":[["2000-01-01T00:00:01Z",33.2]]}]}` {
 		t.Fatalf("unexpected row(0): %s", s)
 	}
 
@@ -1291,7 +1291,7 @@ func TestServer_DropSeriesTagsPreserved(t *testing.T) {
 		t.Fatalf("unexpected error: %s", res.Err)
 	} else if len(res.Series) != 1 {
 		t.Fatalf("unexpected row count: %d", len(res.Series))
-	} else if s := mustMarshalJSON(res); s != `{"series":[{"name":"cpu","columns":["time","value"],"values":[["2000-01-01T00:00:01Z",33.2]]}]}` {
+	} else if s := mustMarshalJSON(res); s != `{"series":[{"name":"cpu","tags":{"host":"serverB","region":"uswest"},"columns":["time","value"],"values":[["2000-01-01T00:00:01Z",33.2]]}]}` {
 		t.Fatalf("unexpected row(0): %s", s)
 	}
 }


### PR DESCRIPTION
Users are getting confused by the fact that `SELECT *` doesn't include tag values. We should include tag keys in the columns and the tag values in the values array.