### PR TITLE
Return empty result set if database not present in shard data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - [#2833](https://github.com/influxdb/influxdb/pull/2833): Make the default config valid.
 - [#2859](https://github.com/influxdb/influxdb/pull/2859): Fix panic on aggregate functions.
 - [#2878](https://github.com/influxdb/influxdb/pull/2878): Re-enable shard precreation.
+- [2865](https://github.com/influxdb/influxdb/pull/2865) -- Return an empty set of results if database does not exist in shard metadata.
 
 ### Features
 - [2858](https://github.com/influxdb/influxdb/pull/2858): Support setting openTSDB write consistency.

--- a/tsdb/query_executor.go
+++ b/tsdb/query_executor.go
@@ -294,7 +294,7 @@ func (q *QueryExecutor) expandWildcards(stmt *influxql.SelectStatement) (*influx
 			// Lookup the database.
 			db := q.store.DatabaseIndex(m.Database)
 			if db == nil {
-				return nil, ErrDatabaseNotFound(m.Database)
+				return nil, nil
 			}
 
 			// Lookup the measurement in the database.
@@ -349,7 +349,7 @@ func (q *QueryExecutor) expandSources(sources influxql.Sources) (influxql.Source
 			// Lookup the database.
 			db := q.store.DatabaseIndex(src.Database)
 			if db == nil {
-				return nil, ErrDatabaseNotFound(src.Database)
+				return nil, nil
 			}
 
 			// Get measurements from the database that match the regex.
@@ -419,7 +419,7 @@ func (q *QueryExecutor) executeDropMeasurementStatement(stmt *influxql.DropMeasu
 	// Find the database.
 	db := q.store.DatabaseIndex(database)
 	if db == nil {
-		return &influxql.Result{Err: ErrDatabaseNotFound(database)}
+		return &influxql.Result{}
 	}
 
 	m := db.Measurement(stmt.Name)
@@ -443,7 +443,7 @@ func (q *QueryExecutor) executeDropSeriesStatement(stmt *influxql.DropSeriesStat
 	// Find the database.
 	db := q.store.DatabaseIndex(database)
 	if db == nil {
-		return &influxql.Result{Err: ErrDatabaseNotFound(database)}
+		return &influxql.Result{}
 	}
 
 	// Expand regex expressions in the FROM clause.
@@ -490,7 +490,7 @@ func (q *QueryExecutor) executeShowSeriesStatement(stmt *influxql.ShowSeriesStat
 	// Find the database.
 	db := q.store.DatabaseIndex(database)
 	if db == nil {
-		return &influxql.Result{Err: ErrDatabaseNotFound(database)}
+		return &influxql.Result{}
 	}
 
 	// Expand regex expressions in the FROM clause.
@@ -601,7 +601,7 @@ func (q *QueryExecutor) executeShowMeasurementsStatement(stmt *influxql.ShowMeas
 	// Find the database.
 	db := q.store.DatabaseIndex(database)
 	if db == nil {
-		return &influxql.Result{Err: ErrDatabaseNotFound(database)}
+		return &influxql.Result{}
 	}
 
 	var measurements Measurements
@@ -660,7 +660,7 @@ func (q *QueryExecutor) executeShowTagKeysStatement(stmt *influxql.ShowTagKeysSt
 	// Find the database.
 	db := q.store.DatabaseIndex(database)
 	if db == nil {
-		return &influxql.Result{Err: ErrDatabaseNotFound(database)}
+		return &influxql.Result{}
 	}
 
 	// Expand regex expressions in the FROM clause.
@@ -713,7 +713,7 @@ func (q *QueryExecutor) executeShowTagValuesStatement(stmt *influxql.ShowTagValu
 	// Find the database.
 	db := q.store.DatabaseIndex(database)
 	if db == nil {
-		return &influxql.Result{Err: ErrDatabaseNotFound(database)}
+		return &influxql.Result{}
 	}
 
 	// Expand regex expressions in the FROM clause.
@@ -791,7 +791,7 @@ func (q *QueryExecutor) executeShowFieldKeysStatement(stmt *influxql.ShowFieldKe
 	// Find the database.
 	db := q.store.DatabaseIndex(database)
 	if db == nil {
-		return &influxql.Result{Err: ErrDatabaseNotFound(database)}
+		return &influxql.Result{}
 	}
 
 	// Expand regex expressions in the FROM clause.

--- a/tsdb/query_executor_test.go
+++ b/tsdb/query_executor_test.go
@@ -239,6 +239,26 @@ func TestDropDatabase(t *testing.T) {
 	}
 }
 
+// Ensure that queries for which there is no data result in an empty set.
+func TestQueryNoData(t *testing.T) {
+	store, executor := testStoreAndExecutor()
+	defer os.RemoveAll(store.path)
+
+	got := executeAndGetJSON("select * from /.*/", executor)
+	expected := `[{}]`
+	if expected != got {
+		t.Fatalf("exp: %s\ngot: %s", expected, got)
+	}
+
+	got = executeAndGetJSON("show series", executor)
+	expected = `[{}]`
+	if expected != got {
+		t.Fatalf("exp: %s\ngot: %s", expected, got)
+	}
+
+	store.Close()
+}
+
 // ensure that authenticate doesn't return an error if the user count is zero and they're attempting
 // to create a user.
 func TestAuthenticateIfUserCountZeroAndCreateUser(t *testing.T) {


### PR DESCRIPTION
Potential fix for https://github.com/influxdb/influxdb/issues/2851

The idea here is that the upper layers should check if a particular database exists. If those checks pass, the query gets to the shard data, but the database does not exist there, it's because no data has been written for that database to the shard. So just return an empty set.