### PR TITLE
Ensure tags are always marshalled the same way

### DIFF
--- a/tsdb/meta_test.go
+++ b/tsdb/meta_test.go
@@ -108,6 +108,10 @@ func TestMarshalTags(t *testing.T) {
 			tags:   map[string]string{"foo": "bar", "baz": "battttt"},
 			result: []byte(`baz|foo|battttt|bar`),
 		},
+		{
+			tags:   map[string]string{"baz": "battttt", "foo": "bar"},
+			result: []byte(`baz|foo|battttt|bar`),
+		},
 	} {
 		result := marshalTags(tt.tags)
 		if !bytes.Equal(result, tt.result) {


### PR DESCRIPTION
This added check ensures it's always alphabetically ordered when
marshalled.