### PR TITLE
Shard storage management

### DIFF
--- a/cluster/coordinator_test.go
+++ b/cluster/coordinator_test.go
@@ -21,11 +21,16 @@ func (f *fakeShardWriter) Write(shardID, nodeID uint64, points []tsdb.Point) err
 }
 
 type fakeStore struct {
-	WriteFn func(shardID uint64, points []tsdb.Point) error
+	WriteFn       func(shardID uint64, points []tsdb.Point) error
+	CreateShardfn func(database, retentionPolicy string, shardID uint64) error
 }
 
 func (f *fakeStore) WriteToShard(shardID uint64, points []tsdb.Point) error {
 	return f.WriteFn(shardID, points)
+}
+
+func (f *fakeStore) CreateShard(database, retentionPolicy string, shardID uint64) error {
+	return f.CreateShardfn(database, retentionPolicy, shardID)
 }
 
 func newTestMetaStore() *test.MetaStore {

--- a/server.go
+++ b/server.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"log"
 	"math"
 	"net/http"
@@ -165,7 +166,12 @@ func (s *Server) openServices() error {
 	// TODO: open metastore
 
 	// Open the local data node. TODO: pass in the data path to the server
-	s.store = tsdb.NewStore("FIXME")
+	// FIXME: Use config data dir
+	path, err := ioutil.TempDir("", "influxdb-alpha1")
+	if err != nil {
+		return err
+	}
+	s.store = tsdb.NewStore(path)
 	if err := s.store.Open(); err != nil {
 		return err
 	}

--- a/server.go
+++ b/server.go
@@ -179,8 +179,12 @@ func (s *Server) openServices() error {
 	// TODO: open the cluster writer
 
 	// Open the coordinator service
-	coordinator := cluster.NewCoordinator()
+	// FIXME: Use the metastores node ID for the current node
+	coordinator := cluster.NewCoordinator(uint64(1))
 	coordinator.Store = s.store
+
+	// FIXME: Add the cluster writer to the coordinator
+	// coordinator.ClusterWriter = ...
 
 	// TODO: add cluster writer to coordinator
 

--- a/tsdb/store_test.go
+++ b/tsdb/store_test.go
@@ -1,0 +1,162 @@
+package tsdb
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestStoreOpen(t *testing.T) {
+	dir, err := ioutil.TempDir("", "store_test")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+
+	if err := os.MkdirAll(filepath.Join(dir, "mydb"), 0600); err != nil {
+		t.Fatalf("failed to create test db dir: %v", err)
+	}
+
+	s := NewStore(dir)
+	if err := s.Open(); err != nil {
+		t.Fatalf("Store.Open() failed: %v", err)
+	}
+
+	if exp := 1; len(s.databaseIndexes) != exp {
+		t.Fatalf("database index count mismatch: got %v, exp %v", len(s.databaseIndexes), exp)
+	}
+}
+
+func TestStoreOpenShard(t *testing.T) {
+	dir, err := ioutil.TempDir("", "store_test")
+	if err != nil {
+		t.Fatalf("Store.Open() failed to create temp dir: %v", err)
+	}
+
+	path := filepath.Join(dir, "mydb", "myrp")
+	if err := os.MkdirAll(path, 0700); err != nil {
+		t.Fatalf("Store.Open() failed to create test db dir: %v", err)
+	}
+
+	shardPath := filepath.Join(path, "1")
+	if _, err := os.Create(shardPath); err != nil {
+		t.Fatalf("Store.Open() failed to create test shard 1: %v", err)
+	}
+
+	s := NewStore(dir)
+	if err := s.Open(); err != nil {
+		t.Fatalf("Store.Open() failed: %v", err)
+	}
+
+	if exp := 1; len(s.databaseIndexes) != exp {
+		t.Fatalf("Store.Open() database index count mismatch: got %v, exp %v", len(s.databaseIndexes), exp)
+	}
+
+	if _, ok := s.databaseIndexes["mydb"]; !ok {
+		t.Errorf("Store.Open() database myb does not exist")
+	}
+
+	if exp := 1; len(s.shards) != exp {
+		t.Fatalf("Store.Open() shard count mismatch: got %v, exp %v", len(s.shards), exp)
+	}
+
+	sh := s.shards[uint64(1)]
+	if sh.path != shardPath {
+		t.Errorf("Store.Open() shard path mismatch: got %v, exp %v", sh.path, shardPath)
+	}
+}
+
+func TestStoreOpenNotDatabaseDir(t *testing.T) {
+	dir, err := ioutil.TempDir("", "store_test")
+	if err != nil {
+		t.Fatalf("Store.Open() failed to create temp dir: %v", err)
+	}
+
+	path := filepath.Join(dir, "bad_db_path")
+	if _, err := os.Create(path); err != nil {
+		t.Fatalf("Store.Open() failed to create test db dir: %v", err)
+	}
+
+	s := NewStore(dir)
+	if err := s.Open(); err != nil {
+		t.Fatalf("Store.Open() failed: %v", err)
+	}
+
+	if exp := 0; len(s.databaseIndexes) != exp {
+		t.Fatalf("Store.Open() database index count mismatch: got %v, exp %v", len(s.databaseIndexes), exp)
+	}
+
+	if exp := 0; len(s.shards) != exp {
+		t.Fatalf("Store.Open() shard count mismatch: got %v, exp %v", len(s.shards), exp)
+	}
+}
+
+func TestStoreOpenNotRPDir(t *testing.T) {
+	dir, err := ioutil.TempDir("", "store_test")
+	if err != nil {
+		t.Fatalf("Store.Open() failed to create temp dir: %v", err)
+	}
+
+	path := filepath.Join(dir, "mydb")
+	if err := os.MkdirAll(path, 0700); err != nil {
+		t.Fatalf("Store.Open() failed to create test db dir: %v", err)
+	}
+
+	rpPath := filepath.Join(path, "myrp")
+	if _, err := os.Create(rpPath); err != nil {
+		t.Fatalf("Store.Open() failed to create test retention policy directory: %v", err)
+	}
+
+	s := NewStore(dir)
+	if err := s.Open(); err != nil {
+		t.Fatalf("Store.Open() failed: %v", err)
+	}
+
+	if exp := 1; len(s.databaseIndexes) != exp {
+		t.Fatalf("Store.Open() database index count mismatch: got %v, exp %v", len(s.databaseIndexes), exp)
+	}
+
+	if _, ok := s.databaseIndexes["mydb"]; !ok {
+		t.Errorf("Store.Open() database myb does not exist")
+	}
+
+	if exp := 0; len(s.shards) != exp {
+		t.Fatalf("Store.Open() shard count mismatch: got %v, exp %v", len(s.shards), exp)
+	}
+}
+
+func TestStoreOpenShardBadShardPath(t *testing.T) {
+	dir, err := ioutil.TempDir("", "store_test")
+	if err != nil {
+		t.Fatalf("Store.Open() failed to create temp dir: %v", err)
+	}
+
+	path := filepath.Join(dir, "mydb", "myrp")
+	if err := os.MkdirAll(path, 0700); err != nil {
+		t.Fatalf("Store.Open() failed to create test db dir: %v", err)
+	}
+
+	// Non-numeric shard ID
+	shardPath := filepath.Join(path, "bad_shard_path")
+	if _, err := os.Create(shardPath); err != nil {
+		t.Fatalf("Store.Open() failed to create test shard 1: %v", err)
+	}
+
+	s := NewStore(dir)
+	if err := s.Open(); err != nil {
+		t.Fatalf("Store.Open() failed: %v", err)
+	}
+
+	if exp := 1; len(s.databaseIndexes) != exp {
+		t.Fatalf("Store.Open() database index count mismatch: got %v, exp %v", len(s.databaseIndexes), exp)
+	}
+
+	if _, ok := s.databaseIndexes["mydb"]; !ok {
+		t.Errorf("Store.Open() database myb does not exist")
+	}
+
+	if exp := 0; len(s.shards) != exp {
+		t.Fatalf("Store.Open() shard count mismatch: got %v, exp %v", len(s.shards), exp)
+	}
+
+}


### PR DESCRIPTION
This PR allows the shard.Store to open existing shards on disk as well as create new shards on-demand when a write is sent to them.
