### PR TITLE
Fix large integers getting converted to floats during remote writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - [#2948](https://github.com/influxdb/influxdb/issues/2948): Field mismatch error message to include measurement name
 - [#2919](https://github.com/influxdb/influxdb/issues/2919): Unable to insert negative floats
 - [#2935](https://github.com/influxdb/influxdb/issues/2935): Hook CPU and memory profiling back up.
+- [#2960](https://github.com/influxdb/influxdb/issues/2960): Cluster Write Errors
 
 ## v0.9.0 [2015-06-11]
 

--- a/tsdb/points.go
+++ b/tsdb/points.go
@@ -920,11 +920,11 @@ func (p Fields) MarshalBinary() []byte {
 		b = append(b, '=')
 		switch t := v.(type) {
 		case int:
-			b = append(b, []byte(strconv.FormatFloat(float64(t), 'g', -1, 64))...)
+			b = append(b, []byte(strconv.FormatInt(int64(t), 10))...)
 		case int32:
-			b = append(b, []byte(strconv.FormatFloat(float64(t), 'g', -1, 64))...)
+			b = append(b, []byte(strconv.FormatInt(int64(t), 10))...)
 		case int64:
-			b = append(b, []byte(strconv.FormatFloat(float64(t), 'g', -1, 64))...)
+			b = append(b, []byte(strconv.FormatInt(t, 10))...)
 		case float64:
 			// ensure there is a decimal in the encoded for
 

--- a/tsdb/points_test.go
+++ b/tsdb/points_test.go
@@ -546,6 +546,30 @@ func TestNewPointFloatNoDecimal(t *testing.T) {
 	)
 }
 
+func TestNewPointFloatScientific(t *testing.T) {
+	test(t, `cpu value=6.632243e+06 1000000000`,
+		NewPoint(
+			"cpu",
+			Tags{},
+			Fields{
+				"value": float64(6632243),
+			},
+			time.Unix(1, 0)),
+	)
+}
+
+func TestNewPointLargeInteger(t *testing.T) {
+	test(t, `cpu value=6632243 1000000000`,
+		NewPoint(
+			"cpu",
+			Tags{},
+			Fields{
+				"value": 6632243, // if incorrectly encoded as a float, it would show up as 6.632243e+06
+			},
+			time.Unix(1, 0)),
+	)
+}
+
 func TestParsePointIntsFloats(t *testing.T) {
 	pts, err := ParsePoints([]byte(`cpu,host=serverA,region=us-east int=10,float=11.0,float2=12.1 1000000000`))
 	if err != nil {


### PR DESCRIPTION
Fixes #2960

Integers were were written back to line protocol using strconv.FormatFloat
incorrectly.  Large integers are written in scientific notation which
causes their type to change to a float when parsed back.  This only happens with remote writes in a cluster.