### PR TITLE
Add an aggregation function for integration using Riemann sums.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - [#3376](https://github.com/influxdb/influxdb/pull/3376): Support for remote shard query mapping
 - [#3372](https://github.com/influxdb/influxdb/pull/3372): Support joining nodes to existing cluster
 - [#3426](https://github.com/influxdb/influxdb/pull/3426): Additional logging for continuous queries. Thanks @jhorwit2
+- [#3344](https://github.com/influxdb/influxdb/pull/3344): Experimental support for an integration aggregation function, by @michaelsproul.
 
 ### Bugfixes
 - [#3405](https://github.com/influxdb/influxdb/pull/3405): Prevent database panic when fields are missing. Thanks @jhorwit2

--- a/influxql/ast.go
+++ b/influxql/ast.go
@@ -998,7 +998,7 @@ func (s *SelectStatement) validateAggregates(tr targetRequirement) error {
 	for _, f := range s.Fields {
 		if c, ok := f.Expr.(*Call); ok {
 			switch c.Name {
-			case "derivative", "non_negative_derivative":
+			case "derivative", "non_negative_derivative", "integral":
 				if min, max, got := 1, 2, len(c.Args); got > max || got < min {
 					return fmt.Errorf("invalid number of arguments for %s, expected at least %d but no more than %d, got %d", c.Name, min, max, got)
 				}

--- a/influxql/functions_test.go
+++ b/influxql/functions_test.go
@@ -71,55 +71,12 @@ func TestMapMean(t *testing.T) {
 		}
 	}
 }
-func TestInitializeMapFuncPercentile(t *testing.T) {
-	// No args
-	c := &Call{
-		Name: "percentile",
-		Args: []Expr{},
-	}
-	_, err := InitializeMapFunc(c)
-	if err == nil {
-		t.Errorf("InitializeMapFunc(%v) expected error. got nil", c)
-	}
-
-	if exp := "expected two arguments for percentile()"; err.Error() != exp {
-		t.Errorf("InitializeMapFunc(%v) mismatch. exp %v got %v", c, exp, err.Error())
-	}
-
-	// No percentile arg
-	c = &Call{
-		Name: "percentile",
-		Args: []Expr{
-			&VarRef{Val: "field1"},
-		},
-	}
-
-	_, err = InitializeMapFunc(c)
-	if err == nil {
-		t.Errorf("InitializeMapFunc(%v) expected error. got nil", c)
-	}
-
-	if exp := "expected two arguments for percentile()"; err.Error() != exp {
-		t.Errorf("InitializeMapFunc(%v) mismatch. exp %v got %v", c, exp, err.Error())
-	}
-}
 
 func TestInitializeMapFuncDerivative(t *testing.T) {
 
 	for _, fn := range []string{"derivative", "non_negative_derivative"} {
-		// No args should fail
-		c := &Call{
-			Name: fn,
-			Args: []Expr{},
-		}
-
-		_, err := InitializeMapFunc(c)
-		if err == nil {
-			t.Errorf("InitializeMapFunc(%v) expected error.  got nil", c)
-		}
-
 		// Single field arg should return MapEcho
-		c = &Call{
+		c := &Call{
 			Name: fn,
 			Args: []Expr{
 				&VarRef{Val: " field1"},
@@ -127,7 +84,7 @@ func TestInitializeMapFuncDerivative(t *testing.T) {
 			},
 		}
 
-		_, err = InitializeMapFunc(c)
+		_, err := InitializeMapFunc(c)
 		if err != nil {
 			t.Errorf("InitializeMapFunc(%v) unexpected error.  got %v", c, err)
 		}


### PR DESCRIPTION
I'd really like an integration aggregation function, so I've written one. At present it only works for `float64` values. Some help making this idiomatic Go would be appreciated. I rarely write Go and don't know all the best practices for dealing with `interface{}`.

Another thing up for discussion is how to deal with the (physical) time unit used during integration. Timestamps are stored as nanoseconds but it seems impractical to make people always deal with for example `W ns` values when integrating power (`W`) over time. For now I've just made the integration unit seconds.

Also up for discussion is what type of Riemann sum to use. At the moment this is a **left Riemann** sum, as that makes the most sense for my particular data-set. The way I see it is that the value stored at a given timestamp would generally *persist* until the next point is inserted. This makes the area of a single block:

```
A_i = v_i * (t_(i + 1) - t_i)
  for 0 <= i <= n - 2

# Or equivalently (the version used in the mapping code):
A_i' = v_(i - 1) * (t_i - t_(i - 1))
  for 1 <= i <= n - 1
```



See: https://en.wikipedia.org/wiki/Riemann_sum

Addresses #1400

Happy to sign whatever if you decide to merge this. Thanks!