### PR TITLE
Fix for escape fields when they are created in tsbd.Point

### DIFF
--- a/tsdb/points.go
+++ b/tsdb/points.go
@@ -62,11 +62,21 @@ var escapeCodes = map[byte][]byte{
 	'=': []byte(`\=`),
 }
 
+var escapeCodesFields = map[byte][]byte{
+	',': []byte(`\,`),
+}
+
 var escapeCodesStr = map[string]string{}
+
+var escapeCodesStrFields = map[string]string{}
 
 func init() {
 	for k, v := range escapeCodes {
 		escapeCodesStr[string(k)] = string(v)
+	}
+
+	for k, v := range escapeCodesFields {
+		escapeCodesStrFields[string(k)] = string(v)
 	}
 }
 
@@ -625,6 +635,13 @@ func escapeString(in string) string {
 	return in
 }
 
+func escapeStringFields(in string) string {
+	for b, esc := range escapeCodesStrFields {
+		in = strings.Replace(in, b, esc, -1)
+	}
+	return in
+}
+
 func unescape(in []byte) []byte {
 	for b, esc := range escapeCodes {
 		in = bytes.Replace(in, esc, []byte{b}, -1)
@@ -941,7 +958,7 @@ func (p Fields) MarshalBinary() []byte {
 			b = append(b, t...)
 		case string:
 			b = append(b, '"')
-			b = append(b, []byte(t)...)
+			b = append(b, []byte(escapeStringFields(t))...)
 			b = append(b, '"')
 		case nil:
 			// skip


### PR DESCRIPTION
#### I receive panic error when I'm trying to write message with commas and internal quotas.
```
# curl -G 'http://localhost:8086/query' --data-urlencode "q=CREATE DATABASE mmm"
{"results":[{}]}
```
```
# curl -XPOST 'http://localhost:8086/write?db=mmm' --data-binary '@t.g'
curl: (52) Empty reply from server
```
```
# cat t.g
{
  "database" : "mmm",
  "retentionPolicy" : "",
  "points" :  [ {
    "measurement" : "http_status",
    "tags" : {
      "service" : "identity-service",
      "hostname" : "host1",
      "url" : "http://localhost:35774/"
    },
    "timestamp" : "2015-06-16T09:28:26.000Z",
    "fields" : {
      "value_meta" : "{Hello\"{,}\" World}",
      "value" : 1.0
    }
  } ],
  "tags" : { }
}
```

The problem is that with creation tsbd.Point:
```
func NewPoint(name string, tags Tags, fields Fields, time time.Time) Point {
        return &point{
                key:    makeKey([]byte(name), tags),
                time:   time,
                fields: fields.MarshalBinary(),
        }
}
```
In function MarshalBinary is error. Because there are added quotas on begin and end of field.
Problem is that we receive string:
```
"{Hello"{,}" World}"
```
instead of expected by function scanFieldValue
```
"{Hello\"{\\,}\" World}"
```

The biggest problem occurs later because with wrong string function scanFieldValue splits string in comma and we receive:
```
panic: unsupported value type during encode fields: <nil>

goroutine 29 [running]:
github.com/influxdb/influxdb/tsdb.(*FieldCodec).EncodeFields(0xc2081084b0, 0xc208146e70, 0x0, 0x0, 0x0, 0x0, 0x0)

```