### PR TITLE
Add Go RPC input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - [2650](https://github.com/influxdb/influxdb/pull/2650): Add SHOW GRANTS FOR USER statement. Thanks @n1tr0g.
 - [3013](https://github.com/influxdb/influxdb/issues/3013): Panic error with inserting values with commas
+- [#2981](https://github.com/influxdb/influxdb/pull/2981): Add Go RPC input.
 
 ### Bugfixes
 

--- a/cmd/influxd/run/config.go
+++ b/cmd/influxd/run/config.go
@@ -11,6 +11,7 @@ import (
 	"github.com/influxdb/influxdb/services/admin"
 	"github.com/influxdb/influxdb/services/collectd"
 	"github.com/influxdb/influxdb/services/continuous_querier"
+	"github.com/influxdb/influxdb/services/gorpc"
 	"github.com/influxdb/influxdb/services/graphite"
 	"github.com/influxdb/influxdb/services/hh"
 	"github.com/influxdb/influxdb/services/httpd"
@@ -36,6 +37,7 @@ type Config struct {
 	Collectd  collectd.Config   `toml:"collectd"`
 	OpenTSDB  opentsdb.Config   `toml:"opentsdb"`
 	UDP       udp.Config        `toml:"udp"`
+	GoRPC     gorpc.Config      `toml:"gorpc"`
 
 	// Snapshot SnapshotConfig `toml:"snapshot"`
 	Monitoring      monitor.Config            `toml:"monitoring"`
@@ -59,6 +61,7 @@ func NewConfig() *Config {
 	c.HTTPD = httpd.NewConfig()
 	c.Collectd = collectd.NewConfig()
 	c.OpenTSDB = opentsdb.NewConfig()
+	c.GoRPC = gorpc.NewConfig()
 
 	c.Monitoring = monitor.NewConfig()
 	c.ContinuousQuery = continuous_querier.NewConfig()

--- a/cmd/influxd/run/config_test.go
+++ b/cmd/influxd/run/config_test.go
@@ -41,6 +41,11 @@ bind-address = ":2000"
 [udp]
 bind-address = ":4444"
 
+[gorpc]
+network = "unix"
+laddr = "/tmp/influxdb.sock"
+auth-enabled = true
+
 [monitoring]
 enabled = true
 
@@ -71,6 +76,12 @@ enabled = true
 		t.Fatalf("unexpected opentsdb bind address: %s", c.OpenTSDB.BindAddress)
 	} else if c.UDP.BindAddress != ":4444" {
 		t.Fatalf("unexpected udp bind address: %s", c.UDP.BindAddress)
+	} else if c.GoRPC.Network != "unix" {
+		t.Fatalf("unexpected gorpc network: %s", c.GoRPC.Network)
+	} else if c.GoRPC.Laddr != "/tmp/influxdb.sock" {
+		t.Fatalf("unexpected gorpc local address: %s", c.GoRPC.Laddr)
+	} else if c.GoRPC.AuthEnabled != true {
+		t.Fatalf("unexpected gorpc auth enabled: %v", c.GoRPC.AuthEnabled)
 	} else if c.Monitoring.Enabled != true {
 		t.Fatalf("unexpected monitoring enabled: %v", c.Monitoring.Enabled)
 	} else if c.ContinuousQuery.Enabled != true {

--- a/cmd/influxd/run/server.go
+++ b/cmd/influxd/run/server.go
@@ -17,6 +17,7 @@ import (
 	"github.com/influxdb/influxdb/services/admin"
 	"github.com/influxdb/influxdb/services/collectd"
 	"github.com/influxdb/influxdb/services/continuous_querier"
+	"github.com/influxdb/influxdb/services/gorpc"
 	"github.com/influxdb/influxdb/services/graphite"
 	"github.com/influxdb/influxdb/services/hh"
 	"github.com/influxdb/influxdb/services/httpd"
@@ -111,6 +112,7 @@ func NewServer(c *Config, version string) (*Server, error) {
 		return nil, err
 	}
 	s.appendUDPService(c.UDP)
+	s.appendGoRPCService(c.GoRPC)
 	s.appendRetentionPolicyService(c.Retention)
 	for _, g := range c.Graphites {
 		if err := s.appendGraphiteService(g); err != nil {
@@ -234,6 +236,16 @@ func (s *Server) appendUDPService(c udp.Config) {
 	}
 	srv := udp.NewService(c)
 	srv.PointsWriter = s.PointsWriter
+	s.Services = append(s.Services, srv)
+}
+
+func (s *Server) appendGoRPCService(c gorpc.Config) {
+	if !c.Enabled {
+		return
+	}
+	srv := gorpc.NewService(c)
+	srv.PointsWriter = s.PointsWriter
+	srv.MetaStore = s.MetaStore
 	s.Services = append(s.Services, srv)
 }
 

--- a/etc/config.sample.toml
+++ b/etc/config.sample.toml
@@ -131,6 +131,18 @@ reporting-disabled = false
   # batch-timeout = "0"
 
 ###
+### [gorpc]
+###
+### Controls the listener for InfluxDB Go RPC  data via TCP or unix domain socket.
+###
+
+[gorpc]
+  enabled = false
+  # auth-enabled = true
+  # network = "unix" #  stream-oriented network: "tcp", "tcp4", "tcp6", "unix" or "unixpacket", If not set, is actually set "unix"
+  # laddr   = "/tmp/influxdb.sock" # Unix networks, the address must be a file system path. or bind-address Ex:"0.0.0.0:5555"
+
+###
 ### [monitoring]
 ###
 

--- a/services/gorpc/config.go
+++ b/services/gorpc/config.go
@@ -1,0 +1,21 @@
+package gorpc
+
+const (
+	DefaultNetwork = "unix"
+	DefaultLaddr   = "/tmp/influxdb.sock"
+)
+
+type Config struct {
+	Enabled     bool   `toml:"enabled"`
+	Network     string `toml:"network"`
+	Laddr       string `toml:"laddr"`
+	AuthEnabled bool   `toml:"auth-enabled"`
+}
+
+// NewConfig returns a new instance of Config with defaults.
+func NewConfig() Config {
+	return Config{
+		Network: DefaultNetwork,
+		Laddr:   DefaultLaddr,
+	}
+}

--- a/services/gorpc/config_test.go
+++ b/services/gorpc/config_test.go
@@ -1,0 +1,32 @@
+package gorpc_test
+
+import (
+	"testing"
+
+	"github.com/BurntSushi/toml"
+	"github.com/influxdb/influxdb/services/gorpc"
+)
+
+func TestConfig_Parse(t *testing.T) {
+	// Parse configuration.
+	var c gorpc.Config
+	if _, err := toml.Decode(`
+enabled = true
+network = "unix"
+laddr = "/tmp/influxdb.sock"
+auth-enabled = true
+`, &c); err != nil {
+		t.Fatal(err)
+	}
+
+	// Validate configuration.
+	if c.Enabled != true {
+		t.Fatalf("unexpected enabled: %v", c.Enabled)
+	} else if c.Network != "unix" {
+		t.Fatalf("unexpected netwrok: %s", c.Network)
+	} else if c.Laddr != "/tmp/influxdb.sock" {
+		t.Fatalf("unexpected local address: %s", c.Laddr)
+	} else if c.AuthEnabled != true {
+		t.Fatalf("unexpected auth-enabled: %v", c.AuthEnabled)
+	}
+}

--- a/services/gorpc/service.go
+++ b/services/gorpc/service.go
@@ -1,0 +1,195 @@
+package gorpc
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"net"
+	"net/rpc"
+	"os"
+	"sync"
+
+	"github.com/influxdb/influxdb/cluster"
+	"github.com/influxdb/influxdb/influxql"
+	"github.com/influxdb/influxdb/meta"
+	"github.com/influxdb/influxdb/tsdb"
+)
+
+type InfluxGoRpc struct {
+	PointsWriter interface {
+		WritePoints(p *cluster.WritePointsRequest) error
+	}
+	MetaStore interface {
+		Database(name string) (*meta.DatabaseInfo, error)
+		Authenticate(username, password string) (ui *meta.UserInfo, err error)
+		Users() ([]meta.UserInfo, error)
+	}
+	Logger *log.Logger
+
+	user        *meta.UserInfo
+	database    *meta.DatabaseInfo
+	requireAuth bool
+}
+
+type Service struct {
+	config Config
+	ln     net.Listener
+	wg     sync.WaitGroup
+	InfluxGoRpc
+}
+
+func NewService(c Config) *Service {
+	return &Service{
+		config: c,
+		InfluxGoRpc: InfluxGoRpc{
+			Logger: log.New(os.Stderr, "[gorpc] ", log.LstdFlags),
+		},
+	}
+}
+
+func (s *Service) Open() (err error) {
+	if s.config.Network == "" {
+		return errors.New("Network has to be specified in config")
+	}
+	if s.config.Laddr == "" {
+		return errors.New("local address has to be specified in config")
+	}
+
+	if s.config.Network == "unix" {
+		if info, err := os.Stat(s.config.Laddr); err == nil && (info.Mode()&os.ModeSocket == os.ModeSocket) {
+			os.Remove(s.config.Laddr)
+		}
+	}
+
+	s.ln, err = net.Listen(s.config.Network, s.config.Laddr)
+	if err != nil {
+		s.Logger.Printf("Failed to set up %s listener at address %s %s", s.config.Network, s.config.Laddr, err)
+		return err
+	}
+	if s.config.Network == "unix" {
+		os.Chmod(s.config.Laddr, os.ModeSocket|0777)
+	}
+
+	s.Logger.Printf("Started listening on %s:%s", s.config.Network, s.config.Laddr)
+
+	s.wg.Add(1)
+	go s.serve()
+
+	return nil
+}
+
+func (s *Service) serve() {
+	defer s.wg.Done()
+
+	for {
+		conn, err := s.ln.Accept()
+		if opErr, ok := err.(*net.OpError); ok && !opErr.Temporary() {
+			s.Logger.Println("GoRPC listener closed")
+			return
+		} else if err != nil {
+			s.Logger.Printf("Failed to read %s:%s message: %s", s.config.Network, s.config.Laddr, err)
+			continue
+		}
+		i := s.InfluxGoRpc
+		i.requireAuth = s.config.AuthEnabled
+		sv := rpc.NewServer()
+		sv.Register(&i)
+		go sv.ServeConn(conn)
+	}
+}
+
+type PostData []tsdb.GoRpcPoint
+type Empty struct{}
+
+func (i *InfluxGoRpc) Post(pd *PostData, reply *Empty) error {
+	var err error
+	if err = writePrivilege(i); err != nil {
+		return err
+	}
+	points := make([]tsdb.Point, len(*pd))
+	for i, point := range *pd {
+		if points[i], err = tsdb.NewGoRpcPoint(point); err != nil {
+			return err
+		}
+	}
+	err = i.PointsWriter.WritePoints(&cluster.WritePointsRequest{
+		Database:         i.database.Name,
+		RetentionPolicy:  "",
+		ConsistencyLevel: cluster.ConsistencyLevelOne,
+		Points:           points,
+	})
+	if err != nil {
+		i.Logger.Println("GoRPC cannot write data: ", err)
+	}
+	return nil
+}
+
+type AuthData struct {
+	Database string
+	Username string
+	Password string
+}
+
+func (i *InfluxGoRpc) Auth(ad *AuthData, reply *Empty) (err error) {
+	i.user, i.database, err = authenticate(i, ad)
+	return
+}
+
+func (s *Service) Close() error {
+	if s.ln == nil {
+		return errors.New("Service already closed")
+	}
+
+	s.ln.Close()
+	s.ln = nil
+	s.wg.Wait()
+	s.Logger.Print("Service closed")
+	return nil
+}
+
+func authenticate(i *InfluxGoRpc, ad *AuthData) (*meta.UserInfo, *meta.DatabaseInfo, error) {
+	var (
+		user *meta.UserInfo
+		db   *meta.DatabaseInfo
+		err  error
+	)
+	if db, err = i.MetaStore.Database(ad.Database); err != nil {
+		return user, db, err
+	}
+	if !i.requireAuth {
+		return user, db, nil
+	}
+
+	// Retrieve user list.
+	uis, err := i.MetaStore.Users()
+	if err != nil {
+		return user, db, err
+	}
+
+	// TODO corylanou: never allow this in the future without users
+	if i.requireAuth && len(uis) > 0 {
+		if ad.Username == "" {
+			return user, db, fmt.Errorf("username required. username:'%s'", ad.Username)
+		}
+		user, err = i.MetaStore.Authenticate(ad.Username, ad.Password)
+		if err != nil {
+			return user, db, err
+		}
+	}
+	return user, db, nil
+}
+
+func writePrivilege(i *InfluxGoRpc) error {
+	if i.requireAuth {
+		if i.user == nil {
+			return fmt.Errorf("User is not authenticate")
+		}
+		if i.database == nil {
+			return fmt.Errorf("Not found database")
+		}
+		if !i.user.Authorize(influxql.WritePrivilege, i.database.Name) {
+			return fmt.Errorf("%q user is not authorized to write to database %q", i.user.Name, i.database.Name)
+		}
+	}
+	return nil
+}

--- a/tsdb/gorpc_points.go
+++ b/tsdb/gorpc_points.go
@@ -1,0 +1,112 @@
+package tsdb
+
+import (
+	"fmt"
+	"hash/fnv"
+	"time"
+)
+
+type GoRpcPoint struct {
+	Time time.Time
+	Name string
+	Tags
+	Fields
+}
+
+type gorpcPoint struct {
+	point GoRpcPoint
+	data  []byte
+}
+
+// NewPoint returns a new point with the given GoRpcPoint
+func NewGoRpcPoint(p GoRpcPoint) (Point, error) {
+	if err := validateFields(p.Fields); err != nil {
+		return nil, err
+	}
+	return &gorpcPoint{point: p}, nil
+}
+
+func (p *gorpcPoint) Data() []byte {
+	return p.data
+}
+
+func (p *gorpcPoint) SetData(b []byte) {
+	p.data = b
+}
+
+func (p *gorpcPoint) Key() []byte {
+	return append(escape([]byte(p.point.Name)), p.point.Tags.hashKey()...)
+}
+
+// Name return the measurement name for the point
+func (p *gorpcPoint) Name() string { return p.point.Name }
+
+// SetName updates the measurement name for the point
+func (p *gorpcPoint) SetName(name string) {
+	p.point.Name = name
+}
+
+// Time return the timesteamp for the point
+func (p *gorpcPoint) Time() time.Time {
+	return p.point.Time
+}
+
+// SetTime updates the timestamp for the point
+func (p *gorpcPoint) SetTime(t time.Time) {
+	p.point.Time = t
+}
+
+// Tags returns the tag set for the point
+func (p *gorpcPoint) Tags() Tags {
+	return p.point.Tags
+}
+
+// SetTags replaces the tags for the point
+func (p *gorpcPoint) SetTags(tags Tags) {
+	p.point.Tags = tags
+}
+
+// AddTag adds or replaces a tag value for a point
+func (p *gorpcPoint) AddTag(key, value string) {
+	p.point.Tags[key] = value
+}
+
+// Fields returns the fiels for the point
+func (p *gorpcPoint) Fields() Fields {
+	return p.point.Fields
+}
+
+// AddField adds or replaces a field value for a point
+func (p *gorpcPoint) AddField(name string, value interface{}) {
+	p.point.Fields[name] = value
+}
+
+func (p *gorpcPoint) String() string {
+	if p.Time().IsZero() {
+		return fmt.Sprintf("%s %v", p.Key(), p.Fields)
+	}
+	return fmt.Sprintf("%s %v %d", p.Key(), p.Fields, p.UnixNano())
+}
+
+func (p *gorpcPoint) HashID() uint64 {
+	h := fnv.New64a()
+	h.Write(p.Key())
+	sum := h.Sum64()
+	return sum
+}
+
+func (p *gorpcPoint) UnixNano() int64 {
+	return p.Time().UnixNano()
+}
+
+func validateFields(fields Fields) error {
+	for key, value := range fields {
+		switch v := value.(type) {
+		case float64, int64, string, bool:
+			continue
+		default:
+			return fmt.Errorf("Unsupported value type:%T key:%s,", v, key)
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
It is a PR to add a  Go RPC input interface, which provides in unix domain socket (or TCP socket).

The purpose of this PR is the following.

* intuitive bulk data insertion from golang code.
* The speed improvement by efficient gob marshal / unmarshal process by Go RPC.
  * Go RPC is 4.5x faster than original http client. (Benchmark code: http://git.io/vLv3t)

benchmark on the aws ec2(c3.8xlarge)
```
$ go test -bench .
testing: warning: no tests to run
PASS
BenchmarkGoRPC        50          24603515 ns/op
BenchmarkClient_Write         10         112689912 ns/op
```

- [x] CHANGELOG.md updated
- [x] Rebased/mergable
- [x] Tests pass
- [x] Sign [CLA](http://influxdb.com/community/cla.html) (if not already signed)