### PR TITLE
Improve write failure error responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ### Bugfixes
 
 - [#2869](https://github.com/influxdb/influxdb/issues/2869): Adding field to existing measurement causes panic
+- [#2849](https://github.com/influxdb/influxdb/issues/2849): RC32: Frequent write errors
+
 
 ## v0.9.0-rc33 [2015-06-09]
 

--- a/cluster/points_writer.go
+++ b/cluster/points_writer.go
@@ -2,6 +2,7 @@ package cluster
 
 import (
 	"errors"
+	"fmt"
 	"log"
 	"os"
 	"strings"
@@ -269,6 +270,7 @@ func (w *PointsWriter) writeToShard(shard *meta.ShardInfo, database, retentionPo
 
 	var wrote int
 	timeout := time.After(DefaultWriteTimeout)
+	var writeError error
 	for _, nodeID := range shard.OwnerIDs {
 		select {
 		case <-w.closing:
@@ -280,6 +282,11 @@ func (w *PointsWriter) writeToShard(shard *meta.ShardInfo, database, retentionPo
 			// If the write returned an error, continue to the next response
 			if err != nil {
 				w.Logger.Printf("write failed for shard %d on node %d: %v", shard.ID, nodeID, err)
+
+				// Keep track of the first error we see to return back to the client
+				if writeError == nil {
+					writeError = err
+				}
 				continue
 			}
 
@@ -294,6 +301,10 @@ func (w *PointsWriter) writeToShard(shard *meta.ShardInfo, database, retentionPo
 
 	if wrote > 0 {
 		return ErrPartialWrite
+	}
+
+	if writeError != nil {
+		return fmt.Errorf("write failed: %v", writeError)
 	}
 
 	return ErrWriteFailed

--- a/cluster/points_writer.go
+++ b/cluster/points_writer.go
@@ -251,7 +251,7 @@ func (w *PointsWriter) writeToShard(shard *meta.ShardInfo, database, retentionPo
 			}
 
 			err := w.ShardWriter.WriteShard(shardID, nodeID, points)
-			if err != nil {
+			if err != nil && tsdb.IsRetryable(err) {
 				// The remote write failed so queue it via hinted handoff
 				hherr := w.HintedHandoff.WriteShard(shardID, nodeID, points)
 

--- a/errors.go
+++ b/errors.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"runtime"
+	"strings"
 )
 
 var (
@@ -31,10 +32,18 @@ func Errorf(format string, a ...interface{}) (err error) {
 
 // IsClientError indicates whether an error is a known client error.
 func IsClientError(err error) bool {
+	if err == nil {
+		return false
+	}
+
 	if err == ErrFieldsRequired {
 		return true
 	}
 	if err == ErrFieldTypeConflict {
+		return true
+	}
+
+	if strings.Contains(err.Error(), ErrFieldTypeConflict.Error()) {
 		return true
 	}
 

--- a/services/hh/processor.go
+++ b/services/hh/processor.go
@@ -153,7 +153,7 @@ func (p *Processor) Process() error {
 				}
 
 				// Try to send the write to the node
-				if err := p.writer.WriteShard(shardID, nodeID, points); err != nil {
+				if err := p.writer.WriteShard(shardID, nodeID, points); err != nil && tsdb.IsRetryable(err) {
 					p.Logger.Printf("remote write failed: %v", err)
 					res <- nil
 					break

--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -366,7 +366,7 @@ func (s *Shard) validateSeriesAndFields(points []Point) ([]*seriesCreate, []*fie
 			if f := mf.Fields[name]; f != nil {
 				// Field present in Metastore, make sure there is no type conflict.
 				if f.Type != influxql.InspectDataType(value) {
-					return nil, nil, fmt.Errorf("input field \"%s\" is type %T, already exists as type %s", name, value, f.Type)
+					return nil, nil, fmt.Errorf("field type conflict: input field \"%s\" is type %T, already exists as type %s", name, value, f.Type)
 				}
 
 				continue // Field is present, and it's of the same type. Nothing more to do.

--- a/tsdb/store.go
+++ b/tsdb/store.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"sync"
 
 	"github.com/influxdb/influxdb/influxql"
@@ -269,4 +270,16 @@ func (s *Store) Close() error {
 	s.databaseIndexes = nil
 
 	return nil
+}
+
+// IsRetryable returns true if this error is temporary and could be retried
+func IsRetryable(err error) bool {
+	if err == nil {
+		return true
+	}
+
+	if strings.Contains(err.Error(), "field type conflict") {
+		return false
+	}
+	return true
 }


### PR DESCRIPTION
If a write failed due to a field type conflict, the error returned to the client was not helpful.  It will now return the error as a 400 with a more descriptive reason for the failure.

This also fixes hinted handoff to not queue these errors since they will never succeed and block the queue.