### PR TITLE
Fix string field value escaping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 
 - [2650](https://github.com/influxdb/influxdb/pull/2650): Add SHOW GRANTS FOR USER statement. Thanks @n1tr0g.
+- [3013](https://github.com/influxdb/influxdb/issues/3013): Panic error with inserting values with commas
 
 ### Bugfixes
 

--- a/tsdb/points_test.go
+++ b/tsdb/points_test.go
@@ -453,7 +453,7 @@ func TestParsePointWithStringWithCommas(t *testing.T) {
 			},
 			Fields{
 				"value": 1.0,
-				"str":   "foo,bar", // commas in string value
+				"str":   `foo\,bar`, // commas in string value
 			},
 			time.Unix(1, 0)),
 	)
@@ -469,6 +469,37 @@ func TestParsePointWithStringWithCommas(t *testing.T) {
 			Fields{
 				"value": 1.0,
 				"str":   "foo,bar", // commas in string value
+			},
+			time.Unix(1, 0)),
+	)
+
+}
+
+func TestParsePointEscapedStringsAndCommas(t *testing.T) {
+	// non-escaped comma and quotes
+	test(t, `cpu,host=serverA,region=us-east value="{Hello\"{,}\" World}" 1000000000`,
+		NewPoint(
+			"cpu",
+			Tags{
+				"host":   "serverA",
+				"region": "us-east",
+			},
+			Fields{
+				"value": `{Hello"{,}" World}`,
+			},
+			time.Unix(1, 0)),
+	)
+
+	// escaped comma and quotes
+	test(t, `cpu,host=serverA,region=us-east value="{Hello\"{\,}\" World}" 1000000000`,
+		NewPoint(
+			"cpu",
+			Tags{
+				"host":   "serverA",
+				"region": "us-east",
+			},
+			Fields{
+				"value": `{Hello"{\,}" World}`,
 			},
 			time.Unix(1, 0)),
 	)


### PR DESCRIPTION
Commas and quotes could get escaped and parsed incorrectly if they
were both present in a string value.

Fixes #3013