### PR TITLE
Require a regex after a regex operator when parsing.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - [#3335](https://github.com/influxdb/influxdb/pull/3335): Don't drop all data on DROP DATABASE. Thanks to @PierreF for the report
 - [#2761](https://github.com/influxdb/influxdb/issues/2761): Make SHOW RETENTION POLICIES consistent with other queries.
 - [#3356](https://github.com/influxdb/influxdb/pull/3356): Disregard semicolons after database name in use command. Thanks @timraymond.
+- [#3351](https://github.com/influxdb/influxdb/pull/3351): Handle malformed regex comparisons during parsing. Thanks @rnubel
 
 ## v0.9.1 [2015-07-02]
 

--- a/influxql/parser.go
+++ b/influxql/parser.go
@@ -1760,6 +1760,11 @@ func (p *Parser) ParseExpr() (Expr, error) {
 			if rhs, err = p.parseRegex(); err != nil {
 				return nil, err
 			}
+			// parseRegex can return an empty type, but we need it to be present
+			if rhs.(*RegexLiteral) == nil {
+				tok, pos, lit := p.scanIgnoreWhitespace()
+				return nil, newParseError(tokstr(tok, lit), []string{"regex"}, pos)
+			}
 		} else {
 			if rhs, err = p.parseUnaryExpr(); err != nil {
 				return nil, err

--- a/influxql/parser_test.go
+++ b/influxql/parser_test.go
@@ -1224,6 +1224,7 @@ func TestParser_ParseStatement(t *testing.T) {
 		{s: `select count() from myseries`, err: `invalid number of arguments for count, expected 1, got 0`},
 		{s: `select derivative() from myseries`, err: `invalid number of arguments for derivative, expected at least 1 but no more than 2, got 0`},
 		{s: `select derivative(mean(value), 1h, 3) from myseries`, err: `invalid number of arguments for derivative, expected at least 1 but no more than 2, got 3`},
+		{s: `SELECT field1 from myseries WHERE host =~ 'asd' LIMIT 1`, err: `found asd, expected regex at line 1, char 42`},
 		{s: `DELETE`, err: `found EOF, expected FROM at line 1, char 8`},
 		{s: `DELETE FROM`, err: `found EOF, expected identifier at line 1, char 13`},
 		{s: `DELETE FROM myseries WHERE`, err: `found EOF, expected identifier, string, number, bool at line 1, char 28`},


### PR DESCRIPTION
Previously, parseRegex could return an empty RegexLiteral
and the expression parser would put that into the right-hand
side of the expression, causing a nil-pointer panic when
the query was later executed. This change adds a check at
the parsing level and returns an error message if a regex
operator (e.g. =~) is not followed by an actual regex.