### PR TITLE
Fix locking on write path for getting measurement field encoding.

### DIFF
--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -136,7 +136,10 @@ func (s *Shard) WritePoints(points []Point) error {
 		// marshal the raw data if it hasn't been marshaled already
 		if p.Data() == nil {
 			// this was populated earlier, don't need to validate that it's there.
-			data, err := s.measurementFields[p.Name()].codec.EncodeFields(p.Fields())
+			s.mu.RLock()
+			mf := s.measurementFields[p.Name()]
+			s.mu.RUnlock()
+			data, err := mf.codec.EncodeFields(p.Fields())
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
I can't reproduce the bug, but I'm guessing this will fix #2808. Have a look @toddboom