### PR TITLE
Fixes #3379 - added check for no fields in point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ### Features
 - [#3376](https://github.com/influxdb/influxdb/pull/3376): Support for remote shard query mapping
 
+### Bugfixes
+- [#3405](https://github.com/influxdb/influxdb/pull/3405): Prevent database panic when fields are missing. Thanks @jhorwit2
+
 ## v0.9.2 [unreleased]
 
 ### Features

--- a/tsdb/points.go
+++ b/tsdb/points.go
@@ -286,6 +286,12 @@ func scanKey(buf []byte, i int) (int, []byte, error) {
 		return i, buf[start:i], fmt.Errorf("invalid tag format")
 	}
 
+	// This check makes sure we actually received fields from the user. #3379
+	// This will catch invalid syntax such as: `cpu,host=serverA,region=us-west`
+	if i >= len(buf) {
+		return i, buf[start:i], fmt.Errorf("missing fields")
+	}
+
 	// Now we know where the key region is within buf, and the locations of tags, we
 	// need to deterimine if duplicate tags exist and if the tags are sorted.  This iterates
 	// 1/2 of the list comparing each end with each other, walking towards the center from

--- a/tsdb/points_test.go
+++ b/tsdb/points_test.go
@@ -150,7 +150,12 @@ func TestParsePointNoValue(t *testing.T) {
 }
 
 func TestParsePointNoFields(t *testing.T) {
-	_, err := ParsePointsString("cpu")
+	_, err := ParsePointsString("cpu_load_short,host=server01,region=us-west")
+	if err == nil {
+		t.Errorf(`ParsePoints("%s") mismatch. got nil, exp error`, "cpu_load_short,host=server01,region=us-west")
+	}
+
+	_, err = ParsePointsString("cpu")
 	if err == nil {
 		t.Errorf(`ParsePoints("%s") mismatch. got nil, exp error`, "cpu")
 	}


### PR DESCRIPTION
#3379 

Before, which caused panic
```
curl -i -XPOST 'http://localhost:8086/write?db=mydb' --data-binary 'cpu_load_short,host=server01,region=us-west'
curl: (52) Empty reply from server
```

after:
```
curl -i -XPOST 'http://localhost:8086/write?db=mydb' --data-binary 'cpu_load_short,host=server01,region=us-west'
HTTP/1.1 400 Bad Request
Request-Id: aecd185d-2f44-11e5-8001-000000000000
X-Influxdb-Version: 0.9
Date: Tue, 21 Jul 2015 01:06:14 GMT
Content-Length: 78
Content-Type: text/plain; charset=utf-8

unable to parse 'cpu_load_short,host=server01,region=us-west': missing fields
```