### PR TITLE
Fix download link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ events, and performing analytics.
 
 ## Features
 
-* Built-in [HTTP API] (http://influxdb.com/docs/v0.9/concepts/reading_and_writing_data.html) so you don't have to write any server side code to get up and running.
+* Built-in [HTTP API](http://influxdb.com/docs/v0.9/concepts/reading_and_writing_data.html) so you don't have to write any server side code to get up and running.
 * Clustering is supported out of the box, so that you can scale horizontally to handle your data.
 * Simple to install and manage, and fast to get data in and out.
 * It aims to answer queries in real-time. That means every data point is
@@ -23,7 +23,7 @@ events, and performing analytics.
 ### Building
 
 You don't need to build the project to use it - you can use any of our
-[pre-built packages](http://influxdb.com/download/) to install InfluxDB. That's
+[pre-built packages](http://influxdb.com/download/index.html) to install InfluxDB. That's
 the recommended way to get it running. However, if you want to contribute to the core of InfluxDB, you'll need to build.
 For those adventurous enough, you can
 [follow along on our docs](http://github.com/influxdb/influxdb/blob/master/CONTRIBUTING.md).


### PR DESCRIPTION
Fixes #3081 

Note, http://influxdb.com/download/ _should_ resolve correctly. I'm still digging into the s3 settings to figure out why that's broken.