### PR TITLE
Require replication factor to equal cluster size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - [#2900](https://github.com/influxdb/influxdb/pull/2900): Use openTSDB input defaults where necessary
 - [#2886](https://github.com/influxdb/influxdb/issues/2886): Refactor backup & restore
 - [#2804](https://github.com/influxdb/influxdb/pull/2804): BREAKING: change time literals to be single quoted in InfluxQL. Thanks @nvcook42!
+- [#2906](https://github.com/influxdb/influxdb/pull/2906): Restrict replication factor to the cluster size
 
 ## v0.9.0-rc33 [2015-06-09]
 

--- a/meta/data.go
+++ b/meta/data.go
@@ -140,6 +140,8 @@ func (data *Data) CreateRetentionPolicy(database string, rpi *RetentionPolicyInf
 	// Validate retention policy.
 	if rpi.Name == "" {
 		return ErrRetentionPolicyNameRequired
+	} else if rpi.ReplicaN != len(data.Nodes) {
+		return ErrReplicationFactorMismatch
 	}
 
 	// Find database.

--- a/meta/errors.go
+++ b/meta/errors.go
@@ -50,6 +50,11 @@ var (
 	// ErrRetentionPolicyDurationTooLow is returned when updating a retention
 	// policy that has a duration lower than the allowed minimum.
 	ErrRetentionPolicyDurationTooLow = errors.New("retention policy duration too low")
+
+	// ErrReplicationFactorMismatch is returned when the replication factor
+	// does not match the number of nodes in the cluster. This is a temporary
+	// restriction until v0.9.1 is released.
+	ErrReplicationFactorMismatch = errors.New("replication factor must match cluster size; this limitation will be lifted in v0.9.1")
 )
 
 var (


### PR DESCRIPTION
## Overview

This pull request adds a requirement that retention policies must be fully committed. This means that the replication factor must be set to whatever the node count is in the cluster.

Fixes #2738