### PR TITLE
Prevent out of range ints and floats from being parsed sucessfully

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@
 - [#2102](https://github.com/influxdb/influxdb/issues/2102): Re-work Graphite input and metric processing
 - [#2996](https://github.com/influxdb/influxdb/issues/2996): Graphite Input Parsing
 - [#3136](https://github.com/influxdb/influxdb/pull/3136): Fix various issues with init.d script. Thanks @ miguelcnf.
+- [2996](https://github.com/influxdb/influxdb/issues/2996): Graphite Input Parsing
+- [3127](https://github.com/influxdb/influxdb/issues/3127): Trying to insert a number larger than the largest signed 64-bit number kills influxd
 
 ## v0.9.0 [2015-06-11]
 


### PR DESCRIPTION
Field values that were out of range for the type would panic the database
when being inserted because the parser would allow them as valid points.
This change prevents those invalid values from being parsed and instead
returns an error.

An alternative fix considered was to handle the error and clamp the value
to the min/max value for the type.  This would treat numeric range errors
slightly differently than other type erros which might lead to confusion.

The simplest fix with the current parser would be to just convert each field
to the type at parse time.  Unfortunately, this adds extra memory allocations
and lowers throughput significantly.  Since out of range values are less common
than in-range values, some heuristics are used to determine when the more
expensive type parsing and range checking is performed.  Essentially, we only
do the slow path when we cannot determine that the value is in an acceptable
type range.

Fixes #3127