### PR TITLE
Allow semicolons to trail database names in "use"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - [#3304](https://github.com/influxdb/influxdb/pull/3304): Fixed httpd logger to log user from query params. Thanks @jhorwit2
 - [#3332](https://github.com/influxdb/influxdb/pull/3332): Add SLIMIT and SOFFSET to string version of AST.
 - [#3335](https://github.com/influxdb/influxdb/pull/3335): Don't drop all data on DROP DATABASE. Thanks to @PierreF for the report
+- [#3356](https://github.com/influxdb/influxdb/pull/3356): Disregard semicolons after database name in use command. Thanks @timraymond.
 
 ## v0.9.1 [2015-07-02]
 

--- a/cmd/influx/main.go
+++ b/cmd/influx/main.go
@@ -321,7 +321,7 @@ func (c *CommandLine) SetAuth(cmd string) {
 }
 
 func (c *CommandLine) use(cmd string) {
-	args := strings.Split(strings.TrimSpace(cmd), " ")
+	args := strings.Split(strings.TrimSuffix(strings.TrimSpace(cmd), ";"), " ")
 	if len(args) != 2 {
 		fmt.Printf("Could not parse database name from %q.\n", cmd)
 		return

--- a/cmd/influx/main_test.go
+++ b/cmd/influx/main_test.go
@@ -75,12 +75,17 @@ func TestParseCommand_Use(t *testing.T) {
 		{cmd: "use db"},
 		{cmd: " use db"},
 		{cmd: "use db "},
+		{cmd: "use db;"},
 		{cmd: "Use db"},
 	}
 
 	for _, test := range tests {
 		if !c.ParseCommand(test.cmd) {
 			t.Fatalf(`Command "use" failed for %q.`, test.cmd)
+		}
+
+		if c.Database != "db" {
+			t.Fatalf(`Command "use" changed database to %q. Expected db`, c.Database)
 		}
 	}
 }


### PR DESCRIPTION
Prior to this commit, the "use" command treated trailing semicolons as
significant parts of the database name. This lead to a confusing user
experience since other parts of influxql treat the trailing semicolon as
a statement separator, or appear to ignore it. A typical use case looks
something like:

```
> show databases;
-- snip --
> use foo;
```

This commit trims off trailing semicolons from database names in "use"
commands if present to match user expectations.

Fixes #2258, where this appears to have been an underlying issue.

- [ ] CHANGELOG.md updated
- [ ] Rebased/mergable
- [ ] Tests pass
- [ ] Sign [CLA](http://influxdb.com/community/cla.html) (if not already signed)