### PR TITLE
Log GOMAXPROCS, version, and commit on start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v0.9.2 [unreleased]
+
+### Bugfixes
+
+- [#3180](https://github.com/influxdb/influxdb/pull/3180): Log GOMAXPROCS, version, and commit on startup.
+
 ## v0.9.1 [unreleased]
 
 ### Features

--- a/cmd/influxd/run/command.go
+++ b/cmd/influxd/run/command.go
@@ -68,7 +68,6 @@ func (cmd *Command) Run(args ...string) error {
 
 	// Set parallelism.
 	runtime.GOMAXPROCS(runtime.NumCPU())
-	fmt.Fprintf(cmd.Stderr, "GOMAXPROCS set to %d\n", runtime.GOMAXPROCS(0))
 
 	// Parse config
 	config, err := cmd.ParseConfig(options.ConfigPath)
@@ -97,6 +96,10 @@ func (cmd *Command) Run(args ...string) error {
 		return fmt.Errorf("open server: %s", err)
 	}
 	cmd.Server = s
+
+	// Mark start-up in log.
+	log.Printf("InfluxDB starting, version %s, commit %s", cmd.Version, cmd.Commit)
+	log.Println("GOMAXPROCS set to", runtime.GOMAXPROCS(0))
 
 	// Begin monitoring the server's error channel.
 	go cmd.monitorServerErrors()


### PR DESCRIPTION
This important information was not in the logs, making troubleshooting of end-user systems awkward.