### PR TITLE
Add tcp.Mux

### DIFF
--- a/tcp/mux.go
+++ b/tcp/mux.go
@@ -1,0 +1,128 @@
+package tcp
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"os"
+	"time"
+)
+
+const (
+	// DefaultTimeout is the default length of time to wait for first byte.
+	DefaultTimeout = 30 * time.Second
+)
+
+// Mux multiplexes a network connection.
+type Mux struct {
+	ln net.Listener
+	m  map[byte]*listener
+
+	// The amount of time to wait for the first header byte.
+	Timeout time.Duration
+
+	// Out-of-band error logger
+	Logger *log.Logger
+}
+
+// NewMux returns a new instance of Mux for ln.
+func NewMux() *Mux {
+	return &Mux{
+		m:       make(map[byte]*listener),
+		Timeout: DefaultTimeout,
+		Logger:  log.New(os.Stderr, "", log.LstdFlags),
+	}
+}
+
+// Serve handles connections from ln and multiplexes then across registered listener.
+func (mux *Mux) Serve(ln net.Listener) error {
+	for {
+		// Wait for the next connection.
+		// If it returns a temporary error then simply retry.
+		// If it returns any other error then exit immediately.
+		conn, err := ln.Accept()
+		if err, ok := err.(interface {
+			Temporary() bool
+		}); ok && err.Temporary() {
+			continue
+		}
+		if err != nil {
+			for _, ln := range mux.m {
+				close(ln.c)
+			}
+			return err
+		}
+
+		// Set a read deadline so connections with no data don't timeout.
+		if err := conn.SetReadDeadline(time.Now().Add(mux.Timeout)); err != nil {
+			conn.Close()
+			mux.Logger.Printf("tcp.Mux: cannot set read deadline: %s", err)
+			continue
+		}
+
+		// Read first byte from connection to determine handler.
+		var typ [1]byte
+		if _, err := io.ReadFull(conn, typ[:]); err != nil {
+			conn.Close()
+			mux.Logger.Printf("tcp.Mux: cannot read header byte: %s", err)
+			continue
+		}
+
+		// Reset read deadline and let the listener handle that.
+		if err := conn.SetReadDeadline(time.Time{}); err != nil {
+			conn.Close()
+			mux.Logger.Printf("tcp.Mux: cannot reset set read deadline: %s", err)
+			continue
+		}
+
+		// Retrieve handler based on first byte.
+		handler := mux.m[typ[0]]
+		if handler == nil {
+			conn.Close()
+			mux.Logger.Printf("tcp.Mux: handler not registered: %d", typ[0])
+			continue
+		}
+
+		// Send connection to handler.
+		handler.c <- conn
+	}
+}
+
+// Listen returns a listener identified by header.
+// Any connection accepted by mux is multiplexed based on the initial header byte.
+func (mux *Mux) Listen(header byte) net.Listener {
+	// Ensure two listeners are not created for the same header byte.
+	if _, ok := mux.m[header]; ok {
+		panic(fmt.Sprintf("listener already registered under header byte: %d", header))
+	}
+
+	// Create a new listener and assign it.
+	ln := &listener{
+		c: make(chan net.Conn),
+	}
+	mux.m[header] = ln
+
+	return ln
+}
+
+// listener is a receiver for connections received by Mux.
+type listener struct {
+	c chan net.Conn
+}
+
+// Accept waits for and returns the next connection to the listener.
+func (ln *listener) Accept() (c net.Conn, err error) {
+	conn, ok := <-ln.c
+	if !ok {
+		return nil, errors.New("network connection closed")
+	}
+	return conn, nil
+}
+
+// Close is a no-op. The mux's listener should be closed instead.
+func (ln *listener) Close() error { return nil }
+
+// Addr always returns nil.
+func (ln *listener) Addr() net.Addr { return nil }

--- a/tcp/mux_test.go
+++ b/tcp/mux_test.go
@@ -1,0 +1,136 @@
+package tcp_test
+
+import (
+	"bytes"
+	"io"
+	"io/ioutil"
+	"log"
+	"net"
+	"strings"
+	"sync"
+	"testing"
+	"testing/quick"
+	"time"
+
+	"github.com/influxdb/influxdb/tcp"
+)
+
+// Ensure the muxer can split a listener's connections across multiple listeners.
+func TestMux(t *testing.T) {
+	if err := quick.Check(func(n uint8, msg []byte) bool {
+		if testing.Verbose() {
+			if len(msg) == 0 {
+				log.Printf("n=%d, <no message>", n)
+			} else {
+				log.Printf("n=%d, hdr=%d, len=%d", n, msg[0], len(msg))
+			}
+		}
+
+		var wg sync.WaitGroup
+
+		// Open single listener on random port.
+		tcpListener, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer tcpListener.Close()
+
+		// Setup muxer & listeners.
+		mux := tcp.NewMux()
+		mux.Timeout = 200 * time.Millisecond
+		if !testing.Verbose() {
+			mux.Logger = log.New(ioutil.Discard, "", 0)
+		}
+		for i := uint8(0); i < n; i++ {
+			ln := mux.Listen(byte(i))
+
+			wg.Add(1)
+			go func(i uint8, ln net.Listener) {
+				defer wg.Done()
+
+				// Wait for a connection for this listener.
+				conn, err := ln.Accept()
+				if conn != nil {
+					defer conn.Close()
+				}
+
+				// If there is no message or the header byte
+				// doesn't match then expect close.
+				if len(msg) == 0 || msg[0] != byte(i) {
+					if err == nil || err.Error() != "network connection closed" {
+						t.Fatalf("unexpected error: %s", err)
+					}
+					return
+				}
+
+				// If the header byte matches this listener
+				// then expect a connection and read the message.
+				var buf bytes.Buffer
+				if _, err := io.CopyN(&buf, conn, int64(len(msg)-1)); err != nil {
+					t.Fatal(err)
+				} else if !bytes.Equal(msg[1:], buf.Bytes()) {
+					t.Fatalf("message mismatch:\n\nexp=%x\n\ngot=%x\n\n", msg[1:], buf.Bytes())
+				}
+
+				// Write response.
+				if _, err := conn.Write([]byte("OK")); err != nil {
+					t.Fatal(err)
+				}
+			}(i, ln)
+		}
+
+		// Begin serving from the listener.
+		go mux.Serve(tcpListener)
+
+		// Write message to TCP listener and read OK response.
+		conn, err := net.Dial("tcp", tcpListener.Addr().String())
+		if err != nil {
+			t.Fatal(err)
+		} else if _, err = conn.Write(msg); err != nil {
+			t.Fatal(err)
+		}
+
+		// Read the response into the buffer.
+		var resp [2]byte
+		_, err = io.ReadFull(conn, resp[:])
+
+		// If the message header is less than n then expect a response.
+		// Otherwise we should get an EOF because the mux closed.
+		if len(msg) > 0 && uint8(msg[0]) < n {
+			if string(resp[:]) != `OK` {
+				t.Fatalf("unexpected response: %s", resp[:])
+			}
+		} else {
+			if err == nil || (err != io.EOF && !strings.Contains(err.Error(), "connection reset by peer")) {
+				t.Fatalf("unexpected error: %s", err)
+			}
+		}
+
+		// Close connection.
+		if err := conn.Close(); err != nil {
+			t.Fatal(err)
+		}
+
+		// Close original TCP listener and wait for all goroutines to close.
+		tcpListener.Close()
+		wg.Wait()
+
+		return true
+	}, nil); err != nil {
+		t.Error(err)
+	}
+}
+
+// Ensure two handlers cannot be registered for the same header byte.
+func TestMux_Listen_ErrAlreadyRegistered(t *testing.T) {
+	defer func() {
+		if r := recover(); r != `listener already registered under header byte: 5` {
+			t.Fatalf("unexpected recover: %#v", r)
+		}
+	}()
+
+	// Register two listeners with the same header byte.
+	mux := tcp.NewMux()
+	mux.Listen(5)
+	mux.Listen(5)
+}


### PR DESCRIPTION
## Overview

This pull request adds `tcp.Mux` which multiplexes connections over TCP using the first byte as the header byte. Users can listen to the muxer using `mux.Listen(hdr)` and obtain a `net.Listener`.