### PR TITLE
Dump run errors to stderr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@
 - [#3183](https://github.com/influxdb/influxdb/issues/3183): using line protocol measurement names cannot contain commas
 - [#3193](https://github.com/influxdb/influxdb/pull/3193): Fix panic for SHOW STATS and in collectd
 - [#3102](https://github.com/influxdb/influxdb/issues/3102): Add authentication cache
+- [#3209](https://github.com/influxdb/influxdb/pull/3209): Dump Run() errors to stderr
 
 ## v0.9.0 [2015-06-11]
 

--- a/cmd/influxd/main.go
+++ b/cmd/influxd/main.go
@@ -33,7 +33,7 @@ func main() {
 
 	m := NewMain()
 	if err := m.Run(os.Args[1:]...); err != nil {
-		fmt.Println(err)
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
When run as service, stdout goes to /dev/null by default. This means
that Run() errors are not visible in the logs, which is tough to debug.
This change will ensure that when run as a service, Run() errors appear
at stderr, which is to the logs by default.