### PR TITLE
Generate cluster id on first node

### DIFF
--- a/meta/data.go
+++ b/meta/data.go
@@ -25,6 +25,7 @@ const (
 type Data struct {
 	Term      uint64 // associated raft term
 	Index     uint64 // associated raft index
+	ClusterID uint64
 	Nodes     []NodeInfo
 	Databases []DatabaseInfo
 	Users     []UserInfo

--- a/meta/internal/meta.pb.go
+++ b/meta/internal/meta.pb.go
@@ -462,6 +462,7 @@ func (m *Command) GetType() Command_Type {
 
 type CreateNodeCommand struct {
 	Host             *string `protobuf:"bytes,1,req" json:"Host,omitempty"`
+	Rand             *uint64 `protobuf:"varint,2,req" json:"Rand,omitempty"`
 	XXX_unrecognized []byte  `json:"-"`
 }
 
@@ -474,6 +475,13 @@ func (m *CreateNodeCommand) GetHost() string {
 		return *m.Host
 	}
 	return ""
+}
+
+func (m *CreateNodeCommand) GetRand() uint64 {
+	if m != nil && m.Rand != nil {
+		return *m.Rand
+	}
+	return 0
 }
 
 var E_CreateNodeCommand_Command = &proto.ExtensionDesc{

--- a/meta/internal/meta.proto
+++ b/meta/internal/meta.proto
@@ -100,6 +100,7 @@ message CreateNodeCommand {
         optional CreateNodeCommand command = 101;
     }
 	required string Host = 1;
+	required uint64 Rand = 2;
 }
 
 message DeleteNodeCommand {

--- a/meta/store_test.go
+++ b/meta/store_test.go
@@ -49,11 +49,26 @@ func TestStore_CreateNode(t *testing.T) {
 		t.Fatalf("unexpected node: %#v", ni)
 	}
 
+	// Ensure cluster id is set.
+	clusterID, err := s.ClusterID()
+	if err != nil {
+		t.Fatal(err)
+	} else if clusterID == 0 {
+		t.Fatal("expected cluster id to be set")
+	}
+
 	// Create another node.
 	if ni, err := s.CreateNode("host1"); err != nil {
 		t.Fatal(err)
 	} else if *ni != (meta.NodeInfo{ID: 3, Host: "host1"}) {
 		t.Fatalf("unexpected node: %#v", ni)
+	}
+
+	// Ensure cluster id remains the same.
+	if id, err := s.ClusterID(); err != nil {
+		t.Fatal(err)
+	} else if id != clusterID {
+		t.Fatalf("cluster id changed: %d", id)
 	}
 }
 


### PR DESCRIPTION
## Overview

This commit sets a cluster ID when the first node is initialized. The ID is generated on every CreateNodeCommand so that it can be applied consistently in the state machine of every server.