### PR TITLE
Export functionality for 0.8 branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ Makefile
 
 # log file
 influxdb.log
+influxdb.log.*
 benchmark.log
 
 # config file

--- a/_vendor/raft/append_entries.go
+++ b/_vendor/raft/append_entries.go
@@ -4,7 +4,7 @@ import (
 	"io"
 	"io/ioutil"
 
-	"code.google.com/p/gogoprotobuf/proto"
+	"github.com/gogo/protobuf/proto"
 	"github.com/influxdb/influxdb/_vendor/raft/protobuf"
 )
 

--- a/_vendor/raft/log_entry.go
+++ b/_vendor/raft/log_entry.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"io"
 
-	"code.google.com/p/gogoprotobuf/proto"
+	"github.com/gogo/protobuf/proto"
 	"github.com/influxdb/influxdb/_vendor/raft/protobuf"
 )
 

--- a/_vendor/raft/protobuf/append_entries_request.pb.go
+++ b/_vendor/raft/protobuf/append_entries_request.pb.go
@@ -21,14 +21,17 @@
 */
 package protobuf
 
-import proto "code.google.com/p/gogoprotobuf/proto"
-import math "math"
+import (
+	math "math"
+
+	"github.com/gogo/protobuf/proto"
+)
 
 // discarding unused import gogoproto "code.google.com/p/gogoprotobuf/gogoproto/gogo.pb"
 
 import io1 "io"
 import fmt4 "fmt"
-import code_google_com_p_gogoprotobuf_proto2 "code.google.com/p/gogoprotobuf/proto"
+import code_google_com_p_gogoprotobuf_proto2 "github.com/gogo/protobuf/proto"
 
 import fmt5 "fmt"
 import strings2 "strings"
@@ -36,7 +39,7 @@ import reflect2 "reflect"
 
 import fmt6 "fmt"
 import strings3 "strings"
-import code_google_com_p_gogoprotobuf_proto3 "code.google.com/p/gogoprotobuf/proto"
+import code_google_com_p_gogoprotobuf_proto3 "github.com/gogo/protobuf/proto"
 import sort1 "sort"
 import strconv1 "strconv"
 import reflect3 "reflect"

--- a/_vendor/raft/protobuf/append_entries_responses.pb.go
+++ b/_vendor/raft/protobuf/append_entries_responses.pb.go
@@ -4,14 +4,14 @@
 
 package protobuf
 
-import proto "code.google.com/p/gogoprotobuf/proto"
+import proto "github.com/gogo/protobuf/proto"
 import math "math"
 
 // discarding unused import gogoproto "code.google.com/p/gogoprotobuf/gogoproto/gogo.pb"
 
 import io2 "io"
 import fmt8 "fmt"
-import code_google_com_p_gogoprotobuf_proto4 "code.google.com/p/gogoprotobuf/proto"
+import code_google_com_p_gogoprotobuf_proto4 "github.com/gogo/protobuf/proto"
 
 import fmt9 "fmt"
 import strings4 "strings"
@@ -19,7 +19,7 @@ import reflect4 "reflect"
 
 import fmt10 "fmt"
 import strings5 "strings"
-import code_google_com_p_gogoprotobuf_proto5 "code.google.com/p/gogoprotobuf/proto"
+import code_google_com_p_gogoprotobuf_proto5 "github.com/gogo/protobuf/proto"
 import sort2 "sort"
 import strconv2 "strconv"
 import reflect5 "reflect"

--- a/_vendor/raft/protobuf/log_entry.pb.go
+++ b/_vendor/raft/protobuf/log_entry.pb.go
@@ -4,14 +4,14 @@
 
 package protobuf
 
-import proto "code.google.com/p/gogoprotobuf/proto"
+import proto "github.com/gogo/protobuf/proto"
 import math "math"
 
 // discarding unused import gogoproto "code.google.com/p/gogoprotobuf/gogoproto/gogo.pb"
 
 import io "io"
 import fmt "fmt"
-import code_google_com_p_gogoprotobuf_proto "code.google.com/p/gogoprotobuf/proto"
+import code_google_com_p_gogoprotobuf_proto "github.com/gogo/protobuf/proto"
 
 import fmt1 "fmt"
 import strings "strings"
@@ -19,7 +19,7 @@ import reflect "reflect"
 
 import fmt2 "fmt"
 import strings1 "strings"
-import code_google_com_p_gogoprotobuf_proto1 "code.google.com/p/gogoprotobuf/proto"
+import code_google_com_p_gogoprotobuf_proto1 "github.com/gogo/protobuf/proto"
 import sort "sort"
 import strconv "strconv"
 import reflect1 "reflect"

--- a/_vendor/raft/protobuf/request_vote_request.pb.go
+++ b/_vendor/raft/protobuf/request_vote_request.pb.go
@@ -4,14 +4,14 @@
 
 package protobuf
 
-import proto "code.google.com/p/gogoprotobuf/proto"
+import proto "github.com/gogo/protobuf/proto"
 import math "math"
 
 // discarding unused import gogoproto "code.google.com/p/gogoprotobuf/gogoproto/gogo.pb"
 
 import io3 "io"
 import fmt12 "fmt"
-import code_google_com_p_gogoprotobuf_proto6 "code.google.com/p/gogoprotobuf/proto"
+import code_google_com_p_gogoprotobuf_proto6 "github.com/gogo/protobuf/proto"
 
 import fmt13 "fmt"
 import strings6 "strings"
@@ -19,7 +19,7 @@ import reflect6 "reflect"
 
 import fmt14 "fmt"
 import strings7 "strings"
-import code_google_com_p_gogoprotobuf_proto7 "code.google.com/p/gogoprotobuf/proto"
+import code_google_com_p_gogoprotobuf_proto7 "github.com/gogo/protobuf/proto"
 import sort3 "sort"
 import strconv3 "strconv"
 import reflect7 "reflect"

--- a/_vendor/raft/protobuf/request_vote_responses.pb.go
+++ b/_vendor/raft/protobuf/request_vote_responses.pb.go
@@ -4,14 +4,14 @@
 
 package protobuf
 
-import proto "code.google.com/p/gogoprotobuf/proto"
+import proto "github.com/gogo/protobuf/proto"
 import math "math"
 
 // discarding unused import gogoproto "code.google.com/p/gogoprotobuf/gogoproto/gogo.pb"
 
 import io4 "io"
 import fmt16 "fmt"
-import code_google_com_p_gogoprotobuf_proto8 "code.google.com/p/gogoprotobuf/proto"
+import code_google_com_p_gogoprotobuf_proto8 "github.com/gogo/protobuf/proto"
 
 import fmt17 "fmt"
 import strings8 "strings"
@@ -19,7 +19,7 @@ import reflect8 "reflect"
 
 import fmt18 "fmt"
 import strings9 "strings"
-import code_google_com_p_gogoprotobuf_proto9 "code.google.com/p/gogoprotobuf/proto"
+import code_google_com_p_gogoprotobuf_proto9 "github.com/gogo/protobuf/proto"
 import sort4 "sort"
 import strconv4 "strconv"
 import reflect9 "reflect"

--- a/_vendor/raft/protobuf/snapshot_recovery_request.pb.go
+++ b/_vendor/raft/protobuf/snapshot_recovery_request.pb.go
@@ -4,14 +4,14 @@
 
 package protobuf
 
-import proto "code.google.com/p/gogoprotobuf/proto"
+import proto "github.com/gogo/protobuf/proto"
 import math "math"
 
 // discarding unused import gogoproto "code.google.com/p/gogoprotobuf/gogoproto/gogo.pb"
 
 import io5 "io"
 import fmt20 "fmt"
-import code_google_com_p_gogoprotobuf_proto10 "code.google.com/p/gogoprotobuf/proto"
+import code_google_com_p_gogoprotobuf_proto10 "github.com/gogo/protobuf/proto"
 
 import fmt21 "fmt"
 import strings10 "strings"
@@ -19,7 +19,7 @@ import reflect10 "reflect"
 
 import fmt22 "fmt"
 import strings11 "strings"
-import code_google_com_p_gogoprotobuf_proto11 "code.google.com/p/gogoprotobuf/proto"
+import code_google_com_p_gogoprotobuf_proto11 "github.com/gogo/protobuf/proto"
 import sort5 "sort"
 import strconv5 "strconv"
 import reflect11 "reflect"

--- a/_vendor/raft/protobuf/snapshot_recovery_response.pb.go
+++ b/_vendor/raft/protobuf/snapshot_recovery_response.pb.go
@@ -4,14 +4,14 @@
 
 package protobuf
 
-import proto "code.google.com/p/gogoprotobuf/proto"
+import proto "github.com/gogo/protobuf/proto"
 import math "math"
 
 // discarding unused import gogoproto "code.google.com/p/gogoprotobuf/gogoproto/gogo.pb"
 
 import io6 "io"
 import fmt24 "fmt"
-import code_google_com_p_gogoprotobuf_proto12 "code.google.com/p/gogoprotobuf/proto"
+import code_google_com_p_gogoprotobuf_proto12 "github.com/gogo/protobuf/proto"
 
 import fmt25 "fmt"
 import strings12 "strings"
@@ -19,7 +19,7 @@ import reflect12 "reflect"
 
 import fmt26 "fmt"
 import strings13 "strings"
-import code_google_com_p_gogoprotobuf_proto13 "code.google.com/p/gogoprotobuf/proto"
+import code_google_com_p_gogoprotobuf_proto13 "github.com/gogo/protobuf/proto"
 import sort6 "sort"
 import strconv6 "strconv"
 import reflect13 "reflect"

--- a/_vendor/raft/protobuf/snapshot_request.pb.go
+++ b/_vendor/raft/protobuf/snapshot_request.pb.go
@@ -4,14 +4,14 @@
 
 package protobuf
 
-import proto "code.google.com/p/gogoprotobuf/proto"
+import proto "github.com/gogo/protobuf/proto"
 import math "math"
 
 // discarding unused import gogoproto "code.google.com/p/gogoprotobuf/gogoproto/gogo.pb"
 
 import io7 "io"
 import fmt28 "fmt"
-import code_google_com_p_gogoprotobuf_proto14 "code.google.com/p/gogoprotobuf/proto"
+import code_google_com_p_gogoprotobuf_proto14 "github.com/gogo/protobuf/proto"
 
 import fmt29 "fmt"
 import strings14 "strings"
@@ -19,7 +19,7 @@ import reflect14 "reflect"
 
 import fmt30 "fmt"
 import strings15 "strings"
-import code_google_com_p_gogoprotobuf_proto15 "code.google.com/p/gogoprotobuf/proto"
+import code_google_com_p_gogoprotobuf_proto15 "github.com/gogo/protobuf/proto"
 import sort7 "sort"
 import strconv7 "strconv"
 import reflect15 "reflect"

--- a/_vendor/raft/protobuf/snapshot_response.pb.go
+++ b/_vendor/raft/protobuf/snapshot_response.pb.go
@@ -4,14 +4,14 @@
 
 package protobuf
 
-import proto "code.google.com/p/gogoprotobuf/proto"
+import proto "github.com/gogo/protobuf/proto"
 import math "math"
 
 // discarding unused import gogoproto "code.google.com/p/gogoprotobuf/gogoproto/gogo.pb"
 
 import io8 "io"
 import fmt32 "fmt"
-import code_google_com_p_gogoprotobuf_proto16 "code.google.com/p/gogoprotobuf/proto"
+import code_google_com_p_gogoprotobuf_proto16 "github.com/gogo/protobuf/proto"
 
 import fmt33 "fmt"
 import strings16 "strings"
@@ -19,7 +19,7 @@ import reflect16 "reflect"
 
 import fmt34 "fmt"
 import strings17 "strings"
-import code_google_com_p_gogoprotobuf_proto17 "code.google.com/p/gogoprotobuf/proto"
+import code_google_com_p_gogoprotobuf_proto17 "github.com/gogo/protobuf/proto"
 import sort8 "sort"
 import strconv8 "strconv"
 import reflect17 "reflect"

--- a/_vendor/raft/request_vote.go
+++ b/_vendor/raft/request_vote.go
@@ -4,7 +4,7 @@ import (
 	"io"
 	"io/ioutil"
 
-	"code.google.com/p/gogoprotobuf/proto"
+	"github.com/gogo/protobuf/proto"
 	"github.com/influxdb/influxdb/_vendor/raft/protobuf"
 )
 

--- a/_vendor/raft/snapshot.go
+++ b/_vendor/raft/snapshot.go
@@ -9,8 +9,8 @@ import (
 	"io/ioutil"
 	"os"
 
-	"code.google.com/p/gogoprotobuf/proto"
 	"github.com/dgnorton/goback"
+	"github.com/gogo/protobuf/proto"
 	"github.com/influxdb/influxdb/_vendor/raft/protobuf"
 )
 

--- a/api/coordinator.go
+++ b/api/coordinator.go
@@ -21,4 +21,5 @@ type Coordinator interface {
 	CreateDatabase(cmn.User, string) error
 	ListDatabases(cmn.User) ([]*cluster.Database, error)
 	DropDatabase(cmn.User, string) error
+	GetShardSpacesForDatabase(database string) []*cluster.ShardSpace
 }

--- a/api/http/api.go
+++ b/api/http/api.go
@@ -307,21 +307,8 @@ func (self *ExportPointsWriter) yield(series *protocol.Series) error {
 			}
 
 			p9 := NewPoint9(name, tags, fields, time.Unix(0, epoch*1000))
+			// Write line protocol
 			self.w.Write([]byte(p9.String()))
-			// Write the series name
-			//self.w.Write(escape([]byte(*series.Name)))
-
-			//// Write space
-			//self.w.Write([]byte{' '})
-
-			//// Write the values
-			//self.w.Write(data)
-
-			//// Write space
-			//self.w.Write([]byte{' '})
-
-			//// Write the timestamp
-			//self.w.Write([]byte(strconv.FormatInt(epoch*1000*1000, 10)))
 
 			// Write a line return
 			self.w.Write([]byte{'\n'})

--- a/api/http/fields.go
+++ b/api/http/fields.go
@@ -1,0 +1,114 @@
+package http
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+var (
+	// Compile the regex that detects unquoted double quote sequences
+	quoteReplacer = regexp.MustCompile(`([^\\])"`)
+
+	escapeCodes = map[byte][]byte{
+		',': []byte(`\,`),
+		'"': []byte(`\"`),
+		' ': []byte(`\ `),
+		'=': []byte(`\=`),
+	}
+
+	escapeCodesStr = map[string]string{}
+)
+
+func init() {
+	for k, v := range escapeCodes {
+		escapeCodesStr[string(k)] = string(v)
+	}
+}
+
+type Fields map[string]interface{}
+
+func (p Fields) MarshalBinary() []byte {
+	b := []byte{}
+	keys := make([]string, len(p))
+	i := 0
+	for k, _ := range p {
+		keys[i] = k
+		i += 1
+	}
+	sort.Strings(keys)
+
+	for _, k := range keys {
+		v := p[k]
+		b = append(b, []byte(escapeString(k))...)
+		b = append(b, '=')
+		switch t := v.(type) {
+		case int:
+			b = append(b, []byte(strconv.FormatInt(int64(t), 10))...)
+		case int32:
+			b = append(b, []byte(strconv.FormatInt(int64(t), 10))...)
+		case uint64:
+			b = append(b, []byte(strconv.FormatUint(t, 10))...)
+		case int64:
+			b = append(b, []byte(strconv.FormatInt(t, 10))...)
+		case float64:
+			// ensure there is a decimal in the encoded for
+
+			val := []byte(strconv.FormatFloat(t, 'f', -1, 64))
+			_, frac := math.Modf(t)
+			hasDecimal := frac != 0
+			b = append(b, val...)
+			if !hasDecimal {
+				b = append(b, []byte(".0")...)
+			}
+		case bool:
+			b = append(b, []byte(strconv.FormatBool(t))...)
+		case []byte:
+			b = append(b, t...)
+		case string:
+			b = append(b, '"')
+			b = append(b, []byte(escapeQuoteString(t))...)
+			b = append(b, '"')
+		case nil:
+			// skip
+		default:
+			// Can't determine the type, so convert to string
+			b = append(b, '"')
+			b = append(b, []byte(escapeQuoteString(fmt.Sprintf("%v", v)))...)
+			b = append(b, '"')
+
+		}
+		b = append(b, ',')
+	}
+	if len(b) > 0 {
+		return b[0 : len(b)-1]
+	}
+	return b
+}
+
+func escapeString(in string) string {
+	for b, esc := range escapeCodesStr {
+		in = strings.Replace(in, b, esc, -1)
+	}
+	return in
+}
+
+// escapeQuoteString returns a copy of in with any double quotes that
+// have not been escaped with escaped quotes
+func escapeQuoteString(in string) string {
+	if strings.IndexAny(in, `"`) == -1 {
+		return in
+	}
+	return quoteReplacer.ReplaceAllString(in, `$1\"`)
+}
+
+func escape(in []byte) []byte {
+	for b, esc := range escapeCodes {
+		in = bytes.Replace(in, []byte{b}, esc, -1)
+	}
+	return in
+}

--- a/api/http/gzip_filter.go
+++ b/api/http/gzip_filter.go
@@ -1,0 +1,24 @@
+package http
+
+import (
+	"compress/gzip"
+	"io"
+	libhttp "net/http"
+)
+
+type gzipResponseWriter struct {
+	io.Writer
+	libhttp.ResponseWriter
+}
+
+func (w gzipResponseWriter) Write(b []byte) (int, error) {
+	return w.Writer.Write(b)
+}
+
+func (w gzipResponseWriter) Flush() {
+	w.Writer.(*gzip.Writer).Flush()
+}
+
+func (w gzipResponseWriter) CloseNotify() <-chan bool {
+	return w.ResponseWriter.(libhttp.CloseNotifier).CloseNotify()
+}

--- a/api/http/http_compression.go
+++ b/api/http/http_compression.go
@@ -45,6 +45,10 @@ func (self *CompressedResponseWriter) Header() libhttp.Header {
 	return self.responseWriter.Header()
 }
 
+func (self *CompressedResponseWriter) CloseNotify() <-chan bool {
+	return self.writer.(libhttp.CloseNotifier).CloseNotify()
+}
+
 func (self *CompressedResponseWriter) Write(bs []byte) (int, error) {
 	return self.writer.Write(bs)
 }

--- a/api/http/http_compression.go
+++ b/api/http/http_compression.go
@@ -46,7 +46,7 @@ func (self *CompressedResponseWriter) Header() libhttp.Header {
 }
 
 func (self *CompressedResponseWriter) CloseNotify() <-chan bool {
-	return self.writer.(libhttp.CloseNotifier).CloseNotify()
+	return self.responseWriter.(libhttp.CloseNotifier).CloseNotify()
 }
 
 func (self *CompressedResponseWriter) Write(bs []byte) (int, error) {

--- a/api/http/points.go
+++ b/api/http/points.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 )
 
 var (
@@ -28,6 +29,89 @@ func init() {
 	for k, v := range escapeCodes {
 		escapeCodesStr[string(k)] = string(v)
 	}
+}
+
+// Point9 represents a 0.9 tsdb point
+type Point9 struct {
+	time time.Time
+
+	// text encoding of measurement and tags
+	// key must always be stored sorted by tags, if the original line was not sorted,
+	// we need to resort it
+	key []byte
+
+	// text encoding of field data
+	fields []byte
+
+	// text encoding of timestamp
+	ts []byte
+
+	// binary encoded field data
+	data []byte
+}
+
+// NewPoint returns a new point with the given measurement name, tags, fields and timestamp
+func NewPoint9(name string, tags Tags, fields Fields, time time.Time) *Point9 {
+	return &Point9{
+		key:    makeKey([]byte(name), tags),
+		time:   time,
+		fields: fields.MarshalBinary(),
+	}
+}
+
+func (p *Point9) String() string {
+	if p.time.IsZero() {
+		return fmt.Sprintf("%s %s", p.key, string(p.fields))
+	}
+	return fmt.Sprintf("%s %s %d", p.key, string(p.fields), p.time.UnixNano())
+}
+
+func makeKey(name []byte, tags Tags) []byte {
+	return append(escape(name), tags.HashKey()...)
+}
+
+type Tags map[string]string
+
+func (t Tags) HashKey() []byte {
+	// Empty maps marshal to empty bytes.
+	if len(t) == 0 {
+		return nil
+	}
+
+	escaped := Tags{}
+	for k, v := range t {
+		ek := escapeString(k)
+		ev := escapeString(v)
+		escaped[ek] = ev
+	}
+
+	// Extract keys and determine final size.
+	sz := len(escaped) + (len(escaped) * 2) // separators
+	keys := make([]string, len(escaped)+1)
+	i := 0
+	for k, v := range escaped {
+		keys[i] = k
+		i += 1
+		sz += len(k) + len(v)
+	}
+	keys = keys[:i]
+	sort.Strings(keys)
+	// Generate marshaled bytes.
+	b := make([]byte, sz)
+	buf := b
+	idx := 0
+	for _, k := range keys {
+		buf[idx] = ','
+		idx += 1
+		copy(buf[idx:idx+len(k)], k)
+		idx += len(k)
+		buf[idx] = '='
+		idx += 1
+		v := escaped[k]
+		copy(buf[idx:idx+len(v)], v)
+		idx += len(v)
+	}
+	return b[:idx]
 }
 
 type Fields map[string]interface{}
@@ -111,4 +195,18 @@ func escape(in []byte) []byte {
 		in = bytes.Replace(in, []byte{b}, esc, -1)
 	}
 	return in
+}
+
+func parseSeriesName(series, separator string) (string, map[string]string, error) {
+	var name string
+	tags := make(map[string]string)
+	vals := strings.Split(series, separator)
+	if len(vals)%2 != 1 {
+		return "", tags, fmt.Errorf("invalid series name format: %s", series)
+	}
+	name = vals[len(vals)-1]
+	for i := 0; i < len(vals)-1; i += 2 {
+		tags[vals[i]] = vals[i+1]
+	}
+	return name, tags, nil
 }

--- a/cluster/cluster_configuration.go
+++ b/cluster/cluster_configuration.go
@@ -768,12 +768,10 @@ func (self *ClusterConfiguration) AuthenticateClusterAdmin(username, password st
 	if user == nil {
 		return nil, common.NewAuthorizationError("Invalid username/password")
 	}
-	// TODO return this to normal auth after testing is finished
-	return user, nil
-	//if user.isValidPwd(password) {
-	//return user, nil
-	//}
-	//return nil, common.NewAuthorizationError("Invalid username/password")
+	if user.isValidPwd(password) {
+		return user, nil
+	}
+	return nil, common.NewAuthorizationError("Invalid username/password")
 }
 
 func (self *ClusterConfiguration) HasContinuousQueries() bool {

--- a/cluster/cluster_configuration.go
+++ b/cluster/cluster_configuration.go
@@ -645,7 +645,7 @@ func (self *ClusterConfiguration) convertNewShardDataToShards(newShards []*NewSh
 			if serverId == self.LocalServer.Id {
 				err := shard.SetLocalStore(self.shardStore, self.LocalServer.Id)
 				if err != nil {
-					log.Error("CliusterConfig convertNewShardDataToShards: ", err)
+					log.Error("ClusterConfig convertNewShardDataToShards: %s", err)
 				}
 			} else {
 				server := self.GetServerById(&serverId)
@@ -757,10 +757,12 @@ func (self *ClusterConfiguration) AuthenticateDbUser(db, username, password stri
 		return nil, common.NewAuthorizationError("Invalid username/password")
 	}
 	user := dbUsers[username]
-	if user.isValidPwd(password) {
-		return user, nil
-	}
-	return nil, common.NewAuthorizationError("Invalid username/password")
+	// TODO return this to normal auth after testing is finished
+	return user, nil
+	//if user.isValidPwd(password) {
+	//return user, nil
+	//}
+	//return nil, common.NewAuthorizationError("Invalid username/password")
 }
 
 func (self *ClusterConfiguration) AuthenticateClusterAdmin(username, password string) (common.User, error) {
@@ -768,10 +770,12 @@ func (self *ClusterConfiguration) AuthenticateClusterAdmin(username, password st
 	if user == nil {
 		return nil, common.NewAuthorizationError("Invalid username/password")
 	}
-	if user.isValidPwd(password) {
-		return user, nil
-	}
-	return nil, common.NewAuthorizationError("Invalid username/password")
+	// TODO return this to normal auth after testing is finished
+	return user, nil
+	//if user.isValidPwd(password) {
+	//return user, nil
+	//}
+	//return nil, common.NewAuthorizationError("Invalid username/password")
 }
 
 func (self *ClusterConfiguration) HasContinuousQueries() bool {
@@ -1072,7 +1076,7 @@ func (self *ClusterConfiguration) AddShards(shards []*NewShardData) ([]*ShardDat
 			if self.LocalServer != nil && serverId == self.LocalServer.Id {
 				err := shard.SetLocalStore(self.shardStore, self.LocalServer.Id)
 				if err != nil {
-					log.Error("AddShards: error setting local store: ", err)
+					log.Error("AddShards: error setting local store: %s", err)
 					return nil, err
 				}
 			} else {

--- a/cluster/cluster_configuration.go
+++ b/cluster/cluster_configuration.go
@@ -757,12 +757,10 @@ func (self *ClusterConfiguration) AuthenticateDbUser(db, username, password stri
 		return nil, common.NewAuthorizationError("Invalid username/password")
 	}
 	user := dbUsers[username]
-	// TODO return this to normal auth after testing is finished
-	return user, nil
-	//if user.isValidPwd(password) {
-	//return user, nil
-	//}
-	//return nil, common.NewAuthorizationError("Invalid username/password")
+	if user.isValidPwd(password) {
+		return user, nil
+	}
+	return nil, common.NewAuthorizationError("Invalid username/password")
 }
 
 func (self *ClusterConfiguration) AuthenticateClusterAdmin(username, password string) (common.User, error) {

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -298,9 +298,6 @@ func parseTomlConfiguration(filename string) (*Configuration, error) {
 	}
 
 	apiReadTimeout := tomlConfiguration.HttpApi.ReadTimeout.Duration
-	if apiReadTimeout == 0 {
-		apiReadTimeout = 5 * time.Second
-	}
 
 	if tomlConfiguration.Cluster.MinBackoff.Duration == 0 {
 		tomlConfiguration.Cluster.MinBackoff = duration{time.Second}

--- a/coordinator/coordinator.go
+++ b/coordinator/coordinator.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"time"
 
-	"code.google.com/p/goprotobuf/proto"
 	log "code.google.com/p/log4go"
+	"github.com/gogo/protobuf/proto"
 	"github.com/influxdb/influxdb/cluster"
 	"github.com/influxdb/influxdb/common"
 	"github.com/influxdb/influxdb/configuration"

--- a/coordinator/coordinator.go
+++ b/coordinator/coordinator.go
@@ -711,6 +711,10 @@ func (self *Coordinator) DropDatabase(user common.User, db string) error {
 	return self.raftServer.DropDatabase(db)
 }
 
+func (self *Coordinator) GetShardSpacesForDatabase(database string) []*cluster.ShardSpace {
+	return self.clusterConfiguration.GetShardSpacesForDatabase(database)
+}
+
 func (self *Coordinator) AuthenticateDbUser(db, username, password string) (common.User, error) {
 	log.Debug("(raft:%s) Authenticating password for %s:%s", self.raftServer.raftServer.Name(), db, username)
 	user, err := self.clusterConfiguration.AuthenticateDbUser(db, username, password)

--- a/datastore/point_iterator.go
+++ b/datastore/point_iterator.go
@@ -3,8 +3,8 @@ package datastore
 import (
 	"time"
 
-	"code.google.com/p/goprotobuf/proto"
 	"code.google.com/p/log4go"
+	"github.com/gogo/protobuf/proto"
 	"github.com/influxdb/influxdb/datastore/storage"
 	"github.com/influxdb/influxdb/metastore"
 	"github.com/influxdb/influxdb/protocol"

--- a/datastore/shard.go
+++ b/datastore/shard.go
@@ -8,8 +8,8 @@ import (
 	"sync"
 	"time"
 
-	"code.google.com/p/goprotobuf/proto"
 	log "code.google.com/p/log4go"
+	"github.com/gogo/protobuf/proto"
 	"github.com/influxdb/influxdb/common"
 	"github.com/influxdb/influxdb/datastore/storage"
 	"github.com/influxdb/influxdb/engine"

--- a/datastore/shard_datastore.go
+++ b/datastore/shard_datastore.go
@@ -162,7 +162,7 @@ func (self *ShardDatastore) GetOrCreateShard(id uint32) (cluster.LocalShardDb, e
 	}
 	init, err := storage.GetInitializer(engine)
 	if err != nil {
-		log.Error("Error opening shard: ", err)
+		log.Error("Error opening shard: %s", err)
 		return nil, err
 	}
 	c := init.NewConfig()

--- a/datastore/utils.go
+++ b/datastore/utils.go
@@ -1,9 +1,9 @@
 package datastore
 
 import (
-	"code.google.com/p/goprotobuf/proto"
 	"code.google.com/p/log4go"
 
+	"github.com/gogo/protobuf/proto"
 	"github.com/influxdb/influxdb/engine"
 	"github.com/influxdb/influxdb/protocol"
 )

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -160,3 +160,12 @@ const gitSha = `foo`
 
 build it with `go build -o ~/go/bin/influxd.0.8.9 -tags rocksdb ./daemon`
 run it with `influxd.0.8.9 -config=/Users/corylanou/go/src/github.com/influxdb/sample_data/config.toml`
+
+### Configuration Changes
+
+To make sure the export endpoint does not timeout, you will need to change your timeout in the config as follows:
+
+```toml
+[api]
+read-timeout = "0s"
+```

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -129,13 +129,32 @@ Useful links
 Getting v08.8.9 Running
 --------------
 
+
+### getting protobufs working
+
+Download and install protobuf.
+
+run:
+
+```
+protoc --go_out=. protocol/*.proto
+```
+
+
+### build parser files
+
+```sh
+cd ./parser
+build_parser.sh
+```
+
 ### leveldb files:
 ```
+brew install leveldb
 mkdir -p /tmp/leveldb.influxdb.amd64
 cd /tmp/leveldb.influxdb.amd64
 wget https://leveldb.googlecode.com/files/leveldb-1.15.0.tar.gz
 tar --strip-components=1 -xvzf leveldb-1.15.0.tar.gz
-
 ```
 
 
@@ -146,10 +165,9 @@ mkdir -p /tmp/rocksdb.influxdb.amd64
 cd /tmp/rocksdb.influxdb.amd64
 wget https://github.com/facebook/rocksdb/archive/rocksdb-3.5.1.tar.gz
 tar --strip-components=1 -xvzf rocksdb-3.5.1.tar.gz
-
 ```
 
-Create a version file in `daemon` called `influxd_version.go` and put the following content in it:
+Create a version file in `daemon` called `version.go` and put the following content in it:
 
 ``` go
 package main

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -125,3 +125,38 @@ Useful links
 - [Go in production](http://peter.bourgon.org/go-in-production/)
 - [Principles of designing Go APIs with channels](https://inconshreveable.com/07-08-2014/principles-of-designing-go-apis-with-channels/)
 - [Common mistakes in Golang](http://soryy.com/blog/2014/common-mistakes-with-go-lang/). Especially this section `Loops, Closures, and Local Variables`
+
+Getting v08.8.9 Running
+--------------
+
+### leveldb files:
+```
+mkdir -p /tmp/leveldb.influxdb.amd64
+cd /tmp/leveldb.influxdb.amd64
+wget https://leveldb.googlecode.com/files/leveldb-1.15.0.tar.gz
+tar --strip-components=1 -xvzf leveldb-1.15.0.tar.gz
+
+```
+
+
+### rocksdb files:
+```
+brew install rocksdb
+mkdir -p /tmp/rocksdb.influxdb.amd64
+cd /tmp/rocksdb.influxdb.amd64
+wget https://github.com/facebook/rocksdb/archive/rocksdb-3.5.1.tar.gz
+tar --strip-components=1 -xvzf rocksdb-3.5.1.tar.gz
+
+```
+
+Create a version file in `daemon` called `influxd_version.go` and put the following content in it:
+
+``` go
+package main
+
+const version = `08.8.9`
+const gitSha = `foo`
+```
+
+build it with `go build -o ~/go/bin/influxd.0.8.9 -tags rocksdb ./daemon`
+run it with `influxd.0.8.9 -config=/Users/corylanou/go/src/github.com/influxdb/sample_data/config.toml`

--- a/engine/aggregator_operators.go
+++ b/engine/aggregator_operators.go
@@ -8,8 +8,7 @@ import (
 	"strings"
 	"time"
 
-	"code.google.com/p/goprotobuf/proto"
-
+	"github.com/gogo/protobuf/proto"
 	"github.com/influxdb/influxdb/common"
 	"github.com/influxdb/influxdb/parser"
 	"github.com/influxdb/influxdb/protocol"

--- a/protocol/protocol_extensions.go
+++ b/protocol/protocol_extensions.go
@@ -6,9 +6,9 @@ import (
 	"sort"
 	"strconv"
 
-	"math"
+	"github.com/gogo/protobuf/proto"
 
-	"code.google.com/p/goprotobuf/proto"
+	"math"
 )
 
 var String = proto.String

--- a/tools/benchmark-storage/config.go
+++ b/tools/benchmark-storage/config.go
@@ -6,7 +6,7 @@ import (
 	"math/rand"
 	"time"
 
-	"code.google.com/p/goprotobuf/proto"
+	"github.com/gogo/protobuf/proto"
 	"github.com/influxdb/influxdb/datastore/storage"
 	"github.com/influxdb/influxdb/protocol"
 )

--- a/wal/log.go
+++ b/wal/log.go
@@ -8,8 +8,8 @@ import (
 	"strconv"
 	"strings"
 
-	"code.google.com/p/goprotobuf/proto"
 	logger "code.google.com/p/log4go"
+	"github.com/gogo/protobuf/proto"
 	"github.com/influxdb/influxdb/configuration"
 	"github.com/influxdb/influxdb/protocol"
 )

--- a/wal/wal.go
+++ b/wal/wal.go
@@ -8,8 +8,8 @@ import (
 	"sort"
 	"strings"
 
-	"code.google.com/p/goprotobuf/proto"
 	logger "code.google.com/p/log4go"
+	"github.com/gogo/protobuf/proto"
 	"github.com/influxdb/influxdb/configuration"
 	"github.com/influxdb/influxdb/protocol"
 )

--- a/wal/wal_test.go
+++ b/wal/wal_test.go
@@ -8,8 +8,8 @@ import (
 	"testing"
 	"time"
 
-	"code.google.com/p/goprotobuf/proto"
 	logger "code.google.com/p/log4go"
+	"github.com/gogo/protobuf/proto"
 	. "github.com/influxdb/influxdb/checkers"
 	"github.com/influxdb/influxdb/configuration"
 	"github.com/influxdb/influxdb/protocol"


### PR DESCRIPTION
This PR will address issue https://github.com/influxdb/influxdb/issues/2378

## Design

This is phase 1 of 2.  This is the `export` function that users of `0.8` need to upgrade to.

Phase one exports raw data from `0.8` to a flat file that includes two sections, `DDL` and `DML`.  You can choose to export them independently (see below).

The `DDL` section contains the sql commands to create databases and retention policies.  the `DML` section is [line protocol](https://github.com/influxdb/influxdb/blob/master/tsdb/README.md) and can be directly posted to the [http endpoint](https://influxdb.com/docs/v0.9/guides/writing_data.html) in `0.9`.  Remember that batching is important and we don't recommend batch sizes over 5k.

You will specify a database and shard group when you export.  This will be done from the `0.8.9` branch that users will have to upgrade to.

To list out your shards, use the following http endpoint:

`/cluster/shard_spaces`

example:
```sh
http://username:password@localhost:8086/cluster/shard_spaces
```

Then, to export a database with then name "metrics" and a shard space with the name "default", issue the following curl command:

```sh
curl -o export http://username:password@http://localhost:8086/export/metrics/default
```

Compression is supported, and will result in a significantly smaller file size.  Use the following command for compression:

```sh
curl -o export.gz --compressed http://username:password@http://localhost:8086/export/metrics/default
```

You can also export just the `DDL` with this option:

```sh
curl -o export.ddl http://username:password@http://localhost:8086/export/metrics/default?l=ddl
```

Or just the `DML` with this option:

```sh
curl -o export.dml.gz --compressed http://username:password@http://localhost:8086/export/metrics/default?l=dml
```

## Assumptions

- Series name mapping follows these [guidelines](https://influxdb.com/docs/v0.8/advanced_topics/schema_design.html)
- Database name will map directly from `0.8` to `0.9`
- Shard Space to Retention Policy mapping
    - Shard Space Duration is ignored, as in `0.9` we determine shard size
    - Regex is used to match the correct series names and only exports that data for the database
    - Duration becomes the new Retention Policy duration

- Users - Not migrating due to inability to get passwords.  Anyone using users will need to manually set these back up in `0.9`

This PR replaces https://github.com/influxdb/influxdb/pull/3001/
