### PR TITLE
Fix panic when droppping measurement while writing to it concurrently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 - [#3155](https://github.com/influxdb/influxdb/pull/3155): Instantiate UDP batcher before listening for UDP traffic, otherwise a panic may result.
 - [#2678](https://github.com/influxdb/influxdb/issues/2678): Server allows tags with an empty string for the key and/or value
 - [#3061](https://github.com/influxdb/influxdb/issues/3061): syntactically incorrect line protocol insert panics the database
+- [#2608](https://github.com/influxdb/influxdb/issues/2608): drop measurement while writing points to that measurement has race condition that can panic
 
 ## v0.9.0 [2015-06-11]
 

--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -243,6 +243,12 @@ func (s *Shard) WritePoints(points []Point) error {
 			s.mu.RLock()
 			mf := s.measurementFields[p.Name()]
 			s.mu.RUnlock()
+
+			// If a measurement is dropped while writes for it are in progress, this could be nil
+			if mf == nil {
+				return ErrFieldNotFound
+			}
+
 			data, err := mf.codec.EncodeFields(p.Fields())
 			if err != nil {
 				return err


### PR DESCRIPTION
There is a race when writing points and dropping measurements where the fields are removed from the index while points are attempting to use them for encoding.

Produces this panic in 0.9.1-rc1
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xb code=0x1 addr=0x8 pc=0x19c625]

goroutine 2744 [running]:
github.com/influxdb/influxdb/tsdb.(*Shard).WritePoints(0xc2081ac000, 0xc21b450000, 0x1388, 0x1800, 0x0, 0x0)
	/Users/jason/go/src/github.com/influxdb/influxdb/tsdb/shard.go:246 +0x415
github.com/influxdb/influxdb/tsdb.(*Store).WriteToShard(0xc208034be0, 0x6, 0xc21b450000, 0x1388, 0x1800, 0x0, 0x0)
	/Users/jason/go/src/github.com/influxdb/influxdb/tsdb/store.go:278 +0xf7
github.com/influxdb/influxdb/cluster.func·002(0x6, 0x1, 0xc21b450000, 0x1388, 0x1800)
	/Users/jason/go/src/github.com/influxdb/influxdb/cluster/points_writer.go:241 +0xfc
created by github.com/influxdb/influxdb/cluster.(*PointsWriter).writeToShard
	/Users/jason/go/src/github.com/influxdb/influxdb/cluster/points_writer.go:271 +0x30b
```

Fixes #2608