### PR TITLE
WAL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [2650](https://github.com/influxdb/influxdb/pull/2650): Add SHOW GRANTS FOR USER statement. Thanks @n1tr0g.
 - [3125](https://github.com/influxdb/influxdb/pull/3125): Graphite Input Protocol Parsing
 - [2746](https://github.com/influxdb/influxdb/pull/2746): New Admin UI/interface
+- [3036](https://github.com/influxdb/influxdb/pull/3036): Write Ahead Log (WAL)
 
 ### Bugfixes
 

--- a/cmd/influxd/run/server.go
+++ b/cmd/influxd/run/server.go
@@ -80,6 +80,10 @@ func NewServer(c *Config, version string) (*Server, error) {
 		reportingDisabled: c.ReportingDisabled,
 	}
 
+	// Copy TSDB configuration.
+	s.TSDBStore.MaxWALSize = c.Data.MaxWALSize
+	s.TSDBStore.WALFlushInterval = time.Duration(c.Data.WALFlushInterval)
+
 	// Initialize query executor.
 	s.QueryExecutor = tsdb.NewQueryExecutor(s.TSDBStore)
 	s.QueryExecutor.MetaStore = s.MetaStore

--- a/tsdb/config.go
+++ b/tsdb/config.go
@@ -19,10 +19,19 @@ const (
 
 	// DefaultRetentionCheckPeriod is the period of time between retention policy checks are run
 	DefaultRetentionCheckPeriod = 10 * time.Minute
+
+	// DefaultMaxWALSize is the default size of the WAL before it is flushed.
+	DefaultMaxWALSize = 100 * 1024 * 1024 // 100MB
+
+	// DefaultWALFlushInterval is the frequency the WAL will get flushed if
+	// it doesn't reach its size threshold.
+	DefaultWALFlushInterval = 10 * time.Minute
 )
 
 type Config struct {
 	Dir                   string        `toml:"dir"`
+	MaxWALSize            int           `toml:"max-wal-size"`
+	WALFlushInterval      toml.Duration `toml:"wal-flush-interval"`
 	RetentionAutoCreate   bool          `toml:"retention-auto-create"`
 	RetentionCheckEnabled bool          `toml:"retention-check-enabled"`
 	RetentionCheckPeriod  toml.Duration `toml:"retention-check-period"`
@@ -31,6 +40,8 @@ type Config struct {
 
 func NewConfig() Config {
 	return Config{
+		MaxWALSize:            DefaultMaxWALSize,
+		WALFlushInterval:      toml.Duration(DefaultWALFlushInterval),
 		RetentionAutoCreate:   DefaultRetentionAutoCreate,
 		RetentionCheckEnabled: DefaultRetentionCheckEnabled,
 		RetentionCheckPeriod:  toml.Duration(DefaultRetentionCheckPeriod),


### PR DESCRIPTION
## Overview

This commit adds a write ahead log to the shard. Entries are cached in memory and periodically flushed back into the index. The goal is to optimize write performance by flushing multiple points into series instead of writing a single point which causes a lot of random write disk overhead.

### TODO

- [x] Add flushing configuration.
- [x] Add periodic flusher.
- [x] Integrate with query engine.
- [x] Partition flushes so that a large section of the WAL can be saved in multiple small batches.