### PR TITLE
Make line protocol round or parse precision as expected

### DIFF
--- a/tsdb/points.go
+++ b/tsdb/points.go
@@ -8,8 +8,6 @@ import (
 	"strconv"
 	"strings"
 	"time"
-
-	"github.com/davecgh/go-spew/spew"
 )
 
 // Point defines the values that will be written to the database
@@ -512,7 +510,6 @@ func (p *point) Time() time.Time {
 			return p.time
 		}
 		p.time = time.Unix(0, ts*p.GetPrecisionMultiplier())
-		spew.Dump(ts, p.precision, p.GetPrecisionMultiplier(), p.time.UTC())
 	}
 
 	return p.time


### PR DESCRIPTION
Line protocol for precision can do two things:

- If specified and a time is provided, it needs to use a multiplier to get it back to nanoseconds
- If specified, but no time is provided, we need to truncate down to the time to observe the precision.