### PR TITLE
Deleted shard groups are not counted as "expired"

### DIFF
--- a/meta/data.go
+++ b/meta/data.go
@@ -586,6 +586,9 @@ func (rpi *RetentionPolicyInfo) ShardGroupByTimestamp(timestamp time.Time) *Shar
 func (rpi *RetentionPolicyInfo) ExpiredShardGroups(t time.Time) []*ShardGroupInfo {
 	groups := make([]*ShardGroupInfo, 0)
 	for i := range rpi.ShardGroups {
+		if rpi.ShardGroups[i].Deleted() {
+			continue
+		}
 		if rpi.Duration != 0 && rpi.ShardGroups[i].EndTime.Add(rpi.Duration).Before(t) {
 			groups = append(groups, &rpi.ShardGroups[i])
 		}

--- a/services/retention/service.go
+++ b/services/retention/service.go
@@ -72,7 +72,7 @@ func (s *Service) deleteShardGroups() {
 			if !s.MetaStore.IsLeader() {
 				continue
 			}
-			s.logger.Println("retention policy enforcement commencing")
+			s.logger.Println("retention policy enforcement check commencing")
 
 			s.MetaStore.VisitRetentionPolicies(func(d meta.DatabaseInfo, r meta.RetentionPolicyInfo) {
 				for _, g := range r.ExpiredShardGroups(time.Now().UTC()) {
@@ -101,7 +101,7 @@ func (s *Service) deleteShards() {
 			return
 
 		case <-ticker.C:
-			s.logger.Println("retention policy shard deletion commencing")
+			s.logger.Println("retention policy shard deletion check commencing")
 
 			deletedShardIDs := make(map[uint64]struct{}, 0)
 			s.MetaStore.VisitRetentionPolicies(func(d meta.DatabaseInfo, r meta.RetentionPolicyInfo) {
@@ -118,7 +118,7 @@ func (s *Service) deleteShards() {
 						s.logger.Printf("failed to delete shard ID %d: %s", id, err.Error())
 						continue
 					}
-					s.logger.Printf("shard ID% deleted", id)
+					s.logger.Printf("shard ID %d deleted", id)
 				}
 			}
 		}


### PR DESCRIPTION
Deleted shard groups are treated as invisible, as far as the system is concerned. They should not be returned in an "expired" shard check.