### PR TITLE
Rename cluster unit test function

### DIFF
--- a/cluster/service_test.go
+++ b/cluster/service_test.go
@@ -30,7 +30,7 @@ type testService struct {
 	createShardFunc func(database, policy string, shardID uint64) error
 }
 
-func newTestService(f func(shardID uint64, points []tsdb.Point) error) testService {
+func newTestWriteService(f func(shardID uint64, points []tsdb.Point) error) testService {
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		panic(err)

--- a/cluster/shard_writer_test.go
+++ b/cluster/shard_writer_test.go
@@ -12,7 +12,7 @@ import (
 
 // Ensure the shard writer can successful write a single request.
 func TestShardWriter_WriteShard_Success(t *testing.T) {
-	ts := newTestService(writeShardSuccess)
+	ts := newTestWriteService(writeShardSuccess)
 	s := cluster.NewService(cluster.Config{})
 	s.Listener = ts.muxln
 	s.TSDBStore = ts
@@ -59,7 +59,7 @@ func TestShardWriter_WriteShard_Success(t *testing.T) {
 
 // Ensure the shard writer can successful write a multiple requests.
 func TestShardWriter_WriteShard_Multiple(t *testing.T) {
-	ts := newTestService(writeShardSuccess)
+	ts := newTestWriteService(writeShardSuccess)
 	s := cluster.NewService(cluster.Config{})
 	s.Listener = ts.muxln
 	s.TSDBStore = ts
@@ -108,7 +108,7 @@ func TestShardWriter_WriteShard_Multiple(t *testing.T) {
 
 // Ensure the shard writer returns an error when the server fails to accept the write.
 func TestShardWriter_WriteShard_Error(t *testing.T) {
-	ts := newTestService(writeShardFail)
+	ts := newTestWriteService(writeShardFail)
 	s := cluster.NewService(cluster.Config{})
 	s.Listener = ts.muxln
 	s.TSDBStore = ts
@@ -136,7 +136,7 @@ func TestShardWriter_WriteShard_Error(t *testing.T) {
 
 // Ensure the shard writer returns an error when dialing times out.
 func TestShardWriter_Write_ErrDialTimeout(t *testing.T) {
-	ts := newTestService(writeShardSuccess)
+	ts := newTestWriteService(writeShardSuccess)
 	s := cluster.NewService(cluster.Config{})
 	s.Listener = ts.muxln
 	s.TSDBStore = ts


### PR DESCRIPTION
Makes future tests, related to shard mapping, clearer.