### PR TITLE
Fix escape field value

### DIFF
--- a/tsdb/points.go
+++ b/tsdb/points.go
@@ -55,11 +55,6 @@ type point struct {
 	data []byte
 }
 
-type escapePairStr struct {
-	b string
-	esc string
-}
-
 var escapeCodes = map[byte][]byte{
 	',': []byte(`\,`),
 	'"': []byte(`\"`),
@@ -67,10 +62,7 @@ var escapeCodes = map[byte][]byte{
 	'=': []byte(`\=`),
 }
 
-var escapeCodesStrFields = []escapePairStr {
-	escapePairStr{string('\\'), string([]byte(`\\`))},
-	escapePairStr{string('"'), string([]byte(`\"`))},
-}
+var escapeReplacerFields = strings.NewReplacer( "\\", "\\\\", "\"", "\\\"")
 
 var escapeCodesStr = map[string]string{}
 
@@ -636,10 +628,7 @@ func escapeString(in string) string {
 }
 
 func escapeStringFields(in string) string {
-	for _, p := range escapeCodesStrFields {
-		in = strings.Replace(in, p.b, p.esc, -1)
-	}
-	return in
+	return escapeReplacerFields.Replace(in)
 }
 
 func unescape(in []byte) []byte {

--- a/tsdb/points.go
+++ b/tsdb/points.go
@@ -62,11 +62,21 @@ var escapeCodes = map[byte][]byte{
 	'=': []byte(`\=`),
 }
 
+var escapeCodesFields = map[byte][]byte{
+	',': []byte(`\,`),
+}
+
 var escapeCodesStr = map[string]string{}
+
+var escapeCodesStrFields = map[string]string{}
 
 func init() {
 	for k, v := range escapeCodes {
 		escapeCodesStr[string(k)] = string(v)
+	}
+
+	for k, v := range escapeCodesFields {
+		escapeCodesStrFields[string(k)] = string(v)
 	}
 }
 
@@ -625,6 +635,13 @@ func escapeString(in string) string {
 	return in
 }
 
+func escapeStringFields(in string) string {
+	for b, esc := range escapeCodesStrFields {
+		in = strings.Replace(in, b, esc, -1)
+	}
+	return in
+}
+
 func unescape(in []byte) []byte {
 	for b, esc := range escapeCodes {
 		in = bytes.Replace(in, esc, []byte{b}, -1)
@@ -943,7 +960,7 @@ func (p Fields) MarshalBinary() []byte {
 			b = append(b, t...)
 		case string:
 			b = append(b, '"')
-			b = append(b, []byte(t)...)
+			b = append(b, []byte(escapeStringFields(t))...)
 			b = append(b, '"')
 		case nil:
 			// skip

--- a/tsdb/points.go
+++ b/tsdb/points.go
@@ -55,6 +55,11 @@ type point struct {
 	data []byte
 }
 
+type escapePairStr struct {
+	b string
+	esc string
+}
+
 var escapeCodes = map[byte][]byte{
 	',': []byte(`\,`),
 	'"': []byte(`\"`),
@@ -62,21 +67,16 @@ var escapeCodes = map[byte][]byte{
 	'=': []byte(`\=`),
 }
 
-var escapeCodesFields = map[byte][]byte{
-	',': []byte(`\,`),
+var escapeCodesStrFields = []escapePairStr {
+	escapePairStr{string('\\'), string([]byte(`\\`))},
+	escapePairStr{string('"'), string([]byte(`\"`))},
 }
 
 var escapeCodesStr = map[string]string{}
 
-var escapeCodesStrFields = map[string]string{}
-
 func init() {
 	for k, v := range escapeCodes {
 		escapeCodesStr[string(k)] = string(v)
-	}
-
-	for k, v := range escapeCodesFields {
-		escapeCodesStrFields[string(k)] = string(v)
 	}
 }
 
@@ -636,8 +636,8 @@ func escapeString(in string) string {
 }
 
 func escapeStringFields(in string) string {
-	for b, esc := range escapeCodesStrFields {
-		in = strings.Replace(in, b, esc, -1)
+	for _, p := range escapeCodesStrFields {
+		in = strings.Replace(in, p.b, p.esc, -1)
 	}
 	return in
 }
@@ -891,7 +891,6 @@ func newFieldsFromBinary(buf []byte) Fields {
 		if len(name) == 0 {
 			continue
 		}
-
 		i, valueBuf = scanFieldValue(buf, i+1)
 		if len(valueBuf) == 0 {
 			fields[string(name)] = nil


### PR DESCRIPTION
#### I receive panic error when I'm trying to write message with commas and nested quotas.
```
# curl -G 'http://localhost:8086/query' --data-urlencode "q=CREATE DATABASE mmm"
{"results":[{}]}
```
```
# curl -XPOST 'http://localhost:8086/write?db=mmm' --data-binary '@t.g'
curl: (52) Empty reply from server
```
```
# cat t.g
{
  "database" : "mmm",
  "retentionPolicy" : "",
  "points" :  [ {
    "measurement" : "http_status",
    "tags" : {
      "service" : "identity-service",
      "hostname" : "host1",
      "url" : "http://localhost:35774/"
    },
    "timestamp" : "2015-06-16T09:28:26.000Z",
    "fields" : {
      "value_meta" : "{Hello\"{,}\" World}",
      "value" : 1.0
    }
  } ],
  "tags" : { }
}
```
```
# curl -XPOST 'http://localhost:8086/write?db=mmm' --data-binary '@t2.g'
curl: (52) Empty reply from server
```
```
# cat t2.g
{
  "database" : "mmm",
  "retentionPolicy" : "",
  "points" :  [ {
    "measurement" : "http_status",
    "tags" : {
      "service" : "identity-service",
      "hostname" : "host1",
      "url" : "http://localhost:35774/"
    },
    "timestamp" : "2015-06-16T09:28:26.000Z",
    "fields" : {
      "value_meta" : "{\"error\":\"\\\"{\\\"version\\\": {\\\"status\\\": \\\"stable\\\", \\\"updated\\\": \\\"2015-03-30T00:00:00Z\\\"}}\\\"}",
      "value" : 1.0
    }
  } ],
  "tags" : { }
}
```

The problem is that with creation tsbd.Point:
```
func NewPoint(name string, tags Tags, fields Fields, time time.Time) Point {
        return &point{
                key:    makeKey([]byte(name), tags),
                time:   time,
                fields: fields.MarshalBinary(),
        }
}
```
In function MarshalBinary is error. Because there are added quotas on begin and end of field.
Problem is that we receive string:
```
"{Hello"{,}" World}"
```
instead of expected by function scanFieldValue
```
"{Hello\"{,}\" World}"
```

The biggest problem occurs later because function scanFieldValue splits this wrong string in comma sign and we receive:
```
panic: unsupported value type during encode fields: <nil>

goroutine 29 [running]:
github.com/influxdb/influxdb/tsdb.(*FieldCodec).EncodeFields(0xc2081084b0, 0xc208146e70, 0x0, 0x0, 0x0, 0x0, 0x0)

```

I run influxdb with and without escaping plus some added debug infos, the results are below:
```
# cat part_run.log
With escaping

MarshalBinary t |{"error":"\"{\"version\": {\"status\": \"stable\", \"updated\": \"2015-03-30T00:00:00Z\"}}\"}|
escapeStringFields in |{"error":"\\"{\\"version\\": {\\"status\\": \\"stable\\", \\"updated\\": \\"2015-03-30T00:00:00Z\\"}}\\"}| b |\| esc |\\|
escapeStringFields in |{\"error\":\"\\\"{\\\"version\\\": {\\\"status\\\": \\\"stable\\\", \\\"updated\\\": \\\"2015-03-30T00:00:00Z\\\"}}\\\"}| b |"| esc |\"|
Fields 
unmarshalBinary p.fields |value=1.0,value_meta="{\"error\":\"\\\"{\\\"version\\\": {\\\"status\\\": \\\"stable\\\", \\\"updated\\\": \\\"2015-03-30T00:00:00Z\\\"}}\\\"}"|
newFieldsFromBinary buf: |1.0,value_meta="{\"error\":\"\\\"{\\\"version\\\": {\\\"status\\\": \\\"stable\\\", \\\"updated\\\": \\\"2015-03-30T00:00:00Z\\\"}}\\\"}"|
newFieldsFromBinary buf: |"{\"error\":\"\\\"{\\\"version\\\": {\\\"status\\\": \\\"stable\\\", \\\"updated\\\": \\\"2015-03-30T00:00:00Z\\\"}}\\\"}"|
Fields 
unmarshalBinary p.fields |value=1.0,value_meta="{\"error\":\"\\\"{\\\"version\\\": {\\\"status\\\": \\\"stable\\\", \\\"updated\\\": \\\"2015-03-30T00:00:00Z\\\"}}\\\"}"|
newFieldsFromBinary buf: |1.0,value_meta="{\"error\":\"\\\"{\\\"version\\\": {\\\"status\\\": \\\"stable\\\", \\\"updated\\\": \\\"2015-03-30T00:00:00Z\\\"}}\\\"}"|
newFieldsFromBinary buf: |"{\"error\":\"\\\"{\\\"version\\\": {\\\"status\\\": \\\"stable\\\", \\\"updated\\\": \\\"2015-03-30T00:00:00Z\\\"}}\\\"}"|
[http] 2015/06/20 12:37:17 127.0.0.1 - - [20/Jun/2015:12:37:17 +0200] POST /write?db=mmm HTTP/1.1 204 0 - curl/7.32.0 52540960-1738-11e5-8001-000000000000 2.623664ms
NewPoint 
MarshalBinary t |{Hello"{,}" World}|
escapeStringFields in |{Hello"{,}" World}| b |\| esc |\\|
escapeStringFields in |{Hello\"{,}\" World}| b |"| esc |\"|
Fields 
unmarshalBinary p.fields |value=1.0,value_meta="{Hello\"{,}\" World}"|
newFieldsFromBinary buf: |1.0,value_meta="{Hello\"{,}\" World}"|
newFieldsFromBinary buf: |"{Hello\"{,}\" World}"|
Fields 
unmarshalBinary p.fields |value=1.0,value_meta="{Hello\"{,}\" World}"|
newFieldsFromBinary buf: |1.0,value_meta="{Hello\"{,}\" World}"|
newFieldsFromBinary buf: |"{Hello\"{,}\" World}"|




Without escaping

NewPoint 
MarshalBinary t |{Hello"{,}" World}|
Fields 
unmarshalBinary p.fields |value=1.0,value_meta="{Hello"{,}" World}"|
newFieldsFromBinary buf: |1.0,value_meta="{Hello"{,}" World}"|
newFieldsFromBinary buf: |"{Hello"{,}" World}"|
Fields 
unmarshalBinary p.fields |value=1.0,value_meta="{Hello"{,}" World}"|
newFieldsFromBinary buf: |1.0,value_meta="{Hello"{,}" World}"|
newFieldsFromBinary buf: |"{Hello"{,}" World}"|
panic: unsupported value type during encode fields: <nil>


NewPoint 
MarshalBinary t |{"error":"\"{\"version\": {\"status\": \"stable\", \"updated\": \"2015-03-30T00:00:00Z\"}}\"}|
Fields 
unmarshalBinary p.fields |value=1.0,value_meta="{"error":"\"{\"version\": {\"status\": \"stable\", \"updated\": \"2015-03-30T00:00:00Z\"}}\"}"|
newFieldsFromBinary buf: |1.0,value_meta="{"error":"\"{\"version\": {\"status\": \"stable\", \"updated\": \"2015-03-30T00:00:00Z\"}}\"}"|
newFieldsFromBinary buf: |"{"error":"\"{\"version\": {\"status\": \"stable\", \"updated\": \"2015-03-30T00:00:00Z\"}}\"}"|
Fields 
unmarshalBinary p.fields |value=1.0,value_meta="{"error":"\"{\"version\": {\"status\": \"stable\", \"updated\": \"2015-03-30T00:00:00Z\"}}\"}"|
newFieldsFromBinary buf: |1.0,value_meta="{"error":"\"{\"version\": {\"status\": \"stable\", \"updated\": \"2015-03-30T00:00:00Z\"}}\"}"|
newFieldsFromBinary buf: |"{"error":"\"{\"version\": {\"status\": \"stable\", \"updated\": \"2015-03-30T00:00:00Z\"}}\"}"|
panic: unsupported value type during encode fields: <nil>
```