### PR TITLE
Services observe enabled

### DIFF
--- a/cmd/influxd/run/server.go
+++ b/cmd/influxd/run/server.go
@@ -76,6 +76,9 @@ func (s *Server) appendAdminService(c admin.Config) {
 }
 
 func (s *Server) appendHTTPDService(c httpd.Config) {
+	if !c.Enabled {
+		return
+	}
 	srv := httpd.NewService(c)
 	srv.Handler.MetaStore = s.MetaStore
 	srv.Handler.QueryExecutor = s.QueryExecutor
@@ -84,21 +87,33 @@ func (s *Server) appendHTTPDService(c httpd.Config) {
 }
 
 func (s *Server) appendCollectdService(c collectd.Config) {
+	if !c.Enabled {
+		return
+	}
 	srv := collectd.NewService(c)
 	s.Services = append(s.Services, srv)
 }
 
 func (s *Server) appendOpenTSDBService(c opentsdb.Config) {
+	if !c.Enabled {
+		return
+	}
 	srv := opentsdb.NewService(c)
 	s.Services = append(s.Services, srv)
 }
 
 func (s *Server) appendGraphiteService(c graphite.Config) {
+	if !c.Enabled {
+		return
+	}
 	srv := graphite.NewService(c)
 	s.Services = append(s.Services, srv)
 }
 
 func (s *Server) appendUDPService(c udp.Config) {
+	if !c.Enabled {
+		return
+	}
 	srv := udp.NewService(c)
 	srv.Server.PointsWriter = s.PointsWriter
 	s.Services = append(s.Services, srv)

--- a/cmd/influxd/run/server_helpers_test.go
+++ b/cmd/influxd/run/server_helpers_test.go
@@ -149,8 +149,6 @@ func NewConfig() *run.Config {
 	c.HTTPD.BindAddress = "127.0.0.1:0"
 	c.HTTPD.LogEnabled = testing.Verbose()
 
-	c.UDP.BindAddress = "127.0.0.1:0"
-	c.UDP.Database = "db0"
 	return c
 }
 


### PR DESCRIPTION
Services were spinning up regardless of if the config was enabled or not.