### PR TITLE
Copy an Batch tags to each point before marshalling

### DIFF
--- a/client/influxdb.go
+++ b/client/influxdb.go
@@ -129,6 +129,10 @@ func (c *Client) Write(bp BatchPoints) (*Response, error) {
 				return nil, err
 			}
 		} else {
+			for k, v := range bp.Tags {
+				p.Tags[k] = v
+			}
+
 			if _, err := b.WriteString(p.MarshalString()); err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
This is to fix https://github.com/influxdb/telegraf/issues/18. The switch away from JSON to the line protocol broke passing the tags specified in BatchPoints.