### PR TITLE
Correct use of config write-tracing on the httpd handler

### DIFF
--- a/services/httpd/config_test.go
+++ b/services/httpd/config_test.go
@@ -36,3 +36,11 @@ pprof-enabled = true
 		t.Fatalf("unexpected pprof enabled: %v", c.PprofEnabled)
 	}
 }
+
+func TestConfig_WriteTracing(t *testing.T) {
+	c := httpd.Config{WriteTracing: true}
+	s := httpd.NewService(c)
+	if !s.Handler.WriteTrace {
+		t.Fatalf("write tracing was not set")
+	}
+}

--- a/services/httpd/handler.go
+++ b/services/httpd/handler.go
@@ -75,12 +75,13 @@ type Handler struct {
 }
 
 // NewHandler returns a new instance of handler with routes.
-func NewHandler(requireAuthentication, loggingEnabled bool) *Handler {
+func NewHandler(requireAuthentication, loggingEnabled, writeTrace bool) *Handler {
 	h := &Handler{
 		mux: pat.New(),
 		requireAuthentication: requireAuthentication,
 		Logger:                log.New(os.Stderr, "[http] ", log.LstdFlags),
 		loggingEnabled:        loggingEnabled,
+		WriteTrace:            writeTrace,
 	}
 
 	h.SetRoutes([]route{

--- a/services/httpd/handler_test.go
+++ b/services/httpd/handler_test.go
@@ -381,7 +381,7 @@ type Handler struct {
 // NewHandler returns a new instance of Handler.
 func NewHandler(requireAuthentication bool) *Handler {
 	h := &Handler{
-		Handler: httpd.NewHandler(requireAuthentication, true),
+		Handler: httpd.NewHandler(requireAuthentication, true, false),
 	}
 	h.Handler.MetaStore = &h.MetaStore
 	h.Handler.QueryExecutor = &h.QueryExecutor

--- a/services/httpd/service.go
+++ b/services/httpd/service.go
@@ -28,6 +28,7 @@ func NewService(c Config) *Service {
 		Handler: NewHandler(
 			c.AuthEnabled,
 			c.LogEnabled,
+			c.WriteTracing,
 		),
 		Logger: log.New(os.Stderr, "[httpd] ", log.LstdFlags),
 	}


### PR DESCRIPTION
The configuration switch wasn't being used when starting the handler.