### PR TITLE
One mapperOutput type to rule them all

### DIFF
--- a/tsdb/engine.go
+++ b/tsdb/engine.go
@@ -471,10 +471,11 @@ func (ae *AggregateExecutor) execute(out chan *influxql.Row) {
 			}
 
 			_, ok := buckets[chunk.Time]
+			values := chunk.Values.([]interface{})
 			if !ok {
-				buckets[chunk.Time] = make([][]interface{}, len(chunk.Values))
+				buckets[chunk.Time] = make([][]interface{}, len(values))
 			}
-			for i, v := range chunk.Values {
+			for i, v := range values {
 				buckets[chunk.Time][i] = append(buckets[chunk.Time][i], v)
 			}
 		}

--- a/tsdb/engine.go
+++ b/tsdb/engine.go
@@ -470,13 +470,14 @@ func (ae *AggregateExecutor) execute(out chan *influxql.Row) {
 				}
 			}
 
-			_, ok := buckets[chunk.Time]
-			values := chunk.Values.([]interface{})
+			startTime := chunk.Values[0].Time
+			_, ok := buckets[startTime]
+			values := chunk.Values[0].Value.([]interface{})
 			if !ok {
-				buckets[chunk.Time] = make([][]interface{}, len(values))
+				buckets[startTime] = make([][]interface{}, len(values))
 			}
 			for i, v := range values {
-				buckets[chunk.Time][i] = append(buckets[chunk.Time][i], v)
+				buckets[startTime][i] = append(buckets[startTime][i], v)
 			}
 		}
 

--- a/tsdb/engine.go
+++ b/tsdb/engine.go
@@ -314,17 +314,17 @@ func (re *RawExecutor) close() {
 // track for that mapper.
 type StatefulAggMapper struct {
 	Mapper
-	bufferedChunk *aggMapperOutput // Last read chunk.
+	bufferedChunk *rawMapperOutput // Last read chunk.
 	drained       bool
 }
 
 // NextChunk wraps an AggregateMapper and some state.
-func (sam *StatefulAggMapper) NextChunk() (*aggMapperOutput, error) {
+func (sam *StatefulAggMapper) NextChunk() (*rawMapperOutput, error) {
 	c, err := sam.Mapper.NextChunk()
 	if err != nil {
 		return nil, err
 	}
-	chunk, ok := c.(*aggMapperOutput)
+	chunk, ok := c.(*rawMapperOutput)
 	if !ok {
 		if chunk == interface{}(nil) {
 			return nil, nil
@@ -422,7 +422,7 @@ func (ae *AggregateExecutor) execute(out chan *influxql.Row) {
 		// Send out data for the next alphabetically-lowest tagset. All Mappers send out in this order
 		// so collect data for this tagset, ignoring all others.
 		tagset := ae.nextMapperTagSet()
-		chunks := []*aggMapperOutput{}
+		chunks := []*rawMapperOutput{}
 
 		// Pull as much as possible from each mapper. Stop when a mapper offers
 		// data for a new tagset, or empties completely.

--- a/tsdb/engine_test.go
+++ b/tsdb/engine_test.go
@@ -559,29 +559,29 @@ func TestProcessRawQueryDerivative(t *testing.T) {
 		name     string
 		fn       string
 		interval time.Duration
-		in       []*rawMapperValue
-		exp      []*rawMapperValue
+		in       []*mapperValue
+		exp      []*mapperValue
 	}{
 		{
 			name:     "empty input",
 			fn:       "derivative",
 			interval: 24 * time.Hour,
-			in:       []*rawMapperValue{},
-			exp:      []*rawMapperValue{},
+			in:       []*mapperValue{},
+			exp:      []*mapperValue{},
 		},
 
 		{
 			name:     "single row returns 0.0",
 			fn:       "derivative",
 			interval: 24 * time.Hour,
-			in: []*rawMapperValue{
-				&rawMapperValue{
+			in: []*mapperValue{
+				{
 					Time:  time.Unix(0, 0).Unix(),
 					Value: 1.0,
 				},
 			},
-			exp: []*rawMapperValue{
-				&rawMapperValue{
+			exp: []*mapperValue{
+				{
 					Time:  time.Unix(0, 0).Unix(),
 					Value: 0.0,
 				},
@@ -591,34 +591,34 @@ func TestProcessRawQueryDerivative(t *testing.T) {
 			name:     "basic derivative",
 			fn:       "derivative",
 			interval: 24 * time.Hour,
-			in: []*rawMapperValue{
-				&rawMapperValue{
+			in: []*mapperValue{
+				{
 					Time:  time.Unix(0, 0).Unix(),
 					Value: 0.0,
 				},
-				&rawMapperValue{
+				{
 					Time:  time.Unix(0, 0).Add(24 * time.Hour).UnixNano(),
 					Value: 3.0,
 				},
-				&rawMapperValue{
+				{
 					Time:  time.Unix(0, 0).Add(48 * time.Hour).UnixNano(),
 					Value: 5.0,
 				},
-				&rawMapperValue{
+				{
 					Time:  time.Unix(0, 0).Add(72 * time.Hour).UnixNano(),
 					Value: 9.0,
 				},
 			},
-			exp: []*rawMapperValue{
-				&rawMapperValue{
+			exp: []*mapperValue{
+				{
 					Time:  time.Unix(0, 0).Add(24 * time.Hour).UnixNano(),
 					Value: 3.0,
 				},
-				&rawMapperValue{
+				{
 					Time:  time.Unix(0, 0).Add(48 * time.Hour).UnixNano(),
 					Value: 2.0,
 				},
-				&rawMapperValue{
+				{
 					Time:  time.Unix(0, 0).Add(72 * time.Hour).UnixNano(),
 					Value: 4.0,
 				},
@@ -628,34 +628,34 @@ func TestProcessRawQueryDerivative(t *testing.T) {
 			name:     "12h interval",
 			fn:       "derivative",
 			interval: 12 * time.Hour,
-			in: []*rawMapperValue{
-				&rawMapperValue{
+			in: []*mapperValue{
+				{
 					Time:  time.Unix(0, 0).UnixNano(),
 					Value: 1.0,
 				},
-				&rawMapperValue{
+				{
 					Time:  time.Unix(0, 0).Add(24 * time.Hour).UnixNano(),
 					Value: 2.0,
 				},
-				&rawMapperValue{
+				{
 					Time:  time.Unix(0, 0).Add(48 * time.Hour).UnixNano(),
 					Value: 3.0,
 				},
-				&rawMapperValue{
+				{
 					Time:  time.Unix(0, 0).Add(72 * time.Hour).UnixNano(),
 					Value: 4.0,
 				},
 			},
-			exp: []*rawMapperValue{
-				&rawMapperValue{
+			exp: []*mapperValue{
+				{
 					Time:  time.Unix(0, 0).Add(24 * time.Hour).UnixNano(),
 					Value: 0.5,
 				},
-				&rawMapperValue{
+				{
 					Time:  time.Unix(0, 0).Add(48 * time.Hour).UnixNano(),
 					Value: 0.5,
 				},
-				&rawMapperValue{
+				{
 					Time:  time.Unix(0, 0).Add(72 * time.Hour).UnixNano(),
 					Value: 0.5,
 				},
@@ -665,35 +665,35 @@ func TestProcessRawQueryDerivative(t *testing.T) {
 			name:     "negative derivatives",
 			fn:       "derivative",
 			interval: 24 * time.Hour,
-			in: []*rawMapperValue{
-				&rawMapperValue{
+			in: []*mapperValue{
+				{
 					Time:  time.Unix(0, 0).Unix(),
 					Value: 1.0,
 				},
-				&rawMapperValue{
+				{
 					Time:  time.Unix(0, 0).Add(24 * time.Hour).UnixNano(),
 					Value: 2.0,
 				},
 				// should go negative
-				&rawMapperValue{
+				{
 					Time:  time.Unix(0, 0).Add(48 * time.Hour).UnixNano(),
 					Value: 0.0,
 				},
-				&rawMapperValue{
+				{
 					Time:  time.Unix(0, 0).Add(72 * time.Hour).UnixNano(),
 					Value: 4.0,
 				},
 			},
-			exp: []*rawMapperValue{
-				&rawMapperValue{
+			exp: []*mapperValue{
+				{
 					Time:  time.Unix(0, 0).Add(24 * time.Hour).UnixNano(),
 					Value: 1.0,
 				},
-				&rawMapperValue{
+				{
 					Time:  time.Unix(0, 0).Add(48 * time.Hour).UnixNano(),
 					Value: -2.0,
 				},
-				&rawMapperValue{
+				{
 					Time:  time.Unix(0, 0).Add(72 * time.Hour).UnixNano(),
 					Value: 4.0,
 				},
@@ -703,31 +703,31 @@ func TestProcessRawQueryDerivative(t *testing.T) {
 			name:     "negative derivatives",
 			fn:       "non_negative_derivative",
 			interval: 24 * time.Hour,
-			in: []*rawMapperValue{
-				&rawMapperValue{
+			in: []*mapperValue{
+				{
 					Time:  time.Unix(0, 0).Unix(),
 					Value: 1.0,
 				},
-				&rawMapperValue{
+				{
 					Time:  time.Unix(0, 0).Add(24 * time.Hour).UnixNano(),
 					Value: 2.0,
 				},
 				// should go negative
-				&rawMapperValue{
+				{
 					Time:  time.Unix(0, 0).Add(48 * time.Hour).UnixNano(),
 					Value: 0.0,
 				},
-				&rawMapperValue{
+				{
 					Time:  time.Unix(0, 0).Add(72 * time.Hour).UnixNano(),
 					Value: 4.0,
 				},
 			},
-			exp: []*rawMapperValue{
-				&rawMapperValue{
+			exp: []*mapperValue{
+				{
 					Time:  time.Unix(0, 0).Add(24 * time.Hour).UnixNano(),
 					Value: 1.0,
 				},
-				&rawMapperValue{
+				{
 					Time:  time.Unix(0, 0).Add(72 * time.Hour).UnixNano(),
 					Value: 4.0,
 				},

--- a/tsdb/mapper.go
+++ b/tsdb/mapper.go
@@ -11,9 +11,13 @@ import (
 	"github.com/influxdb/influxdb/influxql"
 )
 
+// mapperValue is a complex type, which can encapsulate data from both raw and aggregate
+// mappers. This currently allows marshalling and network system to remain simpler. For
+// aggregate output Time is ignored, and actual Time-Value pairs are contained soley
+// within the Value field.
 type mapperValue struct {
-	Time  int64       `json:"time,omitempty"`
-	Value interface{} `json:"value,omitempty"`
+	Time  int64       `json:"time,omitempty"`  // Ignored for aggregate output.
+	Value interface{} `json:"value,omitempty"` // For aggregate, contains interval time multiple values.
 }
 
 type mapperValues []*mapperValue
@@ -25,7 +29,7 @@ func (a mapperValues) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
 type mapperOutput struct {
 	Name   string            `json:"name,omitempty"`
 	Tags   map[string]string `json:"tags,omitempty"`
-	Values mapperValues      `json:"values,omitempty"`
+	Values []*mapperValue    `json:"values,omitempty"` // For aggregates contains a single value at [0]
 }
 
 func (mo *mapperOutput) key() string {

--- a/tsdb/mapper.go
+++ b/tsdb/mapper.go
@@ -193,7 +193,7 @@ type aggMapperOutput struct {
 	Name   string            `json:"name,omitempty"`
 	Tags   map[string]string `json:"tags,omitempty"`
 	Time   int64             `json:"time,omitempty"`
-	Values []interface{}     `json:"values,omitempty"` // 1 entry per map function.
+	Values interface{}       `json:"values,omitempty"` // 1 entry per map function.
 }
 
 func (amo *aggMapperOutput) key() string {
@@ -435,7 +435,8 @@ func (am *AggMapper) NextChunk() (interface{}, error) {
 
 			// Execute the map function which walks the entire interval, and aggregates
 			// the result.
-			output.Values = append(output.Values, am.mapFuncs[i](tagSetCursor))
+			values := output.Values.([]interface{})
+			output.Values = append(values, am.mapFuncs[i](tagSetCursor))
 		}
 		return output, nil
 	}

--- a/tsdb/mapper.go
+++ b/tsdb/mapper.go
@@ -189,15 +189,10 @@ func (rm *RawMapper) Close() {
 	}
 }
 
-type aggMapperValue struct {
-	Time  int64       `json:"time,omitempty"`
-	Value interface{} `json:"value,omitempty"` // 1 entry per map function.
-}
-
 type aggMapperOutput struct {
 	Name   string            `json:"name,omitempty"`
 	Tags   map[string]string `json:"tags,omitempty"`
-	Values []*aggMapperValue `json:"values,omitempty"`
+	Values []*rawMapperValue `json:"values,omitempty"`
 }
 
 func (amo *aggMapperOutput) key() string {
@@ -410,11 +405,11 @@ func (am *AggMapper) NextChunk() (interface{}, error) {
 			output = &aggMapperOutput{
 				Name:   cursor.measurement,
 				Tags:   cursor.tags,
-				Values: make([]*aggMapperValue, 1),
+				Values: make([]*rawMapperValue, 1),
 			}
 			// Aggregate values only use the first entry in the Values field. Set the time
 			// to the start of the interval.
-			output.Values[0] = &aggMapperValue{
+			output.Values[0] = &rawMapperValue{
 				Time:  tmin,
 				Value: make([]interface{}, 0)}
 		}

--- a/tsdb/mapper.go
+++ b/tsdb/mapper.go
@@ -189,16 +189,6 @@ func (rm *RawMapper) Close() {
 	}
 }
 
-type aggMapperOutput struct {
-	Name   string            `json:"name,omitempty"`
-	Tags   map[string]string `json:"tags,omitempty"`
-	Values []*rawMapperValue `json:"values,omitempty"`
-}
-
-func (amo *aggMapperOutput) key() string {
-	return formMeasurementTagSetKey(amo.Name, amo.Tags)
-}
-
 // AggMapper is for retrieving data, for an aggregate query, from a given shard.
 type AggMapper struct {
 	shard *Shard
@@ -383,7 +373,7 @@ func (am *AggMapper) Open() error {
 // returned by AvailTagsSets(). When there is no more data for any tagset nil
 // is returned.
 func (am *AggMapper) NextChunk() (interface{}, error) {
-	var output *aggMapperOutput
+	var output *rawMapperOutput
 	for {
 		if am.currCursorIndex == len(am.cursors) {
 			// All tagset cursors processed. NextChunk'ing complete.
@@ -402,7 +392,7 @@ func (am *AggMapper) NextChunk() (interface{}, error) {
 		// Prep the return data for this tagset. This will hold data for a single interval
 		// for a single tagset.
 		if output == nil {
-			output = &aggMapperOutput{
+			output = &rawMapperOutput{
 				Name:   cursor.measurement,
 				Tags:   cursor.tags,
 				Values: make([]*rawMapperValue, 1),

--- a/tsdb/mapper_test.go
+++ b/tsdb/mapper_test.go
@@ -265,54 +265,54 @@ func TestShardMapper_WriteAndSingleMapperAggregateQuery(t *testing.T) {
 	}{
 		{
 			stmt:     `SELECT sum(value) FROM cpu`,
-			expected: []string{`{"name":"cpu","values":[61]}`, `null`},
+			expected: []string{`{"name":"cpu","values":[{"value":[61]}]}`, `null`},
 		},
 		{
 			stmt:     `SELECT sum(value),mean(value) FROM cpu`,
-			expected: []string{`{"name":"cpu","values":[61,{"Count":2,"Mean":30.5,"ResultType":1}]}`, `null`},
+			expected: []string{`{"name":"cpu","values":[{"value":[61,{"Count":2,"Mean":30.5,"ResultType":1}]}]}`, `null`},
 		},
 		{
 			stmt: `SELECT sum(value) FROM cpu GROUP BY host`,
 			expected: []string{
-				`{"name":"cpu","tags":{"host":"serverA"},"values":[1]}`,
-				`{"name":"cpu","tags":{"host":"serverB"},"values":[60]}`,
+				`{"name":"cpu","tags":{"host":"serverA"},"values":[{"value":[1]}]}`,
+				`{"name":"cpu","tags":{"host":"serverB"},"values":[{"value":[60]}]}`,
 				`null`},
 		},
 		{
 			stmt: `SELECT sum(value) FROM cpu GROUP BY region`,
 			expected: []string{
-				`{"name":"cpu","tags":{"region":"us-east"},"values":[61]}`,
+				`{"name":"cpu","tags":{"region":"us-east"},"values":[{"value":[61]}]}`,
 				`null`},
 		},
 		{
 			stmt: `SELECT sum(value) FROM cpu GROUP BY region,host`,
 			expected: []string{
-				`{"name":"cpu","tags":{"host":"serverA","region":"us-east"},"values":[1]}`,
-				`{"name":"cpu","tags":{"host":"serverB","region":"us-east"},"values":[60]}`,
+				`{"name":"cpu","tags":{"host":"serverA","region":"us-east"},"values":[{"value":[1]}]}`,
+				`{"name":"cpu","tags":{"host":"serverB","region":"us-east"},"values":[{"value":[60]}]}`,
 				`null`},
 		},
 		{
 			stmt: `SELECT sum(value) FROM cpu WHERE host='serverB'`,
 			expected: []string{
-				`{"name":"cpu","values":[60]}`,
+				`{"name":"cpu","values":[{"value":[60]}]}`,
 				`null`},
 		},
 		{
 			stmt: fmt.Sprintf(`SELECT sum(value) FROM cpu WHERE time = '%s'`, pt1time.Format(influxql.DateTimeFormat)),
 			expected: []string{
-				`{"name":"cpu","time":10000000000,"values":[1]}`,
+				`{"name":"cpu","values":[{"time":10000000000,"value":[1]}]}`,
 				`null`},
 		},
 		{
 			stmt: fmt.Sprintf(`SELECT sum(value) FROM cpu WHERE time > '%s'`, pt1time.Format(influxql.DateTimeFormat)),
 			expected: []string{
-				`{"name":"cpu","values":[60]}`,
+				`{"name":"cpu","values":[{"value":[60]}]}`,
 				`null`},
 		},
 		{
 			stmt: fmt.Sprintf(`SELECT sum(value) FROM cpu WHERE time > '%s'`, pt2time.Format(influxql.DateTimeFormat)),
 			expected: []string{
-				`{"name":"cpu","values":[null]}`,
+				`{"name":"cpu","values":[{"value":[null]}]}`,
 				`null`},
 		},
 	}


### PR DESCRIPTION
Introduce `mapperOutput` which is a merging of `rawMapperOuput` and `aggMapperOutput`.

For raw output, there are multiple `mapperValue` objects per `mapperOutput`, with a chunk's worth of `mapperValue` values in each `mapperOutput` object. For aggregates, there is a single `mapperValue` object (at index 0 obviously) which represents a single interval. The object itself encapsulates an slice of aggregated values. These are the values reduced by an Aggregate Executor.

This is really pushing the type system, but needs to be done to cleanly combine the raw and aggregate output mapper types. This change allows the network system and marshaling code to stay simple, allowing each Executor to worry about differences. The upside is that some of the upper-layer code was simplified -- there is now a need for only 1 `StatefulMapper`, for example.