### PR TITLE
Fix invalid field value format not parsed correctly

### DIFF
--- a/tsdb/points.go
+++ b/tsdb/points.go
@@ -300,6 +300,10 @@ func scanFields(buf []byte, i int) (int, []byte, error) {
 	start := skipWhitespace(buf, i)
 	i = start
 	quoted := false
+
+	// tracks whether we've see at least one '='
+	hasSeparator := false
+
 	for {
 		// reached the end of buf?
 		if i >= len(buf) {
@@ -321,6 +325,8 @@ func scanFields(buf []byte, i int) (int, []byte, error) {
 
 		// If we see an =, ensure that there is at least on char after it
 		if buf[i] == '=' && !quoted {
+			hasSeparator = true
+
 			// check for "... value="
 			if i+1 >= len(buf) {
 				return i, buf[start:i], fmt.Errorf("missing field value")
@@ -357,9 +363,15 @@ func scanFields(buf []byte, i int) (int, []byte, error) {
 		}
 		i += 1
 	}
+
 	if quoted {
 		return i, buf[start:i], fmt.Errorf("unbalanced quotes")
 	}
+
+	if !hasSeparator {
+		return i, buf[start:i], fmt.Errorf("invalid field format")
+	}
+
 	return i, buf[start:i], nil
 }
 

--- a/tsdb/points_test.go
+++ b/tsdb/points_test.go
@@ -162,18 +162,24 @@ func TestParsePointMissingTagValue(t *testing.T) {
 func TestParsePointMissingFieldValue(t *testing.T) {
 	_, err := ParsePointsString(`cpu,host=serverA,region=us-west value=`)
 	if err == nil {
-		t.Errorf(`ParsePoints("%s") mismatch. got nil, exp error`, "cpu")
+		t.Errorf(`ParsePoints("%s") mismatch. got nil, exp error`, `cpu,host=serverA,region=us-west value=`)
 	}
 
 	_, err = ParsePointsString(`cpu,host=serverA,region=us-west value= 1000000000`)
 	if err == nil {
-		t.Errorf(`ParsePoints("%s") mismatch. got nil, exp error`, "cpu")
+		t.Errorf(`ParsePoints("%s") mismatch. got nil, exp error`, `cpu,host=serverA,region=us-west value= 1000000000`)
 	}
 
 	_, err = ParsePointsString(`cpu,host=serverA,region=us-west value=,value2=1`)
 	if err == nil {
-		t.Errorf(`ParsePoints("%s") mismatch. got nil, exp error`, "cpu")
+		t.Errorf(`ParsePoints("%s") mismatch. got nil, exp error`, `cpu,host=serverA,region=us-west value=,value2=1`)
 	}
+
+	_, err = ParsePointsString(`cpu,host=server01,region=us-west 1434055562000000000`)
+	if err == nil {
+		t.Errorf(`ParsePoints("%s") mismatch. got nil, exp error`, `cpu,host=server01,region=us-west 1434055562000000000`)
+	}
+
 }
 
 func TestParsePointBadNumber(t *testing.T) {


### PR DESCRIPTION
A field value of just a numeric value would be accepted by the line
protocol parser but the value would be set as the field name and
the value would be nil.  Instead, return an error because all field
values need a field name.