### PR TITLE
Updated wal & flush parameters in default config

### DIFF
--- a/etc/config.sample.toml
+++ b/etc/config.sample.toml
@@ -36,9 +36,9 @@ reporting-disabled = false
 
 [data]
   dir = "/var/opt/influxdb/data"
-  MaxWALSize = 104857600 # Maximum size the WAL can reach before a flush. Defaults to 100MB.
-  WALFlushInterval = "10m" # Maximum time data can sit in WAL before a flush.
-  WALPartitionFlushDelay = "2s" # The delay time between each WAL partition being flushed.
+  max-wal-size = 104857600 # Maximum size the WAL can reach before a flush. Defaults to 100MB.
+  max-flush-interval = "10m" # Maximum time data can sit in WAL before a flush.
+  max-partition-flush-delay = "2s" # The delay time between each WAL partition being flushed.
 
 ###
 ### [cluster]


### PR DESCRIPTION
As you can see [here](https://github.com/influxdb/influxdb/blob/b2b69c63fe9105c1a9ba72f5b2517e1bb896b8bb/tsdb/config.go#L23), it appears the configuration parameters were updated in code, but not the default configuration.