### PR TITLE
Remove obsolete config flags from tsdb

### DIFF
--- a/tsdb/config.go
+++ b/tsdb/config.go
@@ -7,9 +7,6 @@ import (
 )
 
 const (
-	// DefaultRetentionAutoCreate is the default for auto-creating retention policies
-	DefaultRetentionAutoCreate = true
-
 	// DefaultRetentionCheckEnabled is the default for checking for retention policy enforcement
 	DefaultRetentionCheckEnabled = true
 
@@ -32,7 +29,6 @@ type Config struct {
 	Dir                   string        `toml:"dir"`
 	MaxWALSize            int           `toml:"max-wal-size"`
 	WALFlushInterval      toml.Duration `toml:"wal-flush-interval"`
-	RetentionAutoCreate   bool          `toml:"retention-auto-create"`
 	RetentionCheckEnabled bool          `toml:"retention-check-enabled"`
 	RetentionCheckPeriod  toml.Duration `toml:"retention-check-period"`
 	RetentionCreatePeriod toml.Duration `toml:"retention-create-period"`
@@ -42,7 +38,6 @@ func NewConfig() Config {
 	return Config{
 		MaxWALSize:            DefaultMaxWALSize,
 		WALFlushInterval:      toml.Duration(DefaultWALFlushInterval),
-		RetentionAutoCreate:   DefaultRetentionAutoCreate,
 		RetentionCheckEnabled: DefaultRetentionCheckEnabled,
 		RetentionCheckPeriod:  toml.Duration(DefaultRetentionCheckPeriod),
 		RetentionCreatePeriod: toml.Duration(DefaultRetentionCreatePeriod),

--- a/tsdb/config.go
+++ b/tsdb/config.go
@@ -7,16 +7,6 @@ import (
 )
 
 const (
-	// DefaultRetentionCheckEnabled is the default for checking for retention policy enforcement
-	DefaultRetentionCheckEnabled = true
-
-	// DefaultRetentionCreatePeriod represents how often the server will check to see if new
-	// shard groups need to be created in advance for writing
-	DefaultRetentionCreatePeriod = 45 * time.Minute
-
-	// DefaultRetentionCheckPeriod is the period of time between retention policy checks are run
-	DefaultRetentionCheckPeriod = 10 * time.Minute
-
 	// DefaultMaxWALSize is the default size of the WAL before it is flushed.
 	DefaultMaxWALSize = 100 * 1024 * 1024 // 100MB
 
@@ -26,29 +16,14 @@ const (
 )
 
 type Config struct {
-	Dir                   string        `toml:"dir"`
-	MaxWALSize            int           `toml:"max-wal-size"`
-	WALFlushInterval      toml.Duration `toml:"wal-flush-interval"`
-	RetentionCheckEnabled bool          `toml:"retention-check-enabled"`
-	RetentionCheckPeriod  toml.Duration `toml:"retention-check-period"`
-	RetentionCreatePeriod toml.Duration `toml:"retention-create-period"`
+	Dir              string        `toml:"dir"`
+	MaxWALSize       int           `toml:"max-wal-size"`
+	WALFlushInterval toml.Duration `toml:"wal-flush-interval"`
 }
 
 func NewConfig() Config {
 	return Config{
-		MaxWALSize:            DefaultMaxWALSize,
-		WALFlushInterval:      toml.Duration(DefaultWALFlushInterval),
-		RetentionCheckEnabled: DefaultRetentionCheckEnabled,
-		RetentionCheckPeriod:  toml.Duration(DefaultRetentionCheckPeriod),
-		RetentionCreatePeriod: toml.Duration(DefaultRetentionCreatePeriod),
+		MaxWALSize:       DefaultMaxWALSize,
+		WALFlushInterval: toml.Duration(DefaultWALFlushInterval),
 	}
-}
-
-// ShardGroupPreCreateCheckPeriod returns the check interval to pre-create shard groups.
-// If it was not defined in the config, it defaults to DefaultShardGroupPreCreatePeriod
-func (c *Config) ShardGroupPreCreateCheckPeriod() time.Duration {
-	if c.RetentionCreatePeriod != 0 {
-		return time.Duration(c.RetentionCreatePeriod)
-	}
-	return DefaultRetentionCreatePeriod
 }


### PR DESCRIPTION
These flags are obsolete, and holdovers from the recent refactoring for our new design. These features are now controlled as services, and the configuration is controlled there.