### PR TITLE
DROP DATABASE should remove entry from TSDB index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - [#3030](https://github.com/influxdb/influxdb/pull/3030): Fix excessive logging of shard creation.
 - [#3038](https://github.com/influxdb/influxdb/pull/3038): Don't check deleted shards for precreation. Thanks @vladlopes.
 - [#3033](https://github.com/influxdb/influxdb/pull/3033): Add support for marshaling `uint64` in client.
+- [#3090](https://github.com/influxdb/influxdb/pull/3090): Remove database from TSDB index on DROP DATABASE.
 
 ## v0.9.0 [2015-06-11]
 

--- a/tsdb/query_executor.go
+++ b/tsdb/query_executor.go
@@ -279,10 +279,11 @@ func (q *QueryExecutor) expandWildcards(stmt *influxql.SelectStatement) (*influx
 	// Iterate measurements in the FROM clause getting the fields & dimensions for each.
 	for _, src := range stmt.Sources {
 		if m, ok := src.(*influxql.Measurement); ok {
-			// Lookup the database.
+			// Lookup the database. The database may not exist if no data for this database
+			// was ever written to the shard.
 			db := q.store.DatabaseIndex(m.Database)
 			if db == nil {
-				return nil, nil
+				return stmt, nil
 			}
 
 			// Lookup the measurement in the database.

--- a/tsdb/store.go
+++ b/tsdb/store.go
@@ -103,7 +103,11 @@ func (s *Store) DeleteDatabase(name string, shardIDs []uint64) error {
 			shard.Close()
 		}
 	}
-	return os.RemoveAll(s.path)
+	if err := os.RemoveAll(s.path); err != nil {
+		return err
+	}
+	delete(s.databaseIndexes, name)
+	return nil
 }
 
 func (s *Store) Shard(shardID uint64) *Shard {


### PR DESCRIPTION
Fixes issue https://github.com/influxdb/influxdb/issues/3049

This change removes the database object from the TSBD store's index, when `DROP DATABASE` is issued. Without this change, old measurement information remained in memory for the database. This change also exposed another panic-producing bug, whereby the statement object should be returned unmodified when `RewriteDistinct` has nothing to do. 