### PR TITLE
Handle escaped commas in measurement name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
 - [#2678](https://github.com/influxdb/influxdb/issues/2678): Server allows tags with an empty string for the key and/or value
 - [#3061](https://github.com/influxdb/influxdb/issues/3061): syntactically incorrect line protocol insert panics the database
 - [#2608](https://github.com/influxdb/influxdb/issues/2608): drop measurement while writing points to that measurement has race condition that can panic
+- [#3183](https://github.com/influxdb/influxdb/issues/3183): using line protocol measurement names cannot contain commas
 
 ## v0.9.0 [2015-06-11]
 

--- a/tsdb/points.go
+++ b/tsdb/points.go
@@ -266,6 +266,10 @@ func scanKey(buf []byte, i int) (int, []byte, error) {
 
 		// reached end of the block? (next block would be fields)
 		if buf[i] == ' ' {
+			// check for "cpu,tag value=1"
+			if equals == 0 && commas > 0 {
+				return i, buf[start:i], fmt.Errorf("missing tag value")
+			}
 			if equals > 0 && commas-1 != equals-1 {
 				return i, buf[start:i], fmt.Errorf("missing tag value")
 			}
@@ -620,6 +624,10 @@ func skipWhitespace(buf []byte, i int) int {
 			return i
 		}
 
+		if buf[i] == '\\' {
+			i += 2
+			continue
+		}
 		if buf[i] == ' ' || buf[i] == '\t' {
 			i += 1
 			continue
@@ -631,13 +639,18 @@ func skipWhitespace(buf []byte, i int) int {
 
 // scanTo returns the end position in buf and the next consecutive block
 // of bytes, starting from i and ending with stop byte.  If there are leading
-// spaces, they are skipped.
+// spaces or escaped chars, they are skipped.
 func scanTo(buf []byte, i int, stop byte) (int, []byte) {
 	start := i
 	for {
 		// reached the end of buf?
 		if i >= len(buf) {
 			break
+		}
+
+		if buf[i] == '\\' {
+			i += 2
+			continue
 		}
 
 		// reached end of block?
@@ -661,6 +674,10 @@ func scanToSpaceOr(buf []byte, i int, stop byte) (int, []byte) {
 			break
 		}
 
+		if buf[i] == '\\' {
+			i += 2
+			continue
+		}
 		// reached end of block?
 		if buf[i] == stop || buf[i] == ' ' {
 			break

--- a/tsdb/points_test.go
+++ b/tsdb/points_test.go
@@ -198,7 +198,12 @@ func TestParsePointMissingTagName(t *testing.T) {
 }
 
 func TestParsePointMissingTagValue(t *testing.T) {
-	_, err := ParsePointsString(`cpu,host=serverA,region value=1`)
+	_, err := ParsePointsString(`cpu,host value=1`)
+	if err == nil {
+		t.Errorf(`ParsePoints("%s") mismatch. got nil, exp error`, `cpu,host value=1`)
+	}
+
+	_, err = ParsePointsString(`cpu,host=serverA,region value=1`)
 	if err == nil {
 		t.Errorf(`ParsePoints("%s") mismatch. got nil, exp error`, `cpu,host=serverA,region value=1`)
 	}
@@ -423,6 +428,15 @@ func TestParsePointBooleanInvalid(t *testing.T) {
 }
 
 func TestParsePointUnescape(t *testing.T) {
+	test(t, `foo\,bar value=1`,
+		NewPoint(
+			"foo,bar", // comma in the name
+			Tags{},
+			Fields{
+				"value": 1,
+			},
+			time.Unix(0, 0)))
+
 	// commas in measuremnt name
 	test(t, `cpu\,main,regions=east\,west value=1.0`,
 		NewPoint(


### PR DESCRIPTION
Fixes #3183