### PR TITLE
Make `SHOW RETENTION POLICIES` consistent by requiring `ON`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - [#3304](https://github.com/influxdb/influxdb/pull/3304): Fixed httpd logger to log user from query params. Thanks @jhorwit2
 - [#3332](https://github.com/influxdb/influxdb/pull/3332): Add SLIMIT and SOFFSET to string version of AST.
 - [#3335](https://github.com/influxdb/influxdb/pull/3335): Don't drop all data on DROP DATABASE. Thanks to @PierreF for the report
+- [#2761](https://github.com/influxdb/influxdb/issues/2761): Make SHOW RETENTION POLICIES consistent with other queries.
 
 ## v0.9.1 [2015-07-02]
 

--- a/cmd/influxd/run/server_test.go
+++ b/cmd/influxd/run/server_test.go
@@ -236,7 +236,7 @@ func TestServer_RetentionPolicyCommands(t *testing.T) {
 			},
 			&Query{
 				name:    "show retention policy should succeed",
-				command: `SHOW RETENTION POLICIES db0`,
+				command: `SHOW RETENTION POLICIES ON db0`,
 				exp:     `{"results":[{"series":[{"columns":["name","duration","replicaN","default"],"values":[["rp0","1h0m0s",1,false]]}]}]}`,
 			},
 			&Query{
@@ -246,7 +246,7 @@ func TestServer_RetentionPolicyCommands(t *testing.T) {
 			},
 			&Query{
 				name:    "show retention policy should have new altered information",
-				command: `SHOW RETENTION POLICIES db0`,
+				command: `SHOW RETENTION POLICIES ON db0`,
 				exp:     `{"results":[{"series":[{"columns":["name","duration","replicaN","default"],"values":[["rp0","2h0m0s",3,true]]}]}]}`,
 			},
 			&Query{
@@ -256,7 +256,7 @@ func TestServer_RetentionPolicyCommands(t *testing.T) {
 			},
 			&Query{
 				name:    "show retention policy should be empty after dropping them",
-				command: `SHOW RETENTION POLICIES db0`,
+				command: `SHOW RETENTION POLICIES ON db0`,
 				exp:     `{"results":[{"series":[{"columns":["name","duration","replicaN","default"]}]}]}`,
 			},
 			&Query{
@@ -300,7 +300,7 @@ func TestServer_DatabaseRetentionPolicyAutoCreate(t *testing.T) {
 			},
 			&Query{
 				name:    "show retention policies should return auto-created policy",
-				command: `SHOW RETENTION POLICIES db0`,
+				command: `SHOW RETENTION POLICIES ON db0`,
 				exp:     `{"results":[{"series":[{"columns":["name","duration","replicaN","default"],"values":[["default","0",1,true]]}]}]}`,
 			},
 		},
@@ -565,7 +565,7 @@ func TestServer_Query_DefaultDBAndRP(t *testing.T) {
 		},
 		&Query{
 			name:    "default rp exists",
-			command: `show retention policies db0`,
+			command: `show retention policies ON db0`,
 			exp:     `{"results":[{"series":[{"columns":["name","duration","replicaN","default"],"values":[["default","0",1,false],["rp0","1h0m0s",1,true]]}]}]}`,
 		},
 		&Query{

--- a/influxql/parser.go
+++ b/influxql/parser.go
@@ -843,6 +843,12 @@ func (p *Parser) parseShowMeasurementsStatement() (*ShowMeasurementsStatement, e
 func (p *Parser) parseShowRetentionPoliciesStatement() (*ShowRetentionPoliciesStatement, error) {
 	stmt := &ShowRetentionPoliciesStatement{}
 
+	// Expect an "ON" keyword.
+	if tok, pos, lit := p.scanIgnoreWhitespace(); tok != ON {
+		return nil, newParseError(tokstr(tok, lit), []string{"ON"}, pos)
+	}
+
+	// Parse the database.
 	ident, err := p.parseIdent()
 	if err != nil {
 		return nil, err

--- a/influxql/parser_test.go
+++ b/influxql/parser_test.go
@@ -624,7 +624,7 @@ func TestParser_ParseStatement(t *testing.T) {
 
 		// SHOW RETENTION POLICIES
 		{
-			s: `SHOW RETENTION POLICIES mydb`,
+			s: `SHOW RETENTION POLICIES ON mydb`,
 			stmt: &influxql.ShowRetentionPoliciesStatement{
 				Database: "mydb",
 			},
@@ -1233,7 +1233,10 @@ func TestParser_ParseStatement(t *testing.T) {
 		{s: `DROP SERIES FROM src WHERE`, err: `found EOF, expected identifier, string, number, bool at line 1, char 28`},
 		{s: `SHOW CONTINUOUS`, err: `found EOF, expected QUERIES at line 1, char 17`},
 		{s: `SHOW RETENTION`, err: `found EOF, expected POLICIES at line 1, char 16`},
-		{s: `SHOW RETENTION POLICIES`, err: `found EOF, expected identifier at line 1, char 25`},
+		{s: `SHOW RETENTION ON`, err: `found ON, expected POLICIES at line 1, char 16`},
+		{s: `SHOW RETENTION POLICIES`, err: `found EOF, expected ON at line 1, char 25`},
+		{s: `SHOW RETENTION POLICIES mydb`, err: `found mydb, expected ON at line 1, char 25`},
+		{s: `SHOW RETENTION POLICIES ON`, err: `found EOF, expected identifier at line 1, char 28`},
 		{s: `SHOW FOO`, err: `found FOO, expected CONTINUOUS, DATABASES, FIELD, GRANTS, MEASUREMENTS, RETENTION, SERIES, SERVERS, TAG, USERS at line 1, char 6`},
 		{s: `SHOW STATS ON`, err: `found EOF, expected string at line 1, char 15`},
 		{s: `SHOW GRANTS`, err: `found EOF, expected FOR at line 1, char 13`},

--- a/meta/statement_executor_test.go
+++ b/meta/statement_executor_test.go
@@ -513,7 +513,7 @@ func TestStatementExecutor_ExecuteStatement_ShowRetentionPolicies(t *testing.T) 
 		}, nil
 	}
 
-	if res := e.ExecuteStatement(influxql.MustParseStatement(`SHOW RETENTION POLICIES db0`)); res.Err != nil {
+	if res := e.ExecuteStatement(influxql.MustParseStatement(`SHOW RETENTION POLICIES ON db0`)); res.Err != nil {
 		t.Fatal(res.Err)
 	} else if !reflect.DeepEqual(res.Series, influxql.Rows{
 		{
@@ -535,7 +535,7 @@ func TestStatementExecutor_ExecuteStatement_ShowRetentionPolicies_Err(t *testing
 		return nil, errors.New("marker")
 	}
 
-	if res := e.ExecuteStatement(influxql.MustParseStatement(`SHOW RETENTION POLICIES db0`)); res.Err == nil || res.Err.Error() != "marker" {
+	if res := e.ExecuteStatement(influxql.MustParseStatement(`SHOW RETENTION POLICIES ON db0`)); res.Err == nil || res.Err.Error() != "marker" {
 		t.Fatalf("unexpected error: %s", res.Err)
 	}
 }
@@ -547,7 +547,7 @@ func TestStatementExecutor_ExecuteStatement_ShowRetentionPolicies_ErrDatabaseNot
 		return nil, nil
 	}
 
-	if res := e.ExecuteStatement(influxql.MustParseStatement(`SHOW RETENTION POLICIES db0`)); res.Err != meta.ErrDatabaseNotFound {
+	if res := e.ExecuteStatement(influxql.MustParseStatement(`SHOW RETENTION POLICIES ON db0`)); res.Err != meta.ErrDatabaseNotFound {
 		t.Fatalf("unexpected error: %s", res.Err)
 	}
 }


### PR DESCRIPTION
Not going to support backwards compatibility on this one. The lack of `ON` violates the the norms of the query language and seems like it's omission was originally unintentional.

Also need to update all occurrences of `SHOW RETENTION POLICIES mydb` in the docs.