### PR TITLE
Add support for marshaling `uint64` in client.

### DIFF
--- a/tsdb/points.go
+++ b/tsdb/points.go
@@ -923,6 +923,8 @@ func (p Fields) MarshalBinary() []byte {
 			b = append(b, []byte(strconv.FormatInt(int64(t), 10))...)
 		case int32:
 			b = append(b, []byte(strconv.FormatInt(int64(t), 10))...)
+		case uint64:
+			b = append(b, []byte(strconv.FormatUint(t, 10))...)
 		case int64:
 			b = append(b, []byte(strconv.FormatInt(t, 10))...)
 		case float64:


### PR DESCRIPTION
I spotted this when testing out Telegraf. I don't see any reason it shouldn't get handled here.