### PR TITLE
Ensure target Graphite database exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - [#2869](https://github.com/influxdb/influxdb/issues/2869): Adding field to existing measurement causes panic
 - [#2849](https://github.com/influxdb/influxdb/issues/2849): RC32: Frequent write errors
 - [#2700](https://github.com/influxdb/influxdb/issues/2700): Incorrect error message in database EncodeFields
-
+- [#2897](https://github.com/influxdb/influxdb/pull/2897): Ensure target Graphite database exists
 
 ## v0.9.0-rc33 [2015-06-09]
 

--- a/cmd/influxd/run/server.go
+++ b/cmd/influxd/run/server.go
@@ -172,6 +172,7 @@ func (s *Server) appendGraphiteService(c graphite.Config) error {
 	}
 
 	srv.PointsWriter = s.PointsWriter
+	srv.MetaStore = s.MetaStore
 	s.Services = append(s.Services, srv)
 	return nil
 }

--- a/services/graphite/service_test.go
+++ b/services/graphite/service_test.go
@@ -273,10 +273,15 @@ func Test_ServerGraphiteTCP(t *testing.T) {
 		},
 	}
 	service.PointsWriter = &pointsWriter
-	service.MetaStore = &DatabaseCreator{}
+	dbCreator := DatabaseCreator{}
+	service.MetaStore = &dbCreator
 
 	if err := service.Open(); err != nil {
 		t.Fatalf("failed to open Graphite service: %s", err.Error())
+	}
+
+	if !dbCreator.Created {
+		t.Fatalf("failed to create target database")
 	}
 
 	// Connect to the graphite endpoint we just spun up
@@ -341,10 +346,15 @@ func Test_ServerGraphiteUDP(t *testing.T) {
 		},
 	}
 	service.PointsWriter = &pointsWriter
-	service.MetaStore = &DatabaseCreator{}
+	dbCreator := DatabaseCreator{}
+	service.MetaStore = &dbCreator
 
 	if err := service.Open(); err != nil {
 		t.Fatalf("failed to open Graphite service: %s", err.Error())
+	}
+
+	if !dbCreator.Created {
+		t.Fatalf("failed to create target database")
 	}
 
 	// Connect to the graphite endpoint we just spun up
@@ -375,9 +385,11 @@ func (w *PointsWriter) WritePoints(p *cluster.WritePointsRequest) error {
 }
 
 type DatabaseCreator struct {
+	Created bool
 }
 
 func (d *DatabaseCreator) CreateDatabaseIfNotExists(name string) (*meta.DatabaseInfo, error) {
+	d.Created = true
 	return nil, nil
 }
 

--- a/services/graphite/service_test.go
+++ b/services/graphite/service_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/influxdb/influxdb/cluster"
+	"github.com/influxdb/influxdb/meta"
 	"github.com/influxdb/influxdb/services/graphite"
 	"github.com/influxdb/influxdb/toml"
 	"github.com/influxdb/influxdb/tsdb"
@@ -272,6 +273,7 @@ func Test_ServerGraphiteTCP(t *testing.T) {
 		},
 	}
 	service.PointsWriter = &pointsWriter
+	service.MetaStore = &DatabaseCreator{}
 
 	if err := service.Open(); err != nil {
 		t.Fatalf("failed to open Graphite service: %s", err.Error())
@@ -339,6 +341,7 @@ func Test_ServerGraphiteUDP(t *testing.T) {
 		},
 	}
 	service.PointsWriter = &pointsWriter
+	service.MetaStore = &DatabaseCreator{}
 
 	if err := service.Open(); err != nil {
 		t.Fatalf("failed to open Graphite service: %s", err.Error())
@@ -369,6 +372,13 @@ type PointsWriter struct {
 
 func (w *PointsWriter) WritePoints(p *cluster.WritePointsRequest) error {
 	return w.WritePointsFn(p)
+}
+
+type DatabaseCreator struct {
+}
+
+func (d *DatabaseCreator) CreateDatabaseIfNotExists(name string) (*meta.DatabaseInfo, error) {
+	return nil, nil
 }
 
 // Test Helpers


### PR DESCRIPTION
This change ensures the configured Graphite database exists before the service starts writing to it.