### PR TITLE
Fix field conflict type error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v0.9.1 [unreleased]
+
+### Bugfixes
+
+- [#2908](https://github.com/influxdb/influxdb/issues/2908): Field mismatch error messages need to be updated
+
 ## v0.9.0 [2015-06-11]
 
 ### Bugfixes

--- a/influxql/ast.go
+++ b/influxql/ast.go
@@ -51,6 +51,24 @@ func InspectDataType(v interface{}) DataType {
 	}
 }
 
+func (d DataType) String() string {
+	switch d {
+	case Float:
+		return "float"
+	case Integer:
+		return "integer"
+	case Boolean:
+		return "boolean"
+	case String:
+		return "string"
+	case Time:
+		return "time"
+	case Duration:
+		return "duration"
+	}
+	return "unknown"
+}
+
 // Node represents a node in the InfluxDB abstract syntax tree.
 type Node interface {
 	node()


### PR DESCRIPTION
Change of internal types from string to ints causes the error message to be reported incorrectly.