### PR TITLE
Fixed httpd logger to get user from query params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - [#3298](https://github.com/influxdb/influxdb/pull/3298): Corrected WAL & flush parameters in default config. Thanks @jhorwit2
 - [#3152](https://github.com/influxdb/influxdb/issues/3159): High CPU Usage with unsorted writes
 - [#3307](https://github.com/influxdb/influxdb/pull/3307): Fix regression parsing boolean values True/False
+- [#3304](https://github.com/influxdb/influxdb/pull/3304): Fixed httpd logger to log user from query params. Thanks @jhorwit2
 
 ## v0.9.1 [2015-07-02]
 

--- a/services/httpd/response_logger.go
+++ b/services/httpd/response_logger.go
@@ -120,6 +120,12 @@ func parseUsername(r *http.Request) string {
 		}
 	}
 
+	// Try to get the username from the query param 'u'
+	q := url.Query()
+	if u := q.Get("u"); u != "" {
+		username = u
+	}
+
 	// Try to get it from the authorization header if set there
 	if username == "" {
 		if u, _, ok := r.BasicAuth(); ok {


### PR DESCRIPTION
Before 
```
[http] 2015/07/12 19:41:17 ::1 - - [12/Jul/2015:19:41:17 -0400] GET /query?u=root&p=root&db=test HTTP/1.1 400 68 - Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.124 Safari/537.36 7dc2edc3-28ef-11e5-8001-000000000000 1.033983ms
```

After
```
[http] 2015/07/12 19:40:49 ::1 - root [12/Jul/2015:19:40:49 -0400] GET /query?u=root&p=root&db=test HTTP/1.1 400 68 - Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.124 Safari/537.36 6cf04b18-28ef-11e5-8005-000000000000 1.075422ms
```