### PR TITLE
Integrate batching with UDP

### DIFF
--- a/cmd/influxd/config.go
+++ b/cmd/influxd/config.go
@@ -193,6 +193,9 @@ type Config struct {
 		Enabled     bool   `toml:"enabled"`
 		BindAddress string `toml:"bind-address"`
 		Port        int    `toml:"port"`
+
+		BatchSize    int      `toml:"batch-size"`
+		BatchTimeout Duration `toml:"batch-timeout"`
 	} `toml:"udp"`
 
 	Broker Broker `toml:"broker"`

--- a/cmd/influxd/run.go
+++ b/cmd/influxd/run.go
@@ -388,6 +388,8 @@ func (cmd *RunCommand) Open(config *Config, join string) *Node {
 		if cmd.config.UDP.Enabled {
 			log.Printf("Starting UDP listener on %s", cmd.config.APIAddrUDP())
 			u := udp.NewUDPServer(s)
+			u.SetBatchSize(cmd.config.UDP.BatchSize)
+			u.SetBatchTimeout(time.Duration(cmd.config.UDP.BatchTimeout))
 			if err := u.ListenAndServe(cmd.config.APIAddrUDP()); err != nil {
 				log.Printf("Failed to start UDP listener on %s: %s", cmd.config.APIAddrUDP(), err)
 			}

--- a/etc/config.sample.toml
+++ b/etc/config.sample.toml
@@ -73,6 +73,8 @@ enabled = false
 enabled = false
 # bind-address = "0.0.0.0"
 # port = 4444
+# batch-size = 0 # How many points to batch up internally before writing.
+# batch-timeout = "0ms" # Maximum time to wait before sending batch, regardless of current size.
 
 # Broker configuration. Brokers are nodes which participate in distributed
 # consensus.

--- a/udp/udp.go
+++ b/udp/udp.go
@@ -5,6 +5,9 @@ import (
 	"encoding/json"
 	"log"
 	"net"
+	"os"
+	"sync"
+	"time"
 
 	"github.com/influxdb/influxdb"
 	"github.com/influxdb/influxdb/client"
@@ -22,57 +25,97 @@ type SeriesWriter interface {
 // UDPServer
 type UDPServer struct {
 	writer SeriesWriter
+	conn   *net.UDPConn
+	addr   *net.UDPAddr
+	wg     sync.WaitGroup
+
+	batchSize    int
+	batchTimeout time.Duration
+
+	Logger *log.Logger
 }
 
 // NewUDPServer returns a new instance of a UDPServer
 func NewUDPServer(w SeriesWriter) *UDPServer {
 	u := UDPServer{
 		writer: w,
+		Logger: log.New(os.Stderr, "[udp] ", log.LstdFlags),
 	}
 	return &u
 }
 
-// ListenAndServe binds the server to the given UDP interface.
-func (u *UDPServer) ListenAndServe(iface string) error {
-	addr, err := net.ResolveUDPAddr("udp", iface)
+// ListenAndServe instructs the UDPServer to start processing data
+// on the given interface. iface must be in the form host:port.
+func (u *UDPServer) ListenAndServe(iface string) (err error) {
+	u.addr, err = net.ResolveUDPAddr("udp", iface)
 	if err != nil {
-		log.Printf("Failed resolve UDP address %s: %s", iface, err)
+		u.Logger.Printf("Failed to resolve UDP address %s: %s", iface, err)
 		return err
 	}
 
-	conn, err := net.ListenUDP("udp", addr)
+	u.conn, err = net.ListenUDP("udp", u.addr)
 	if err != nil {
-		log.Printf("Failed set up UDP listener at address %s: %s", addr, err)
+		u.Logger.Printf("Failed to set up UDP listener at address %s: %s", u.addr, err)
 		return err
 	}
 
 	var bp client.BatchPoints
 	buf := make([]byte, udpBufferSize)
 
+	batcher := influxdb.NewPointBatcher(u.batchSize, u.batchTimeout)
+	batcher.Start()
+
+	// Start processing batches.
+	var wg sync.WaitGroup
+	done := make(chan struct{})
+	wg.Add(1)
 	go func() {
+		defer wg.Done()
 		for {
-			_, _, err := conn.ReadFromUDP(buf)
+			select {
+			case batch := <-batcher.Out():
+				_, e := u.writer.WriteSeries(bp.Database, bp.RetentionPolicy, batch)
+				if e != nil {
+					u.Logger.Printf("Failed to write point batch to database %q: %s\n", bp.Database, e)
+				}
+			case <-done:
+				return
+			}
+		}
+	}()
+
+	u.wg.Add(1)
+	go func() {
+		defer u.wg.Done()
+		for {
+			_, _, err := u.conn.ReadFromUDP(buf)
 			if err != nil {
-				log.Printf("Failed read UDP message: %s.", err)
-				continue
+				u.Logger.Printf("Failed to read UDP message: %s.", err)
+				batcher.Flush()
+				close(done)
+				wg.Wait()
+				return
 			}
 
 			dec := json.NewDecoder(bytes.NewReader(buf))
 			if err := dec.Decode(&bp); err != nil {
-				log.Printf("Failed decode JSON UDP message")
+				u.Logger.Printf("Failed to decode JSON UDP message")
 				continue
 			}
 
 			points, err := influxdb.NormalizeBatchPoints(bp)
 			if err != nil {
-				log.Printf("Failed normalize batch points")
+				u.Logger.Printf("Failed to normalize batch points")
 				continue
 			}
 
-			if msgIndex, err := u.writer.WriteSeries(bp.Database, bp.RetentionPolicy, points); err != nil {
-				log.Printf("Server write failed. Message index was %d: %s", msgIndex, err)
+			for _, point := range points {
+				batcher.In() <- point
 			}
 		}
 	}()
 	return nil
 }
+
+func (u *UDPServer) SetBatchSize(sz int)             { u.batchSize = sz }
+func (u *UDPServer) SetBatchTimeout(d time.Duration) { u.batchTimeout = d }


### PR DESCRIPTION
Hello there,

I'm sending my points over UDP and noticed that points writing to database is very slow because it doesn't use the newly introduced points batcher.
Here's a proposal to integrate it with UDP, please tell me what you think (I'm quite new to Go and InfluxDB so feedback is welcome).

Hoping this will be useful,
Renan