### PR TITLE
Remove restrictions on existence of fields and tags

### DIFF
--- a/cmd/influxd/run/server_test.go
+++ b/cmd/influxd/run/server_test.go
@@ -891,7 +891,7 @@ func TestServer_Query_Tags(t *testing.T) {
 		&Query{
 			name:    "tag without field should return error",
 			command: `SELECT host FROM db0.rp0.cpu`,
-			exp:     `{"results":[{"error":"select statement must include at least one field"}]}`,
+			exp:     `{"results":[{}]}`,
 		},
 		&Query{
 			name:    "field with tag should succeed",
@@ -1039,14 +1039,14 @@ func TestServer_Query_Common(t *testing.T) {
 			exp:     fmt.Sprintf(`{"results":[{"series":[{"name":"cpu","columns":["time","value"],"values":[["%s",1]]}]}]}`, now.Format(time.RFC3339Nano)),
 		},
 		&Query{
-			name:    "selecting a measurement that doesn't exist should error",
+			name:    "selecting a measurement that doesn't exist should result in empty set",
 			command: `SELECT value FROM db0.rp0.idontexist`,
 			exp:     `{"results":[{}]}`,
 		},
 		&Query{
-			name:    "selecting a field that doesn't exist should error",
+			name:    "selecting a field that doesn't exist should result in empty set",
 			command: `SELECT idontexist FROM db0.rp0.cpu`,
-			exp:     `{"results":[{"error":"unknown field or tag name in select clause: idontexist"}]}`,
+			exp:     `{"results":[{}]}`,
 		},
 		&Query{
 			name:    "selecting wildcard without specifying a database should error",
@@ -2030,10 +2030,10 @@ func TestServer_Query_AcrossShardsAndFields(t *testing.T) {
 			exp:     `{"results":[{"series":[{"name":"cpu","columns":["time","core"],"values":[["2015-01-01T00:00:00Z",4]]}]}]}`,
 		},
 		&Query{
-			name:    "error for non-existent field",
+			name:    "empty result set from non-existent field",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT foo FROM cpu`,
-			exp:     `{"results":[{"error":"unknown field or tag name in select clause: foo"}]}`,
+			exp:     `{"results":[{}]}`,
 		},
 	}...)
 

--- a/tsdb/mapper.go
+++ b/tsdb/mapper.go
@@ -223,7 +223,8 @@ func (lm *LocalMapper) Open() error {
 
 	// If the query does not aggregate, then at least 1 SELECT field should be present.
 	if lm.rawMode && len(lm.selectFields) == 0 {
-		return fmt.Errorf("select statement must include at least one field")
+		// None of the SELECT fields exist in this data. Wipe out all tagset cursors.
+		lm.cursors = nil
 	}
 
 	return nil

--- a/tsdb/mapper.go
+++ b/tsdb/mapper.go
@@ -642,7 +642,7 @@ type tagSetsAndFields struct {
 }
 
 // createTagSetsAndFields returns the tagsets and various fields given a measurement and
-// SELECT statement. It also ensures that the fields and tags exist.
+// SELECT statement.
 func createTagSetsAndFields(m *Measurement, stmt *influxql.SelectStatement) (*tagSetsAndFields, error) {
 	_, tagKeys, err := stmt.Dimensions.Normalize()
 	if err != nil {
@@ -659,11 +659,10 @@ func createTagSetsAndFields(m *Measurement, stmt *influxql.SelectStatement) (*ta
 			sfs.add(n)
 			continue
 		}
-		if !m.HasTagKey(n) {
-			return nil, fmt.Errorf("unknown field or tag name in select clause: %s", n)
+		if m.HasTagKey(n) {
+			sts.add(n)
+			tagKeys = append(tagKeys, n)
 		}
-		sts.add(n)
-		tagKeys = append(tagKeys, n)
 	}
 	for _, n := range stmt.NamesInWhere() {
 		if n == "time" {
@@ -672,9 +671,6 @@ func createTagSetsAndFields(m *Measurement, stmt *influxql.SelectStatement) (*ta
 		if m.HasField(n) {
 			wfs.add(n)
 			continue
-		}
-		if !m.HasTagKey(n) {
-			return nil, fmt.Errorf("unknown field or tag name in where clause: %s", n)
 		}
 	}
 

--- a/tsdb/meta.go
+++ b/tsdb/meta.go
@@ -1221,9 +1221,11 @@ func newStringSet() stringSet {
 	return make(map[string]struct{})
 }
 
-// add adds a string to the set.
-func (s stringSet) add(ss string) {
-	s[ss] = struct{}{}
+// add adds strings to the set.
+func (s stringSet) add(ss ...string) {
+	for _, n := range ss {
+		s[n] = struct{}{}
+	}
 }
 
 // contains returns whether the set contains the given string.


### PR DESCRIPTION
The system can no longer be sure which fields and tags exist on a composite series (tagsets). So this change removes restrictions on the existence of fields and tags and just return empty sets.

Some production code needed fixing, and some tests needed updating.