### PR TITLE
should check measurement name is null

### DIFF
--- a/server.go
+++ b/server.go
@@ -1827,6 +1827,10 @@ func (s *Server) WriteSeries(database, retentionPolicy string, points []Point) (
 			return ErrDatabaseNotFound(database)
 		}
 		for _, p := range points {
+			if p.Measurement == "" {
+				return ErrMeasurementNameRequired
+			}
+
 			measurement, series := db.MeasurementAndSeries(p.Measurement, p.Tags)
 			if series == nil {
 				s.Logger.Printf("series not found: name=%s, tags=%#v", p.Measurement, p.Tags)
@@ -1920,6 +1924,10 @@ func (s *Server) createMeasurementsIfNotExists(database, retentionPolicy string,
 		}
 
 		for _, p := range points {
+			if p.Measurement == "" {
+				return ErrMeasurementNameRequired
+			}
+
 			measurement, series := db.MeasurementAndSeries(p.Measurement, p.Tags)
 
 			if series == nil {


### PR DESCRIPTION
when users do not provide measurement name in point, influxdb will return  {"error":"bucket name required"} . It's not appropriate to return errors of boltdb here.

So when writing series, we should check measurement name first to ensure everything will go well.