### PR TITLE
Hinted Handoff Write Support

### DIFF
--- a/cluster/points_writer.go
+++ b/cluster/points_writer.go
@@ -51,6 +51,7 @@ type PointsWriter struct {
 		Database(name string) (di *meta.DatabaseInfo, err error)
 		RetentionPolicy(database, policy string) (*meta.RetentionPolicyInfo, error)
 		CreateShardGroupIfNotExists(database, policy string, timestamp time.Time) (*meta.ShardGroupInfo, error)
+		ShardOwner(shardID uint64) (string, string, *meta.ShardGroupInfo)
 	}
 
 	TSDBStore interface {

--- a/cluster/points_writer_test.go
+++ b/cluster/points_writer_test.go
@@ -137,16 +137,9 @@ func TestPointsWriter_WritePoints(t *testing.T) {
 		{
 			name:        "write any success",
 			consistency: cluster.ConsistencyLevelAny,
-			err:         []error{nil, nil, nil},
+			err:         []error{fmt.Errorf("a failure"), nil, fmt.Errorf("a failure")},
 			expErr:      nil,
 		},
-		{
-			name:        "write any failure",
-			consistency: cluster.ConsistencyLevelAny,
-			err:         []error{fmt.Errorf("a failure"), fmt.Errorf("a failure"), fmt.Errorf("a failure")},
-			expErr:      cluster.ErrWriteFailed,
-		},
-
 		// Consistency all
 		{
 			name:        "write all success",
@@ -193,6 +186,14 @@ func TestPointsWriter_WritePoints(t *testing.T) {
 			consistency: cluster.ConsistencyLevelOne,
 			err:         []error{fmt.Errorf("a failure"), fmt.Errorf("a failure"), fmt.Errorf("a failure")},
 			expErr:      cluster.ErrWriteFailed,
+		},
+
+		// Hinted handoff w/ ANY
+		{
+			name:        "hinted handoff write succeed",
+			consistency: cluster.ConsistencyLevelAny,
+			err:         []error{fmt.Errorf("a failure"), fmt.Errorf("a failure"), fmt.Errorf("a failure")},
+			expErr:      nil,
 		},
 	}
 
@@ -242,12 +243,19 @@ func TestPointsWriter_WritePoints(t *testing.T) {
 			},
 		}
 
+		hh := &fakeShardWriter{
+			ShardWriteFn: func(shardID, nodeID uint64, points []tsdb.Point) error {
+				return nil
+			},
+		}
+
 		ms := NewMetaStore()
 		ms.NodeIDFn = func() uint64 { return 1 }
 		c := cluster.PointsWriter{
-			MetaStore:   ms,
-			ShardWriter: sw,
-			TSDBStore:   store,
+			MetaStore:     ms,
+			ShardWriter:   sw,
+			TSDBStore:     store,
+			HintedHandoff: hh,
 		}
 
 		if err := c.WritePoints(pr); err != test.expErr {

--- a/cluster/points_writer_test.go
+++ b/cluster/points_writer_test.go
@@ -313,6 +313,7 @@ type MetaStore struct {
 	RetentionPolicyFn             func(database, name string) (*meta.RetentionPolicyInfo, error)
 	CreateShardGroupIfNotExistsFn func(database, policy string, timestamp time.Time) (*meta.ShardGroupInfo, error)
 	DatabaseFn                    func(database string) (*meta.DatabaseInfo, error)
+	ShardOwnerFn                  func(shardID uint64) (string, string, *meta.ShardGroupInfo)
 }
 
 func (m MetaStore) NodeID() uint64 { return m.NodeIDFn() }
@@ -327,6 +328,10 @@ func (m MetaStore) CreateShardGroupIfNotExists(database, policy string, timestam
 
 func (m MetaStore) Database(database string) (*meta.DatabaseInfo, error) {
 	return m.DatabaseFn(database)
+}
+
+func (m MetaStore) ShardOwner(shardID uint64) (string, string, *meta.ShardGroupInfo) {
+	return m.ShardOwnerFn(shardID)
 }
 
 func NewRetentionPolicy(name string, duration time.Duration, nodeCount int) *meta.RetentionPolicyInfo {

--- a/cluster/service_test.go
+++ b/cluster/service_test.go
@@ -23,10 +23,11 @@ func (m *metaStore) Node(nodeID uint64) (*meta.NodeInfo, error) {
 }
 
 type testService struct {
-	nodeID         uint64
-	writeShardFunc func(shardID uint64, points []tsdb.Point) error
-	ln             net.Listener
-	muxln          net.Listener
+	nodeID          uint64
+	ln              net.Listener
+	muxln           net.Listener
+	writeShardFunc  func(shardID uint64, points []tsdb.Point) error
+	createShardFunc func(database, policy string, shardID uint64) error
 }
 
 func newTestService(f func(shardID uint64, points []tsdb.Point) error) testService {
@@ -61,6 +62,10 @@ type serviceResponse struct {
 
 func (t testService) WriteToShard(shardID uint64, points []tsdb.Point) error {
 	return t.writeShardFunc(shardID, points)
+}
+
+func (t testService) CreateShard(database, policy string, shardID uint64) error {
+	return t.createShardFunc(database, policy, shardID)
 }
 
 func writeShardSuccess(shardID uint64, points []tsdb.Point) error {

--- a/cluster/shard_writer.go
+++ b/cluster/shard_writer.go
@@ -139,6 +139,10 @@ func (c *connFactory) dial() (net.Conn, error) {
 		return nil, err
 	}
 
+	if ni == nil {
+		return nil, fmt.Errorf("node %d does not exist", c.nodeID)
+	}
+
 	conn, err := net.DialTimeout("tcp", ni.Host, c.timeout)
 	if err != nil {
 		return nil, err

--- a/cluster/shard_writer_test.go
+++ b/cluster/shard_writer_test.go
@@ -130,7 +130,7 @@ func TestShardWriter_WriteShard_Error(t *testing.T) {
 	))
 
 	if err := w.WriteShard(shardID, ownerID, points); err == nil || err.Error() != "error code 1: write shard: failed to write" {
-		t.Fatalf("unexpected error: %s", err)
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 

--- a/cmd/influxd/run/config.go
+++ b/cmd/influxd/run/config.go
@@ -74,6 +74,7 @@ func NewDemoConfig() (*Config, error) {
 
 	c.Meta.Dir = filepath.Join(u.HomeDir, ".influxdb/meta")
 	c.Data.Dir = filepath.Join(u.HomeDir, ".influxdb/data")
+	c.HintedHandoff.Dir = filepath.Join(u.HomeDir, ".influxdb/hh")
 
 	c.Admin.Enabled = true
 	c.Monitoring.Enabled = false
@@ -87,6 +88,8 @@ func (c *Config) Validate() error {
 		return errors.New("Meta.Dir must be specified")
 	} else if c.Data.Dir == "" {
 		return errors.New("Data.Dir must be specified")
+	} else if c.HintedHandoff.Dir == "" {
+		return errors.New("HintedHandoff.Dir must be specified")
 	}
 	return nil
 }

--- a/cmd/influxd/run/config.go
+++ b/cmd/influxd/run/config.go
@@ -12,6 +12,7 @@ import (
 	"github.com/influxdb/influxdb/services/collectd"
 	"github.com/influxdb/influxdb/services/continuous_querier"
 	"github.com/influxdb/influxdb/services/graphite"
+	"github.com/influxdb/influxdb/services/hh"
 	"github.com/influxdb/influxdb/services/httpd"
 	"github.com/influxdb/influxdb/services/monitor"
 	"github.com/influxdb/influxdb/services/opentsdb"
@@ -37,6 +38,8 @@ type Config struct {
 	// Snapshot SnapshotConfig `toml:"snapshot"`
 	Monitoring      monitor.Config            `toml:"monitoring"`
 	ContinuousQuery continuous_querier.Config `toml:"continuous_queries"`
+
+	HintedHandoff hh.Config `toml:"hinted-handoff"`
 }
 
 // NewConfig returns an instance of Config with reasonable defaults.
@@ -54,6 +57,7 @@ func NewConfig() *Config {
 	c.Monitoring = monitor.NewConfig()
 	c.ContinuousQuery = continuous_querier.NewConfig()
 	c.Retention = retention.NewConfig()
+	c.HintedHandoff = hh.NewConfig()
 
 	return c
 }

--- a/cmd/influxd/run/server.go
+++ b/cmd/influxd/run/server.go
@@ -11,6 +11,7 @@ import (
 	"github.com/influxdb/influxdb/services/collectd"
 	"github.com/influxdb/influxdb/services/continuous_querier"
 	"github.com/influxdb/influxdb/services/graphite"
+	"github.com/influxdb/influxdb/services/hh"
 	"github.com/influxdb/influxdb/services/httpd"
 	"github.com/influxdb/influxdb/services/opentsdb"
 	"github.com/influxdb/influxdb/services/retention"
@@ -35,6 +36,7 @@ type Server struct {
 	QueryExecutor *tsdb.QueryExecutor
 	PointsWriter  *cluster.PointsWriter
 	ShardWriter   *cluster.ShardWriter
+	HintedHandoff *hh.Service
 
 	Services []Service
 }
@@ -62,11 +64,15 @@ func NewServer(c *Config) *Server {
 	s.ShardWriter = cluster.NewShardWriter(time.Duration(c.Cluster.ShardWriterTimeout))
 	s.ShardWriter.MetaStore = s.MetaStore
 
+	// Create the hinted handoff service
+	s.HintedHandoff = hh.NewService(c.HintedHandoff)
+
 	// Initialize points writer.
 	s.PointsWriter = cluster.NewPointsWriter()
 	s.PointsWriter.MetaStore = s.MetaStore
 	s.PointsWriter.TSDBStore = s.TSDBStore
 	s.PointsWriter.ShardWriter = s.ShardWriter
+	s.PointsWriter.HintedHandoff = s.HintedHandoff
 
 	// Append services.
 	s.appendClusterService(c.Cluster)
@@ -216,6 +222,11 @@ func (s *Server) Open() error {
 			return fmt.Errorf("open tsdb store: %s", err)
 		}
 
+		// Open the hinted handoff service
+		if err := s.HintedHandoff.Open(); err != nil {
+			return fmt.Errorf("open hinted handoff: %s", err)
+		}
+
 		for _, service := range s.Services {
 			if err := service.Open(); err != nil {
 				return fmt.Errorf("open service: %s", err)
@@ -242,6 +253,9 @@ func (s *Server) Close() error {
 	}
 	if s.TSDBStore != nil {
 		s.TSDBStore.Close()
+	}
+	if s.HintedHandoff != nil {
+		s.HintedHandoff.Close()
 	}
 	for _, service := range s.Services {
 		service.Close()

--- a/cmd/influxd/run/server.go
+++ b/cmd/influxd/run/server.go
@@ -93,6 +93,7 @@ func NewServer(c *Config) *Server {
 func (s *Server) appendClusterService(c cluster.Config) {
 	srv := cluster.NewService(c)
 	srv.TSDBStore = s.TSDBStore
+	srv.MetaStore = s.MetaStore
 	s.Services = append(s.Services, srv)
 }
 

--- a/cmd/influxd/run/server.go
+++ b/cmd/influxd/run/server.go
@@ -65,7 +65,7 @@ func NewServer(c *Config) *Server {
 	s.ShardWriter.MetaStore = s.MetaStore
 
 	// Create the hinted handoff service
-	s.HintedHandoff = hh.NewService(c.HintedHandoff)
+	s.HintedHandoff = hh.NewService(c.HintedHandoff, s.ShardWriter)
 
 	// Initialize points writer.
 	s.PointsWriter = cluster.NewPointsWriter()

--- a/cmd/influxd/run/server_helpers_test.go
+++ b/cmd/influxd/run/server_helpers_test.go
@@ -67,6 +67,7 @@ func OpenServer(c *run.Config, joinURLs string) *Server {
 func (s *Server) Close() {
 	os.RemoveAll(s.Config.Meta.Dir)
 	os.RemoveAll(s.Config.Data.Dir)
+	os.RemoveAll(s.Config.HintedHandoff.Dir)
 	s.Server.Close()
 }
 
@@ -151,6 +152,8 @@ func NewConfig() *run.Config {
 	c.Meta.CommitTimeout = toml.Duration(5 * time.Millisecond)
 
 	c.Data.Dir = MustTempFile()
+
+	c.HintedHandoff.Dir = MustTempFile()
 
 	c.HTTPD.Enabled = true
 	c.HTTPD.BindAddress = "127.0.0.1:0"

--- a/meta/store.go
+++ b/meta/store.go
@@ -786,12 +786,15 @@ func (s *Store) VisitRetentionPolicies(f func(d DatabaseInfo, r RetentionPolicyI
 }
 
 // VisitShardGroups calls the given function with full shard group details.
-func (s *Store) VisitShardGroups(f func(d DatabaseInfo, r RetentionPolicyInfo, s ShardGroupInfo)) {
+func (s *Store) VisitShardGroups(f func(d *DatabaseInfo, r *RetentionPolicyInfo, sgi *ShardGroupInfo)) {
 	s.read(func(data *Data) error {
-		for _, di := range data.Databases {
-			for _, rp := range di.RetentionPolicies {
-				for _, sg := range rp.ShardGroups {
-					f(di, rp, sg)
+		for i := range data.Databases {
+			db := &data.Databases[i]
+			for j := range db.RetentionPolicies {
+				rp := &db.RetentionPolicies[j]
+				for k := range rp.ShardGroups {
+					sg := &rp.ShardGroups[k]
+					f(db, rp, sg)
 				}
 			}
 		}
@@ -810,6 +813,23 @@ func (s *Store) ShardGroupByTimestamp(database, policy string, timestamp time.Ti
 			return errInvalidate
 		}
 		return nil
+	})
+	return
+}
+
+func (s *Store) ShardOwner(shardID uint64) (database, policy string, sgi *ShardGroupInfo) {
+	s.VisitShardGroups(func(d *DatabaseInfo, r *RetentionPolicyInfo, s *ShardGroupInfo) {
+		if s.Deleted() {
+			return
+		}
+
+		for _, sh := range s.Shards {
+			if sh.ID == shardID {
+				database = d.Name
+				policy = r.Name
+				sgi = s
+			}
+		}
 	})
 	return
 }

--- a/services/hh/config.go
+++ b/services/hh/config.go
@@ -8,7 +8,7 @@ import (
 
 const (
 	// DefaultMaxSize is the default maximum size of all hinted handoff queues in bytes.
-	DefaultMaxSize = 1024 ^ 3
+	DefaultMaxSize = 1024 * 1024 * 1024
 
 	// DefaultRetryInterval is the default amout of time the system waits before
 	// attempting to flush hinted handoff queues.
@@ -21,7 +21,8 @@ const (
 
 type Config struct {
 	Enabled        bool          `toml:"enabled"`
-	MaxSize        int           `toml:"max-size"`
+	Dir            string        `toml:"dir"`
+	MaxSize        int64         `toml:"max-size"`
 	RetryInterval  toml.Duration `toml:"retry-interval"`
 	MaxBackoffTime toml.Duration `toml:"max-backoff-time"`
 }

--- a/services/hh/config.go
+++ b/services/hh/config.go
@@ -10,28 +10,35 @@ const (
 	// DefaultMaxSize is the default maximum size of all hinted handoff queues in bytes.
 	DefaultMaxSize = 1024 * 1024 * 1024
 
+	// DefaultMaxAge is the default maximum amount of time that a hinted handoff write
+	// can stay in the queue.  After this time, the write will be purged.
+	DefaultMaxAge = 7 * 24 * time.Hour
+
+	// DefaultRetryRateLimit is the default rate that hinted handoffs will be retried.
+	// The rate is in bytes per second and applies across all nodes when retried.   A
+	// value of 0 disables the rate limit.
+	DefaultRetryRateLimit = 0
+
 	// DefaultRetryInterval is the default amout of time the system waits before
 	// attempting to flush hinted handoff queues.
 	DefaultRetryInterval = time.Second
-
-	// DefaultMaxBackoffTime is the default maximum time to wait when a node with pending
-	// hinted handoff writes is unavailable.
-	DefaultMaxBackoffTime = 5 * time.Minute
 )
 
 type Config struct {
 	Enabled        bool          `toml:"enabled"`
 	Dir            string        `toml:"dir"`
 	MaxSize        int64         `toml:"max-size"`
+	MaxAge         toml.Duration `toml:"max-age"`
+	RetryRateLimit int64         `toml:"retry-rate-limit"`
 	RetryInterval  toml.Duration `toml:"retry-interval"`
-	MaxBackoffTime toml.Duration `toml:"max-backoff-time"`
 }
 
 func NewConfig() Config {
 	return Config{
 		Enabled:        true,
 		MaxSize:        DefaultMaxSize,
+		MaxAge:         toml.Duration(DefaultMaxAge),
+		RetryRateLimit: DefaultRetryRateLimit,
 		RetryInterval:  toml.Duration(DefaultRetryInterval),
-		MaxBackoffTime: toml.Duration(DefaultMaxBackoffTime),
 	}
 }

--- a/services/hh/config.go
+++ b/services/hh/config.go
@@ -1,0 +1,36 @@
+package hh
+
+import (
+	"time"
+
+	"github.com/influxdb/influxdb/toml"
+)
+
+const (
+	// DefaultMaxSize is the default maximum size of all hinted handoff queues in bytes.
+	DefaultMaxSize = 1024 ^ 3
+
+	// DefaultRetryInterval is the default amout of time the system waits before
+	// attempting to flush hinted handoff queues.
+	DefaultRetryInterval = time.Second
+
+	// DefaultMaxBackoffTime is the default maximum time to wait when a node with pending
+	// hinted handoff writes is unavailable.
+	DefaultMaxBackoffTime = 5 * time.Minute
+)
+
+type Config struct {
+	Enabled        bool          `toml:"enabled"`
+	MaxSize        int           `toml:"max-size"`
+	RetryInterval  toml.Duration `toml:"retry-interval"`
+	MaxBackoffTime toml.Duration `toml:"max-backoff-time"`
+}
+
+func NewConfig() Config {
+	return Config{
+		Enabled:        true,
+		MaxSize:        DefaultMaxSize,
+		RetryInterval:  toml.Duration(DefaultRetryInterval),
+		MaxBackoffTime: toml.Duration(DefaultMaxBackoffTime),
+	}
+}

--- a/services/hh/config_test.go
+++ b/services/hh/config_test.go
@@ -33,7 +33,7 @@ max-size=2048
 		t.Fatalf("unexpected max backoff time: got %v, exp %v", c.MaxBackoffTime, exp)
 	}
 
-	if exp := 2048; c.MaxSize != exp {
+	if exp := int64(2048); c.MaxSize != exp {
 		t.Fatalf("unexpected retry interval: got %v, exp %v", c.MaxSize, exp)
 	}
 }

--- a/services/hh/config_test.go
+++ b/services/hh/config_test.go
@@ -1,0 +1,39 @@
+package hh_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/BurntSushi/toml"
+	"github.com/influxdb/influxdb/services/hh"
+)
+
+func TestConfigParse(t *testing.T) {
+	// Parse configuration.
+	var c hh.Config
+	if _, err := toml.Decode(`
+enabled = false
+retry-interval = "10m"
+max-backoff-time = "20m"
+max-size=2048
+`, &c); err != nil {
+		t.Fatal(err)
+	}
+
+	// Validate configuration.
+	if exp := true; c.Enabled == true {
+		t.Fatalf("unexpected enabled: got %v, exp %v", c.Enabled, exp)
+	}
+
+	if exp := 10 * time.Minute; c.RetryInterval.String() != exp.String() {
+		t.Fatalf("unexpected retry interval: got %v, exp %v", c.RetryInterval, exp)
+	}
+
+	if exp := 20 * time.Minute; c.MaxBackoffTime.String() != exp.String() {
+		t.Fatalf("unexpected max backoff time: got %v, exp %v", c.MaxBackoffTime, exp)
+	}
+
+	if exp := 2048; c.MaxSize != exp {
+		t.Fatalf("unexpected retry interval: got %v, exp %v", c.MaxSize, exp)
+	}
+}

--- a/services/hh/config_test.go
+++ b/services/hh/config_test.go
@@ -14,8 +14,9 @@ func TestConfigParse(t *testing.T) {
 	if _, err := toml.Decode(`
 enabled = false
 retry-interval = "10m"
-max-backoff-time = "20m"
 max-size=2048
+max-age="20m"
+retry-rate-limit=1000
 `, &c); err != nil {
 		t.Fatal(err)
 	}
@@ -29,11 +30,16 @@ max-size=2048
 		t.Fatalf("unexpected retry interval: got %v, exp %v", c.RetryInterval, exp)
 	}
 
-	if exp := 20 * time.Minute; c.MaxBackoffTime.String() != exp.String() {
-		t.Fatalf("unexpected max backoff time: got %v, exp %v", c.MaxBackoffTime, exp)
+	if exp := 20 * time.Minute; c.MaxAge.String() != exp.String() {
+		t.Fatalf("unexpected max age: got %v, exp %v", c.MaxAge, exp)
 	}
 
 	if exp := int64(2048); c.MaxSize != exp {
 		t.Fatalf("unexpected retry interval: got %v, exp %v", c.MaxSize, exp)
 	}
+
+	if exp := int64(1000); c.RetryRateLimit != exp {
+		t.Fatalf("unexpected retry rate limit: got %v, exp %v", c.RetryRateLimit, exp)
+	}
+
 }

--- a/services/hh/doc.go
+++ b/services/hh/doc.go
@@ -1,0 +1,5 @@
+/*
+Package hh implements a hinted handoff for writes
+
+*/
+package hh

--- a/services/hh/processor.go
+++ b/services/hh/processor.go
@@ -1,0 +1,146 @@
+package hh
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strconv"
+	"sync"
+
+	"github.com/influxdb/influxdb/tsdb"
+)
+
+type Processor struct {
+	mu sync.RWMutex
+
+	dir     string
+	maxSize int64
+	queues  map[uint64]*queue
+	writer  shardWriter
+}
+
+func NewProcessor(dir string, maxSize int64, writer shardWriter) (*Processor, error) {
+	p := &Processor{
+		dir:     dir,
+		maxSize: maxSize,
+		queues:  map[uint64]*queue{},
+		writer:  writer,
+	}
+
+	// Create the root directory if it doesn't already exist.
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return nil, fmt.Errorf("mkdir all: %s", err)
+	}
+
+	if err := p.loadQueues(); err != nil {
+		return p, err
+	}
+	return p, nil
+}
+
+func (p *Processor) loadQueues() error {
+	files, err := ioutil.ReadDir(p.dir)
+	if err != nil {
+		return err
+	}
+
+	for _, file := range files {
+
+		nodeID, err := strconv.ParseUint(file.Name(), 10, 64)
+		if err != nil {
+			return err
+		}
+
+		if _, err := p.addQueue(nodeID); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (p *Processor) addQueue(nodeID uint64) (*queue, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	path := filepath.Join(p.dir, strconv.FormatUint(nodeID, 10))
+	if err := os.MkdirAll(path, 0700); err != nil {
+		return nil, err
+	}
+
+	queue, err := newQueue(path, p.maxSize)
+	if err != nil {
+		return nil, err
+	}
+	if err := queue.Open(); err != nil {
+		return nil, err
+	}
+	p.queues[nodeID] = queue
+	return queue, nil
+}
+
+func (p *Processor) WriteShard(shardID, ownerID uint64, points []tsdb.Point) error {
+	queue, ok := p.queues[ownerID]
+	if !ok {
+		var err error
+		if queue, err = p.addQueue(ownerID); err != nil {
+			return err
+		}
+	}
+
+	b := p.marshalWrite(shardID, points)
+	return queue.Append(b)
+}
+
+func (p *Processor) Process() error {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+
+	// FIXME: each queue should be processed in its own goroutine
+	for nodeID, queue := range p.queues {
+		for {
+			// Get the current block from the queue
+			buf, err := queue.Current()
+			if err != nil {
+				break
+			}
+
+			// unmarshal the byte slice back to shard ID and points
+			shardID, points, err := p.unmarshalWrite(buf)
+			if err != nil {
+				// TODO: If we ever get and error here, we should probably drop the
+				// the write and let anti-entropy resolve it.  This would be an urecoverable
+				// error and could block the queue indefinitely.
+				return err
+			}
+
+			// Try to send the write to the node
+			if err := p.writer.WriteShard(shardID, nodeID, points); err != nil {
+				break
+			}
+
+			// If we get here, the write succeed to advance the queue to the next item
+			if err := queue.Advance(); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (p *Processor) marshalWrite(shardID uint64, points []tsdb.Point) []byte {
+	b := make([]byte, 8)
+	binary.BigEndian.PutUint64(b, shardID)
+	for _, p := range points {
+		b = append(b, []byte(p.String())...)
+		b = append(b, '\n')
+	}
+	return b
+}
+
+func (p *Processor) unmarshalWrite(b []byte) (uint64, []tsdb.Point, error) {
+	ownerID := binary.BigEndian.Uint64(b[:8])
+	points, err := tsdb.ParsePoints(b[8:])
+	return ownerID, points, err
+}

--- a/services/hh/processor.go
+++ b/services/hh/processor.go
@@ -31,7 +31,6 @@ type ProcessorOptions struct {
 }
 
 func NewProcessor(dir string, writer shardWriter, options ProcessorOptions) (*Processor, error) {
-
 	p := &Processor{
 		dir:    dir,
 		queues: map[uint64]*queue{},
@@ -69,7 +68,6 @@ func (p *Processor) loadQueues() error {
 	}
 
 	for _, file := range files {
-
 		nodeID, err := strconv.ParseUint(file.Name(), 10, 64)
 		if err != nil {
 			return err

--- a/services/hh/processor_test.go
+++ b/services/hh/processor_test.go
@@ -48,7 +48,7 @@ func TestProcessorProcess(t *testing.T) {
 		},
 	}
 
-	p, err := NewProcessor(dir, 1024, sh)
+	p, err := NewProcessor(dir, sh, ProcessorOptions{MaxSize: 1024})
 	if err != nil {
 		t.Fatalf("Process() failed to create processor: %v", err)
 	}

--- a/services/hh/processor_test.go
+++ b/services/hh/processor_test.go
@@ -1,0 +1,80 @@
+package hh
+
+import (
+	"io/ioutil"
+	"testing"
+	"time"
+
+	"github.com/influxdb/influxdb/tsdb"
+)
+
+type fakeShardWriter struct {
+	ShardWriteFn func(shardID, nodeID uint64, points []tsdb.Point) error
+}
+
+func (f *fakeShardWriter) WriteShard(shardID, nodeID uint64, points []tsdb.Point) error {
+	return f.ShardWriteFn(shardID, nodeID, points)
+}
+
+func TestProcessorProcess(t *testing.T) {
+	dir, err := ioutil.TempDir("", "processor_test")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+
+	// expected data to be queue and sent to the shardWriter
+	var expShardID, expNodeID, count = uint64(100), uint64(200), 0
+	pt := tsdb.NewPoint("cpu", tsdb.Tags{"foo": "bar"}, tsdb.Fields{"value": 1.0}, time.Unix(0, 0))
+
+	sh := &fakeShardWriter{
+		ShardWriteFn: func(shardID, nodeID uint64, points []tsdb.Point) error {
+			count += 1
+			if shardID != expShardID {
+				t.Errorf("Process() shardID mismatch: got %v, exp %v", shardID, expShardID)
+			}
+			if nodeID != expNodeID {
+				t.Errorf("Process() nodeID mismatch: got %v, exp %v", nodeID, expNodeID)
+			}
+
+			if exp := 1; len(points) != exp {
+				t.Fatalf("Process() points mismatch: got %v, exp %v", len(points), exp)
+			}
+
+			if points[0].String() != pt.String() {
+				t.Fatalf("Process() points mismatch:\n got %v\n exp %v", points[0].String(), pt.String())
+			}
+
+			return nil
+		},
+	}
+
+	p, err := NewProcessor(dir, 1024, sh)
+	if err != nil {
+		t.Fatalf("Process() failed to create processor: %v", err)
+	}
+
+	// This should queue the writes
+	if err := p.WriteShard(expShardID, expNodeID, []tsdb.Point{pt}); err != nil {
+		t.Fatalf("Process() failed to write points: %v", err)
+	}
+
+	// This should send the write to the shard writer
+	if err := p.Process(); err != nil {
+		t.Fatalf("Process() failed to write points: %v", err)
+	}
+
+	if exp := 1; count != exp {
+		t.Fatalf("Process() write count mismatch: got %v, exp %v", count, exp)
+	}
+
+	// Queue should be empty so no writes should be send again
+	if err := p.Process(); err != nil {
+		t.Fatalf("Process() failed to write points: %v", err)
+	}
+
+	// Count should stay the same
+	if exp := 1; count != exp {
+		t.Fatalf("Process() write count mismatch: got %v, exp %v", count, exp)
+	}
+
+}

--- a/services/hh/queue.go
+++ b/services/hh/queue.go
@@ -1,0 +1,625 @@
+package hh
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strconv"
+	"sync"
+)
+
+var (
+	ErrNotOpen     = fmt.Errorf("queue not open")
+	ErrQueueFull   = fmt.Errorf("queue is full")
+	ErrSegmentFull = fmt.Errorf("segment is full")
+)
+
+const (
+	defaultSegmentSize = 10 * 1024 * 1024
+	footerSize         = 8
+)
+
+// queue is a bounded, disk-backed, append-only type that combines queue and
+// log semantics.  byte slices can be appended and read back in-order.
+// The queue maintains a pointer to the current head
+// byte slice and can re-read from the head until it has been advanced.
+//
+// Internally, the queue writes byte slices to multiple segment files so
+// that disk space can be reclaimed. When a segment file is larger than
+// the max segement size, a new file is created.   Segments are removed
+// after their head pointer has advanced past the last entry.  The first
+// segment is the head, and the last segment is the tail.  Reads are from
+// the head segment and writes tail segment.
+//
+// queues can have a max size configured such that when the size of all
+// segments on disk exceeds the size, write will fail.
+//
+// ┌─────┐
+// │Head │
+// ├─────┘
+// │
+// ▼
+// ┌─────────────────┐ ┌─────────────────┐┌─────────────────┐
+// │Segment 1 - 10MB │ │Segment 2 - 10MB ││Segment 3 - 10MB │
+// └─────────────────┘ └─────────────────┘└─────────────────┘
+//                                                          ▲
+//                                                          │
+//                                                          │
+//                                                     ┌─────┐
+//                                                     │Tail │
+//                                                     └─────┘
+type queue struct {
+	mu sync.RWMutex
+
+	// Directory to create segments
+	dir string
+
+	// The head and tail segments.  Reads are from the beginning of head,
+	// writes are appended to the tail.
+	head, tail *segment
+
+	// The maximum size in bytes of a segment file before a new one should be created
+	maxSegmentSize int64
+
+	// The maximum size allowed in bytes of all segments before writes will return
+	// an error
+	maxSize int64
+
+	// The segments that exist on disk
+	segments segments
+}
+
+type segments []*segment
+
+// newQueue create a queue that will store segments in dir and that will
+// consume more than maxSize on disk.
+func newQueue(dir string, maxSize int64) (*queue, error) {
+	return &queue{
+		dir:            dir,
+		maxSegmentSize: defaultSegmentSize,
+		maxSize:        maxSize,
+		segments:       segments{},
+	}, nil
+}
+
+// Open opens the queue for reading and writing
+func (l *queue) Open() error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	segments, err := l.loadSegments()
+	if err != nil {
+		return err
+	}
+	l.segments = segments
+
+	if len(l.segments) == 0 {
+		_, err := l.addSegment()
+		if err != nil {
+			return err
+		}
+	}
+
+	l.head = l.segments[0]
+	l.tail = l.segments[len(l.segments)-1]
+
+	// If the head has been fully advanced and the segment size is modified,
+	// existing segments an get stuck and never allow clients to advance further.
+	// This advances the segment if the current head is already at the end.
+	_, err = l.head.current()
+	if err == io.EOF {
+		return l.trimHead()
+	}
+
+	return nil
+}
+
+// Close stops the queue for reading and writing
+func (l *queue) Close() error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	for _, s := range l.segments {
+		if err := s.close(); err != nil {
+			return err
+		}
+	}
+	l.head = nil
+	l.tail = nil
+	l.segments = nil
+	return nil
+}
+
+// SetMaxSegmentSize updates the max segment size for new and existing
+// segments.
+func (l *queue) SetMaxSegmentSize(size int64) error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	l.maxSegmentSize = size
+
+	for _, s := range l.segments {
+		s.SetMaxSegmentSize(size)
+	}
+
+	if l.tail.diskUsage() >= l.maxSegmentSize {
+		segment, err := l.addSegment()
+		if err != nil {
+			return err
+		}
+		l.tail = segment
+	}
+	return nil
+}
+
+// diskUsage returns the total size on disk used by the queue
+func (l *queue) diskUsage() int64 {
+	var size int64
+	for _, s := range l.segments {
+		size += s.diskUsage()
+	}
+	return size
+}
+
+// addSegment creates a new empty segment file
+func (l *queue) addSegment() (*segment, error) {
+	nextID, err := l.nextSegmentID()
+	if err != nil {
+		return nil, err
+	}
+
+	segment, err := newSegment(filepath.Join(l.dir, strconv.FormatUint(nextID, 10)), l.maxSegmentSize)
+	if err != nil {
+		return nil, err
+	}
+
+	l.segments = append(l.segments, segment)
+	return segment, nil
+}
+
+// loadSegments loads all segments on disk
+func (l *queue) loadSegments() (segments, error) {
+	segments := []*segment{}
+
+	files, err := ioutil.ReadDir(l.dir)
+	if err != nil {
+		return segments, err
+	}
+
+	for _, segment := range files {
+		// Segments should be files.  Skip anything that is not a dir.
+		if segment.IsDir() {
+			continue
+		}
+
+		// Segments file names are all numeric
+		_, err := strconv.ParseUint(segment.Name(), 10, 64)
+		if err != nil {
+			continue
+		}
+
+		segment, err := newSegment(filepath.Join(l.dir, segment.Name()), l.maxSegmentSize)
+		if err != nil {
+			return segments, err
+		}
+
+		segments = append(segments, segment)
+	}
+	return segments, nil
+}
+
+// nextSegmentID returns the next segment ID that is free
+func (l *queue) nextSegmentID() (uint64, error) {
+	segments, err := ioutil.ReadDir(l.dir)
+	if err != nil {
+		return 0, err
+	}
+
+	var maxID uint64
+	for _, segment := range segments {
+		// Segments should be files.  Skip anything that is not a dir.
+		if segment.IsDir() {
+			continue
+		}
+
+		// Segments file names are all numeric
+		segmentID, err := strconv.ParseUint(segment.Name(), 10, 64)
+		if err != nil {
+			continue
+		}
+
+		if segmentID > maxID {
+			maxID = segmentID
+		}
+	}
+
+	return maxID + 1, nil
+}
+
+// Append appends a byte slice to the end of the queue
+func (l *queue) Append(b []byte) error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if l.tail == nil {
+		return ErrNotOpen
+	}
+
+	if l.diskUsage()+int64(len(b)) > l.maxSize {
+		return ErrQueueFull
+	}
+
+	// Append the entry to the tail, if the segment is full,
+	// try to create new segement and retry the append
+	if err := l.tail.append(b); err == ErrSegmentFull {
+		segment, err := l.addSegment()
+		if err != nil {
+			return err
+		}
+		l.tail = segment
+		return l.tail.append(b)
+	}
+	return nil
+}
+
+// Current returns the current byte slice at the head of the queue
+func (l *queue) Current() ([]byte, error) {
+	if l.head == nil {
+		return nil, ErrNotOpen
+	}
+
+	return l.head.current()
+}
+
+// Advance moves the head point to the next byte slice in the queue
+func (l *queue) Advance() error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.head == nil {
+		return ErrNotOpen
+	}
+
+	err := l.head.advance()
+	if err == io.EOF {
+		if err := l.trimHead(); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (l *queue) trimHead() error {
+	if len(l.segments) > 1 {
+		l.segments = l.segments[1:]
+
+		if err := l.head.close(); err != nil {
+			return err
+		}
+		if err := os.Remove(l.head.path); err != nil {
+			return err
+		}
+		l.head = l.segments[0]
+	}
+	return nil
+}
+
+// Segment is a queue using a single file.  The structure of a segment is a series
+// lengths + block with a single footer point to the position in the segement of the
+// current head block.
+//
+// ┌──────────────────────────┐ ┌──────────────────────────┐ ┌────────────┐
+// │         Block 1          │ │         Block 2          │ │   Footer   │
+// └──────────────────────────┘ └──────────────────────────┘ └────────────┘
+// ┌────────────┐┌────────────┐ ┌────────────┐┌────────────┐ ┌────────────┐
+// │Block 1 Len ││Block 1 Body│ │Block 2 Len ││Block 2 Body│ │Head Offset │
+// │  8 bytes   ││  N bytes   │ │  8 bytes   ││  N bytes   │ │  8 bytes   │
+// └────────────┘└────────────┘ └────────────┘└────────────┘ └────────────┘
+//
+// The footer holds the pointer to the head entry at the end of the segment to allow writes
+// to seek to the end and write sequentially (vs having to seek back to the beginning of
+// the segment to update the head pointer).  Reads must seek to the end then back into the
+// segment offset stored in the footer.
+//
+// Segments store arbitrary byte slices and leave the serialization to the caller.  Segments
+// are created with a max size and will block writes when the segment is full.
+type segment struct {
+	mu sync.RWMutex
+
+	size int64
+	file *os.File
+	path string
+
+	pos         int64
+	currentSize int64
+	maxSize     int64
+}
+
+func newSegment(path string, maxSize int64) (*segment, error) {
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0600)
+	if err != nil {
+		return nil, err
+	}
+
+	stats, err := os.Stat(path)
+	if err != nil {
+		return nil, err
+	}
+
+	s := &segment{file: f, path: path, size: stats.Size(), maxSize: maxSize}
+
+	if err := s.open(); err != nil {
+		return nil, err
+	}
+
+	return s, nil
+}
+
+func (l *segment) open() error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	// If it's a new segment then write the location of the current record in this segment
+	if l.size == 0 {
+		l.pos = 0
+		l.currentSize = 0
+
+		if err := l.writeUint64(uint64(l.pos)); err != nil {
+			return err
+		}
+
+		if err := l.file.Sync(); err != nil {
+			return err
+		}
+
+		l.size = footerSize
+
+		return nil
+	}
+
+	// Existing segment so read the current position and the size of the current block
+	if err := l.seekEnd(-footerSize); err != nil {
+		return err
+	}
+
+	pos, err := l.readUint64()
+	if err != nil {
+		return err
+	}
+	l.pos = int64(pos)
+
+	if err := l.seekToCurrent(); err != nil {
+		return err
+	}
+
+	// If we're at the end of the segment, don't read the current block size,
+	// it's 0.
+	if l.pos < l.size-footerSize {
+		currentSize, err := l.readUint64()
+		if err != nil {
+			return err
+		}
+		l.currentSize = int64(currentSize)
+	}
+
+	return nil
+}
+
+// append adds byte slice to the end of segment
+func (l *segment) append(b []byte) error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if l.file == nil {
+		return ErrNotOpen
+	}
+
+	if l.size+int64(len(b)) > l.maxSize {
+		return ErrSegmentFull
+	}
+
+	if err := l.seekEnd(-footerSize); err != nil {
+		return err
+	}
+
+	if err := l.writeUint64(uint64(len(b))); err != nil {
+		return err
+	}
+
+	if err := l.writeBytes(b); err != nil {
+		return err
+	}
+
+	if err := l.writeUint64(uint64(l.pos)); err != nil {
+		return err
+	}
+
+	if err := l.file.Sync(); err != nil {
+		return err
+	}
+
+	if l.currentSize == 0 {
+		l.currentSize = int64(len(b))
+	}
+
+	l.size += int64(len(b)) + 8 // uint64 for slice length
+
+	return nil
+}
+
+// current returns byte slice that the current segment points
+func (l *segment) current() ([]byte, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if int64(l.pos) == l.size-8 {
+		return nil, io.EOF
+	}
+
+	if err := l.seekToCurrent(); err != nil {
+		return nil, err
+	}
+
+	// read the record size
+	sz, err := l.readUint64()
+	if err != nil {
+		return nil, err
+	}
+	l.currentSize = int64(sz)
+
+	b := make([]byte, sz)
+	if err := l.readBytes(b); err != nil {
+		return nil, err
+	}
+
+	return b, nil
+}
+
+// advance advances the current value pointer
+func (l *segment) advance() error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if l.file == nil {
+		return ErrNotOpen
+	}
+
+	// If we're ad the end of the file, can't advance
+	if int64(l.pos) == l.size-footerSize {
+		l.currentSize = 0
+		return io.EOF
+	}
+
+	if err := l.seekEnd(-footerSize); err != nil {
+		return err
+	}
+
+	pos := l.pos + l.currentSize + 8
+	if err := l.writeUint64(uint64(l.pos)); err != nil {
+		return err
+	}
+
+	if err := l.file.Sync(); err != nil {
+		return err
+	}
+	l.pos = pos
+
+	if err := l.seekToCurrent(); err != nil {
+		return err
+	}
+
+	sz, err := l.readUint64()
+	if err != nil {
+		return err
+	}
+	l.currentSize = int64(sz)
+
+	if int64(l.pos) == l.size-footerSize {
+		l.currentSize = 0
+		return io.EOF
+	}
+
+	return nil
+}
+
+func (l *segment) close() error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if err := l.file.Close(); err != nil {
+		return err
+	}
+	l.file = nil
+	return nil
+}
+
+func (l *segment) diskUsage() int64 {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	return l.size
+}
+
+func (l *segment) SetMaxSegmentSize(size int64) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.maxSize = size
+}
+
+func (l *segment) seekToCurrent() error {
+	return l.seek(int64(l.pos))
+}
+
+func (l *segment) seek(pos int64) error {
+	n, err := l.file.Seek(pos, os.SEEK_SET)
+	if err != nil {
+		return err
+	}
+
+	if n != pos {
+		return fmt.Errorf("bad seek. exp %v, got %v", 0, n)
+	}
+
+	return nil
+}
+
+func (l *segment) seekEnd(pos int64) error {
+	_, err := l.file.Seek(pos, os.SEEK_END)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (l *segment) filePos() int64 {
+	n, _ := l.file.Seek(0, os.SEEK_CUR)
+	return n
+}
+
+func (l *segment) readUint64() (uint64, error) {
+	b := make([]byte, 8)
+	if err := l.readBytes(b); err != nil {
+		return 0, err
+	}
+	return btou64(b), nil
+}
+
+func (l *segment) writeUint64(sz uint64) error {
+	return l.writeBytes(u64tob(sz))
+}
+
+func (l *segment) writeBytes(b []byte) error {
+	n, err := l.file.Write(b)
+	if err != nil {
+		return err
+	}
+
+	if n != len(b) {
+		return fmt.Errorf("short write. got %d, exp %d", n, len(b))
+	}
+	return nil
+}
+
+func (l *segment) readBytes(b []byte) error {
+	n, err := l.file.Read(b)
+	if err != nil {
+		return err
+	}
+
+	if n != len(b) {
+		return fmt.Errorf("bad read. exp %v, got %v", 0, n)
+	}
+	return nil
+}
+
+func u64tob(v uint64) []byte {
+	b := make([]byte, 8)
+	binary.BigEndian.PutUint64(b, v)
+	return b
+}
+
+func btou64(b []byte) uint64 {
+	return binary.BigEndian.Uint64(b)
+}

--- a/services/hh/queue.go
+++ b/services/hh/queue.go
@@ -513,7 +513,7 @@ func (l *segment) advance() error {
 		return ErrNotOpen
 	}
 
-	// If we're ad the end of the file, can't advance
+	// If we're at the end of the file, can't advance
 	if int64(l.pos) == l.size-footerSize {
 		l.currentSize = 0
 		return io.EOF

--- a/services/hh/queue_test.go
+++ b/services/hh/queue_test.go
@@ -1,0 +1,280 @@
+package hh
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func BenchmarkQueueAppend(b *testing.B) {
+	dir, err := ioutil.TempDir("", "hh_queue")
+	if err != nil {
+		b.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(dir)
+
+	q, err := newQueue(dir, 1024*1024*1024)
+	if err != nil {
+		b.Fatalf("failed to create queue: %v", err)
+	}
+
+	if err := q.Open(); err != nil {
+		b.Fatalf("failed to open queue: %v", err)
+	}
+
+	for i := 0; i < b.N; i++ {
+		if err := q.Append([]byte(fmt.Sprintf("%d", i))); err != nil {
+			println(q.diskUsage())
+			b.Fatalf("Queue.Append failed: %v", err)
+		}
+	}
+}
+
+func TestQueueAppendOne(t *testing.T) {
+	dir, err := ioutil.TempDir("", "hh_queue")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(dir)
+
+	q, err := newQueue(dir, 1024)
+	if err != nil {
+		t.Fatalf("failed to create queue: %v", err)
+	}
+
+	if err := q.Open(); err != nil {
+		t.Fatalf("failed to open queue: %v", err)
+	}
+
+	if err := q.Append([]byte("test")); err != nil {
+		t.Fatalf("Queue.Append failed: %v", err)
+	}
+
+	exp := filepath.Join(dir, "1")
+	stats, err := os.Stat(exp)
+	if os.IsNotExist(err) {
+		t.Fatalf("Queue.Append file not exists. exp %v to exist", exp)
+	}
+
+	// 8 byte header ptr + 8 byte record len + record len
+	if exp := int64(8 + 8 + 4); stats.Size() != exp {
+		t.Fatalf("Queue.Append file size mismatch. got %v, exp %v", stats.Size(), exp)
+	}
+
+	cur, err := q.Current()
+	if err != nil {
+		t.Fatalf("Queue.Current failed: %v", err)
+	}
+
+	if exp := "test"; string(cur) != exp {
+		t.Errorf("Queue.Current mismatch: got %v, exp %v", string(cur), exp)
+	}
+}
+
+func TestQueueAppendMultiple(t *testing.T) {
+	dir, err := ioutil.TempDir("", "hh_queue")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(dir)
+
+	q, err := newQueue(dir, 1024)
+	if err != nil {
+		t.Fatalf("failed to create queue: %v", err)
+	}
+
+	if err := q.Open(); err != nil {
+		t.Fatalf("failed to open queue: %v", err)
+	}
+
+	if err := q.Append([]byte("one")); err != nil {
+		t.Fatalf("Queue.Append failed: %v", err)
+	}
+
+	if err := q.Append([]byte("two")); err != nil {
+		t.Fatalf("Queue.Append failed: %v", err)
+	}
+
+	for _, exp := range []string{"one", "two"} {
+		cur, err := q.Current()
+		if err != nil {
+			t.Fatalf("Queue.Current failed: %v", err)
+		}
+
+		if string(cur) != exp {
+			t.Errorf("Queue.Current mismatch: got %v, exp %v", string(cur), exp)
+		}
+
+		if err := q.Advance(); err != nil {
+			t.Fatalf("Queue.Advance failed: %v", err)
+		}
+	}
+}
+
+func TestQueueAdvancePastEnd(t *testing.T) {
+	dir, err := ioutil.TempDir("", "hh_queue")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(dir)
+
+	// create the queue
+	q, err := newQueue(dir, 1024)
+	if err != nil {
+		t.Fatalf("failed to create queue: %v", err)
+	}
+
+	if err := q.Open(); err != nil {
+		t.Fatalf("failed to open queue: %v", err)
+	}
+
+	// append one entry, should go to the first segment
+	if err := q.Append([]byte("one")); err != nil {
+		t.Fatalf("Queue.Append failed: %v", err)
+	}
+
+	// set the segment size low to force a new segment to be created
+	q.SetMaxSegmentSize(12)
+
+	// Should go into a new segement
+	if err := q.Append([]byte("two")); err != nil {
+		t.Fatalf("Queue.Append failed: %v", err)
+	}
+
+	// should read from first segment
+	cur, err := q.Current()
+	if err != nil {
+		t.Fatalf("Queue.Current failed: %v", err)
+	}
+
+	if exp := "one"; string(cur) != exp {
+		t.Errorf("Queue.Current mismatch: got %v, exp %v", string(cur), exp)
+	}
+
+	if err := q.Advance(); err != nil {
+		t.Fatalf("Queue.Advance failed: %v", err)
+	}
+
+	// ensure the first segment file is removed since we've advanced past the end
+	_, err = os.Stat(filepath.Join(dir, "1"))
+	if !os.IsNotExist(err) {
+		t.Fatalf("Queue.Advance should have removed the segment")
+	}
+
+	// should read from second segment
+	cur, err = q.Current()
+	if err != nil {
+		t.Fatalf("Queue.Current failed: %v", err)
+	}
+
+	if exp := "two"; string(cur) != exp {
+		t.Errorf("Queue.Current mismatch: got %v, exp %v", string(cur), exp)
+	}
+
+	_, err = os.Stat(filepath.Join(dir, "2"))
+	if os.IsNotExist(err) {
+		t.Fatalf("Queue.Advance should have removed the segment")
+	}
+
+	if err := q.Advance(); err != nil {
+		t.Fatalf("Queue.Advance failed: %v", err)
+	}
+
+	cur, err = q.Current()
+	if err != io.EOF {
+		t.Fatalf("Queue.Current should have returned error")
+	}
+}
+
+func TestQueueFull(t *testing.T) {
+	dir, err := ioutil.TempDir("", "hh_queue")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(dir)
+
+	// create the queue
+	q, err := newQueue(dir, 10)
+	if err != nil {
+		t.Fatalf("failed to create queue: %v", err)
+	}
+
+	if err := q.Open(); err != nil {
+		t.Fatalf("failed to open queue: %v", err)
+	}
+
+	if err := q.Append([]byte("one")); err != ErrQueueFull {
+		t.Fatalf("Queue.Append expected to return queue full")
+	}
+}
+
+func TestQueueReopen(t *testing.T) {
+	dir, err := ioutil.TempDir("", "hh_queue")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(dir)
+
+	// create the queue
+	q, err := newQueue(dir, 1024)
+	if err != nil {
+		t.Fatalf("failed to create queue: %v", err)
+	}
+
+	if err := q.Open(); err != nil {
+		t.Fatalf("failed to open queue: %v", err)
+	}
+
+	if err := q.Append([]byte("one")); err != nil {
+		t.Fatalf("Queue.Append failed: %v", err)
+	}
+
+	cur, err := q.Current()
+	if err != nil {
+		t.Fatalf("Queue.Current failed: %v", err)
+	}
+
+	if exp := "one"; string(cur) != exp {
+		t.Errorf("Queue.Current mismatch: got %v, exp %v", string(cur), exp)
+	}
+
+	// close and re-open the queue
+	if err := q.Close(); err != nil {
+		t.Fatalf("Queue.Close failed: %v", err)
+	}
+
+	if err := q.Open(); err != nil {
+		t.Fatalf("failed to re-open queue: %v", err)
+	}
+
+	// Make sure we can read back the last current value
+	cur, err = q.Current()
+	if err != nil {
+		t.Fatalf("Queue.Current failed: %v", err)
+	}
+
+	if exp := "one"; string(cur) != exp {
+		t.Errorf("Queue.Current mismatch: got %v, exp %v", string(cur), exp)
+	}
+
+	if err := q.Append([]byte("two")); err != nil {
+		t.Fatalf("Queue.Append failed: %v", err)
+	}
+
+	if err := q.Advance(); err != nil {
+		t.Fatalf("Queue.Advance failed: %v", err)
+	}
+
+	cur, err = q.Current()
+	if err != nil {
+		t.Fatalf("Queue.Current failed: %v", err)
+	}
+
+	if exp := "two"; string(cur) != exp {
+		t.Errorf("Queue.Current mismatch: got %v, exp %v", string(cur), exp)
+	}
+
+}

--- a/services/hh/service.go
+++ b/services/hh/service.go
@@ -1,29 +1,109 @@
 package hh
 
 import (
+	"fmt"
+	"io"
 	"log"
 	"os"
+	"sync"
+	"time"
 
 	"github.com/influxdb/influxdb/tsdb"
 )
 
+var ErrHintedHandoffDisabled = fmt.Errorf("hinted handoff disabled")
+
 type Service struct {
+	mu      sync.RWMutex
+	closing chan struct{}
+
 	Logger *log.Logger
 	cfg    Config
+
+	ShardWriter shardWriter
+
+	HintedHandoff interface {
+		WriteShard(shardID, ownerID uint64, points []tsdb.Point) error
+		Process() error
+	}
+}
+
+type shardWriter interface {
+	WriteShard(shardID, ownerID uint64, points []tsdb.Point) error
 }
 
 // NewService returns a new instance of Service.
-func NewService(c Config) *Service {
+func NewService(c Config, w shardWriter) *Service {
 	s := &Service{
 		cfg:    c,
 		Logger: log.New(os.Stderr, "[handoff] ", log.LstdFlags),
 	}
+	// FIXME: add exponential backoff, throughput limit, max TTL config options
+	processor, err := NewProcessor(c.Dir, c.MaxSize, w)
+	if err != nil {
+		s.Logger.Fatalf("Failed to start hinted handoff processor: %v", err)
+	}
+	s.HintedHandoff = processor
 	return s
 }
 
-func (s *Service) WriteShard(shardID, ownerID uint64, points []tsdb.Point) error {
+func (s *Service) Open() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.closing = make(chan struct{})
+
+	go s.retryWrites()
+
+	// go s.expireWrites()
+	// go s.evictWrites()
+
 	return nil
 }
 
-func (s *Service) Open() error  { return nil }
-func (s *Service) Close() error { return nil }
+func (s *Service) Close() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.closing != nil {
+		close(s.closing)
+		s.closing = nil
+	}
+	return nil
+}
+
+// WriteShard queues the points write for shardID to node ownerID to handoff queue
+func (s *Service) WriteShard(shardID, ownerID uint64, points []tsdb.Point) error {
+	if !s.cfg.Enabled {
+		return ErrHintedHandoffDisabled
+	}
+
+	return s.HintedHandoff.WriteShard(shardID, ownerID, points)
+}
+
+func (s *Service) retryWrites() {
+	ticker := time.NewTicker(time.Duration(s.cfg.RetryInterval))
+	defer ticker.Stop()
+	for {
+		select {
+		case <-s.closing:
+			return
+		case <-ticker.C:
+			if err := s.HintedHandoff.Process(); err != nil && err != io.EOF {
+				s.Logger.Printf("retried write failed: %v", err)
+			}
+		}
+	}
+}
+
+// expireWrites will cause the handoff queues to remove writes that are older
+// than the configured threshold
+func (s *Service) expireWrites() {
+	panic("not implemented")
+}
+
+// purgeWrites will cause the handoff queues to remove writes that are no longer
+// valid.  e.g. queued writes for a node that has been removed
+func (s *Service) purgeWrites() {
+	panic("not implemented")
+}

--- a/services/hh/service.go
+++ b/services/hh/service.go
@@ -38,8 +38,11 @@ func NewService(c Config, w shardWriter) *Service {
 		cfg:    c,
 		Logger: log.New(os.Stderr, "[handoff] ", log.LstdFlags),
 	}
-	// FIXME: add exponential backoff, throughput limit, max TTL config options
-	processor, err := NewProcessor(c.Dir, c.MaxSize, w)
+	processor, err := NewProcessor(c.Dir, w, ProcessorOptions{
+		MaxSize:        c.MaxSize,
+		MaxAge:         time.Duration(c.MaxAge),
+		RetryRateLimit: c.RetryRateLimit,
+	})
 	if err != nil {
 		s.Logger.Fatalf("Failed to start hinted handoff processor: %v", err)
 	}

--- a/services/hh/service.go
+++ b/services/hh/service.go
@@ -1,0 +1,29 @@
+package hh
+
+import (
+	"log"
+	"os"
+
+	"github.com/influxdb/influxdb/tsdb"
+)
+
+type Service struct {
+	Logger *log.Logger
+	cfg    Config
+}
+
+// NewService returns a new instance of Service.
+func NewService(c Config) *Service {
+	s := &Service{
+		cfg:    c,
+		Logger: log.New(os.Stderr, "[handoff] ", log.LstdFlags),
+	}
+	return s
+}
+
+func (s *Service) WriteShard(shardID, ownerID uint64, points []tsdb.Point) error {
+	return nil
+}
+
+func (s *Service) Open() error  { return nil }
+func (s *Service) Close() error { return nil }

--- a/services/hh/service.go
+++ b/services/hh/service.go
@@ -70,7 +70,6 @@ func (s *Service) Close() error {
 
 	if s.closing != nil {
 		close(s.closing)
-		s.closing = nil
 	}
 	return nil
 }

--- a/services/hh/service.go
+++ b/services/hh/service.go
@@ -57,9 +57,7 @@ func (s *Service) Open() error {
 	s.closing = make(chan struct{})
 
 	go s.retryWrites()
-
 	go s.expireWrites()
-	// go s.evictWrites()
 
 	return nil
 }

--- a/tsdb/store_test.go
+++ b/tsdb/store_test.go
@@ -13,6 +13,7 @@ func TestStoreOpen(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create temp dir: %v", err)
 	}
+	defer os.RemoveAll(dir)
 
 	if err := os.MkdirAll(filepath.Join(dir, "mydb"), 0600); err != nil {
 		t.Fatalf("failed to create test db dir: %v", err)
@@ -33,6 +34,7 @@ func TestStoreOpenShard(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Store.Open() failed to create temp dir: %v", err)
 	}
+	defer os.RemoveAll(dir)
 
 	path := filepath.Join(dir, "mydb", "myrp")
 	if err := os.MkdirAll(path, 0700); err != nil {
@@ -118,6 +120,7 @@ func TestStoreOpenNotDatabaseDir(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Store.Open() failed to create temp dir: %v", err)
 	}
+	defer os.RemoveAll(dir)
 
 	path := filepath.Join(dir, "bad_db_path")
 	if _, err := os.Create(path); err != nil {
@@ -177,6 +180,7 @@ func TestStoreOpenShardBadShardPath(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Store.Open() failed to create temp dir: %v", err)
 	}
+	defer os.RemoveAll(dir)
 
 	path := filepath.Join(dir, "mydb", "myrp")
 	if err := os.MkdirAll(path, 0700); err != nil {


### PR DESCRIPTION
This PR adds support for hinted handoffs for writes.  If a write to a remote node fails, it will be queued in a hinted handoff queue and retried later.  The queue is local to the node receiving the write and is stored on disk.  

The queues on disk are stored (by default) at the same level as the `data` and `meta` and in a `hh` dir.  Under that dir, is a directory per node ID.  This is the queue directory for a remote node.  Under that directory is the queue's segment files.  A segment is a set of writes that need to be retried to the owning node.  Segments have a max size they can reach (default 10MB) before a new segment is added.  When all the write have successfully been sent to the remote node, that segment is removed.

The hinted handoff queue can have a max size and age.  The max size controls how much disk space will be used before writes to it will return an error.  The max age determine how long segment files can live on disk.  The default is 7 days.  After that point, old segments will be removed and anti-entropy will need to reconcile the writes.

Still TODO:

- [ ] Add retry throttling limits to avoid thundering herd when node comes back online
- [ ] Process write queues in parallel (currently just serial)
- [ ] Handle node removal.  They will expire after 7d currently but will continue to retry them until they expire.  Can also manually delete the node dir on disk if needed.
- [ ] Handle corrupted queue files on disk.  If a segment gets corrupted somehow, we should be able to recover gracefully from it or at least ensure a proper log message exists so that an admin can delete that segment manually.
