### PR TITLE
Sort points after appending if needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - [#3255](https://github.com/influxdb/influxdb/pull/3255): Flush WAL on start-up as soon as possible.
 - [#3289](https://github.com/influxdb/influxdb/issues/3289): InfluxDB crashes on floats without decimal
 - [#3298](https://github.com/influxdb/influxdb/pull/3298): Corrected WAL & flush parameters in default config. Thanks @jhorwit2
+- [#3152](https://github.com/influxdb/influxdb/issues/3159): High CPU Usage with unsorted writes
 
 ## v0.9.1 [2015-07-02]
 


### PR DESCRIPTION
Writing points that were not sorted by time could cause very high
CPU usages and increased latencies because each point inserted would
cause the in-memory cache to be resorted.  The worst case would be
writing a large batch of N points in reverse time order which would
invoke N sorts of the slice.

This patch keeps track of which slices need to be sorted and sorts
them once at the end.  In the previous example, the N sorts becomes
one.  There is still a pathalogical case that would require N/2 sorts.
For example, 10000 points split across 5000 series.  Each series has two
points that are in reverse time order.  This would incur 5000 sorts still.

Fixes #3159