### PR TITLE
Move to a single LocalMapper type

### DIFF
--- a/tsdb/store.go
+++ b/tsdb/store.go
@@ -309,10 +309,7 @@ func (s *Store) CreateMapper(shardID uint64, query string, chunkSize int) (Mappe
 		return nil, nil
 	}
 
-	if (stmt.IsRawQuery && !stmt.HasDistinct()) || stmt.IsSimpleDerivative() {
-		return NewRawMapper(shard, stmt, chunkSize), nil
-	}
-	return NewAggMapper(shard, stmt), nil
+	return NewLocalMapper(shard, stmt, chunkSize), nil
 }
 
 func (s *Store) Close() error {


### PR DESCRIPTION
This proposed change consolidates the `RawMapper` and `AggMapper` type into a single type `LocalMapper`. The difference in operation between raw mode and aggregate mode is now embedded within the code of the type itself, as opposed to be represented by two different types.

This implementation is similar to the pre-distributed queries implementation, but with the added concept of a `TagSetCursor` (explained in the earlier DQ PR).

This change may make it easier to implement distributed meta-queries such as `SHOW MEASUREMENTS` and `DROP ....` because the higher layers such as executors will just instantiate 1 type of Mapper, but drive it differently depending on the query type.

The next logical step would be to have these Mappers take the type `influxql.Statement` during construction, and use that to determine if the query is raw, aggregate, or meta, and call the relevant code when `NextChunk` is called (which today either calls `nextChunkRaw` or `nextChunkAgg`.