### PR TITLE
Enforce retention policies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - [2751](https://github.com/influxdb/influxdb/pull/2751): Add UDP input. UPD only supports the line protocol now.
 
 ### Bugfixes
+- [2776](https://github.com/influxdb/influxdb/issues/2776): Re-implement retention policy enforcement.
 - [2635](https://github.com/influxdb/influxdb/issues/2635): Fix querying against boolean field in WHERE clause.
 - [2644](https://github.com/influxdb/influxdb/issues/2644): Make SHOW queries work with FROM /<regex>/.
 - [2501](https://github.com/influxdb/influxdb/issues/2501): Name the FlagSet for the shell and add a version flag. Thanks @neonstalwart

--- a/cmd/influxd/run/config.go
+++ b/cmd/influxd/run/config.go
@@ -19,6 +19,7 @@ import (
 	"github.com/influxdb/influxdb/services/httpd"
 	"github.com/influxdb/influxdb/services/monitor"
 	"github.com/influxdb/influxdb/services/opentsdb"
+	"github.com/influxdb/influxdb/services/retention"
 	"github.com/influxdb/influxdb/services/udp"
 	"github.com/influxdb/influxdb/tsdb"
 )
@@ -69,9 +70,10 @@ type Config struct {
 		JoinURLs string `toml:"join-urls"`
 	} `toml:"initialization"`
 
-	Meta    meta.Config    `toml:"meta"`
-	Data    tsdb.Config    `toml:"data"`
-	Cluster cluster.Config `toml:"cluster"`
+	Meta      meta.Config      `toml:"meta"`
+	Data      tsdb.Config      `toml:"data"`
+	Cluster   cluster.Config   `toml:"cluster"`
+	Retention retention.Config `toml:"retention"`
 
 	Admin     admin.Config      `toml:"admin"`
 	HTTPD     httpd.Config      `toml:"api"`

--- a/cmd/influxd/run/server.go
+++ b/cmd/influxd/run/server.go
@@ -73,6 +73,9 @@ func (s *Server) appendClusterService(c cluster.Config) {
 }
 
 func (s *Server) appendRetentionPolicyService(c retention.Config) {
+	if !c.Enabled {
+		return
+	}
 	srv := retention.NewService(c)
 	srv.MetaStore = s.MetaStore
 	srv.TSDBStore = s.TSDBStore

--- a/cmd/influxd/run/server.go
+++ b/cmd/influxd/run/server.go
@@ -11,6 +11,7 @@ import (
 	"github.com/influxdb/influxdb/services/graphite"
 	"github.com/influxdb/influxdb/services/httpd"
 	"github.com/influxdb/influxdb/services/opentsdb"
+	"github.com/influxdb/influxdb/services/retention"
 	"github.com/influxdb/influxdb/services/udp"
 	"github.com/influxdb/influxdb/tsdb"
 )
@@ -57,6 +58,7 @@ func NewServer(c *Config, joinURLs string) *Server {
 	s.appendCollectdService(c.Collectd)
 	s.appendOpenTSDBService(c.OpenTSDB)
 	s.appendUDPService(c.UDP)
+	s.appendRetentionPolicyService(c.Retention)
 	for _, g := range c.Graphites {
 		s.appendGraphiteService(g)
 	}
@@ -66,6 +68,13 @@ func NewServer(c *Config, joinURLs string) *Server {
 
 func (s *Server) appendClusterService(c cluster.Config) {
 	srv := cluster.NewService(c)
+	srv.TSDBStore = s.TSDBStore
+	s.Services = append(s.Services, srv)
+}
+
+func (s *Server) appendRetentionPolicyService(c retention.Config) {
+	srv := retention.NewService(c)
+	srv.MetaStore = s.MetaStore
 	srv.TSDBStore = s.TSDBStore
 	s.Services = append(s.Services, srv)
 }

--- a/meta/data.go
+++ b/meta/data.go
@@ -582,6 +582,28 @@ func (rpi *RetentionPolicyInfo) ShardGroupByTimestamp(timestamp time.Time) *Shar
 	return nil
 }
 
+// ExpiredShardGroups returns the Shard Groups which are considered expired, for the given time.
+func (rpi *RetentionPolicyInfo) ExpiredShardGroups(t time.Time) []*ShardGroupInfo {
+	groups := make([]*ShardGroupInfo, 0)
+	for i := range rpi.ShardGroups {
+		if rpi.Duration != 0 && rpi.ShardGroups[i].EndTime.Add(rpi.Duration).Before(t) {
+			groups = append(groups, &rpi.ShardGroups[i])
+		}
+	}
+	return groups
+}
+
+// DeletedShardGroups returns the Shard Groups which are marked as deleted.
+func (rpi *RetentionPolicyInfo) DeletedShardGroups() []*ShardGroupInfo {
+	groups := make([]*ShardGroupInfo, 0)
+	for i := range rpi.ShardGroups {
+		if rpi.ShardGroups[i].Deleted() {
+			groups = append(groups, &rpi.ShardGroups[i])
+		}
+	}
+	return groups
+}
+
 // protobuf returns a protocol buffers object.
 func (rpi *RetentionPolicyInfo) protobuf() *internal.RetentionPolicyInfo {
 	return &internal.RetentionPolicyInfo{

--- a/meta/data_test.go
+++ b/meta/data_test.go
@@ -365,8 +365,9 @@ func TestData_DeleteShardGroup(t *testing.T) {
 
 	if err := data.DeleteShardGroup("db0", "rp0", 1); err != nil {
 		t.Fatal(err)
-	} else if len(data.Databases[0].RetentionPolicies[0].ShardGroups) != 0 {
-		t.Fatalf("unexpected shard groups: %#v", data.Databases[0].RetentionPolicies[0].ShardGroups)
+	}
+	if sg := data.Databases[0].RetentionPolicies[0].ShardGroups[0]; !sg.Deleted() {
+		t.Fatalf("shard group not correctly flagged as deleted")
 	}
 }
 

--- a/meta/store.go
+++ b/meta/store.go
@@ -195,6 +195,15 @@ func (s *Store) close() error {
 	return nil
 }
 
+// IsLeader returns whether this node is a leader of the cluster.
+func (s *Store) IsLeader() bool {
+	// Check if store has already been closed.
+	if !s.opened {
+		return false
+	}
+	return s.raft.State() == raft.Leader
+}
+
 // readID reads the local node ID from the ID file.
 func (s *Store) readID() error {
 	b, err := ioutil.ReadFile(s.IDPath())

--- a/meta/store.go
+++ b/meta/store.go
@@ -560,6 +560,21 @@ func (s *Store) ShardGroups(database, policy string) (a []ShardGroupInfo, err er
 	return
 }
 
+// VisitShardGroups calls the given function with full shard group details.
+func (s *Store) VisitShardGroups(f func(d DatabaseInfo, r RetentionPolicyInfo, s ShardGroupInfo)) {
+	s.read(func(data *Data) error {
+		for _, di := range data.Databases {
+			for _, rp := range di.RetentionPolicies {
+				for _, sg := range rp.ShardGroups {
+					f(di, rp, sg)
+				}
+			}
+		}
+		return nil
+	})
+	return
+}
+
 // ShardGroupByTimestamp returns a shard group for a policy by timestamp.
 func (s *Store) ShardGroupByTimestamp(database, policy string, timestamp time.Time) (sgi *ShardGroupInfo, err error) {
 	err = s.read(func(data *Data) error {

--- a/meta/store.go
+++ b/meta/store.go
@@ -525,7 +525,7 @@ func (s *Store) CreateShardGroupIfNotExists(database, policy string, timestamp t
 	// Try to find shard group locally first.
 	if sgi, err := s.ShardGroupByTimestamp(database, policy, timestamp); err != nil {
 		return nil, err
-	} else if sgi != nil {
+	} else if sgi != nil && !sgi.Deleted() {
 		return sgi, nil
 	}
 

--- a/meta/store.go
+++ b/meta/store.go
@@ -560,6 +560,19 @@ func (s *Store) ShardGroups(database, policy string) (a []ShardGroupInfo, err er
 	return
 }
 
+// VisitRetentionPolicies calls the given function with full retention policy details.
+func (s *Store) VisitRetentionPolicies(f func(d DatabaseInfo, r RetentionPolicyInfo)) {
+	s.read(func(data *Data) error {
+		for _, di := range data.Databases {
+			for _, rp := range di.RetentionPolicies {
+				f(di, rp)
+			}
+		}
+		return nil
+	})
+	return
+}
+
 // VisitShardGroups calls the given function with full shard group details.
 func (s *Store) VisitShardGroups(f func(d DatabaseInfo, r RetentionPolicyInfo, s ShardGroupInfo)) {
 	s.read(func(data *Data) error {

--- a/services/retention/config.go
+++ b/services/retention/config.go
@@ -1,0 +1,8 @@
+package retention
+
+import "time"
+
+type Config struct {
+	Enabled       bool
+	CheckInterval time.Duration
+}

--- a/services/retention/config.go
+++ b/services/retention/config.go
@@ -1,8 +1,10 @@
 package retention
 
-import "time"
+import (
+	"github.com/influxdb/influxdb/toml"
+)
 
 type Config struct {
-	Enabled       bool
-	CheckInterval time.Duration
+	Enabled       bool          `toml:"enabled"`
+	CheckInterval toml.Duration `toml:"check-interval"`
 }

--- a/services/retention/config_test.go
+++ b/services/retention/config_test.go
@@ -1,0 +1,27 @@
+package retention_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/BurntSushi/toml"
+	"github.com/influxdb/influxdb/services/retention"
+)
+
+func TestConfig_Parse(t *testing.T) {
+	// Parse configuration.
+	var c retention.Config
+	if _, err := toml.Decode(`
+enabled = true
+check-interval = "1s"
+`, &c); err != nil {
+		t.Fatal(err)
+	}
+
+	// Validate configuration.
+	if c.Enabled != true {
+		t.Fatalf("unexpected enabled state: %v", c.Enabled)
+	} else if time.Duration(c.CheckInterval) != time.Second {
+		t.Fatalf("unexpected check interval: %v", c.CheckInterval)
+	}
+}

--- a/services/retention/service.go
+++ b/services/retention/service.go
@@ -1,0 +1,99 @@
+package retention
+
+import (
+	"log"
+	"os"
+	"sync"
+	"time"
+)
+
+import (
+	"github.com/influxdb/influxdb/meta"
+)
+
+// Service represents the retention policy enforcement service.
+type Service struct {
+	MetaStore interface {
+		IsLeader() bool
+		VisitShardGroups(f func(d meta.DatabaseInfo, r meta.RetentionPolicyInfo, s meta.ShardGroupInfo))
+		DeleteShardGroup(database, policy string, id uint64) error
+	}
+	TSDBStore interface {
+		ShardIDs() []uint64
+		DeleteShard(shardID uint64) error
+	}
+
+	enabled       bool
+	checkInterval time.Duration
+	wg            sync.WaitGroup
+	done          chan struct{}
+
+	logger *log.Logger
+}
+
+// NewService returns a configure retention policy enforcement service.
+func NewService(c Config) *Service {
+	return &Service{
+		enabled:       c.Enabled,
+		checkInterval: c.CheckInterval,
+		done:          make(chan struct{}),
+		logger:        log.New(os.Stderr, "[retention] ", log.LstdFlags),
+	}
+}
+
+// Open starts retention policy enforcement.
+func (s *Service) Open() error {
+	if !s.enabled {
+		return nil
+	}
+
+	s.wg.Add(2)
+	go s.deleteShardGroups()
+	go s.deleteShards()
+	return nil
+}
+
+// Close stops retention policy enforcement.
+func (s *Service) Close() error {
+	close(s.done)
+	s.wg.Wait()
+	return nil
+}
+
+func (s *Service) deleteShardGroups() {
+	defer s.wg.Done()
+
+	ticker := time.NewTicker(s.checkInterval)
+	for {
+		select {
+		case <-s.done:
+			s.logger.Println("retention policy enforcement terminating")
+			return
+
+		case <-ticker.C:
+			// Only run this on the leader, but always allow the loop to check
+			// as the leader can change.
+			if !s.MetaStore.IsLeader() {
+				return
+			}
+			s.logger.Println("retention policy enforcement commencing")
+
+			s.MetaStore.VisitShardGroups(func(d meta.DatabaseInfo, r meta.RetentionPolicyInfo, g meta.ShardGroupInfo) {
+				if r.Duration != 0 && g.EndTime.Add(r.Duration).Before(time.Now().UTC()) {
+					if err := s.MetaStore.DeleteShardGroup(d.Name, r.Name, g.ID); err != nil {
+						s.logger.Printf("failed to delete shard group %d from database %s, retention policy %s: %s",
+							g.ID, d.Name, r.Name, err.Error())
+					} else {
+						s.logger.Printf("deleted shard group %d from database %s, retention policy %s",
+							g.ID, d.Name, r.Name)
+					}
+				}
+
+			})
+		}
+	}
+}
+
+func (s *Service) deleteShards() {
+	defer s.wg.Done()
+}

--- a/services/retention/service.go
+++ b/services/retention/service.go
@@ -59,6 +59,7 @@ func (s *Service) deleteShardGroups() {
 	defer s.wg.Done()
 
 	ticker := time.NewTicker(s.checkInterval)
+	defer ticker.Stop()
 	for {
 		select {
 		case <-s.done:
@@ -92,6 +93,7 @@ func (s *Service) deleteShards() {
 	defer s.wg.Done()
 
 	ticker := time.NewTicker(s.checkInterval)
+	defer ticker.Stop()
 	for {
 		select {
 		case <-s.done:

--- a/services/retention/service.go
+++ b/services/retention/service.go
@@ -35,7 +35,7 @@ type Service struct {
 func NewService(c Config) *Service {
 	return &Service{
 		enabled:       c.Enabled,
-		checkInterval: c.CheckInterval,
+		checkInterval: time.Duration(c.CheckInterval),
 		done:          make(chan struct{}),
 		logger:        log.New(os.Stderr, "[retention] ", log.LstdFlags),
 	}

--- a/services/retention/service.go
+++ b/services/retention/service.go
@@ -34,7 +34,6 @@ type Service struct {
 // NewService returns a configure retention policy enforcement service.
 func NewService(c Config) *Service {
 	return &Service{
-		enabled:       c.Enabled,
 		checkInterval: time.Duration(c.CheckInterval),
 		done:          make(chan struct{}),
 		logger:        log.New(os.Stderr, "[retention] ", log.LstdFlags),
@@ -43,10 +42,6 @@ func NewService(c Config) *Service {
 
 // Open starts retention policy enforcement.
 func (s *Service) Open() error {
-	if !s.enabled {
-		return nil
-	}
-
 	s.wg.Add(2)
 	go s.deleteShardGroups()
 	go s.deleteShards()

--- a/tsdb/store.go
+++ b/tsdb/store.go
@@ -95,6 +95,15 @@ func (s *Store) Shard(shardID uint64) *Shard {
 	return s.shards[shardID]
 }
 
+// ShardIDs returns a slice of all ShardIDs under management.
+func (s *Store) ShardIDs() []uint64 {
+	ids := make([]uint64, 0, len(s.shards))
+	for i, _ := range s.shards {
+		ids = append(ids, i)
+	}
+	return ids
+}
+
 func (s *Store) ValidateAggregateFieldsInStatement(shardID uint64, measurementName string, stmt *influxql.SelectStatement) error {
 	s.mu.RLock()
 	shard := s.shards[shardID]

--- a/tsdb/store_test.go
+++ b/tsdb/store_test.go
@@ -98,6 +98,11 @@ func TestStoreOpenShardCreateDelete(t *testing.T) {
 		t.Fatalf("Store.Open() shard count mismatch: got %v, exp %v", len(s.shards), exp)
 	}
 
+	shardIDs := s.ShardIDs()
+	if len(shardIDs) != 1 || shardIDs[0] != 1 {
+		t.Fatalf("Store.Open() ShardIDs not correct: got %v, exp %v", s.ShardIDs(), []uint64{1})
+	}
+
 	if err := s.DeleteShard(1); err != nil {
 		t.Fatalf("Store.Open() failed to delete shard: %v", err)
 	}


### PR DESCRIPTION
This change adds a new service to the system for Retention Policy enforcement.

Enforcement is composed of two parts: 

- a goroutine, that only runs on the leader, which periodically walks all `ShardGroups` and deletes any `ShardGroups` that have expired. Note that with this change ShardGroups are not actually deleted. Instead they have a tombstone flag set. This is so it is explicit that a `ShardGroup`, and its associated shards, can be safely deleted.
- a second goroutine that runs on every node, which checks each shard in the TSBD store against the list of shards which should actually exist. If the shard is part of a tombstoned `ShardGroup` it is deleted.