### PR TITLE
One Query Executor to rule them all

### DIFF
--- a/tsdb/engine_test.go
+++ b/tsdb/engine_test.go
@@ -804,7 +804,7 @@ func (t *testQEShardMapper) CreateMapper(shard meta.ShardInfo, stmt string, chun
 	return t.store.CreateMapper(shard.ID, stmt, chunkSize)
 }
 
-func executeAndGetResults(executor Executor) string {
+func executeAndGetResults(executor *Executor) string {
 	ch := executor.Execute()
 
 	var rows []*influxql.Row


### PR DESCRIPTION
This change significantly simplifies query executor code. Before this change there were two types of executors -- `RawExecutor` and `AggregateExecutor`. These two types only differed in *one function* `Execute()`. Otherwise all other methods on the Executors were common and duplicated between executors.

This change merges the two executors into a single type called, wait for it, `Executor` and simply switches `execute()` functions depending on the statement type. The core query engine code has not changed, this simply merges and deletes a bunch of duplicated code.