### PR TITLE
Add ability to silence logging for testing

### DIFF
--- a/services/collectd/service.go
+++ b/services/collectd/service.go
@@ -111,6 +111,11 @@ func (s *Service) Close() error {
 	return nil
 }
 
+// SetLogger sets the internal logger to the logger passed in.
+func (s *Service) SetLogger(l *log.Logger) {
+	s.Logger = l
+}
+
 // SetTypes sets collectd types db.
 func (s *Service) SetTypes(types string) (err error) {
 	s.typesdb, err = gollectd.TypesDB([]byte(types))

--- a/services/continuous_querier/service.go
+++ b/services/continuous_querier/service.go
@@ -100,6 +100,11 @@ func (s *Service) Close() error {
 	return nil
 }
 
+// SetLogger sets the internal logger to the logger passed in.
+func (s *Service) SetLogger(l *log.Logger) {
+	s.Logger = l
+}
+
 // Run runs the specified continuous query, or all CQs if none is specified.
 func (s *Service) Run(database, name string) error {
 	var dbs []meta.DatabaseInfo

--- a/services/graphite/service.go
+++ b/services/graphite/service.go
@@ -100,6 +100,11 @@ func (s *Service) Close() error {
 	return nil
 }
 
+// SetLogger sets the internal logger to the logger passed in.
+func (s *Service) SetLogger(l *log.Logger) {
+	s.logger = l
+}
+
 func (s *Service) Addr() net.Addr {
 	return s.addr
 }

--- a/services/hh/service.go
+++ b/services/hh/service.go
@@ -76,6 +76,11 @@ func (s *Service) Close() error {
 	return nil
 }
 
+// SetLogger sets the internal logger to the logger passed in.
+func (s *Service) SetLogger(l *log.Logger) {
+	s.Logger = l
+}
+
 // WriteShard queues the points write for shardID to node ownerID to handoff queue
 func (s *Service) WriteShard(shardID, ownerID uint64, points []tsdb.Point) error {
 	if !s.cfg.Enabled {

--- a/services/retention/service.go
+++ b/services/retention/service.go
@@ -55,6 +55,11 @@ func (s *Service) Close() error {
 	return nil
 }
 
+// SetLogger sets the internal logger to the logger passed in.
+func (s *Service) SetLogger(l *log.Logger) {
+	s.logger = l
+}
+
 func (s *Service) deleteShardGroups() {
 	defer s.wg.Done()
 

--- a/services/udp/service.go
+++ b/services/udp/service.go
@@ -151,6 +151,11 @@ func (s *Service) Close() error {
 	return nil
 }
 
+// SetLogger sets the internal logger to the logger passed in.
+func (s *Service) SetLogger(l *log.Logger) {
+	s.Logger = l
+}
+
 func (s *Service) Addr() net.Addr {
 	return s.addr
 }


### PR DESCRIPTION
`SetLogger` is used by testing to silence logging.  We had this on some of our services, but not all.  Passing `-v` to tests will allow for all logging to come through, however, if verbose is not on, then only your tests messages are logged, which is extremely helpful for testing.