### PR TITLE
client: fixes nil map assignment when writing batch points out

### DIFF
--- a/client/influxdb.go
+++ b/client/influxdb.go
@@ -130,6 +130,9 @@ func (c *Client) Write(bp BatchPoints) (*Response, error) {
 			}
 		} else {
 			for k, v := range bp.Tags {
+				if p.Tags == nil {
+					p.Tags = make(map[string]string, len(bp.Tags))
+				}
 				p.Tags[k] = v
 			}
 


### PR DESCRIPTION
ran into this when using telegraf, 'load' does not assign any tags and so when you go to add tags on each batch entry, you get an `assignment to nil map` panic. it seems sane to support nil `Tags` for each `client.Point`, happy to skin the cat differently but this should do the trick. thanks!