### PR TITLE
Allow PointerWriter timeout to be configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Bugfixes
 
 - [#3180](https://github.com/influxdb/influxdb/pull/3180): Log GOMAXPROCS, version, and commit on startup.
+- [#3218](https://github.com/influxdb/influxdb/pull/3218): Allow write timeouts to be configurable.
 
 
 ## v0.9.1 [unreleased]

--- a/cluster/config.go
+++ b/cluster/config.go
@@ -7,18 +7,23 @@ import (
 )
 
 const (
+	// DefaultWriteTimeout is the default timeout for a complete write to succeed.
+	DefaultWriteTimeout = 5 * time.Second
+
 	// DefaultShardWriterTimeout is the default timeout set on shard writers.
 	DefaultShardWriterTimeout = 5 * time.Second
 )
 
 // Config represents the configuration for the the clustering service.
 type Config struct {
+	WriteTimeout       toml.Duration `toml:"write-timeout"`
 	ShardWriterTimeout toml.Duration `toml:"shard-writer-timeout"`
 }
 
 // NewConfig returns an instance of Config with defaults.
 func NewConfig() Config {
 	return Config{
+		WriteTimeout:       toml.Duration(DefaultWriteTimeout),
 		ShardWriterTimeout: toml.Duration(DefaultShardWriterTimeout),
 	}
 }

--- a/cluster/config_test.go
+++ b/cluster/config_test.go
@@ -13,12 +13,15 @@ func TestConfig_Parse(t *testing.T) {
 	var c cluster.Config
 	if _, err := toml.Decode(`
 shard-writer-timeout = "10s"
+write-timeout = "20s"
 `, &c); err != nil {
 		t.Fatal(err)
 	}
 
 	// Validate configuration.
 	if time.Duration(c.ShardWriterTimeout) != 10*time.Second {
-		t.Fatalf("unexpected bind address: %s", c.ShardWriterTimeout)
+		t.Fatalf("unexpected shard-writer timeout: %s", c.ShardWriterTimeout)
+	} else if time.Duration(c.WriteTimeout) != 20*time.Second {
+		t.Fatalf("unexpected write timeout s: %s", c.WriteTimeout)
 	}
 }

--- a/cmd/influxd/run/server.go
+++ b/cmd/influxd/run/server.go
@@ -99,6 +99,7 @@ func NewServer(c *Config, version string) (*Server, error) {
 
 	// Initialize points writer.
 	s.PointsWriter = cluster.NewPointsWriter()
+	s.PointsWriter.WriteTimeout = time.Duration(c.Cluster.WriteTimeout)
 	s.PointsWriter.MetaStore = s.MetaStore
 	s.PointsWriter.TSDBStore = s.TSDBStore
 	s.PointsWriter.ShardWriter = s.ShardWriter

--- a/etc/config.sample.toml
+++ b/etc/config.sample.toml
@@ -48,7 +48,8 @@ reporting-disabled = false
 ###
 
 [cluster]
-  shard-writer-timeout = "5s"
+  shard-writer-timeout = "5s" # The time within which a shard must respond to write.
+  write-timeout = "5s" # The time within which a write operation must complete on the cluster.
 
 ###
 ### [retention]


### PR DESCRIPTION
This change makes the time the system will wait for the write to complete, across the cluster, configurable. Previously this was hardcoded to 5 seconds