### PR TITLE
Make Authenticate return true if no users and creating a root user.

### DIFF
--- a/meta/store.go
+++ b/meta/store.go
@@ -626,6 +626,15 @@ func (s *Store) SetPrivilege(username, database string, p influxql.Privilege) er
 	)
 }
 
+// UserCount returns the number of users defined in the cluster.
+func (s *Store) UserCount() (count int, err error) {
+	err = s.read(func(data *Data) error {
+		count = len(data.Users)
+		return nil
+	})
+	return
+}
+
 // read executes a function with the current metadata.
 // If an error is returned then the cache is invalidated and retried.
 //

--- a/meta/store_test.go
+++ b/meta/store_test.go
@@ -541,6 +541,28 @@ func TestStore_UpdateUser(t *testing.T) {
 	}
 }
 
+// Ensure the store can return the count of users in it.
+func TestStore_UserCount(t *testing.T) {
+	s := MustOpenStore()
+	defer s.Close()
+	<-s.LeaderCh()
+
+	if count, err := s.UserCount(); count != 0 && err != nil {
+		t.Fatalf("expected user count to be 0 but was %d", count)
+	}
+
+	// Create users.
+	if _, err := s.CreateUser("susy", "pass", true); err != nil {
+		t.Fatal(err)
+	} else if _, err := s.CreateUser("bob", "pass", true); err != nil {
+		t.Fatal(err)
+	}
+
+	if count, err := s.UserCount(); count != 2 && err != nil {
+		t.Fatalf("expected user count to be 2 but was %d", count)
+	}
+}
+
 // Store is a test wrapper for meta.Store.
 type Store struct {
 	*meta.Store


### PR DESCRIPTION
* Added `UserCount` to `meta.Store`.
* Updated query executor authenticate method to return true for situations where the person is attempting to create the first root user.
* Add a few tests for Authenticate