### PR TITLE
Hinted handoff throttling

### DIFF
--- a/cluster/points_writer_test.go
+++ b/cluster/points_writer_test.go
@@ -251,12 +251,11 @@ func TestPointsWriter_WritePoints(t *testing.T) {
 
 		ms := NewMetaStore()
 		ms.NodeIDFn = func() uint64 { return 1 }
-		c := cluster.PointsWriter{
-			MetaStore:     ms,
-			ShardWriter:   sw,
-			TSDBStore:     store,
-			HintedHandoff: hh,
-		}
+		c := cluster.NewPointsWriter()
+		c.MetaStore = ms
+		c.ShardWriter = sw
+		c.TSDBStore = store
+		c.HintedHandoff = hh
 
 		if err := c.WritePoints(pr); err != test.expErr {
 			t.Errorf("PointsWriter.WritePoints(): '%s' error: got %v, exp %v", test.name, err, test.expErr)

--- a/cluster/service.go
+++ b/cluster/service.go
@@ -184,7 +184,7 @@ func (s *Service) processWriteShardRequest(buf []byte) error {
 	}
 
 	if err != nil {
-		return fmt.Errorf("write shard: %s", err)
+		return fmt.Errorf("write shard %d: %s", req.ShardID(), err)
 	}
 
 	return nil

--- a/cluster/shard_writer_test.go
+++ b/cluster/shard_writer_test.go
@@ -129,7 +129,7 @@ func TestShardWriter_WriteShard_Error(t *testing.T) {
 		"cpu", tsdb.Tags{"host": "server01"}, map[string]interface{}{"value": int64(100)}, now,
 	))
 
-	if err := w.WriteShard(shardID, ownerID, points); err == nil || err.Error() != "error code 1: write shard: failed to write" {
+	if err := w.WriteShard(shardID, ownerID, points); err == nil || err.Error() != "error code 1: write shard 1: failed to write" {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/services/hh/limiter.go
+++ b/services/hh/limiter.go
@@ -1,0 +1,61 @@
+package hh
+
+import "time"
+
+type limiter struct {
+	count int64
+	limit int64
+	start time.Time
+	delay float64
+}
+
+// NewRateLimiter returns a new limiter configured to restrict a process to the limit per second.
+// limit is the maximum amount that can be used per second.  The limit should be > 0.  A limit
+// <= 0, will not limit the processes.
+func NewRateLimiter(limit int64) *limiter {
+	return &limiter{
+		start: time.Now(),
+		limit: limit,
+		delay: 0.5,
+	}
+}
+
+// Update updates the amount used
+func (t *limiter) Update(count int) {
+	t.count += int64(count)
+}
+
+// Delay returns the amount of time, up to 1 second, that caller should wait
+// to maintain the configured rate
+func (t *limiter) Delay() time.Duration {
+	if t.limit > 0 {
+
+		delta := time.Now().Sub(t.start).Seconds()
+		rate := int64(float64(t.count) / delta)
+
+		// Determine how far off from the max rate we are
+		delayAdj := float64((t.limit - rate)) / float64(t.limit)
+
+		// Don't adjust by more than 1 second at a time
+		delayAdj = t.clamp(delayAdj, -1, 1)
+
+		t.delay -= delayAdj
+		if t.delay < 0 {
+			t.delay = 0
+		}
+
+		return time.Duration(t.delay) * time.Second
+	}
+	return time.Duration(0)
+}
+
+func (t *limiter) clamp(value, min, max float64) float64 {
+	if value < min {
+		return min
+	}
+
+	if value > max {
+		return max
+	}
+	return value
+}

--- a/services/hh/limiter_test.go
+++ b/services/hh/limiter_test.go
@@ -1,0 +1,47 @@
+package hh
+
+import (
+	"testing"
+	"time"
+)
+
+func TestLimiter(t *testing.T) {
+	l := NewRateLimiter(0)
+	l.Update(500)
+	if l.Delay().Nanoseconds() != 0 {
+		t.Errorf("limiter with no limit mismatch: got %v, exp 0", l.Delay())
+	}
+}
+
+func TestLimiterWithinLimit(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Shipping TestLimiterWithinLimit")
+	}
+
+	l := NewRateLimiter(1000)
+	for i := 0; i < 100; i++ {
+		// 50 ever 100ms = 500/s which should be within the rate
+		l.Update(50)
+		l.Delay()
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	// Should not have any delay
+	delay := l.Delay().Seconds()
+	if exp := int(0); int(delay) != exp {
+		t.Errorf("limiter rate mismatch: got %v, exp %v", int(delay), exp)
+	}
+
+}
+
+func TestLimiterExceeded(t *testing.T) {
+	l := NewRateLimiter(1000)
+	for i := 0; i < 10; i++ {
+		l.Update(200)
+		l.Delay()
+	}
+	delay := l.Delay().Seconds()
+	if int(delay) == 0 {
+		t.Errorf("limiter rate mismatch. expected non-zero delay")
+	}
+}

--- a/services/hh/processor.go
+++ b/services/hh/processor.go
@@ -126,11 +126,12 @@ func (p *Processor) Process() error {
 
 			// Log how many writes we successfully sent at the end
 			var sent int
-			defer func() {
+			start := time.Now()
+			defer func(start time.Time) {
 				if sent > 0 {
-					p.Logger.Printf("%d queued writes sent to node %d", sent, nodeID)
+					p.Logger.Printf("%d queued writes sent to node %d in %s", sent, nodeID, time.Since(start))
 				}
-			}()
+			}(start)
 
 			limiter := NewRateLimiter(p.retryRateLimit)
 			for {

--- a/services/hh/processor.go
+++ b/services/hh/processor.go
@@ -37,6 +37,7 @@ func NewProcessor(dir string, writer shardWriter, options ProcessorOptions) (*Pr
 		dir:    dir,
 		queues: map[uint64]*queue{},
 		writer: writer,
+		Logger: log.New(os.Stderr, "[handoff] ", log.LstdFlags),
 	}
 	p.setOptions(options)
 
@@ -122,6 +123,16 @@ func (p *Processor) Process() error {
 	res := make(chan error, len(p.queues))
 	for nodeID, q := range p.queues {
 		go func(nodeID uint64, q *queue) {
+
+			// Log how many writes we successfully sent at the end
+			var sent int
+			defer func() {
+				if sent > 0 {
+					p.Logger.Printf("%d queued writes sent to node %d", sent, nodeID)
+				}
+			}()
+
+			limiter := NewRateLimiter(p.retryRateLimit)
 			for {
 				// Get the current block from the queue
 				buf, err := q.Current()
@@ -152,6 +163,15 @@ func (p *Processor) Process() error {
 					res <- err
 					return
 				}
+
+				sent += 1
+
+				// Update how many bytes we've sent
+				limiter.Update(len(buf))
+
+				// Block to maintain the throughput rate
+				time.Sleep(limiter.Delay())
+
 			}
 		}(nodeID, q)
 	}


### PR DESCRIPTION
This adds some hinted handoff queue processing rate limits to reduce the rate of writes sent to nodes coming back online.

Also adds some logging around the processing of the queues and more context when writes fail.