### PR TITLE
Set log prefix for Metastore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,9 @@
 
 - [#3180](https://github.com/influxdb/influxdb/pull/3180): Log GOMAXPROCS, version, and commit on startup.
 - [#3218](https://github.com/influxdb/influxdb/pull/3218): Allow write timeouts to be configurable.
-- [#3184](https://github.com/influxdb/influxdb/pull/3184): Support basic auth in admin interface. Thanks @jipperinbham! 
+- [#3184](https://github.com/influxdb/influxdb/pull/3184): Support basic auth in admin interface. Thanks @jipperinbham!
 - [#3236](https://github.com/influxdb/influxdb/pull/3236): Fix display issues in admin interface.
+- [#3232](https://github.com/influxdb/influxdb/pull/3232): Set logging prefix for metastore.
 
 ## v0.9.1 [2015-07-02]
 

--- a/meta/store.go
+++ b/meta/store.go
@@ -138,7 +138,7 @@ func NewStore(c Config) *Store {
 		hashPassword: func(password string) ([]byte, error) {
 			return bcrypt.GenerateFromPassword([]byte(password), BcryptCost)
 		},
-		Logger: log.New(os.Stderr, "", log.LstdFlags),
+		Logger: log.New(os.Stderr, "[metastore] ", log.LstdFlags),
 	}
 }
 


### PR DESCRIPTION
Log messages from this package do not look the same as all other log messages, which looks odd.