### PR TITLE
Fixed httpd logger to get user from query params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@
 - [#3223](https://github.com/influxdb/influxdb/issues/323): default graphite template cannot have extra tags
 - [#3255](https://github.com/influxdb/influxdb/pull/3255): Flush WAL on start-up as soon as possible.
 - [#3289](https://github.com/influxdb/influxdb/issues/3289): InfluxDB crashes on floats without decimal
+- [#3298](https://github.com/influxdb/influxdb/pull/3298): Corrected WAL & flush parameters in default config. Thanks @jhorwit2
+- [#3303](https://github.com/influxdb/influxdb/pull/3303): Fixed httpd logger to log user from query params. Thanks @jhorwit2
+
 
 ## v0.9.1 [2015-07-02]
 

--- a/cmd/influx/main.go
+++ b/cmd/influx/main.go
@@ -52,15 +52,15 @@ func main() {
 	c := CommandLine{}
 
 	fs := flag.NewFlagSet("InfluxDB shell version "+version, flag.ExitOnError)
-	fs.StringVar(&c.Host, "host", default_host, "influxdb host to connect to")
-	fs.IntVar(&c.Port, "port", default_port, "influxdb port to connect to")
-	fs.StringVar(&c.Username, "username", c.Username, "username to connect to the server.")
-	fs.StringVar(&c.Password, "password", c.Password, `password to connect to the server.  Leaving blank will prompt for password (--password="")`)
-	fs.StringVar(&c.Database, "database", c.Database, "database to connect to the server.")
-	fs.BoolVar(&c.Ssl, "ssl", false, "use https for connecting to cluster")
-	fs.StringVar(&c.Format, "format", default_format, "format specifies the format of the server responses:  json, csv, or column")
-	fs.BoolVar(&c.Pretty, "pretty", false, "turns on pretty print for the json format")
-	fs.BoolVar(&c.ShouldDump, "dump", false, "dump the contents of the given database to stdout")
+	fs.StringVar(&c.Host, "host", default_host, "Influxdb host to connect to.")
+	fs.IntVar(&c.Port, "port", default_port, "Influxdb port to connect to.")
+	fs.StringVar(&c.Username, "username", c.Username, "Username to connect to the server.")
+	fs.StringVar(&c.Password, "password", c.Password, `Password to connect to the server.  Leaving blank will prompt for password (--password="").`)
+	fs.StringVar(&c.Database, "database", c.Database, "Database to connect to the server.")
+	fs.BoolVar(&c.Ssl, "ssl", false, "Use https for connecting to cluster.")
+	fs.StringVar(&c.Format, "format", default_format, "Format specifies the format of the server responses:  json, csv, or column.")
+	fs.BoolVar(&c.Pretty, "pretty", false, "Turns on pretty print for the json format.")
+	fs.BoolVar(&c.ShouldDump, "dump", false, "Dump the contents of the given database to stdout.")
 	fs.StringVar(&c.Execute, "execute", c.Execute, "Execute command and quit.")
 	fs.BoolVar(&c.ShowVersion, "version", false, "Displays the InfluxDB version.")
 
@@ -76,7 +76,7 @@ func main() {
   -database 'database name'
        Database to connect to the server.
   -password 'password'
-      Password to connect to the server.  Leaving blank will prompt for password (--password '')
+      Password to connect to the server.  Leaving blank will prompt for password (--password '').
   -username 'username'
        Username to connect to the server.
   -ssl
@@ -92,13 +92,13 @@ func main() {
 
 Examples:
 
-    # Use influx in a non-interactive mode to query the database "metrics" and pretty print json
+    # Use influx in a non-interactive mode to query the database "metrics" and pretty print json:
     $ influx -database 'metrics' -execute 'select * from cpu' -format 'json' -pretty
 
-    # Dumping out your data
+	# Dumping out your data:
     $ influx  -database 'metrics' -dump
 
-    # Connect to a specific database on startup and set database context
+	# Connect to a specific database on startup and set database context:
     $ influx -database 'metrics' -host 'localhost' -port '8086'
 `)
 	}

--- a/services/httpd/response_logger.go
+++ b/services/httpd/response_logger.go
@@ -119,6 +119,11 @@ func parseUsername(r *http.Request) string {
 			username = name
 		}
 	}
+	
+	q := url.Query()
+	if u := q.Get("u"); u != "" {
+		username = u
+	}
 
 	// Try to get it from the authorization header if set there
 	if username == "" {

--- a/services/httpd/response_logger.go
+++ b/services/httpd/response_logger.go
@@ -119,7 +119,8 @@ func parseUsername(r *http.Request) string {
 			username = name
 		}
 	}
-	
+
+	// Try to get the username from the query param 'u'
 	q := url.Query()
 	if u := q.Get("u"); u != "" {
 		username = u


### PR DESCRIPTION
Before 
```
[http] 2015/07/12 19:41:17 ::1 - - [12/Jul/2015:19:41:17 -0400] GET /query?u=root&p=root&db=test HTTP/1.1 400 68 - Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.124 Safari/537.36 7dc2edc3-28ef-11e5-8001-000000000000 1.033983ms
```

After
```
[http] 2015/07/12 19:40:49 ::1 - root [12/Jul/2015:19:40:49 -0400] GET /query?u=root&p=root&db=test HTTP/1.1 400 68 - Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.124 Safari/537.36 6cf04b18-28ef-11e5-8005-000000000000 1.075422ms
```