### PR TITLE
Handle malformed regex comparisons during parsing (fixes #3301)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - [#3304](https://github.com/influxdb/influxdb/pull/3304): Fixed httpd logger to log user from query params. Thanks @jhorwit2
 - [#3332](https://github.com/influxdb/influxdb/pull/3332): Add SLIMIT and SOFFSET to string version of AST.
 - [#3335](https://github.com/influxdb/influxdb/pull/3335): Don't drop all data on DROP DATABASE. Thanks to @PierreF for the report
+- [#3351](https://github.com/influxdb/influxdb/pull/3351): Handle malformed regex comparisons during parsing
 
 ## v0.9.1 [2015-07-02]
 

--- a/influxql/parser.go
+++ b/influxql/parser.go
@@ -1754,6 +1754,11 @@ func (p *Parser) ParseExpr() (Expr, error) {
 			if rhs, err = p.parseRegex(); err != nil {
 				return nil, err
 			}
+			// parseRegex can return an empty type, but we need it to be present
+			if rhs.(*RegexLiteral) == nil {
+				tok, pos, lit := p.scanIgnoreWhitespace()
+				return nil, newParseError(tokstr(tok, lit), []string{"regex"}, pos)
+			}
 		} else {
 			if rhs, err = p.parseUnaryExpr(); err != nil {
 				return nil, err

--- a/influxql/parser_test.go
+++ b/influxql/parser_test.go
@@ -1224,6 +1224,7 @@ func TestParser_ParseStatement(t *testing.T) {
 		{s: `select count() from myseries`, err: `invalid number of arguments for count, expected 1, got 0`},
 		{s: `select derivative() from myseries`, err: `invalid number of arguments for derivative, expected at least 1 but no more than 2, got 0`},
 		{s: `select derivative(mean(value), 1h, 3) from myseries`, err: `invalid number of arguments for derivative, expected at least 1 but no more than 2, got 3`},
+		{s: `SELECT field1 from myseries WHERE host =~ 'asd' LIMIT 1`, err: `found asd, expected regex at line 1, char 42`},
 		{s: `DELETE`, err: `found EOF, expected FROM at line 1, char 8`},
 		{s: `DELETE FROM`, err: `found EOF, expected identifier at line 1, char 13`},
 		{s: `DELETE FROM myseries WHERE`, err: `found EOF, expected identifier, string, number, bool at line 1, char 28`},


### PR DESCRIPTION
Previously, if your query used a regex operator but didn't follow it with a regex, parseRegex would return an empty RegexLiteral, and the expression parser would put that into the right-hand side of the expression. This caused a nil-pointer panic when the query was later executed. This change adds a check at the parsing level and returns an error message if a regex operator (e.g. =~) is not followed by an actual regex.

Before, doing the following would cause a panic and kill the server:
```sql
> SELECT * FROM cpu WHERE value = 0 AND region =~ 'adf' LIMIT 2;
ERR: Get http://localhost:8086/query?db=mydb&q=SELECT+%2A+FROM+cpu+WHERE+value+%3D+0+AND+region+%3D~+%27adf%27+LIMIT+2%3B: EOF
```

After, we gracefully handle the problem during the parsing stage:
```sql
> SELECT * FROM cpu WHERE value = 0 AND region =~ 'adf' LIMIT 2;
ERR: error parsing query: found adf, expected regex at line 1, char 48
```

- [x] CHANGELOG.md updated
- [x] Rebased/mergable
- [x] Tests pass
- [x] Sign [CLA](http://influxdb.com/community/cla.html) (if not already signed)