### PR TITLE
Fix wrong value used for incorrect type error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - [#2869](https://github.com/influxdb/influxdb/issues/2869): Adding field to existing measurement causes panic
 - [#2849](https://github.com/influxdb/influxdb/issues/2849): RC32: Frequent write errors
+- [#2700](https://github.com/influxdb/influxdb/issues/2700): Incorrect error message in database EncodeFields
 
 
 ## v0.9.0-rc33 [2015-06-09]

--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -519,7 +519,7 @@ func (f *FieldCodec) EncodeFields(values map[string]interface{}) ([]byte, error)
 		if field == nil {
 			panic(fmt.Sprintf("field does not exist for %s", k))
 		} else if influxql.InspectDataType(v) != field.Type {
-			return nil, fmt.Errorf("field \"%s\" is type %T, mapped as type %s", k, k, field.Type)
+			return nil, fmt.Errorf("field \"%s\" is type %T, mapped as type %s", k, v, field.Type)
 		}
 
 		var buf []byte


### PR DESCRIPTION
Would result in saying that the field type was always a string which
is incorrect.  The field key is a string but the value may not be.

Fixes #2700