### PR TITLE
Clean shutdown of influxd server

### DIFF
--- a/cmd/influxd/run/command.go
+++ b/cmd/influxd/run/command.go
@@ -32,6 +32,7 @@ type Command struct {
 	Commit  string
 
 	closing chan struct{}
+	Closed  chan struct{}
 
 	Stdin  io.Reader
 	Stdout io.Writer
@@ -44,6 +45,7 @@ type Command struct {
 func NewCommand() *Command {
 	return &Command{
 		closing: make(chan struct{}),
+		Closed:  make(chan struct{}),
 		Stdin:   os.Stdin,
 		Stdout:  os.Stdout,
 		Stderr:  os.Stderr,
@@ -109,6 +111,8 @@ func (cmd *Command) Run(args ...string) error {
 
 // Close shuts down the server.
 func (cmd *Command) Close() error {
+	defer close(cmd.Closed)
+	close(cmd.closing)
 	if cmd.Server != nil {
 		return cmd.Server.Close()
 	}

--- a/cmd/influxd/run/server.go
+++ b/cmd/influxd/run/server.go
@@ -7,7 +7,6 @@ import (
 	"net"
 	"net/http"
 	"os"
-	"os/signal"
 	"runtime"
 	"runtime/pprof"
 	"time"
@@ -349,6 +348,7 @@ func (s *Server) Close() error {
 	for _, service := range s.Services {
 		service.Close()
 	}
+
 	close(s.closing)
 	return nil
 }
@@ -456,13 +456,6 @@ func startProfile(cpuprofile, memprofile string) {
 		runtime.MemProfileRate = 4096
 	}
 
-	go func() {
-		c := make(chan os.Signal, 1)
-		signal.Notify(c, os.Interrupt)
-		<-c
-		stopProfile()
-		os.Exit(0)
-	}()
 }
 
 // StopProfile closes the cpu and memory profiles if they are running.


### PR DESCRIPTION
There was not a clean shutdown path for influxd run command. The startProfiler() method was listening to signals but was forcing an os.Exit().

With this PR, I am implementing signal trapping and allowing opportunity for server to clean shutdown, sending Close() calls to the Server object appropriately. 

Upon first signal, a timeout of 30 seconds is started, and if the clean shutdown hasn't been clompleted  yet, a hard shutdown is initialized.