### PR TITLE
Fix querying measurement and fields with spaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - [#3356](https://github.com/influxdb/influxdb/pull/3356): Disregard semicolons after database name in use command. Thanks @timraymond.
 - [#3351](https://github.com/influxdb/influxdb/pull/3351): Handle malformed regex comparisons during parsing. Thanks @rnubel
 - [#3256](https://github.com/influxdb/influxdb/pull/3256): Remove unnecessary timeout in WaitForLeader(). Thanks @cannium.
+- [#3319](https://github.com/influxdb/influxdb/issues/3319): restarting process irrevocably BREAKS measurements with spaces
 
 ## v0.9.1 [2015-07-02]
 

--- a/influxql/ast.go
+++ b/influxql/ast.go
@@ -1946,10 +1946,32 @@ func (f *Field) Name() string {
 
 // String returns a string representation of the field.
 func (f *Field) String() string {
-	if f.Alias == "" {
-		return f.Expr.String()
+	str := f.Expr.String()
+
+	switch f.Expr.(type) {
+	case *VarRef:
+		quoted := false
+		// Escape any double-quotes in the field
+		if strings.Contains(str, `"`) {
+			str = strings.Replace(str, `"`, `\"`, -1)
+			quoted = true
+		}
+
+		// Escape any single-quotes in the field
+		if strings.Contains(str, `'`) {
+			quoted = true
+		}
+
+		// Double-quote field names with spaces or that were previously escaped
+		if strings.Contains(str, " ") || quoted {
+			str = fmt.Sprintf("\"%s\"", str)
+		}
 	}
-	return fmt.Sprintf("%s AS %s", f.Expr.String(), f.Alias)
+
+	if f.Alias == "" {
+		return str
+	}
+	return fmt.Sprintf("%s AS %s", str, fmt.Sprintf(`"%s"`, f.Alias))
 }
 
 // Sort Interface for Fields

--- a/influxql/ast_test.go
+++ b/influxql/ast_test.go
@@ -577,6 +577,45 @@ func TestRewrite(t *testing.T) {
 	}
 }
 
+// Ensure that the String() value of a statement is parseable
+func TestParseString(t *testing.T) {
+	var tests = []struct {
+		stmt string
+	}{
+		{
+			stmt: `SELECT "cpu load" FROM myseries`,
+		},
+		{
+			stmt: `SELECT "cpu load" FROM "my series"`,
+		},
+		{
+			stmt: `SELECT "cpu\"load" FROM myseries`,
+		},
+		{
+			stmt: `SELECT "cpu'load" FROM myseries`,
+		},
+		{
+			stmt: `SELECT "cpu load" FROM "my\"series"`,
+		},
+		{
+			stmt: `SELECT * FROM myseries`,
+		},
+	}
+
+	for _, tt := range tests {
+		// Parse statement.
+		stmt, err := influxql.NewParser(strings.NewReader(tt.stmt)).ParseStatement()
+		if err != nil {
+			t.Fatalf("invalid statement: %q: %s", tt.stmt, err)
+		}
+
+		_, err = influxql.NewParser(strings.NewReader(stmt.String())).ParseStatement()
+		if err != nil {
+			t.Fatalf("failed to parse string: %v\norig: %v\ngot: %v", err, tt.stmt, stmt.String())
+		}
+	}
+}
+
 // Ensure an expression can be reduced.
 func TestEval(t *testing.T) {
 	for i, tt := range []struct {

--- a/tsdb/meta.go
+++ b/tsdb/meta.go
@@ -80,6 +80,7 @@ func (s *DatabaseIndex) createSeriesIndexIfNotExists(measurementName string, ser
 
 // createMeasurementIndexIfNotExists creates or retrieves an in memory index object for the measurement
 func (s *DatabaseIndex) createMeasurementIndexIfNotExists(name string) *Measurement {
+	name = unescapeString(name)
 	m := s.measurements[name]
 	if m == nil {
 		m = NewMeasurement(name, s)
@@ -437,7 +438,6 @@ func (m *Measurement) DropSeries(seriesID uint64) {
 // filters walks the where clause of a select statement and returns a map with all series ids
 // matching the where clause and any filter expression that should be applied to each
 func (m *Measurement) filters(stmt *influxql.SelectStatement) (map[uint64]influxql.Expr, error) {
-
 	if stmt.Condition == nil || stmt.OnlyTimeDimensions() {
 		seriesIdsToExpr := make(map[uint64]influxql.Expr)
 		for _, id := range m.seriesIDs {

--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -706,7 +706,7 @@ func (s *Shard) loadMetadataIndex() error {
 				m.fieldNames[name] = struct{}{}
 			}
 			mf.codec = newFieldCodec(mf.Fields)
-			s.measurementFields[string(k)] = mf
+			s.measurementFields[m.Name] = mf
 		}
 
 		// load series metadata


### PR DESCRIPTION
In 0.9.1, measurement and field names were getting added to the shard index with and without escaped characters differently from 0.9.0.  This prevented queries against the measurements because the parser would look for an unescaped measurement, but the index would have the escaped version causing the measurement to not be queryable.  This fix ensures that the index versions are unescaped and also fixes some query bugs where fields and measurements with spaces would not be parseable.

Fixes #3319 