### PR TITLE
Make anonymous reporting opt-in

### DIFF
--- a/etc/config.sample.toml
+++ b/etc/config.sample.toml
@@ -1,12 +1,12 @@
 ### Welcome to the InfluxDB configuration file.
 
-# Once every 24 hours InfluxDB will report anonymous data to m.influxdb.com
+# If you opt in, once every 24 hours InfluxDB will report anonymous data to m.influxdb.com
 # The data includes raft id (random 8 bytes), os, arch, version, and metadata.
 # We don't track ip addresses of servers reporting. This is only used
 # to track the number of instances running and the versions, which
 # is very helpful for us.
-# Change this option to true to disable reporting.
-reporting-disabled = false
+# Change this option to false to enable reporting.
+reporting-disabled = true
 
 ###
 ### [meta]


### PR DESCRIPTION
My backend data store phoning home to the developers without my explicit approval is unexpected and undesirable behavior. This should be opt-in, regardless of how innocent the intent and implementation.