### PR TITLE
Logging tweaks, sanitize passwords and note if authentication is enabled

### DIFF
--- a/influxql/ast.go
+++ b/influxql/ast.go
@@ -372,7 +372,7 @@ func (s *CreateUserStatement) String() string {
 	_, _ = buf.WriteString("CREATE USER ")
 	_, _ = buf.WriteString(s.Name)
 	_, _ = buf.WriteString(" WITH PASSWORD ")
-	_, _ = buf.WriteString(s.Password)
+	_, _ = buf.WriteString("[REDACTED]")
 	if s.Admin {
 		_, _ = buf.WriteString(" WITH ALL PRIVILEGES")
 	}
@@ -498,7 +498,7 @@ func (s *SetPasswordUserStatement) String() string {
 	_, _ = buf.WriteString("SET PASSWORD FOR ")
 	_, _ = buf.WriteString(s.Name)
 	_, _ = buf.WriteString(" = ")
-	_, _ = buf.WriteString(s.Password)
+	_, _ = buf.WriteString("[REDACTED]")
 	return buf.String()
 }
 

--- a/services/httpd/response_logger.go
+++ b/services/httpd/response_logger.go
@@ -134,3 +134,8 @@ func parseUsername(r *http.Request) string {
 	}
 	return username
 }
+
+// Sanitize passwords from query string for logging.
+func sanitize(r *http.Request, s string) {
+	r.URL.RawQuery = strings.Replace(r.URL.RawQuery, s, "[REDACTED]", -1)
+}

--- a/services/httpd/service.go
+++ b/services/httpd/service.go
@@ -38,6 +38,8 @@ func NewService(c Config) *Service {
 
 // Open starts the service
 func (s *Service) Open() error {
+	s.Logger.Println("authentication enabled:", s.Handler.requireAuthentication)
+
 	// Open listener.
 	ln, err := net.Listen("tcp", s.addr)
 	if err != nil {


### PR DESCRIPTION
Related to https://github.com/influxdb/influxdb/issues/3271 and https://github.com/influxdb/influxdb/issues/3107.

- Redacts passwords set as a url query parameter for all requests.
- Redacts passwords for create user and set password query statements.
- Redacts passwords when printing create user and set password statements.
- Log whether authentication is enabled.