### PR TITLE
Create UDP batcher before listening for UDP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v0.9.2 [unreleased]
+
+### Bugfixes
+
+- [3155](https://github.com/influxdb/influxdb/pull/3155): Instantiate UDP batcher before listening for UDP traffic, otherwise a panic may result.
+
 ## v0.9.1 [2015-06-26]
 
 ### Features

--- a/services/udp/service.go
+++ b/services/udp/service.go
@@ -39,9 +39,10 @@ type Service struct {
 
 func NewService(c Config) *Service {
 	return &Service{
-		config: c,
-		done:   make(chan struct{}),
-		Logger: log.New(os.Stderr, "[udp] ", log.LstdFlags),
+		config:  c,
+		done:    make(chan struct{}),
+		batcher: tsdb.NewPointBatcher(c.BatchSize, time.Duration(c.BatchTimeout)),
+		Logger:  log.New(os.Stderr, "[udp] ", log.LstdFlags),
 	}
 }
 
@@ -66,8 +67,6 @@ func (s *Service) Open() (err error) {
 	}
 
 	s.Logger.Printf("Started listening on %s", s.config.BindAddress)
-
-	s.batcher = tsdb.NewPointBatcher(s.config.BatchSize, time.Duration(s.config.BatchTimeout))
 
 	s.wg.Add(2)
 	go s.serve()


### PR DESCRIPTION
Otherwise a packet may be received before the batcher has been instantiated and a panic in batcher stats may result.