### PR TITLE
Actually set HTTP version in response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@
 - [#2919](https://github.com/influxdb/influxdb/issues/2919): Unable to insert negative floats
 - [#2935](https://github.com/influxdb/influxdb/issues/2935): Hook CPU and memory profiling back up.
 - [#2960](https://github.com/influxdb/influxdb/issues/2960): Cluster Write Errors
-- [#2928](https://github.com/influxdb/influxdb/pull/2928): Correctly set InfluxDB version in HTTP response headers. Thanks @neonstalwart.
+- [#2928](https://github.com/influxdb/influxdb/pull/2928): Start work to set InfluxDB version in HTTP response headers. Thanks @neonstalwart.
+- [#2969](https://github.com/influxdb/influxdb/pull/2969): Actually set HTTP version in responses.
 
 ## v0.9.0 [2015-06-11]
 

--- a/cmd/influxd/run/command.go
+++ b/cmd/influxd/run/command.go
@@ -87,11 +87,10 @@ func (cmd *Command) Run(args ...string) error {
 	}
 
 	// Create server from config and start it.
-	s, err := NewServer(config)
+	s, err := NewServer(config, cmd.Version)
 	if err != nil {
 		return fmt.Errorf("create server: %s", err)
 	}
-	s.Version = cmd.Version
 	s.CPUProfile = options.CPUProfile
 	s.MemProfile = options.MemProfile
 	if err := s.Open(); err != nil {

--- a/cmd/influxd/run/command.go
+++ b/cmd/influxd/run/command.go
@@ -91,7 +91,6 @@ func (cmd *Command) Run(args ...string) error {
 	if err != nil {
 		return fmt.Errorf("create server: %s", err)
 	}
-	s.Commit = cmd.Commit
 	s.Version = cmd.Version
 	s.CPUProfile = options.CPUProfile
 	s.MemProfile = options.MemProfile

--- a/cmd/influxd/run/server.go
+++ b/cmd/influxd/run/server.go
@@ -33,7 +33,7 @@ import (
 // It is built using a Config and it manages the startup and shutdown of all
 // services in the proper order.
 type Server struct {
-	Version string
+	version string // Build version
 
 	err     chan error
 	closing chan struct{}
@@ -64,9 +64,10 @@ type Server struct {
 }
 
 // NewServer returns a new instance of Server built from a config.
-func NewServer(c *Config) (*Server, error) {
+func NewServer(c *Config, version string) (*Server, error) {
 	// Construct base meta store and data store.
 	s := &Server{
+		version: version,
 		err:     make(chan error),
 		closing: make(chan struct{}),
 
@@ -162,7 +163,7 @@ func (s *Server) appendHTTPDService(c httpd.Config) {
 	srv.Handler.MetaStore = s.MetaStore
 	srv.Handler.QueryExecutor = s.QueryExecutor
 	srv.Handler.PointsWriter = s.PointsWriter
-	srv.Handler.Version = s.Version
+	srv.Handler.Version = s.version
 
 	// If a ContinuousQuerier service has been started, attach it.
 	for _, srvc := range s.Services {
@@ -390,7 +391,7 @@ func (s *Server) reportServer() {
     "name":"reports",
     "columns":["os", "arch", "version", "server_id", "cluster_id", "num_series", "num_measurements", "num_databases"],
     "points":[["%s", "%s", "%s", "%x", "%x", "%d", "%d", "%d"]]
-  }]`, runtime.GOOS, runtime.GOARCH, s.Version, s.MetaStore.NodeID(), clusterID, numSeries, numMeasurements, numDatabases)
+  }]`, runtime.GOOS, runtime.GOARCH, s.version, s.MetaStore.NodeID(), clusterID, numSeries, numMeasurements, numDatabases)
 
 	data := bytes.NewBufferString(json)
 

--- a/cmd/influxd/run/server.go
+++ b/cmd/influxd/run/server.go
@@ -34,7 +34,6 @@ import (
 // services in the proper order.
 type Server struct {
 	Version string
-	Commit  string
 
 	err     chan error
 	closing chan struct{}

--- a/cmd/influxd/run/server_helpers_test.go
+++ b/cmd/influxd/run/server_helpers_test.go
@@ -30,7 +30,7 @@ type Server struct {
 
 // NewServer returns a new instance of Server.
 func NewServer(c *run.Config) *Server {
-	srv, _ := run.NewServer(c)
+	srv, _ := run.NewServer(c, "testServer")
 	s := Server{
 		Server: srv,
 		Config: c,

--- a/cmd/influxd/run/server_test.go
+++ b/cmd/influxd/run/server_test.go
@@ -3,12 +3,26 @@ package run_test
 import (
 	"fmt"
 	"log"
+	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
 	"testing"
 	"time"
 )
+
+// Ensure that HTTP responses include the InfluxDB version.
+func TestServer_HTTPResponseVersion(t *testing.T) {
+	version := "v1234"
+	s := OpenServerWithVersion(NewConfig(), version)
+	defer s.Close()
+
+	resp, _ := http.Get(s.URL() + "/query")
+	got := resp.Header.Get("X-Influxdb-Version")
+	if version != version {
+		t.Errorf("Server responded with incorrect version, exp %s, got %s", version, got)
+	}
+}
 
 // Ensure the database commands work.
 func TestServer_DatabaseCommands(t *testing.T) {


### PR DESCRIPTION
The HTTP version was being set using information in the Server, but the Server's version wasn't set at the time. Move version into `NewServer` so it's now required.

Version is worth special-casing here, since the build information is pretty important, and many components need it.
