### PR TITLE
Remove measurement from shard index on DROP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - [#2969](https://github.com/influxdb/influxdb/pull/2969): Actually set HTTP version in responses.
 - [#2993](https://github.com/influxdb/influxdb/pull/2993): Don't log each UDP batch.
 - [#2994](https://github.com/influxdb/influxdb/pull/2994): Don't panic during wilcard expanasion if no default database specified.
+- [#3002](https://github.com/influxdb/influxdb/pull/3002): Remove measurement from shard's index on DROP MEASUREMENT.
 
 ## v0.9.0 [2015-06-11]
 

--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -294,6 +294,10 @@ func (s *Shard) deleteMeasurement(name string, seriesKeys []string) error {
 		return err
 	}
 
+	// Remove entry from shard index.
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.measurementFields, name)
 	return nil
 }
 


### PR DESCRIPTION
When a measurement is DROPped, its record in the shard's inverted index must also be deleted.

Fixes issue #2955.