### PR TITLE
Added additional logging to continuous queries

### DIFF
--- a/etc/config.sample.toml
+++ b/etc/config.sample.toml
@@ -176,6 +176,7 @@ reporting-disabled = false
 ###
 
 [continuous_queries]
+  log-enabled = true
   enabled = true
   recompute-previous-n = 2
   recompute-no-older-than = "10m"

--- a/services/continuous_querier/config.go
+++ b/services/continuous_querier/config.go
@@ -18,6 +18,9 @@ const (
 
 // Config represents a configuration for the continuous query service.
 type Config struct {
+	// Enables logging in CQ service to display when CQ's are processed and how many points are wrote.
+	LogEnabled bool `toml:"log-enabled"`
+
 	// If this flag is set to false, both the brokers and data nodes should ignore any CQ processing.
 	Enabled bool `toml:"enabled"`
 
@@ -52,6 +55,7 @@ type Config struct {
 // NewConfig returns a new instance of Config with defaults.
 func NewConfig() Config {
 	return Config{
+		LogEnabled:             true,
 		Enabled:                true,
 		RecomputePreviousN:     DefaultRecomputePreviousN,
 		RecomputeNoOlderThan:   toml.Duration(DefaultRecomputeNoOlderThan),


### PR DESCRIPTION
I found myself running into some continuous query issues and had no easy way to debug or see if they are even working. This is a simple PR, but should be useful to give users some info into what's running and when. 


I also added start/stop logging, which fits the format for other services. 