### PR TITLE
fix #2714: make parse err on regex op w/ nonregex

### DIFF
--- a/influxql/parser.go
+++ b/influxql/parser.go
@@ -20,6 +20,13 @@ const (
 	DateTimeFormat = "2006-01-02 15:04:05.999999"
 )
 
+type requirement int
+
+const (
+	Optional requirement = iota
+	Required
+)
+
 // Parser represents an InfluxQL parser.
 type Parser struct {
 	s *bufScanner
@@ -1449,7 +1456,7 @@ func (p *Parser) parseSource() (Source, error) {
 	m := &Measurement{}
 
 	// Attempt to parse a regex.
-	re, err := p.parseRegex()
+	re, err := p.parseRegex(Optional)
 	if err != nil {
 		return nil, err
 	} else if re != nil {
@@ -1470,7 +1477,7 @@ func (p *Parser) parseSource() (Source, error) {
 		return m, nil
 	}
 	// Check again for regex.
-	re, err = p.parseRegex()
+	re, err = p.parseRegex(Optional)
 	if err != nil {
 		return nil, err
 	} else if re != nil {
@@ -1744,7 +1751,7 @@ func (p *Parser) ParseExpr() (Expr, error) {
 		if IsRegexOp(op) {
 			// RHS of a regex operator must be a regular expression.
 			p.consumeWhitespace()
-			if rhs, err = p.parseRegex(); err != nil {
+			if rhs, err = p.parseRegex(Required); err != nil {
 				return nil, err
 			}
 		} else {
@@ -1863,7 +1870,7 @@ func (p *Parser) parseUnaryExpr() (Expr, error) {
 }
 
 // parseRegex parses a regular expression.
-func (p *Parser) parseRegex() (*RegexLiteral, error) {
+func (p *Parser) parseRegex(r requirement) (*RegexLiteral, error) {
 	nextRune := p.peekRune()
 	if isWhitespace(nextRune) {
 		p.consumeWhitespace()
@@ -1872,7 +1879,11 @@ func (p *Parser) parseRegex() (*RegexLiteral, error) {
 	// If the next character is not a '/', then return nils.
 	nextRune = p.peekRune()
 	if nextRune != '/' {
-		return nil, nil
+		if r == Optional {
+			return nil, nil
+		}
+		tok, pos, lit := p.scanIgnoreWhitespace()
+		return nil, newParseError(tokstr(tok, lit), []string{"regex"}, pos)
 	}
 
 	tok, pos, lit := p.s.ScanRegex()

--- a/influxql/parser_test.go
+++ b/influxql/parser_test.go
@@ -1154,6 +1154,7 @@ func TestParser_ParseStatement(t *testing.T) {
 		{s: `select count() from myseries`, err: `invalid number of arguments for count, expected 1, got 0`},
 		{s: `select derivative() from myseries`, err: `invalid number of arguments for derivative, expected at least 1 but no more than 2, got 0`},
 		{s: `select derivative(mean(value), 1h, 3) from myseries`, err: `invalid number of arguments for derivative, expected at least 1 but no more than 2, got 3`},
+		{s: `select * from foo where bar =~ 'baz'`, err: `found baz, expected regex at line 1, char 31`},
 		{s: `DELETE`, err: `found EOF, expected FROM at line 1, char 8`},
 		{s: `DELETE FROM`, err: `found EOF, expected identifier at line 1, char 13`},
 		{s: `DELETE FROM myseries WHERE`, err: `found EOF, expected identifier, string, number, bool at line 1, char 28`},


### PR DESCRIPTION
Using a regex operator, in a query, with a non-regex expression should return a parse error.  E.g., the following query should generate a parse error:
```
select * from cpu where foo =~ 'bar'
```

because it should be:
```
select * from cpu where foo =~ /bar/
```