### PR TITLE
Fix panic when adding field to existing measurement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v0.9.0-rc34 [unreleased]
+
+### Bugfixes
+
+- [#2869](https://github.com/influxdb/influxdb/issues/2869): Adding field to existing measurement causes panic
+
 ## v0.9.0-rc33 [2015-06-09]
 
 ### Bugfixes

--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -369,11 +369,6 @@ func (s *Shard) validateSeriesAndFields(points []Point) ([]*seriesCreate, []*fie
 					return nil, nil, fmt.Errorf("input field \"%s\" is type %T, already exists as type %s", name, value, f.Type)
 				}
 
-				data, err := mf.codec.EncodeFields(p.Fields())
-				if err != nil {
-					return nil, nil, err
-				}
-				p.SetData(data)
 				continue // Field is present, and it's of the same type. Nothing more to do.
 			}
 


### PR DESCRIPTION
Fixes #2869

When adding a new field to an existing measurment, `Shard.validateSeriesAndFields`
would also encode the fields as a side-effect.  In the case of a new field
that needed to be created, the encoding would fail because the field type
had not been created for the measurement yet.  The `validateSeriesAndFields` returns a slice of fields that need to be created before encoding can occur.

 The fields are re-encoded after `validateSeriesAndFields` returns and after the field encoding have been
setup properly so this additional encoding during validation isn't necessary.  

Encoding happens here: https://github.com/influxdb/influxdb/blob/master/tsdb/shard.go#L142