### PR TITLE
Graphite fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - [#3184](https://github.com/influxdb/influxdb/pull/3184): Support basic auth in admin interface. Thanks @jipperinbham!
 - [#3236](https://github.com/influxdb/influxdb/pull/3236): Fix display issues in admin interface.
 - [#3232](https://github.com/influxdb/influxdb/pull/3232): Set logging prefix for metastore.
+- [#3230](https://github.com/influxdb/influxdb/issues/3230): panic: unable to parse bool value
 
 ## v0.9.1 [2015-07-02]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 - [#3236](https://github.com/influxdb/influxdb/pull/3236): Fix display issues in admin interface.
 - [#3232](https://github.com/influxdb/influxdb/pull/3232): Set logging prefix for metastore.
 - [#3230](https://github.com/influxdb/influxdb/issues/3230): panic: unable to parse bool value
+- [#3245](https://github.com/influxdb/influxdb/issues/3245): Error using graphite plugin with multiple filters
+
 
 ## v0.9.1 [2015-07-02]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - [#3232](https://github.com/influxdb/influxdb/pull/3232): Set logging prefix for metastore.
 - [#3230](https://github.com/influxdb/influxdb/issues/3230): panic: unable to parse bool value
 - [#3245](https://github.com/influxdb/influxdb/issues/3245): Error using graphite plugin with multiple filters
+- [#3223](https://github.com/influxdb/influxdb/issues/323): default graphite template cannot have extra tags
 
 
 ## v0.9.1 [2015-07-02]

--- a/services/graphite/config.go
+++ b/services/graphite/config.go
@@ -116,8 +116,15 @@ func (c *Config) validateTemplates() error {
 		filter := ""
 		tags := ""
 		if len(parts) >= 2 {
-			filter = parts[0]
-			template = parts[1]
+			// We could have <filter> <template>  or <template> <tags>.  Equals is only allowed in
+			// tags section.
+			if strings.Contains(parts[1], "=") {
+				template = parts[0]
+				tags = parts[1]
+			} else {
+				filter = parts[0]
+				template = parts[1]
+			}
 		}
 
 		if len(parts) == 3 {

--- a/services/graphite/parser.go
+++ b/services/graphite/parser.go
@@ -286,7 +286,7 @@ func (n *node) search(lineParts []string) *template {
 
 	// Find the index of child with an exact match
 	i := sort.Search(length, func(i int) bool {
-		return n.children[i].value == lineParts[0]
+		return n.children[i].value >= lineParts[0]
 	})
 
 	// Found an exact match, so search that child sub-tree

--- a/services/graphite/parser.go
+++ b/services/graphite/parser.go
@@ -47,8 +47,12 @@ func NewParserWithOptions(options Options) (*Parser, error) {
 		// Format is [filter] <template> [tag1=value1,tag2=value2]
 		parts := strings.Fields(pattern)
 		if len(parts) >= 2 {
-			filter = parts[0]
-			template = parts[1]
+			if strings.Contains(parts[1], "=") {
+				template = parts[0]
+			} else {
+				filter = parts[0]
+				template = parts[1]
+			}
 		}
 
 		// Parse out the default tags specific to this template

--- a/services/graphite/service.go
+++ b/services/graphite/service.go
@@ -232,14 +232,12 @@ func (s *Service) handleLine(line string) {
 	}
 
 	f, ok := point.Fields()["value"].(float64)
-	if !ok {
-		return
-	}
-
-	// Drop NaN and +/-Inf data points since they are not supported values
-	if math.IsNaN(f) || math.IsInf(f, 0) {
-		s.logger.Printf("dropping unsupported value: '%v'", line)
-		return
+	if ok {
+		// Drop NaN and +/-Inf data points since they are not supported values
+		if math.IsNaN(f) || math.IsInf(f, 0) {
+			s.logger.Printf("dropping unsupported value: '%v'", line)
+			return
+		}
 	}
 
 	s.batcher.In() <- point

--- a/services/graphite/service.go
+++ b/services/graphite/service.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"fmt"
 	"log"
+	"math"
 	"net"
 	"os"
 	"strings"
@@ -227,6 +228,17 @@ func (s *Service) handleLine(line string) {
 	point, err := s.parser.Parse(line)
 	if err != nil {
 		s.logger.Printf("unable to parse line: %s", err)
+		return
+	}
+
+	f, ok := point.Fields()["value"].(float64)
+	if !ok {
+		return
+	}
+
+	// Drop NaN and +/-Inf data points since they are not supported values
+	if math.IsNaN(f) || math.IsInf(f, 0) {
+		s.logger.Printf("dropping unsupported value: '%v'", line)
 		return
 	}
 

--- a/statik/statik.go
+++ b/statik/statik.go
@@ -1,7 +1,7 @@
 package statik
 
 import (
-		"github.com/rakyll/statik/fs"
+	"github.com/rakyll/statik/fs"
 )
 
 func init() {

--- a/tsdb/batcher.go
+++ b/tsdb/batcher.go
@@ -77,8 +77,10 @@ func (b *PointBatcher) Start() {
 				atomic.AddUint64(&b.stats.PointTotal, 1)
 				if batch == nil {
 					batch = make([]Point, 0, b.size)
-					timer = time.NewTimer(b.duration)
-					timerCh = timer.C
+					if b.duration > 0 {
+						timer = time.NewTimer(b.duration)
+						timerCh = timer.C
+					}
 				}
 
 				batch = append(batch, p)

--- a/tsdb/points.go
+++ b/tsdb/points.go
@@ -996,7 +996,7 @@ type Fields map[string]interface{}
 
 func parseNumber(val []byte) (interface{}, error) {
 	for i := 0; i < len(val); i++ {
-		// If there is a decimal or an N (NaN), parse as float
+		// If there is a decimal or an N (NaN), I (Inf), parse as float
 		if val[i] == '.' || val[i] == 'N' || val[i] == 'n' || val[i] == 'I' || val[i] == 'i' {
 			return strconv.ParseFloat(string(val), 64)
 		}

--- a/tsdb/points.go
+++ b/tsdb/points.go
@@ -997,7 +997,7 @@ type Fields map[string]interface{}
 func parseNumber(val []byte) (interface{}, error) {
 	for i := 0; i < len(val); i++ {
 		// If there is a decimal or an N (NaN), parse as float
-		if val[i] == '.' || val[i] == 'N' || val[i] == 'n' {
+		if val[i] == '.' || val[i] == 'N' || val[i] == 'n' || val[i] == 'I' || val[i] == 'i' {
 			return strconv.ParseFloat(string(val), 64)
 		}
 		if val[i] < '0' && val[i] > '9' {
@@ -1034,8 +1034,11 @@ func newFieldsFromBinary(buf []byte) Fields {
 		// If the first char is a double-quote, then unmarshal as string
 		if valueBuf[0] == '"' {
 			value = unescapeQuoteString(string(valueBuf[1 : len(valueBuf)-1]))
-			// Check for numeric characters
-		} else if (valueBuf[0] >= '0' && valueBuf[0] <= '9') || valueBuf[0] == '-' || valueBuf[0] == '.' || valueBuf[0] == 'N' || valueBuf[0] == 'n' {
+			// Check for numeric characters and special NaN or Inf
+		} else if (valueBuf[0] >= '0' && valueBuf[0] <= '9') || valueBuf[0] == '-' || valueBuf[0] == '+' || valueBuf[0] == '.' ||
+			valueBuf[0] == 'N' || valueBuf[0] == 'n' || // NaN
+			valueBuf[0] == 'I' || valueBuf[0] == 'i' { // Inf
+
 			value, err = parseNumber(valueBuf)
 			if err != nil {
 				panic(fmt.Sprintf("unable to parse number value '%v': %v", string(valueBuf), err))

--- a/tsdb/points.go
+++ b/tsdb/points.go
@@ -406,7 +406,7 @@ func scanFields(buf []byte, i int) (int, []byte, error) {
 				return i, buf[start:i], fmt.Errorf("missing field value")
 			}
 
-			if isNumeric(buf[i+1]) || buf[i+1] == '-' {
+			if isNumeric(buf[i+1]) || buf[i+1] == '-' || buf[i+1] == 'N' || buf[i+1] == 'n' {
 				var err error
 				i, _, err = scanNumber(buf, i+1)
 				if err != nil {
@@ -526,6 +526,15 @@ func scanNumber(buf []byte, i int) (int, []byte, error) {
 		if (buf[i] == '+' || buf[i] == '-') && buf[i-1] == 'e' {
 			i += 1
 			continue
+		}
+
+		// NaN is a valid float
+		if i+3 < len(buf) && (buf[i] == 'N' || buf[i] == 'n') {
+			if (buf[i+1] == 'a' || buf[i+1] == 'A') && (buf[i+2] == 'N' || buf[i+2] == 'n') {
+				i += 3
+				continue
+			}
+			return i, buf[start:i], fmt.Errorf("invalid number")
 		}
 
 		if !isNumeric(buf[i]) {
@@ -987,7 +996,8 @@ type Fields map[string]interface{}
 
 func parseNumber(val []byte) (interface{}, error) {
 	for i := 0; i < len(val); i++ {
-		if val[i] == '.' {
+		// If there is a decimal or an N (NaN), parse as float
+		if val[i] == '.' || val[i] == 'N' || val[i] == 'n' {
 			return strconv.ParseFloat(string(val), 64)
 		}
 		if val[i] < '0' && val[i] > '9' {
@@ -1025,7 +1035,7 @@ func newFieldsFromBinary(buf []byte) Fields {
 		if valueBuf[0] == '"' {
 			value = unescapeQuoteString(string(valueBuf[1 : len(valueBuf)-1]))
 			// Check for numeric characters
-		} else if (valueBuf[0] >= '0' && valueBuf[0] <= '9') || valueBuf[0] == '-' || valueBuf[0] == '.' {
+		} else if (valueBuf[0] >= '0' && valueBuf[0] <= '9') || valueBuf[0] == '-' || valueBuf[0] == '.' || valueBuf[0] == 'N' || valueBuf[0] == 'n' {
 			value, err = parseNumber(valueBuf)
 			if err != nil {
 				panic(fmt.Sprintf("unable to parse number value '%v': %v", string(valueBuf), err))

--- a/tsdb/points.go
+++ b/tsdb/points.go
@@ -1098,7 +1098,11 @@ func (p Fields) MarshalBinary() []byte {
 		case nil:
 			// skip
 		default:
-			panic(fmt.Sprintf("unknown type: %T", v))
+			// Can't determine the type, so convert to string
+			b = append(b, '"')
+			b = append(b, []byte(escapeQuoteString(fmt.Sprintf("%v", v)))...)
+			b = append(b, '"')
+
 		}
 		b = append(b, ',')
 	}

--- a/tsdb/points_test.go
+++ b/tsdb/points_test.go
@@ -1078,3 +1078,22 @@ func TestNewPointEscaped(t *testing.T) {
 		t.Errorf("NewPoint().String() mismatch.\ngot %v\nexp %v", pt.String(), exp)
 	}
 }
+
+func TestNewPointUnhandledType(t *testing.T) {
+	// nil value
+	pt := NewPoint("cpu", nil, Fields{"value": nil}, time.Unix(0, 0))
+	if exp := `cpu value= 0`; pt.String() != exp {
+		t.Errorf("NewPoint().String() mismatch.\ngot %v\nexp %v", pt.String(), exp)
+	}
+
+	// unsupported type gets stored as string
+	now := time.Unix(0, 0)
+	pt = NewPoint("cpu", nil, Fields{"value": now}, time.Unix(0, 0))
+	if exp := `cpu value="1969-12-31 17:00:00 -0700 MST" 0`; pt.String() != exp {
+		t.Errorf("NewPoint().String() mismatch.\ngot %v\nexp %v", pt.String(), exp)
+	}
+
+	if exp := "1969-12-31 17:00:00 -0700 MST"; pt.Fields()["value"] != exp {
+		t.Errorf("NewPoint().String() mismatch.\ngot %v\nexp %v", pt.String(), exp)
+	}
+}

--- a/tsdb/points_test.go
+++ b/tsdb/points_test.go
@@ -1087,13 +1087,13 @@ func TestNewPointUnhandledType(t *testing.T) {
 	}
 
 	// unsupported type gets stored as string
-	now := time.Unix(0, 0)
+	now := time.Unix(0, 0).UTC()
 	pt = NewPoint("cpu", nil, Fields{"value": now}, time.Unix(0, 0))
-	if exp := `cpu value="1969-12-31 17:00:00 -0700 MST" 0`; pt.String() != exp {
+	if exp := `cpu value="1970-01-01 00:00:00 +0000 UTC" 0`; pt.String() != exp {
 		t.Errorf("NewPoint().String() mismatch.\ngot %v\nexp %v", pt.String(), exp)
 	}
 
-	if exp := "1969-12-31 17:00:00 -0700 MST"; pt.Fields()["value"] != exp {
+	if exp := "1970-01-01 00:00:00 +0000 UTC"; pt.Fields()["value"] != exp {
 		t.Errorf("NewPoint().String() mismatch.\ngot %v\nexp %v", pt.String(), exp)
 	}
 }


### PR DESCRIPTION
This PR fixes a few panics and bugs related to the graphite input.  The main changes are:
* Handle `NaN` and `Inf` values more sanely.  Previously, panics could occur
* Fix default parsing template not allowing extra tags
* Convert graphite batcher to be shared for the service versus tied to a connection.  This should improve throughput and reduce disk IO.