### PR TITLE
Fix parse stuck in loop causing 500 timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Bugfixes
 - [#3405](https://github.com/influxdb/influxdb/pull/3405): Prevent database panic when fields are missing. Thanks @jhorwit2
+- [#3411](https://github.com/influxdb/influxdb/issues/3411): 500 timeout on write
 
 ## v0.9.2 [unreleased]
 

--- a/tsdb/points.go
+++ b/tsdb/points.go
@@ -638,10 +638,6 @@ func skipWhitespace(buf []byte, i int) int {
 			return i
 		}
 
-		if buf[i] == '\\' {
-			i += 2
-			continue
-		}
 		if buf[i] == ' ' || buf[i] == '\t' {
 			i += 1
 			continue
@@ -1029,6 +1025,7 @@ func newFieldsFromBinary(buf []byte) Fields {
 		if len(name) == 0 {
 			continue
 		}
+		name = unescape(name)
 
 		i, valueBuf = scanFieldValue(buf, i+1)
 		if len(valueBuf) == 0 {
@@ -1056,7 +1053,7 @@ func newFieldsFromBinary(buf []byte) Fields {
 				panic(fmt.Sprintf("unable to parse bool value '%v': %v\n", string(valueBuf), err))
 			}
 		}
-		fields[string(unescape(name))] = value
+		fields[string(name)] = value
 		i += 1
 	}
 	return fields

--- a/tsdb/points_test.go
+++ b/tsdb/points_test.go
@@ -572,6 +572,17 @@ func TestParsePointUnescape(t *testing.T) {
 				"value": 1.0,
 			},
 			time.Unix(0, 0)))
+
+	// field name using escape char.
+	test(t, `cpu \a=1`,
+		NewPoint(
+			"cpu",
+			Tags{},
+			Fields{
+				"\\a": 1, // Left as parsed since it's not a known escape sequence.
+			},
+			time.Unix(0, 0)))
+
 }
 
 func TestParsePointWithTags(t *testing.T) {


### PR DESCRIPTION
The `points.Fields()` func would would get stuck in a scanning loop in `newFieldsFromBinary()` because the original fields section of the input was not parsed correctly.  `skipWhitespace` would skip over escape chars when it should only skip over whitespace.  It resulted in the fields section sometimes being set `=1` instead of `\a=1`.  The `=1` value cause the infinite loop in `newFieldsFromBinary()`

Fixes #3411