### PR TITLE
Fix a number of issues in sysV init script.

### DIFF
--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -158,7 +158,7 @@ case $1 in
         if which start-stop-daemon > /dev/null 2>&1; then
             start-stop-daemon --chuid $GROUP:$USER --start --quiet --pidfile $pidfile --exec $daemon -- -pidfile $pidfile -config $config $INFLUXD_OPTS >>$STDOUT 2>>$STDERR &
         else
-            nohup $daemon -pidfile $pidfile -config $config $INFLUXD_OPTS >>$STDOUT 2>>$STDERR &
+            su $USER -c "nohup $daemon -pidfile $pidfile -config $config $INFLUXD_OPTS >>$STDOUT 2>>$STDERR &"
         fi
 
         wait_for_startup && is_process_running

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -76,7 +76,7 @@ function killproc() {
         echo "Expected three arguments, e.g. $0 -p pidfile signal"
     fi
 
-    pid=`cat $2`
+    pid=$(cat $2)
 
     kill -s $3 $pid
 }


### PR DESCRIPTION
When using the sysV init script the service actions return codes were not being properly set.

What this means is that the init script would return successfully even when, for instance, it failed to load the configuration and the process wasn't left running.

As the influx process doesn't fork itself we're waiting for the pid file to be created and checking the status of the process afterwards.