### PR TITLE
Export WaitForLeader on MetaStore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Bugfixes
 
 - [#2908](https://github.com/influxdb/influxdb/issues/2908): Field mismatch error messages need to be updated
+- [#2931](https://github.com/influxdb/influxdb/pull/2931): Services and reporting should wait until cluster has leader.
 
 ## v0.9.0 [2015-06-11]
 

--- a/cmd/influxd/run/server.go
+++ b/cmd/influxd/run/server.go
@@ -337,6 +337,10 @@ func (s *Server) Close() error {
 // startServerReporting starts periodic server reporting.
 func (s *Server) startServerReporting() {
 	for {
+		if err := s.MetaStore.WaitForLeader(30 * time.Second); err != nil {
+			log.Printf("no leader available for reporting: %s", err.Error())
+			continue
+		}
 		s.reportServer()
 		<-time.After(24 * time.Hour)
 	}

--- a/meta/store.go
+++ b/meta/store.go
@@ -186,7 +186,6 @@ func (s *Store) Open() error {
 	if s.id == 0 {
 		go s.init()
 	} else {
-		s.waitForLeader(10 * time.Second)
 		close(s.ready)
 	}
 
@@ -331,7 +330,7 @@ func (s *Store) init() {
 // Writes the id of the node to file on success.
 func (s *Store) createLocalNode() error {
 	// Wait for leader.
-	if err := s.waitForLeader(5 * time.Second); err != nil {
+	if err := s.WaitForLeader(5 * time.Second); err != nil {
 		return fmt.Errorf("wait for leader: %s", err)
 	}
 
@@ -354,8 +353,8 @@ func (s *Store) createLocalNode() error {
 	return nil
 }
 
-// waitForLeader sleeps until a leader is found or a timeout occurs.
-func (s *Store) waitForLeader(timeout time.Duration) error {
+// WaitForLeader sleeps until a leader is found or a timeout occurs.
+func (s *Store) WaitForLeader(timeout time.Duration) error {
 	// Begin timeout timer.
 	timer := time.NewTimer(timeout)
 	defer timer.Stop()

--- a/meta/store.go
+++ b/meta/store.go
@@ -355,6 +355,10 @@ func (s *Store) createLocalNode() error {
 
 // WaitForLeader sleeps until a leader is found or a timeout occurs.
 func (s *Store) WaitForLeader(timeout time.Duration) error {
+	if s.raft.Leader() != "" {
+		return nil
+	}
+
 	// Begin timeout timer.
 	timer := time.NewTimer(timeout)
 	defer timer.Stop()

--- a/services/collectd/service_test.go
+++ b/services/collectd/service_test.go
@@ -225,6 +225,10 @@ func (ms *testMetaStore) CreateDatabaseIfNotExists(name string) (*meta.DatabaseI
 	return ms.CreateDatabaseIfNotExistsFn(name)
 }
 
+func (ms *testMetaStore) WaitForLeader(d time.Duration) error {
+	return nil
+}
+
 func wait(c chan struct{}, d time.Duration) (err error) {
 	select {
 	case <-c:

--- a/services/graphite/service_test.go
+++ b/services/graphite/service_test.go
@@ -393,6 +393,10 @@ func (d *DatabaseCreator) CreateDatabaseIfNotExists(name string) (*meta.Database
 	return nil, nil
 }
 
+func (d *DatabaseCreator) WaitForLeader(t time.Duration) error {
+	return nil
+}
+
 // Test Helpers
 func errstr(err error) string {
 	if err != nil {

--- a/services/opentsdb/service_test.go
+++ b/services/opentsdb/service_test.go
@@ -161,3 +161,7 @@ type DatabaseCreator struct {
 func (d *DatabaseCreator) CreateDatabaseIfNotExists(name string) (*meta.DatabaseInfo, error) {
 	return nil, nil
 }
+
+func (d *DatabaseCreator) WaitForLeader(t time.Duration) error {
+	return nil
+}


### PR DESCRIPTION
This exported function can then be used by Services and
server-reporting, so those components don't make progress until the
cluster is ready.