### PR TITLE
Add cluster consistency parsing to cluster package

### DIFF
--- a/cluster/points_writer.go
+++ b/cluster/points_writer.go
@@ -43,9 +43,9 @@ var (
 	// ErrWriteFailed is returned when no writes succeeded.
 	ErrWriteFailed = errors.New("write failed")
 
-	// ErrConsistencyLevelParseError is returned when parsing the string version
+	// ErrInvalidConsistencyLevel is returned when parsing the string version
 	// of a consistency level.
-	ErrConsistencyLevelParseError = errors.New("write failed")
+	ErrInvalidConsistencyLevel = errors.New("invalid consistency level")
 )
 
 func ParseConsistencyLevel(level string) (ConsistencyLevel, error) {
@@ -59,7 +59,7 @@ func ParseConsistencyLevel(level string) (ConsistencyLevel, error) {
 	case "all":
 		return ConsistencyLevelAll, nil
 	default:
-		return 0, ErrConsistencyLevelParseError
+		return 0, ErrInvalidConsistencyLevel
 	}
 }
 

--- a/cluster/points_writer.go
+++ b/cluster/points_writer.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"log"
 	"os"
+	"strings"
 	"sync"
 	"time"
 
@@ -41,7 +42,26 @@ var (
 
 	// ErrWriteFailed is returned when no writes succeeded.
 	ErrWriteFailed = errors.New("write failed")
+
+	// ErrConsistencyLevelParseError is returned when parsing the string version
+	// of a consistency level.
+	ErrConsistencyLevelParseError = errors.New("write failed")
 )
+
+func ParseConsistencyLevel(level string) (ConsistencyLevel, error) {
+	switch strings.ToLower(level) {
+	case "any":
+		return ConsistencyLevelAny, nil
+	case "one":
+		return ConsistencyLevelOne, nil
+	case "quorum":
+		return ConsistencyLevelQuorum, nil
+	case "all":
+		return ConsistencyLevelAll, nil
+	default:
+		return 0, ErrConsistencyLevelParseError
+	}
+}
 
 // PointsWriter handles writes across multiple local and remote data nodes.
 type PointsWriter struct {

--- a/cmd/influxd/run/command.go
+++ b/cmd/influxd/run/command.go
@@ -84,7 +84,10 @@ func (cmd *Command) Run(args ...string) error {
 	}
 
 	// Create server from config and start it.
-	s := NewServer(config)
+	s, err := NewServer(config)
+	if err != nil {
+		return fmt.Errorf("create server: %s", err)
+	}
 	if err := s.Open(); err != nil {
 		return fmt.Errorf("open server: %s", err)
 	}

--- a/cmd/influxd/run/server_helpers_test.go
+++ b/cmd/influxd/run/server_helpers_test.go
@@ -30,9 +30,9 @@ type Server struct {
 
 // NewServer returns a new instance of Server.
 func NewServer(c *run.Config) *Server {
-
+	srv, _ := run.NewServer(c)
 	s := Server{
-		Server: run.NewServer(c),
+		Server: srv,
 		Config: c,
 	}
 	// Set the logger to discard unless verbose is on

--- a/services/graphite/config.go
+++ b/services/graphite/config.go
@@ -3,7 +3,6 @@ package graphite
 import (
 	"strings"
 
-	"github.com/influxdb/influxdb/cluster"
 	"github.com/influxdb/influxdb/toml"
 )
 
@@ -55,20 +54,4 @@ func NewConfig() Config {
 // LastEnabled returns whether the server should interpret the last field as "name".
 func (c *Config) LastEnabled() bool {
 	return c.NamePosition == strings.ToLower("last")
-}
-
-// ConsistencyAsEnum returns the enumerated write consistency level.
-func (c *Config) ConsistencyAsEnum() cluster.ConsistencyLevel {
-	switch strings.ToLower(c.ConsistencyLevel) {
-	case "any":
-		return cluster.ConsistencyLevelAny
-	case "one":
-		return cluster.ConsistencyLevelOne
-	case "quorum":
-		return cluster.ConsistencyLevelQuorum
-	case "all":
-		return cluster.ConsistencyLevelAll
-	default:
-		return cluster.ConsistencyLevelOne
-	}
 }

--- a/services/graphite/service_test.go
+++ b/services/graphite/service_test.go
@@ -241,9 +241,9 @@ func Test_ServerGraphiteTCP(t *testing.T) {
 	config.BatchTimeout = toml.Duration(time.Second)
 	config.BindAddress = ":0"
 
-	service := graphite.NewService(config)
-	if service == nil {
-		t.Fatal("failed to create Graphite service")
+	service, err := graphite.NewService(config)
+	if err != nil {
+		t.Fatalf("failed to create Graphite service: %s", err.Error())
 	}
 
 	// Allow test to wait until points are written.
@@ -307,9 +307,9 @@ func Test_ServerGraphiteUDP(t *testing.T) {
 	config.BindAddress = ":10000"
 	config.Protocol = "udp"
 
-	service := graphite.NewService(config)
-	if service == nil {
-		t.Fatal("failed to create Graphite service")
+	service, err := graphite.NewService(config)
+	if err != nil {
+		t.Fatalf("failed to create Graphite service: %s", err.Error())
 	}
 
 	// Allow test to wait until points are written.


### PR DESCRIPTION
Right now failed parsing is indicated by returning a nil Graphite object. This will surely blow up later, but I don't any other component checking for failed services either.

Any suggestions @benbjohnson ?