### PR TITLE
Fix UDP service, broken by 092bc3f and uncorrectly fixed in cc78fe4

### DIFF
--- a/cmd/influxd/run/server.go
+++ b/cmd/influxd/run/server.go
@@ -164,6 +164,7 @@ func (s *Server) appendUDPService(c udp.Config) {
 	}
 	srv := udp.NewService(c)
 	srv.PointsWriter = s.PointsWriter
+	s.Services = append(s.Services, srv)
 }
 
 func (s *Server) appendContinuousQueryService(c continuous_querier.Config) {


### PR DESCRIPTION
It's ashame because it was merged in time for RC32... but it seems like some people have trouble handling merge conflicts.