### PR TITLE
Fixes #3403 - Added check for escaped single quote in string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [#3405](https://github.com/influxdb/influxdb/pull/3405): Prevent database panic when fields are missing. Thanks @jhorwit2
 - [#3411](https://github.com/influxdb/influxdb/issues/3411): 500 timeout on write
 - [#3420](https://github.com/influxdb/influxdb/pull/3420): Catch opentsdb malformed tags. Thanks @nathanielc.
+- [#3404](https://github.com/influxdb/influxdb/pull/3404): Added support for escaped single quotes in query string. Thanks @jhorwit2
 
 ## v0.9.2 [unreleased]
 

--- a/influxql/scanner.go
+++ b/influxql/scanner.go
@@ -514,6 +514,8 @@ func ScanString(r io.RuneScanner) (string, error) {
 				_, _ = buf.WriteRune('\\')
 			} else if ch1 == '"' {
 				_, _ = buf.WriteRune('"')
+			} else if ch1 == '\'' {
+				_, _ = buf.WriteRune('\'')
 			} else {
 				return string(ch0) + string(ch1), errBadEscape
 			}

--- a/influxql/scanner_test.go
+++ b/influxql/scanner_test.go
@@ -243,6 +243,7 @@ func TestScanString(t *testing.T) {
 		{in: `"foo\nbar"`, out: "foo\nbar"},
 		{in: `"foo\\bar"`, out: `foo\bar`},
 		{in: `"foo\"bar"`, out: `foo"bar`},
+		{in: `'foo\'bar'`, out: `foo'bar`},
 
 		{in: `"foo` + "\n", out: `foo`, err: "bad string"}, // newline in string
 		{in: `"foo`, out: `foo`, err: "bad string"},        // unclosed quotes


### PR DESCRIPTION
#3403 

```
> create database test;
> use test
Using database test
> insert test value="foo'bar"
> select * from test
name: test
----------
time				value
2015-07-21T00:15:43.034952116Z	foo'bar

> select * from test where value = 'foo'bar'
ERR: error parsing query: found bar, expected SELECT, DELETE, SHOW, CREATE, DROP, GRANT, REVOKE, ALTER, SET at line 1, char 39
> select * from test where value = 'foo''bar'
ERR: error parsing query: found bar, expected SELECT, DELETE, SHOW, CREATE, DROP, GRANT, REVOKE, ALTER, SET at line 1, char 38
> select * from test where value = 'foo\'bar'
name: test
----------
time				value
2015-07-21T00:15:43.034952116Z	foo'bar

> select * from test where value = 'foo'bar'
ERR: error parsing query: found bar, expected SELECT, DELETE, SHOW, CREATE, DROP, GRANT, REVOKE, ALTER, SET at line 1, char 39
> 
```