### PR TITLE
Fix panic during wildcard expansion if no database specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - [#2928](https://github.com/influxdb/influxdb/pull/2928): Start work to set InfluxDB version in HTTP response headers. Thanks @neonstalwart.
 - [#2969](https://github.com/influxdb/influxdb/pull/2969): Actually set HTTP version in responses.
 - [#2993](https://github.com/influxdb/influxdb/pull/2993): Don't log each UDP batch.
+- [#2994](https://github.com/influxdb/influxdb/pull/2994): Don't panic during wilcard expanasion if no default database specified.
 
 ## v0.9.0 [2015-06-11]
 

--- a/cmd/influxd/run/server_test.go
+++ b/cmd/influxd/run/server_test.go
@@ -847,7 +847,7 @@ func TestServer_Query_Common(t *testing.T) {
 		&Query{
 			name:    "selecting a from a non-existent database should error",
 			command: `SELECT value FROM db1.rp0.cpu`,
-			exp:     `{"results":[{"error":"database not found"}]}`,
+			exp:     `{"results":[{"error":"database not found: db1"}]}`,
 		},
 		&Query{
 			name:    "selecting a from a non-existent retention policy should error",
@@ -869,6 +869,16 @@ func TestServer_Query_Common(t *testing.T) {
 			name:    "selecting a field that doesn't exist should error",
 			command: `SELECT idontexist FROM db0.rp0.cpu`,
 			exp:     `{"results":[{"error":"unknown field or tag name in select clause: idontexist"}]}`,
+		},
+		&Query{
+			name:    "selecting wildcard without specifying a database should error",
+			command: `SELECT * FROM cpu`,
+			exp:     `{"results":[{"error":"database name required"}]}`,
+		},
+		&Query{
+			name:    "selecting explicit field without specifying a database should error",
+			command: `SELECT value FROM cpu`,
+			exp:     `{"results":[{"error":"database name required"}]}`,
 		},
 	}...)
 

--- a/tsdb/query_executor.go
+++ b/tsdb/query_executor.go
@@ -154,7 +154,7 @@ func (q *QueryExecutor) ExecuteQuery(query *influxql.Query, database string, chu
 			var res *influxql.Result
 			switch stmt := stmt.(type) {
 			case *influxql.SelectStatement:
-				if err := q.executeSelectStatement(i, stmt, database, results, chunkSize); err != nil {
+				if err := q.executeSelectStatement(i, stmt, results, chunkSize); err != nil {
 					results <- &influxql.Result{Err: err}
 					break
 				}
@@ -214,7 +214,7 @@ func (q *QueryExecutor) ExecuteQuery(query *influxql.Query, database string, chu
 }
 
 // executeSelectStatement plans and executes a select statement against a database.
-func (q *QueryExecutor) executeSelectStatement(statementID int, stmt *influxql.SelectStatement, database string, results chan *influxql.Result, chunkSize int) error {
+func (q *QueryExecutor) executeSelectStatement(statementID int, stmt *influxql.SelectStatement, results chan *influxql.Result, chunkSize int) error {
 	// Perform any necessary query re-writing.
 	stmt, err := q.rewriteSelectStatement(stmt)
 	if err != nil {


### PR DESCRIPTION
Statements were only being normalized if a default database was included
in the query (usually via the query param 'db'). However if no default
database was included, and none was an explicit part of the measurement
name, no database-existence check was run. This results in a later panic
with wildcard expansion.

Fixes #2932 