### PR TITLE
Return error when parsing invalid field values for line protocol

### DIFF
--- a/tsdb/points.go
+++ b/tsdb/points.go
@@ -318,6 +318,19 @@ func scanFields(buf []byte, i int) (int, []byte, error) {
 			continue
 		}
 
+		// If we see an =, ensure that there is at least on char after it
+		if buf[i] == '=' {
+			// check for "... value="
+			if i+1 >= len(buf) {
+				return i, buf[start:i], fmt.Errorf("missing field value")
+			}
+
+			// check for "... value=,value2=..."
+			if buf[i+1] == ',' || buf[i+1] == ' ' {
+				return i, buf[start:i], fmt.Errorf("missing field value")
+			}
+		}
+
 		// reached end of block?
 		if buf[i] == ' ' && !quoted {
 			break

--- a/tsdb/points.go
+++ b/tsdb/points.go
@@ -319,7 +319,7 @@ func scanFields(buf []byte, i int) (int, []byte, error) {
 		}
 
 		// If we see an =, ensure that there is at least on char after it
-		if buf[i] == '=' {
+		if buf[i] == '=' && !quoted {
 			// check for "... value="
 			if i+1 >= len(buf) {
 				return i, buf[start:i], fmt.Errorf("missing field value")
@@ -333,6 +333,15 @@ func scanFields(buf []byte, i int) (int, []byte, error) {
 			if isNumeric(buf[i+1]) || buf[i+1] == '-' {
 				var err error
 				i, _, err = scanNumber(buf, i+1)
+				if err != nil {
+					return i, buf[start:i], err
+				} else {
+					continue
+				}
+				// If next byte is not a double-quote, the value must be a boolean
+			} else if buf[i+1] != '"' {
+				var err error
+				i, _, err = scanBoolean(buf, i+1)
 				if err != nil {
 					return i, buf[start:i], err
 				} else {
@@ -434,6 +443,65 @@ func scanNumber(buf []byte, i int) (int, []byte, error) {
 	}
 
 	return i, buf[start:i], nil
+}
+
+// scanBoolean returns the end position within buf, start at i after
+// scanning over buf for boolean. Valid values for a boolean are
+// t, T, true, TRUE, f, F, false, FALSE.  It returns an error if a invalid boolean
+// is scanned.
+func scanBoolean(buf []byte, i int) (int, []byte, error) {
+	start := i
+
+	if i < len(buf) && (buf[i] != 't' && buf[i] != 'f' && buf[i] != 'T' && buf[i] != 'F') {
+		return i, buf[start:i], fmt.Errorf("invalid boolean")
+	}
+
+	i += 1
+	for {
+		if i >= len(buf) {
+			break
+		}
+
+		if buf[i] == ',' || buf[i] == ' ' {
+			break
+		}
+		i += 1
+	}
+
+	// Single char bool (t, T, f, F) is ok
+	if i-start == 1 {
+		return i, buf[start:i], nil
+	}
+
+	// length must be 4 for true or TRUE
+	if (buf[start] == 't' || buf[start] == 'T') && i-start != 4 {
+		return i, buf[start:i], fmt.Errorf("invalid boolean")
+	}
+
+	// length must be 5 for false or FALSE
+	if (buf[start] == 'f' || buf[start] == 'F') && i-start != 5 {
+		return i, buf[start:i], fmt.Errorf("invalid boolean")
+	}
+
+	// Otherwise
+	valid := false
+	switch buf[start] {
+	case 't':
+		valid = bytes.Equal(buf[start:i], []byte("true"))
+	case 'f':
+		valid = bytes.Equal(buf[start:i], []byte("false"))
+	case 'T':
+		valid = bytes.Equal(buf[start:i], []byte("TRUE"))
+	case 'F':
+		valid = bytes.Equal(buf[start:i], []byte("FALSE"))
+	}
+
+	if !valid {
+		return i, buf[start:i], fmt.Errorf("invalid boolean")
+	}
+
+	return i, buf[start:i], nil
+
 }
 
 // skipWhitespace returns the end position within buf, starting at i after
@@ -826,8 +894,7 @@ func newFieldsFromBinary(buf []byte) Fields {
 		} else {
 			value, err = strconv.ParseBool(string(valueBuf))
 			if err != nil {
-				fmt.Printf("unable to parse bool value '%v': %v\n", string(valueBuf), err)
-				value = false
+				panic(fmt.Sprintf("unable to parse bool value '%v': %v\n", string(valueBuf), err))
 			}
 		}
 		fields[string(unescape(name))] = value

--- a/tsdb/points.go
+++ b/tsdb/points.go
@@ -95,7 +95,7 @@ func ParsePointsWithPrecision(buf []byte, defaultTime time.Time, precision strin
 
 		pt, err := parsePoint(block, defaultTime, precision)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("unable to parse '%s': %v", string(block), err)
 		}
 		points = append(points, pt)
 
@@ -412,7 +412,7 @@ func scanNumber(buf []byte, i int) (int, []byte, error) {
 
 		// Can't have more than 1 decimal (e.g. 1.1.1 should fail)
 		if decimals > 1 {
-			return i, buf[start:i], fmt.Errorf("invalid number: %s", string(buf[start:i+1]))
+			return i, buf[start:i], fmt.Errorf("invalid number")
 		}
 
 		// `e` is valid for floats but not as the first char
@@ -428,7 +428,7 @@ func scanNumber(buf []byte, i int) (int, []byte, error) {
 		}
 
 		if !isNumeric(buf[i]) {
-			return i, buf[start:i], fmt.Errorf("invalid number: %s", string(buf[start:i+1]))
+			return i, buf[start:i], fmt.Errorf("invalid number")
 		}
 		i += 1
 	}

--- a/tsdb/points_test.go
+++ b/tsdb/points_test.go
@@ -254,6 +254,13 @@ func TestParsePointFloatNegativeScientific(t *testing.T) {
 	}
 }
 
+func TestParsePointBooleanInvalid(t *testing.T) {
+	_, err := ParsePointsString(`cpu,host=serverA,region=us-west value=a`)
+	if err == nil {
+		t.Errorf(`ParsePoints("%s") mismatch. got nil, exp error`, `cpu,host=serverA,region=us-west value=a`)
+	}
+}
+
 func TestParsePointUnescape(t *testing.T) {
 	// commas in measuremnt name
 	test(t, `cpu\,main,regions=east\,west value=1.0`,
@@ -479,7 +486,7 @@ func TestParsePointWithStringWithEquals(t *testing.T) {
 }
 
 func TestParsePointWithBoolField(t *testing.T) {
-	test(t, `cpu,host=serverA,region=us-east bool=true,boolTrue=t,false=false,falseVal=f 1000000000`,
+	test(t, `cpu,host=serverA,region=us-east true=true,t=t,T=T,TRUE=TRUE,false=false,f=f,F=F,FALSE=FALSE 1000000000`,
 		NewPoint(
 			"cpu",
 			Tags{
@@ -487,10 +494,14 @@ func TestParsePointWithBoolField(t *testing.T) {
 				"region": "us-east",
 			},
 			Fields{
-				"bool":     true,
-				"boolTrue": true,
-				"false":    false,
-				"falseVal": false,
+				"t":     true,
+				"T":     true,
+				"true":  true,
+				"TRUE":  true,
+				"f":     false,
+				"F":     false,
+				"false": false,
+				"FALSE": false,
 			},
 			time.Unix(1, 0)),
 	)

--- a/tsdb/points_test.go
+++ b/tsdb/points_test.go
@@ -159,6 +159,24 @@ func TestParsePointMissingTagValue(t *testing.T) {
 	}
 }
 
+func TestParsePointMissingFieldValue(t *testing.T) {
+	_, err := ParsePointsString(`cpu,host=serverA,region=us-west value=`)
+	if err == nil {
+		t.Errorf(`ParsePoints("%s") mismatch. got nil, exp error`, "cpu")
+	}
+
+	_, err = ParsePointsString(`cpu,host=serverA,region=us-west value= 1000000000`)
+	if err == nil {
+		t.Errorf(`ParsePoints("%s") mismatch. got nil, exp error`, "cpu")
+	}
+
+	_, err = ParsePointsString(`cpu,host=serverA,region=us-west value=,value2=1`)
+	if err == nil {
+		t.Errorf(`ParsePoints("%s") mismatch. got nil, exp error`, "cpu")
+	}
+
+}
+
 func TestParsePointUnescape(t *testing.T) {
 	// commas in measuremnt name
 	test(t, `cpu\,main,regions=east\,west value=1.0`,

--- a/tsdb/points_test.go
+++ b/tsdb/points_test.go
@@ -174,7 +174,84 @@ func TestParsePointMissingFieldValue(t *testing.T) {
 	if err == nil {
 		t.Errorf(`ParsePoints("%s") mismatch. got nil, exp error`, "cpu")
 	}
+}
 
+func TestParsePointBadNumber(t *testing.T) {
+	_, err := ParsePointsString(`cpu,host=serverA,region=us-west value=1a`)
+	if err == nil {
+		t.Errorf(`ParsePoints("%s") mismatch. got nil, exp error`, `cpu,host=serverA,region=us-west value=1a`)
+	}
+}
+
+func TestParsePointNumberNonNumeric(t *testing.T) {
+	_, err := ParsePointsString(`cpu,host=serverA,region=us-west value=.1a`)
+	if err == nil {
+		t.Errorf(`ParsePoints("%s") mismatch. got nil, exp error`, `cpu,host=serverA,region=us-west value=.1a`)
+	}
+}
+
+func TestParsePointNegativeWrongPlace(t *testing.T) {
+	_, err := ParsePointsString(`cpu,host=serverA,region=us-west value=0.-1`)
+	if err == nil {
+		t.Errorf(`ParsePoints("%s") mismatch. got nil, exp error`, `cpu,host=serverA,region=us-west value=0.-1`)
+	}
+}
+
+func TestParsePointFloatMultipleDecimals(t *testing.T) {
+	_, err := ParsePointsString(`cpu,host=serverA,region=us-west value=1.1.1`)
+	if err == nil {
+		t.Errorf(`ParsePoints("%s") mismatch. got nil, exp error`, `cpu,host=serverA,region=us-west value=1.1.1`)
+	}
+	println(err.Error())
+}
+
+func TestParsePointInteger(t *testing.T) {
+	_, err := ParsePointsString(`cpu,host=serverA,region=us-west value=1`)
+	if err != nil {
+		t.Errorf(`ParsePoints("%s") mismatch. got %v, exp nil`, `cpu,host=serverA,region=us-west value=1`, err)
+	}
+}
+
+func TestParsePointNegativeInteger(t *testing.T) {
+	_, err := ParsePointsString(`cpu,host=serverA,region=us-west value=-1`)
+	if err != nil {
+		t.Errorf(`ParsePoints("%s") mismatch. got %v, exp nil`, `cpu,host=serverA,region=us-west value=-1`, err)
+	}
+}
+
+func TestParsePointNegativeFloat(t *testing.T) {
+	_, err := ParsePointsString(`cpu,host=serverA,region=us-west value=-1.0`)
+	if err != nil {
+		t.Errorf(`ParsePoints("%s") mismatch. got %v, exp nil`, `cpu,host=serverA,region=us-west value=-1.0`, err)
+	}
+}
+
+func TestParsePointFloatNoLeadingDigit(t *testing.T) {
+	_, err := ParsePointsString(`cpu,host=serverA,region=us-west value=.1`)
+	if err != nil {
+		t.Errorf(`ParsePoints("%s") mismatch. got %v, exp nil`, `cpu,host=serverA,region=us-west value=-1.0`, err)
+	}
+}
+
+func TestParsePointFloatScientific(t *testing.T) {
+	_, err := ParsePointsString(`cpu,host=serverA,region=us-west value=1.0e4`)
+	if err != nil {
+		t.Errorf(`ParsePoints("%s") mismatch. got %v, exp nil`, `cpu,host=serverA,region=us-west value=1.0e4`, err)
+	}
+}
+
+func TestParsePointFloatScientificDecimal(t *testing.T) {
+	_, err := ParsePointsString(`cpu,host=serverA,region=us-west value=1.0e-4`)
+	if err != nil {
+		t.Errorf(`ParsePoints("%s") mismatch. got %v, exp nil`, `cpu,host=serverA,region=us-west value=1.0e-4`, err)
+	}
+}
+
+func TestParsePointFloatNegativeScientific(t *testing.T) {
+	_, err := ParsePointsString(`cpu,host=serverA,region=us-west value=-1.0e-4`)
+	if err != nil {
+		t.Errorf(`ParsePoints("%s") mismatch. got %v, exp nil`, `cpu,host=serverA,region=us-west value=-1.0e-4`, err)
+	}
 }
 
 func TestParsePointUnescape(t *testing.T) {


### PR DESCRIPTION
This fixes a few issues when invalid field values are sent via the line protocol.  It fixes no values being sent as well as some cases of invalid numbers that could slip though which will not fail at parsing.

Fixes #2927 