### PR TITLE
catch opentsdb malformed tags if they are missing keys or values

### DIFF
--- a/services/opentsdb/service.go
+++ b/services/opentsdb/service.go
@@ -216,7 +216,7 @@ func (s *Service) handleTelnetConn(conn net.Conn) {
 		tags := make(map[string]string)
 		for t := range tagStrs {
 			parts := strings.SplitN(tagStrs[t], "=", 2)
-			if len(parts) != 2 {
+			if len(parts) != 2 || len(parts[0]) == 0 || len(parts[1]) == 0 {
 				s.Logger.Println("TSDBServer: malformed tag data", tagStrs[t])
 				continue
 			}

--- a/services/opentsdb/service.go
+++ b/services/opentsdb/service.go
@@ -216,7 +216,7 @@ func (s *Service) handleTelnetConn(conn net.Conn) {
 		tags := make(map[string]string)
 		for t := range tagStrs {
 			parts := strings.SplitN(tagStrs[t], "=", 2)
-			if len(parts) != 2 || len(parts[0]) == 0 || len(parts[1]) == 0 {
+			if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
 				s.Logger.Println("TSDBServer: malformed tag data", tagStrs[t])
 				continue
 			}


### PR DESCRIPTION
Catch bad OpenTSDB tags before they make it to the handoff process.

https://github.com/influxdb/influxdb/issues/3417

