### PR TITLE
Remote write fixes

### DIFF
--- a/cluster/client_pool.go
+++ b/cluster/client_pool.go
@@ -25,9 +25,9 @@ func (c *clientPool) setPool(nodeID uint64, p pool.Pool) {
 }
 
 func (c *clientPool) getPool(nodeID uint64) (pool.Pool, bool) {
-	c.mu.Lock()
+	c.mu.RLock()
 	p, ok := c.pool[nodeID]
-	c.mu.Unlock()
+	c.mu.RUnlock()
 	return p, ok
 }
 
@@ -42,9 +42,9 @@ func (c *clientPool) size() int {
 }
 
 func (c *clientPool) conn(nodeID uint64) (net.Conn, error) {
-	c.mu.Lock()
+	c.mu.RLock()
 	conn, err := c.pool[nodeID].Get()
-	c.mu.Unlock()
+	c.mu.RUnlock()
 	return conn, err
 }
 

--- a/cluster/shard_writer.go
+++ b/cluster/shard_writer.go
@@ -43,7 +43,9 @@ func (w *ShardWriter) WriteShard(shardID, ownerID uint64, points []tsdb.Point) e
 	if !ok {
 		panic("wrong connection type")
 	}
-	defer conn.Close() // return to pool
+	defer func(conn net.Conn) {
+		conn.Close() // return to pool
+	}(conn)
 
 	// Build write request.
 	var request WriteShardRequest

--- a/services/hh/queue.go
+++ b/services/hh/queue.go
@@ -524,7 +524,7 @@ func (l *segment) advance() error {
 	}
 
 	pos := l.pos + l.currentSize + 8
-	if err := l.writeUint64(uint64(l.pos)); err != nil {
+	if err := l.writeUint64(uint64(pos)); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Fixes a few issues with remote writes and hinted handoff.

1. When a node in a cluster was restarted, the connection pools to the restart server on the other servers would be left in a bad state and never connect successfully again until restarted as well.
2. When reconnecting, a deadlock would also occur
3. Restarting a node would always retry that last hinted handoff write even if it was already sent successfully before.