### PR TITLE
Fix parsing tag and fields with missing name or values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@
 - [#3127](https://github.com/influxdb/influxdb/issues/3127): Trying to insert a number larger than the largest signed 64-bit number kills influxd
 - [#3131](https://github.com/influxdb/influxdb/pull/3131): Copy batch tags to each point before marshalling
 - [#3155](https://github.com/influxdb/influxdb/pull/3155): Instantiate UDP batcher before listening for UDP traffic, otherwise a panic may result.
+- [#2678](https://github.com/influxdb/influxdb/issues/2678): Server allows tags with an empty string for the key and/or value
+- [#3061](https://github.com/influxdb/influxdb/issues/3061): syntactically incorrect line protocol insert panics the database
 
 ## v0.9.0 [2015-06-11]
 

--- a/tsdb/points.go
+++ b/tsdb/points.go
@@ -205,25 +205,40 @@ func scanKey(buf []byte, i int) (int, []byte, error) {
 	// tracks how many commas we've seen so we know how many values are indices.
 	// Since indices is an arbitraily large slice,
 	// we need to know how many values in the buffer are in use.
-	separators := 0
+	commas := 0
 
 	// tracks whether we've see an '='
-	hasSeparator := false
+	equals := 0
 
 	// loop over each byte in buf
 	for {
 		// reached the end of buf?
 		if i >= len(buf) {
-			if !hasSeparator && separators > 0 {
-				return i, buf[start:i], fmt.Errorf("missing value")
+			if equals == 0 && commas > 0 {
+				return i, buf[start:i], fmt.Errorf("missing tag value")
 			}
 
 			break
 		}
 
 		if buf[i] == '=' {
+			// Check for "cpu,=value" but allow "cpu,a\,=value"
+			if buf[i-1] == ',' && buf[i-2] != '\\' {
+				return i, buf[start:i], fmt.Errorf("missing tag name")
+			}
+
+			// Check for "cpu,\ =value"
+			if buf[i-1] == ' ' && buf[i-2] != '\\' {
+				return i, buf[start:i], fmt.Errorf("missing tag name")
+			}
+
 			i += 1
-			hasSeparator = true
+			equals += 1
+
+			// Check for "cpu,a=1,b= value=1"
+			if i < len(buf) && buf[i] == ' ' {
+				return i, buf[start:i], fmt.Errorf("missing tag value")
+			}
 			continue
 		}
 
@@ -235,36 +250,46 @@ func scanKey(buf []byte, i int) (int, []byte, error) {
 
 		// At a tag separator (comma), track it's location
 		if buf[i] == ',' {
-			if !hasSeparator && separators > 0 {
-				return i, buf[start:i], fmt.Errorf("missing value")
+			if equals == 0 && commas > 0 {
+				return i, buf[start:i], fmt.Errorf("missing tag value")
 			}
 			i += 1
-			indices[separators] = i
-			separators += 1
-			hasSeparator = false
+			indices[commas] = i
+			commas += 1
+
+			// Check for "cpu, value=1"
+			if i < len(buf) && buf[i] == ' ' {
+				return i, buf[start:i], fmt.Errorf("missing tag key")
+			}
 			continue
 		}
 
 		// reached end of the block? (next block would be fields)
 		if buf[i] == ' ' {
-			if !hasSeparator && separators > 0 {
-				return i, buf[start:i], fmt.Errorf("missing value")
+			if equals > 0 && commas-1 != equals-1 {
+				return i, buf[start:i], fmt.Errorf("missing tag value")
 			}
-			indices[separators] = i + 1
+			indices[commas] = i + 1
 			break
 		}
 
 		i += 1
 	}
 
+	// check that all field sections had key and values (e.g. prevent "a=1,b"
+	// We're using commas -1 because there should always be a comma after measurement
+	if equals > 0 && commas-1 != equals-1 {
+		return i, buf[start:i], fmt.Errorf("invalid tag format")
+	}
+
 	// Now we know where the key region is within buf, and the locations of tags, we
 	// need to deterimine if duplicate tags exist and if the tags are sorted.  This iterates
 	// 1/2 of the list comparing each end with each other, walking towards the center from
 	// both sides.
-	for j := 0; j < separators/2; j++ {
+	for j := 0; j < commas/2; j++ {
 		// get the left and right tags
 		_, left := scanTo(buf[indices[j]:indices[j+1]-1], 0, '=')
-		_, right := scanTo(buf[indices[separators-j-1]:indices[separators-j]-1], 0, '=')
+		_, right := scanTo(buf[indices[commas-j-1]:indices[commas-j]-1], 0, '=')
 
 		// If the tags are equal, then there are duplicate tags, and we should abort
 		if bytes.Equal(left, right) {
@@ -282,13 +307,13 @@ func scanKey(buf []byte, i int) (int, []byte, error) {
 	// uses the tag indices we created earlier.  The actual buffer is not sorted, the
 	// indices are using the buffer for value comparison.  After the indices are sorted,
 	// the buffer is reconstructed from the sorted indices.
-	if !sorted && separators > 0 {
+	if !sorted && commas > 0 {
 		// Get the measurement name for later
 		measurement := buf[start : indices[0]-1]
 
 		// Sort the indices
-		indices := indices[:separators]
-		insertionSort(0, separators, buf, indices)
+		indices := indices[:commas]
+		insertionSort(0, commas, buf, indices)
 
 		// Create a new key using the measurement and sorted indices
 		b := make([]byte, len(buf[start:i]))

--- a/tsdb/points.go
+++ b/tsdb/points.go
@@ -193,7 +193,7 @@ func scanKey(buf []byte, i int) (int, []byte, error) {
 
 	i = start
 
-	// Determiens whether the tags are sort, assume they are
+	// Determines whether the tags are sort, assume they are
 	sorted := true
 
 	// indices holds the indexes within buf of the start of each tag.  For example,
@@ -203,7 +203,7 @@ func scanKey(buf []byte, i int) (int, []byte, error) {
 	indices := make([]int, 100)
 
 	// tracks how many commas we've seen so we know how many values are indices.
-	// Since indices is an arbitraily large slice,
+	// Since indices is an arbitrarily large slice,
 	// we need to know how many values in the buffer are in use.
 	commas := 0
 

--- a/tsdb/points_test.go
+++ b/tsdb/points_test.go
@@ -146,6 +146,22 @@ func TestParsePointNoFields(t *testing.T) {
 	if err == nil {
 		t.Errorf(`ParsePoints("%s") mismatch. got nil, exp error`, "cpu")
 	}
+
+	_, err = ParsePointsString("cpu,")
+	if err == nil {
+		t.Errorf(`ParsePoints("%s") mismatch. got nil, exp error`, "cpu,")
+	}
+
+	_, err = ParsePointsString("cpu, value=1")
+	if err == nil {
+		t.Errorf(`ParsePoints("%s") mismatch. got nil, exp error`, "cpu, value=1")
+	}
+
+	_, err = ParsePointsString("cpu,,, value=1")
+	if err == nil {
+		t.Errorf(`ParsePoints("%s") mismatch. got nil, exp error`, "cpu,,, value=1")
+	}
+
 }
 
 func TestParsePointNoTimestamp(t *testing.T) {
@@ -159,10 +175,36 @@ func TestParsePointMissingQuote(t *testing.T) {
 	}
 }
 
+func TestParsePointMissingTagName(t *testing.T) {
+	_, err := ParsePointsString(`cpu,host=serverA,=us-east value=1`)
+	if err == nil {
+		t.Errorf(`ParsePoints("%s") mismatch. got nil, exp error`, `cpu,host=serverA,=us-east value=1`)
+	}
+
+	_, err = ParsePointsString(`cpu,host=serverAa\,,=us-east value=1`)
+	if err == nil {
+		t.Errorf(`ParsePoints("%s") mismatch. got nil, exp error`, `cpu,host=serverAa\,,=us-east value=1`)
+	}
+
+	_, err = ParsePointsString(`cpu,host=serverA\,,=us-east value=1`)
+	if err == nil {
+		t.Errorf(`ParsePoints("%s") mismatch. got nil, exp error`, `cpu,host=serverA\,,=us-east value=1`)
+	}
+
+	_, err = ParsePointsString(`cpu,host=serverA,\ =us-east value=1`)
+	if err != nil {
+		t.Errorf(`ParsePoints("%s") mismatch. got %v, exp nil`, `cpu,host=serverA,\ =us-east value=1`, err)
+	}
+}
+
 func TestParsePointMissingTagValue(t *testing.T) {
 	_, err := ParsePointsString(`cpu,host=serverA,region value=1`)
 	if err == nil {
-		t.Errorf(`ParsePoints("%s") mismatch. got nil, exp error`, "cpu")
+		t.Errorf(`ParsePoints("%s") mismatch. got nil, exp error`, `cpu,host=serverA,region value=1`)
+	}
+	_, err = ParsePointsString(`cpu,host=serverA,region= value=1`)
+	if err == nil {
+		t.Errorf(`ParsePoints("%s") mismatch. got nil, exp error`, `cpu,host=serverA,region= value=1`)
 	}
 }
 

--- a/tsdb/points_test.go
+++ b/tsdb/points_test.go
@@ -166,6 +166,28 @@ func TestParsePointMissingTagValue(t *testing.T) {
 	}
 }
 
+func TestParsePointMissingFieldName(t *testing.T) {
+	_, err := ParsePointsString(`cpu,host=serverA,region=us-west =`)
+	if err == nil {
+		t.Errorf(`ParsePoints("%s") mismatch. got nil, exp error`, `cpu,host=serverA,region=us-west =`)
+	}
+
+	_, err = ParsePointsString(`cpu,host=serverA,region=us-west =123`)
+	if err == nil {
+		t.Errorf(`ParsePoints("%s") mismatch. got nil, exp error`, `cpu,host=serverA,region=us-west =123`)
+	}
+
+	_, err = ParsePointsString(`cpu,host=serverA,region=us-west a\ =123`)
+	if err != nil {
+		t.Errorf(`ParsePoints("%s") mismatch. got nil, exp error`, `cpu,host=serverA,region=us-west a\ =123`)
+	}
+	_, err = ParsePointsString(`cpu,host=serverA,region=us-west value=123,=456`)
+	if err == nil {
+		t.Errorf(`ParsePoints("%s") mismatch. got nil, exp error`, `cpu,host=serverA,region=us-west value=123,=456`)
+	}
+
+}
+
 func TestParsePointMissingFieldValue(t *testing.T) {
 	_, err := ParsePointsString(`cpu,host=serverA,region=us-west value=`)
 	if err == nil {
@@ -187,6 +209,10 @@ func TestParsePointMissingFieldValue(t *testing.T) {
 		t.Errorf(`ParsePoints("%s") mismatch. got nil, exp error`, `cpu,host=server01,region=us-west 1434055562000000000`)
 	}
 
+	_, err = ParsePointsString(`cpu,host=server01,region=us-west value=1,b`)
+	if err == nil {
+		t.Errorf(`ParsePoints("%s") mismatch. got nil, exp error`, `cpu,host=server01,region=us-west value=1,b`)
+	}
 }
 
 func TestParsePointBadNumber(t *testing.T) {
@@ -594,7 +620,7 @@ func TestParsePointEscapedStringsAndCommas(t *testing.T) {
 }
 
 func TestParsePointWithStringWithEquals(t *testing.T) {
-	test(t, `cpu,host=serverA,region=us-east str="foo=bar",value=1.0, 1000000000`,
+	test(t, `cpu,host=serverA,region=us-east str="foo=bar",value=1.0 1000000000`,
 		NewPoint(
 			"cpu",
 			Tags{


### PR DESCRIPTION
Some combinations of tag and fields would get parsed correctly when they should not.

Fixes #2678 #3061