### PR TITLE
Flush WAL as fast as possible on start-up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 - [#3230](https://github.com/influxdb/influxdb/issues/3230): panic: unable to parse bool value
 - [#3245](https://github.com/influxdb/influxdb/issues/3245): Error using graphite plugin with multiple filters
 - [#3223](https://github.com/influxdb/influxdb/issues/323): default graphite template cannot have extra tags
-
+- [#3255](https://github.com/influxdb/influxdb/pull/3255): Flush WAL on start-up as soon as possible.
 
 ## v0.9.1 [2015-07-02]
 

--- a/tsdb/store.go
+++ b/tsdb/store.go
@@ -286,7 +286,7 @@ func (s *Store) Flush() error {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	for shardID, sh := range s.shards {
-		if err := sh.Flush(); err != nil {
+		if err := sh.Flush(s.WALPartitionFlushDelay); err != nil {
 			return fmt.Errorf("flush: shard=%d, err=%s", shardID, err)
 		}
 	}


### PR DESCRIPTION
This addresses complaints of long start-up times when there is lots of data sitting in the WAL.