### PR TITLE
Fixes typos in sample config file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Bugfixes
 - [2635](https://github.com/influxdb/influxdb/issues/2635): Fix querying against boolean field in WHERE clause.
 - [2644](https://github.com/influxdb/influxdb/issues/2644): Make SHOW queries work with FROM /<regex>/.
+- [2647](https://github.com/influxdb/influxdb/pull/2647): Fixes typos in sample config file
 
 ## v0.9.0-rc31 [2015-05-21]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 ### Bugfixes
 - [2635](https://github.com/influxdb/influxdb/issues/2635): Fix querying against boolean field in WHERE clause.
 - [2644](https://github.com/influxdb/influxdb/issues/2644): Make SHOW queries work with FROM /<regex>/.
-- [2647](https://github.com/influxdb/influxdb/pull/2647): Fixes typos in sample config file
+- [2647](https://github.com/influxdb/influxdb/issues/2647): Fixes typos in sample config file
 
 ## v0.9.0-rc31 [2015-05-21]
 

--- a/etc/config.sample.toml
+++ b/etc/config.sample.toml
@@ -43,7 +43,7 @@ port = 8083
 [[graphite]] # 1 or more of these sections may be present.
 enabled = false
 # protocol = "" # Set to "tcp" or "udp"
-# address = "0.0.0.0" # If not set, is actually set to bind-address.
+# bind-address = "0.0.0.0" # If not set, is actually set to bind-address.
 # port = 2003
 # name-position = "last"
 # name-separator = "-"
@@ -52,23 +52,23 @@ enabled = false
 # Configure the collectd input.
 [collectd]
 enabled = false
-#address = "0.0.0.0" # If not set, is actually set to bind-address.
-#port = 25827
-#database = "collectd_database"
-#typesdb = "types.db"
+# bind-address = "0.0.0.0" # If not set, is actually set to bind-address.
+# port = 25827
+# database = "collectd_database"
+# typesdb = "types.db"
 
 # Configure the OpenTSDB input.
 [opentsdb]
 enabled = false
-#address = "0.0.0.0" # If not set, is actually set to bind-address.
-#port = 4242
-#database = "opentsdb_database"
+# address = "0.0.0.0" # If not set, is actually set to bind-address.
+# port = 4242
+# database = "opentsdb_database"
 
 # Configure UDP listener for series data.
 [udp]
 enabled = false
-#bind-address = "0.0.0.0"
-#port = 4444
+# bind-address = "0.0.0.0"
+# port = 4444
 
 # Broker configuration. Brokers are nodes which participate in distributed
 # consensus.


### PR DESCRIPTION
I have been working on installing the latest version of Influx (0.9) onto a system that is not connected to the internet. This involves building it from source, on 64-bit Ubuntu 14.04, and sourcing any dependencies without resorting to `go get`. 

Like most users I start with the sample config file and tweak it to suit my scenario. While looking at various details I noticed that the ``etc/config.sample.toml`` contains fields which do not match the code. This means that if I uncomment these fields their values will not be used which is not what a normal user would expect.

The code that parses the Collectd section of the configuration file tries to read a field called ``bind-address`` and if it can't be found then the fallback ``defaultBindAddr`` is used. Similarly, the Graphite section parsing code does the same thing.

In the Influx sample configuration file ``etc/config.sample.toml`` the address fields for both Collectd and Graphite are labelled ``address``. A normal user would expect to be able to uncomment these and have them work. However, because of the mismatch already mentioned, this would not happen.

**Collectd**:

[etc/config.sample.toml](https://github.com/influxdb/influxdb/blob/master/etc/config.sample.toml#L55):

	#address = "0.0.0.0" # If not set, is actually set to bind-address.

[cmd/influxd/config.go](https://github.com/influxdb/influxdb/blob/master/cmd/influxd/config.go#L479):

	BindAddress string `toml:"bind-address"`


**Graphite**:

[etc/config.sample.toml](https://github.com/influxdb/influxdb/blob/master/etc/config.sample.toml#L46):

	#address = "0.0.0.0" # If not set, is actually set to bind-address.

[cmd/influxd/config.go](https://github.com/influxdb/influxdb/blob/master/cmd/influxd/config.go#L505):

	BindAddress string `toml:"bind-address"`


The config_test.go file contains the correct ``bind-address`` fields. So, it just looks like the content in the ``etc/config.sample.toml`` has become inconsistent with the code.

This pull request just fixes the fields in the ``etc/config.sample.toml`` so they are consistent with the code. It also adds a space after some of the comment characters so the file looks consistent.

A better long term solution might be to generate the default configuration file from the application. This would hopefully avoid the issue of inconsistency between the sample configuration file and what the code expects.

From a consistency perspective it would be good if the ``address`` field under the ``opentsdb`` section also used ``bind-address`` like the ``Collectd`` and ``Graphite`` sections. This is likely a job for a separate pull request.
