### PR TITLE
Correctly check if raw derivative is required

### DIFF
--- a/tsdb/mapper.go
+++ b/tsdb/mapper.go
@@ -184,7 +184,7 @@ func (rm *RawMapper) NextChunk() (interface{}, error) {
 
 // Close closes the mapper.
 func (rm *RawMapper) Close() {
-	if rm.tx != nil {
+	if rm != nil && rm.tx != nil {
 		_ = rm.tx.Rollback()
 	}
 }
@@ -469,7 +469,7 @@ func (am *AggMapper) TagSets() []string {
 
 // Close closes the mapper.
 func (am *AggMapper) Close() {
-	if am.tx != nil {
+	if am != nil && am.tx != nil {
 		_ = am.tx.Rollback()
 	}
 }

--- a/tsdb/store.go
+++ b/tsdb/store.go
@@ -309,7 +309,7 @@ func (s *Store) CreateMapper(shardID uint64, query string, chunkSize int) (Mappe
 		return nil, nil
 	}
 
-	if stmt.IsRawQuery && !stmt.HasDistinct() {
+	if (stmt.IsRawQuery && !stmt.HasDistinct()) || stmt.IsSimpleDerivative() {
 		return NewRawMapper(shard, stmt, chunkSize), nil
 	}
 	return NewAggMapper(shard, stmt), nil


### PR DESCRIPTION
The multiple checks for Mapper and Executor type -- the lack of DRYness
in this code -- meant the same checks would need to be copied. Therefore
this change, as well as fixing the bug, improves the situation a little
bit by *asking* the Mappers what type of Executor is required. This code
is still not ideal.

Fixes #3355.