### PR TITLE
Optimize Query Engine

### DIFF
--- a/influxql/functions.go
+++ b/influxql/functions.go
@@ -244,7 +244,7 @@ func InitializeUnmarshaller(c *Call) (UnmarshalFunc, error) {
 // MapCount computes the number of values in an iterator.
 func MapCount(itr Iterator) interface{} {
 	n := float64(0)
-	for _, k, _ := itr.Next(); k != 0; _, k, _ = itr.Next() {
+	for _, k, _ := itr.Next(); k != -1; _, k, _ = itr.Next() {
 		n++
 	}
 	if n > 0 {
@@ -330,7 +330,7 @@ func (d distinctValues) Less(i, j int) bool {
 func MapDistinct(itr Iterator) interface{} {
 	var index = make(map[interface{}]struct{})
 
-	for _, time, value := itr.Next(); time != 0; _, time, value = itr.Next() {
+	for _, time, value := itr.Next(); time != -1; _, time, value = itr.Next() {
 		index[value] = struct{}{}
 	}
 
@@ -384,7 +384,7 @@ func ReduceDistinct(values []interface{}) interface{} {
 func MapCountDistinct(itr Iterator) interface{} {
 	var index = make(map[interface{}]struct{})
 
-	for _, time, value := itr.Next(); time != 0; _, time, value = itr.Next() {
+	for _, time, value := itr.Next(); time != -1; _, time, value = itr.Next() {
 		index[value] = struct{}{}
 	}
 
@@ -429,7 +429,7 @@ func MapSum(itr Iterator) interface{} {
 	n := float64(0)
 	count := 0
 	var resultType NumberType
-	for _, k, v := itr.Next(); k != 0; _, k, v = itr.Next() {
+	for _, k, v := itr.Next(); k != -1; _, k, v = itr.Next() {
 		count++
 		switch n1 := v.(type) {
 		case float64:
@@ -483,7 +483,7 @@ func ReduceSum(values []interface{}) interface{} {
 func MapMean(itr Iterator) interface{} {
 	out := &meanMapOutput{}
 
-	for _, k, v := itr.Next(); k != 0; _, k, v = itr.Next() {
+	for _, k, v := itr.Next(); k != -1; _, k, v = itr.Next() {
 		out.Count++
 		switch n1 := v.(type) {
 		case float64:
@@ -692,7 +692,7 @@ func MapMin(itr Iterator) interface{} {
 	pointsYielded := false
 	var val float64
 
-	for _, k, v := itr.Next(); k != 0; _, k, v = itr.Next() {
+	for _, k, v := itr.Next(); k != -1; _, k, v = itr.Next() {
 		switch n := v.(type) {
 		case float64:
 			val = n
@@ -755,7 +755,7 @@ func MapMax(itr Iterator) interface{} {
 	pointsYielded := false
 	var val float64
 
-	for _, k, v := itr.Next(); k != 0; _, k, v = itr.Next() {
+	for _, k, v := itr.Next(); k != -1; _, k, v = itr.Next() {
 		switch n := v.(type) {
 		case float64:
 			val = n
@@ -822,7 +822,7 @@ func MapSpread(itr Iterator) interface{} {
 	pointsYielded := false
 	var val float64
 
-	for _, k, v := itr.Next(); k != 0; _, k, v = itr.Next() {
+	for _, k, v := itr.Next(); k != -1; _, k, v = itr.Next() {
 		switch n := v.(type) {
 		case float64:
 			val = n
@@ -881,7 +881,7 @@ func ReduceSpread(values []interface{}) interface{} {
 func MapStddev(itr Iterator) interface{} {
 	var values []float64
 
-	for _, k, v := itr.Next(); k != 0; _, k, v = itr.Next() {
+	for _, k, v := itr.Next(); k != -1; _, k, v = itr.Next() {
 		switch n := v.(type) {
 		case float64:
 			values = append(values, n)
@@ -939,7 +939,7 @@ func MapFirst(itr Iterator) interface{} {
 	out := &firstLastMapOutput{}
 	pointsYielded := false
 
-	for _, k, v := itr.Next(); k != 0; _, k, v = itr.Next() {
+	for _, k, v := itr.Next(); k != -1; _, k, v = itr.Next() {
 		// Initialize first
 		if !pointsYielded {
 			out.Time = k
@@ -989,7 +989,7 @@ func MapLast(itr Iterator) interface{} {
 	out := &firstLastMapOutput{}
 	pointsYielded := false
 
-	for _, k, v := itr.Next(); k != 0; _, k, v = itr.Next() {
+	for _, k, v := itr.Next(); k != -1; _, k, v = itr.Next() {
 		// Initialize last
 		if !pointsYielded {
 			out.Time = k
@@ -1039,7 +1039,7 @@ func ReduceLast(values []interface{}) interface{} {
 func MapEcho(itr Iterator) interface{} {
 	var values []interface{}
 
-	for _, k, v := itr.Next(); k != 0; _, k, v = itr.Next() {
+	for _, k, v := itr.Next(); k != -1; _, k, v = itr.Next() {
 		values = append(values, v)
 	}
 	return values
@@ -1091,7 +1091,7 @@ func IsNumeric(c *Call) bool {
 // MapRawQuery is for queries without aggregates
 func MapRawQuery(itr Iterator) interface{} {
 	var values []*rawQueryMapOutput
-	for _, k, v := itr.Next(); k != 0; _, k, v = itr.Next() {
+	for _, k, v := itr.Next(); k != -1; _, k, v = itr.Next() {
 		val := &rawQueryMapOutput{k, v}
 		values = append(values, val)
 	}

--- a/influxql/functions.go
+++ b/influxql/functions.go
@@ -18,7 +18,7 @@ import (
 // Iterator represents a forward-only iterator over a set of points.
 // These are used by the MapFunctions in this file
 type Iterator interface {
-	Next() (seriesKey string, time int64, value interface{})
+	Next() (time int64, value interface{})
 }
 
 // MapFunc represents a function used for mapping over a sequential series of data.
@@ -244,7 +244,7 @@ func InitializeUnmarshaller(c *Call) (UnmarshalFunc, error) {
 // MapCount computes the number of values in an iterator.
 func MapCount(itr Iterator) interface{} {
 	n := float64(0)
-	for _, k, _ := itr.Next(); k != -1; _, k, _ = itr.Next() {
+	for k, _ := itr.Next(); k != -1; k, _ = itr.Next() {
 		n++
 	}
 	if n > 0 {
@@ -330,7 +330,7 @@ func (d distinctValues) Less(i, j int) bool {
 func MapDistinct(itr Iterator) interface{} {
 	var index = make(map[interface{}]struct{})
 
-	for _, time, value := itr.Next(); time != -1; _, time, value = itr.Next() {
+	for time, value := itr.Next(); time != -1; time, value = itr.Next() {
 		index[value] = struct{}{}
 	}
 
@@ -384,7 +384,7 @@ func ReduceDistinct(values []interface{}) interface{} {
 func MapCountDistinct(itr Iterator) interface{} {
 	var index = make(map[interface{}]struct{})
 
-	for _, time, value := itr.Next(); time != -1; _, time, value = itr.Next() {
+	for time, value := itr.Next(); time != -1; time, value = itr.Next() {
 		index[value] = struct{}{}
 	}
 
@@ -429,7 +429,7 @@ func MapSum(itr Iterator) interface{} {
 	n := float64(0)
 	count := 0
 	var resultType NumberType
-	for _, k, v := itr.Next(); k != -1; _, k, v = itr.Next() {
+	for k, v := itr.Next(); k != -1; k, v = itr.Next() {
 		count++
 		switch n1 := v.(type) {
 		case float64:
@@ -483,7 +483,7 @@ func ReduceSum(values []interface{}) interface{} {
 func MapMean(itr Iterator) interface{} {
 	out := &meanMapOutput{}
 
-	for _, k, v := itr.Next(); k != -1; _, k, v = itr.Next() {
+	for k, v := itr.Next(); k != -1; k, v = itr.Next() {
 		out.Count++
 		switch n1 := v.(type) {
 		case float64:
@@ -692,7 +692,7 @@ func MapMin(itr Iterator) interface{} {
 	pointsYielded := false
 	var val float64
 
-	for _, k, v := itr.Next(); k != -1; _, k, v = itr.Next() {
+	for k, v := itr.Next(); k != -1; k, v = itr.Next() {
 		switch n := v.(type) {
 		case float64:
 			val = n
@@ -755,7 +755,7 @@ func MapMax(itr Iterator) interface{} {
 	pointsYielded := false
 	var val float64
 
-	for _, k, v := itr.Next(); k != -1; _, k, v = itr.Next() {
+	for k, v := itr.Next(); k != -1; k, v = itr.Next() {
 		switch n := v.(type) {
 		case float64:
 			val = n
@@ -822,7 +822,7 @@ func MapSpread(itr Iterator) interface{} {
 	pointsYielded := false
 	var val float64
 
-	for _, k, v := itr.Next(); k != -1; _, k, v = itr.Next() {
+	for k, v := itr.Next(); k != -1; k, v = itr.Next() {
 		switch n := v.(type) {
 		case float64:
 			val = n
@@ -881,7 +881,7 @@ func ReduceSpread(values []interface{}) interface{} {
 func MapStddev(itr Iterator) interface{} {
 	var values []float64
 
-	for _, k, v := itr.Next(); k != -1; _, k, v = itr.Next() {
+	for k, v := itr.Next(); k != -1; k, v = itr.Next() {
 		switch n := v.(type) {
 		case float64:
 			values = append(values, n)
@@ -939,7 +939,7 @@ func MapFirst(itr Iterator) interface{} {
 	out := &firstLastMapOutput{}
 	pointsYielded := false
 
-	for _, k, v := itr.Next(); k != -1; _, k, v = itr.Next() {
+	for k, v := itr.Next(); k != -1; k, v = itr.Next() {
 		// Initialize first
 		if !pointsYielded {
 			out.Time = k
@@ -989,7 +989,7 @@ func MapLast(itr Iterator) interface{} {
 	out := &firstLastMapOutput{}
 	pointsYielded := false
 
-	for _, k, v := itr.Next(); k != -1; _, k, v = itr.Next() {
+	for k, v := itr.Next(); k != -1; k, v = itr.Next() {
 		// Initialize last
 		if !pointsYielded {
 			out.Time = k
@@ -1039,7 +1039,7 @@ func ReduceLast(values []interface{}) interface{} {
 func MapEcho(itr Iterator) interface{} {
 	var values []interface{}
 
-	for _, k, v := itr.Next(); k != -1; _, k, v = itr.Next() {
+	for k, v := itr.Next(); k != -1; k, v = itr.Next() {
 		values = append(values, v)
 	}
 	return values
@@ -1091,7 +1091,7 @@ func IsNumeric(c *Call) bool {
 // MapRawQuery is for queries without aggregates
 func MapRawQuery(itr Iterator) interface{} {
 	var values []*rawQueryMapOutput
-	for _, k, v := itr.Next(); k != -1; _, k, v = itr.Next() {
+	for k, v := itr.Next(); k != -1; k, v = itr.Next() {
 		val := &rawQueryMapOutput{k, v}
 		values = append(values, val)
 	}

--- a/influxql/functions_test.go
+++ b/influxql/functions_test.go
@@ -20,14 +20,14 @@ type testIterator struct {
 	values []point
 }
 
-func (t *testIterator) Next() (seriesKey string, timestamp int64, value interface{}) {
+func (t *testIterator) Next() (timestamp int64, value interface{}) {
 	if len(t.values) > 0 {
 		v := t.values[0]
 		t.values = t.values[1:]
-		return v.seriesKey, v.time, v.value
+		return v.time, v.value
 	}
 
-	return "0", -1, nil
+	return -1, nil
 }
 
 func TestMapMeanNoValues(t *testing.T) {

--- a/influxql/functions_test.go
+++ b/influxql/functions_test.go
@@ -27,7 +27,7 @@ func (t *testIterator) Next() (seriesKey string, timestamp int64, value interfac
 		return v.seriesKey, v.time, v.value
 	}
 
-	return "0", 0, nil
+	return "0", -1, nil
 }
 
 func TestMapMeanNoValues(t *testing.T) {

--- a/tsdb/mapper.go
+++ b/tsdb/mapper.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"math"
 	"sort"
 	"strings"
 
@@ -208,10 +209,16 @@ func (lm *LocalMapper) Open() error {
 					continue
 				}
 				cm := newSeriesCursor(c, t.Filters[i])
-				cm.SeekTo(lm.queryTMin)
 				cursors = append(cursors, cm)
 			}
+
 			tsc := newTagSetCursor(m.Name, t.Tags, cursors, lm.shard.FieldCodec(m.Name))
+			// Prime the buffers.
+			for i := 0; i < len(tsc.cursors); i++ {
+				k, v := tsc.cursors[i].SeekTo(lm.queryTMin)
+				tsc.keyBuffer[i] = k
+				tsc.valueBuffer[i] = v
+			}
 			lm.cursors = append(lm.cursors, tsc)
 		}
 		sort.Sort(tagSetCursors(lm.cursors))
@@ -287,7 +294,7 @@ func (lm *LocalMapper) nextChunkAgg() (interface{}, error) {
 			// All tagset cursors processed. NextChunk'ing complete.
 			return nil, nil
 		}
-		cursor := lm.cursors[lm.currCursorIndex]
+		tsc := lm.cursors[lm.currCursorIndex]
 		tmin, tmax := lm.nextInterval()
 
 		if tmin < 0 {
@@ -301,8 +308,8 @@ func (lm *LocalMapper) nextChunkAgg() (interface{}, error) {
 		// for a single tagset.
 		if output == nil {
 			output = &MapperOutput{
-				Name:   cursor.measurement,
-				Tags:   cursor.tags,
+				Name:   tsc.measurement,
+				Tags:   tsc.tags,
 				Values: make([]*mapperValue, 1),
 			}
 			// Aggregate values only use the first entry in the Values field. Set the time
@@ -320,14 +327,19 @@ func (lm *LocalMapper) nextChunkAgg() (interface{}, error) {
 		}
 
 		for i := range lm.mapFuncs {
-			// Set the cursor to the start of the interval. This is not ideal, as it should
-			// really calculate the values all in 1 pass, but that would require changes
-			// to the mapper functions, which can come later.
-			cursor.SeekTo(tmin)
+			// Prime the tagset cursor for the start of the interval. This is not ideal, as
+			// it should really calculate the values all in 1 pass, but that would require
+			// changes to the mapper functions, which can come later.
+			// Prime the buffers.
+			for i := 0; i < len(tsc.cursors); i++ {
+				k, v := tsc.cursors[i].SeekTo(tmin)
+				tsc.keyBuffer[i] = k
+				tsc.valueBuffer[i] = v
+			}
 
 			// Wrap the tagset cursor so it implements the mapping functions interface.
 			f := func() (seriesKey string, time int64, value interface{}) {
-				return cursor.Next(qmin, tmax, []string{lm.fieldNames[i]}, lm.whereFields)
+				return tsc.Next(qmin, tmax, []string{lm.fieldNames[i]}, lm.whereFields)
 			}
 
 			tagSetCursor := &aggTagSetCursor{
@@ -424,6 +436,12 @@ type tagSetCursor struct {
 	tags        map[string]string // Tag key-value pairs
 	cursors     []*seriesCursor   // Underlying series cursors.
 	decoder     *FieldCodec       // decoder for the raw data bytes
+
+	// Lookahead buffers for the cursors. Performance analysis shows that it is critical
+	// that these buffers are part of the tagSetCursor type and not part of the the
+	// cursors type.
+	keyBuffer   []int64  // The current timestamp key for each cursor
+	valueBuffer [][]byte // The current value for each cursor
 }
 
 // tagSetCursors represents a sortable slice of tagSetCursors.
@@ -449,6 +467,8 @@ func newTagSetCursor(m string, t map[string]string, c []*seriesCursor, d *FieldC
 		tags:        t,
 		cursors:     c,
 		decoder:     d,
+		keyBuffer:   make([]int64, len(c)),
+		valueBuffer: make([][]byte, len(c)),
 	}
 }
 
@@ -459,49 +479,65 @@ func (tsc *tagSetCursor) key() string {
 // Next returns the next matching series-key, timestamp and byte slice for the tagset. Filtering
 // is enforced on the values. If there is no matching value, then a nil result is returned.
 func (tsc *tagSetCursor) Next(tmin, tmax int64, selectFields, whereFields []string) (string, int64, interface{}) {
+	_ = "breakpoint"
 	for {
-		// Find the cursor with the lowest timestamp, as that is the one to be read next.
-		minCursor := tsc.nextCursor(tmin, tmax)
-		if minCursor == nil {
-			// No cursor of this tagset has any matching data.
-			return "", 0, nil
+		// find the minimum timestamp
+		min := -1
+		minKey := int64(math.MaxInt64)
+		for i, k := range tsc.keyBuffer {
+			if k != -1 && (k == tmin) || k < tmax && k < minKey && k >= tmin {
+				min = i
+				minKey = k
+			}
 		}
-		timestamp, bytes := minCursor.Next()
+
+		// Return if there is no more data for this tagset.
+		if min == -1 {
+			return "", -1, nil
+		}
+
+		// set the current timestamp and seriesID
+		timestamp := tsc.keyBuffer[min]
 
 		var value interface{}
 		if len(selectFields) > 1 {
-			if fieldsWithNames, err := tsc.decoder.DecodeFieldsWithNames(bytes); err == nil {
+			if fieldsWithNames, err := tsc.decoder.DecodeFieldsWithNames(tsc.valueBuffer[min]); err == nil {
 				value = fieldsWithNames
 
 				// if there's a where clause, make sure we don't need to filter this value
-				if minCursor.filter != nil && !matchesWhere(minCursor.filter, fieldsWithNames) {
+				if tsc.cursors[min].filter != nil && !matchesWhere(tsc.cursors[min].filter, fieldsWithNames) {
 					value = nil
 				}
 			}
 		} else {
 			// With only 1 field SELECTed, decoding all fields may be avoidable, which is faster.
 			var err error
-			value, err = tsc.decoder.DecodeByName(selectFields[0], bytes)
+			value, err = tsc.decoder.DecodeByName(selectFields[0], tsc.valueBuffer[min])
 			if err != nil {
-				continue
-			}
-
-			// If there's a WHERE clase, see if we need to filter
-			if minCursor.filter != nil {
-				// See if the WHERE is only on this field or on one or more other fields.
-				// If the latter, we'll have to decode everything
-				if len(whereFields) == 1 && whereFields[0] == selectFields[0] {
-					if !matchesWhere(minCursor.filter, map[string]interface{}{selectFields[0]: value}) {
-						value = nil
-					}
-				} else { // Decode everything
-					fieldsWithNames, err := tsc.decoder.DecodeFieldsWithNames(bytes)
-					if err != nil || !matchesWhere(minCursor.filter, fieldsWithNames) {
-						value = nil
+				value = nil
+			} else {
+				// If there's a WHERE clase, see if we need to filter
+				if tsc.cursors[min].filter != nil {
+					// See if the WHERE is only on this field or on one or more other fields.
+					// If the latter, we'll have to decode everything
+					if len(whereFields) == 1 && whereFields[0] == selectFields[0] {
+						if !matchesWhere(tsc.cursors[min].filter, map[string]interface{}{selectFields[0]: value}) {
+							value = nil
+						}
+					} else { // Decode everything
+						fieldsWithNames, err := tsc.decoder.DecodeFieldsWithNames(tsc.valueBuffer[min])
+						if err != nil || !matchesWhere(tsc.cursors[min].filter, fieldsWithNames) {
+							value = nil
+						}
 					}
 				}
 			}
 		}
+
+		// Advance the cursor
+		nextKey, nextVal := tsc.cursors[min].Next()
+		tsc.keyBuffer[min] = nextKey
+		tsc.valueBuffer[min] = nextVal
 
 		// Value didn't match, look for the next one.
 		if value == nil {
@@ -512,101 +548,38 @@ func (tsc *tagSetCursor) Next(tmin, tmax int64, selectFields, whereFields []stri
 	}
 }
 
-// SeekTo seeks each underlying cursor to the specified key.
-func (tsc *tagSetCursor) SeekTo(key int64) {
-	for _, c := range tsc.cursors {
-		c.SeekTo(key)
-	}
-}
-
-// IsEmpty returns whether the tagsetCursor has any more data for the given interval.
-func (tsc *tagSetCursor) IsEmptyForInterval(tmin, tmax int64) bool {
-	for _, c := range tsc.cursors {
-		k, _ := c.Peek()
-		if k != 0 && k >= tmin && k <= tmax {
-			return false
-		}
-	}
-	return true
-}
-
-// nextCursor returns the series cursor with the lowest next timestamp, within in the specified
-// range. If none exists, nil is returned.
-func (tsc *tagSetCursor) nextCursor(tmin, tmax int64) *seriesCursor {
-	var minCursor *seriesCursor
-	var timestamp int64
-	for _, c := range tsc.cursors {
-		timestamp, _ = c.Peek()
-		if timestamp != 0 && ((timestamp == tmin) || (timestamp >= tmin && timestamp < tmax)) {
-			if minCursor == nil {
-				minCursor = c
-			} else {
-				if currMinTimestamp, _ := minCursor.Peek(); timestamp < currMinTimestamp {
-					minCursor = c
-				}
-			}
-		}
-	}
-	return minCursor
-}
-
 // seriesCursor is a cursor that walks a single series. It provides lookahead functionality.
 type seriesCursor struct {
-	cursor      *shardCursor // BoltDB cursor for a series
-	filter      influxql.Expr
-	keyBuffer   int64  // The current timestamp key for the cursor
-	valueBuffer []byte // The current value for the cursor
+	cursor *shardCursor // BoltDB cursor for a series
+	filter influxql.Expr
 }
 
 // newSeriesCursor returns a new instance of a series cursor.
 func newSeriesCursor(b *shardCursor, filter influxql.Expr) *seriesCursor {
 	return &seriesCursor{
-		cursor:    b,
-		filter:    filter,
-		keyBuffer: -1, // Nothing buffered.
+		cursor: b,
+		filter: filter,
 	}
 }
 
-// Peek returns the next timestamp and value, without changing what will be
-// be returned by a call to Next()
-func (mc *seriesCursor) Peek() (key int64, value []byte) {
-	if mc.keyBuffer == -1 {
-		k, v := mc.cursor.Next()
-		if k == nil {
-			mc.keyBuffer = 0
-		} else {
-			mc.keyBuffer = int64(btou64(k))
-			mc.valueBuffer = v
-		}
+// Seek positions returning the timestamp and value at that key.
+func (sc *seriesCursor) SeekTo(key int64) (timestamp int64, value []byte) {
+	k, v := sc.cursor.Seek(u64tob(uint64(key)))
+	if k == nil {
+		timestamp = -1
+	} else {
+		timestamp, value = int64(btou64(k)), v
 	}
-
-	key, value = mc.keyBuffer, mc.valueBuffer
 	return
 }
 
-// SeekTo positions the cursor at the key, such that Next() will return
-// the key and value at key.
-func (mc *seriesCursor) SeekTo(key int64) {
-	k, v := mc.cursor.Seek(u64tob(uint64(key)))
-	if k == nil {
-		mc.keyBuffer = 0
-	} else {
-		mc.keyBuffer, mc.valueBuffer = int64(btou64(k)), v
-	}
-}
-
 // Next returns the next timestamp and value from the cursor.
-func (mc *seriesCursor) Next() (key int64, value []byte) {
-	if mc.keyBuffer != -1 {
-		key, value = mc.keyBuffer, mc.valueBuffer
-		mc.keyBuffer, mc.valueBuffer = -1, nil
+func (sc *seriesCursor) Next() (key int64, value []byte) {
+	k, v := sc.cursor.Next()
+	if k == nil {
+		key = -1
 	} else {
-		k, v := mc.cursor.Next()
-		if k == nil {
-			key = 0
-		} else {
-			key, value = int64(btou64(k)), v
-		}
+		key, value = int64(btou64(k)), v
 	}
 	return
 }


### PR DESCRIPTION
This change moves tracking of next timestamp and values to simple
slices, as performance measurement showed that Peek() on TagSet cursors
was a huge performance drain. There is much more that can be done here,
but with this in place query performance has been restored to 0.9.1
levels.

This change also uses -1 to indicate that no value is available for a
given timestamp.