### PR TITLE
add timeout for raft Wait

### DIFF
--- a/raft/errors.go
+++ b/raft/errors.go
@@ -54,6 +54,10 @@ var (
 	// ErrSnapshotting is returned when an action cannot be performed because
 	// the log is in the middle of a snapshot.
 	ErrSnapshotting = errors.New("snapshotting")
+
+	// ErrWaitTotalElapsed is returned when the time spent waiting for
+	// an index to be applied has exceeed the max wait time.
+	ErrWaitTotalElapsed = errors.New("total wait time exceeded")
 )
 
 // Internal marker errors.


### PR DESCRIPTION
Sets timeout to a constant value.
Without a timeout, the wait can go on indefinitely.
A different implementation could be to have a default Wait call with index arg that would use a constant amount of time and a separate Wait call with index AND explicit time arg that would wait given amount of time. @benbjohnson , would the default/explicit be useful or overkill?