### PR TITLE
Add measurement name to type conflict error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - [#2908](https://github.com/influxdb/influxdb/issues/2908): Field mismatch error messages need to be updated
 - [#2931](https://github.com/influxdb/influxdb/pull/2931): Services and reporting should wait until cluster has leader.
 - [#2943](https://github.com/influxdb/influxdb/issues/2943): Ensure default retention policies are fully replicated
+- [#2948](https://github.com/influxdb/influxdb/issues/2948): Field mismatch error message to include measurement name
+
 
 ## v0.9.0 [2015-06-11]
 

--- a/services/httpd/handler.go
+++ b/services/httpd/handler.go
@@ -391,6 +391,7 @@ func (h *Handler) serveWriteJSON(w http.ResponseWriter, r *http.Request, body []
 func (h *Handler) writeError(w http.ResponseWriter, result influxql.Result, statusCode int) {
 	w.WriteHeader(statusCode)
 	w.Write([]byte(result.Err.Error()))
+	w.Write([]byte("\n"))
 }
 
 // serveWriteLine receives incoming series data in line protocol format and writes it to the database.

--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -369,7 +369,7 @@ func (s *Shard) validateSeriesAndFields(points []Point) ([]*seriesCreate, []*fie
 			if f := mf.Fields[name]; f != nil {
 				// Field present in shard metadata, make sure there is no type conflict.
 				if f.Type != influxql.InspectDataType(value) {
-					return nil, nil, fmt.Errorf("field type conflict: input field \"%s\" is type %T, already exists as type %s", name, value, f.Type)
+					return nil, nil, fmt.Errorf("field type conflict: input field \"%s\" on measurement \"%s\" is type %T, already exists as type %s", name, p.Name(), value, f.Type)
 				}
 
 				continue // Field is present, and it's of the same type. Nothing more to do.


### PR DESCRIPTION
Makes these errors easier to find when writing large batches of points.

Fixes #2948