### PR TITLE
Support incremental cluster joins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - [#3376](https://github.com/influxdb/influxdb/pull/3376): Support for remote shard query mapping
 - [#3372](https://github.com/influxdb/influxdb/pull/3372): Support joining nodes to existing cluster
 - [#3426](https://github.com/influxdb/influxdb/pull/3426): Additional logging for continuous queries. Thanks @jhorwit2
+- [#3478](https://github.com/influxdb/influxdb/pull/3478)): Support incremental cluster joins
 
 ### Bugfixes
 - [#3405](https://github.com/influxdb/influxdb/pull/3405): Prevent database panic when fields are missing. Thanks @jhorwit2

--- a/cmd/influxd/run/command.go
+++ b/cmd/influxd/run/command.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strconv"
+	"strings"
 
 	"github.com/BurntSushi/toml"
 )
@@ -83,7 +84,7 @@ func (cmd *Command) Run(args ...string) error {
 	}
 
 	if options.Join != "" {
-		config.Meta.Join = options.Join
+		config.Meta.Peers = strings.Split(options.Join, ",")
 	}
 
 	// Validate the configuration.

--- a/cmd/influxd/run/server.go
+++ b/cmd/influxd/run/server.go
@@ -380,6 +380,7 @@ func (s *Server) startServerReporting() {
 		}
 		if err := s.MetaStore.WaitForLeader(30 * time.Second); err != nil {
 			log.Printf("no leader available for reporting: %s", err.Error())
+			time.Sleep(time.Second)
 			continue
 		}
 		s.reportServer()

--- a/cmd/influxd/run/server.go
+++ b/cmd/influxd/run/server.go
@@ -373,6 +373,11 @@ func (s *Server) Close() error {
 // startServerReporting starts periodic server reporting.
 func (s *Server) startServerReporting() {
 	for {
+		select {
+		case <-s.closing:
+			return
+		default:
+		}
 		if err := s.MetaStore.WaitForLeader(30 * time.Second); err != nil {
 			log.Printf("no leader available for reporting: %s", err.Error())
 			continue

--- a/meta/config.go
+++ b/meta/config.go
@@ -38,9 +38,6 @@ type Config struct {
 	LeaderLeaseTimeout  toml.Duration `toml:"leader-lease-timeout"`
 	CommitTimeout       toml.Duration `toml:"commit-timeout"`
 	ClusterTracing      bool          `toml:"cluster-tracing"`
-
-	// The join command-line argument
-	Join string `toml:"-"`
 }
 
 func NewConfig() *Config {

--- a/meta/rpc.go
+++ b/meta/rpc.go
@@ -395,11 +395,13 @@ func (r *rpc) call(dest string, req proto.Message) (proto.Message, error) {
 
 	// Should always have a size and type
 	if exp := 16; len(data) < exp {
+		r.traceCluster("recv: %v", string(data))
 		return nil, fmt.Errorf("rpc %v failed: short read: got %v, exp %v", rpcType, len(data), exp)
 	}
 
 	sz := btou64(data[0:8])
 	if len(data[8:]) != int(sz) {
+		r.traceCluster("recv: %v", string(data))
 		return nil, fmt.Errorf("rpc %v failed: short read: got %v, exp %v", rpcType, len(data[8:]), sz)
 	}
 

--- a/meta/rpc_test.go
+++ b/meta/rpc_test.go
@@ -159,7 +159,7 @@ func TestRPCJoin(t *testing.T) {
 		t.Fatalf("failed to join: %v", err)
 	}
 
-	if exp := false; res.RaftEnabled != false {
+	if exp := true; res.RaftEnabled != true {
 		t.Fatalf("raft enabled mismatch: got %v, exp %v", res.RaftEnabled, exp)
 	}
 
@@ -230,7 +230,7 @@ func (f *fakeStore) cachedData() *Data {
 
 func (f *fakeStore) IsLeader() bool            { return true }
 func (f *fakeStore) Leader() string            { return f.leader }
-func (f *fakeStore) Peers() []string           { return []string{f.leader} }
+func (f *fakeStore) Peers() ([]string, error)  { return []string{f.leader}, nil }
 func (f *fakeStore) AddPeer(host string) error { return nil }
 func (f *fakeStore) CreateNode(host string) (*NodeInfo, error) {
 	return &NodeInfo{ID: f.newNodeID, Host: host}, nil

--- a/meta/state.go
+++ b/meta/state.go
@@ -17,7 +17,7 @@ import (
 // across local or remote nodes.  It is a form of the state design pattern and allows
 // the meta.Store to change its behavior with the raft layer at runtime.
 type raftState interface {
-	openRaft() error
+	open() error
 	initialize() error
 	leader() string
 	isLeader() bool
@@ -76,7 +76,7 @@ func (r *localRaft) invalidate() error {
 	return nil
 }
 
-func (r *localRaft) openRaft() error {
+func (r *localRaft) open() error {
 	s := r.store
 	// Setup raft configuration.
 	config := raft.DefaultConfig()
@@ -308,7 +308,7 @@ func (r *remoteRaft) addPeer(addr string) error {
 	return fmt.Errorf("cannot add peer using remote raft")
 }
 
-func (r *remoteRaft) openRaft() error {
+func (r *remoteRaft) open() error {
 	go func() {
 		for {
 			select {

--- a/meta/statement_executor_test.go
+++ b/meta/statement_executor_test.go
@@ -121,15 +121,18 @@ func TestStatementExecutor_ExecuteStatement_ShowServers(t *testing.T) {
 			{ID: 2, Host: "node1"},
 		}, nil
 	}
+	e.Store.PeersFn = func() ([]string, error) {
+		return []string{"node0"}, nil
+	}
 
 	if res := e.ExecuteStatement(influxql.MustParseStatement(`SHOW SERVERS`)); res.Err != nil {
 		t.Fatal(res.Err)
 	} else if !reflect.DeepEqual(res.Series, influxql.Rows{
 		{
-			Columns: []string{"id", "url"},
+			Columns: []string{"id", "url", "raft"},
 			Values: [][]interface{}{
-				{uint64(1), "http://node0"},
-				{uint64(2), "http://node1"},
+				{uint64(1), "http://node0", true},
+				{uint64(2), "http://node1", false},
 			},
 		},
 	}) {
@@ -778,6 +781,7 @@ func NewStatementExecutor() *StatementExecutor {
 // StatementExecutorStore represents a mock implementation of StatementExecutor.Store.
 type StatementExecutorStore struct {
 	NodesFn                     func() ([]meta.NodeInfo, error)
+	PeersFn                     func() ([]string, error)
 	DatabaseFn                  func(name string) (*meta.DatabaseInfo, error)
 	DatabasesFn                 func() ([]meta.DatabaseInfo, error)
 	CreateDatabaseFn            func(name string) (*meta.DatabaseInfo, error)
@@ -802,6 +806,10 @@ type StatementExecutorStore struct {
 
 func (s *StatementExecutorStore) Nodes() ([]meta.NodeInfo, error) {
 	return s.NodesFn()
+}
+
+func (s *StatementExecutorStore) Peers() ([]string, error) {
+	return s.PeersFn()
 }
 
 func (s *StatementExecutorStore) Database(name string) (*meta.DatabaseInfo, error) {

--- a/meta/store.go
+++ b/meta/store.go
@@ -171,41 +171,6 @@ func (s *Store) IDPath() string { return filepath.Join(s.path, "id") }
 
 // Open opens and initializes the raft store.
 func (s *Store) Open() error {
-	// If we have a join addr, attempt to join
-	if s.join != "" {
-
-		joined := false
-		for _, join := range strings.Split(s.join, ",") {
-			res, err := s.rpc.join(s.Addr.String(), join)
-			if err != nil {
-				s.Logger.Printf("join failed: %v", err)
-				continue
-			}
-			joined = true
-
-			s.Logger.Printf("joined remote node %v", join)
-			s.Logger.Printf("raftEnabled=%v raftNodes=%v", res.RaftEnabled, res.RaftNodes)
-
-			s.peers = res.RaftNodes
-			s.id = res.NodeID
-
-			if err := s.writeNodeID(res.NodeID); err != nil {
-				return err
-			}
-
-			if !res.RaftEnabled {
-				s.raftState = &remoteRaft{s}
-				if err := s.invalidate(); err != nil {
-					return err
-				}
-			}
-		}
-
-		if !joined {
-			return fmt.Errorf("failed to join existing cluster at %v", s.join)
-		}
-	}
-
 	// Verify that no more than 3 peers.
 	// https://github.com/influxdb/influxdb/issues/2750
 	if len(s.peers) > MaxRaftNodes {
@@ -230,6 +195,11 @@ func (s *Store) Open() error {
 			return ErrStoreOpen
 		}
 		s.opened = true
+
+		// load our raft state
+		if err := s.loadState(); err != nil {
+			return err
+		}
 
 		// Create the root directory if it doesn't already exist.
 		if err := s.createRootDir(); err != nil {
@@ -264,11 +234,131 @@ func (s *Store) Open() error {
 	s.wg.Add(1)
 	go s.serveRPCListener()
 
+	// Join an existing cluster if we needed
+	if err := s.joinCluster(); err != nil {
+		return fmt.Errorf("join: %v", err)
+	}
+
 	// If the ID doesn't exist then create a new node.
 	if s.id == 0 {
 		go s.init()
 	} else {
 		close(s.ready)
+	}
+
+	return nil
+}
+
+// loadState sets the appropriate raftState from our persistent storage
+func (s *Store) loadState() error {
+	peers, err := readPeersJSON(filepath.Join(s.path, "peers.json"))
+	if err != nil {
+		return err
+	}
+
+	// If we have existing peers, use those.  This will override what's in the
+	// config.
+	if len(peers) > 0 {
+		s.peers = peers
+	}
+
+	// if no peers on disk, we need to start raft in order to initialize a new
+	// cluster or join an existing one.
+	if len(peers) == 0 {
+		s.raftState = &localRaft{store: s}
+		// if we have a raft database, (maybe restored), we should start raft locally
+	} else if _, err := os.Stat(filepath.Join(s.path, "raft.db")); err == nil {
+		s.raftState = &localRaft{store: s}
+		// otherwise, we should use remote raft
+	} else {
+		s.raftState = &remoteRaft{store: s}
+	}
+	return nil
+}
+
+func (s *Store) joinCluster() error {
+	// No join options, so nothing to do
+	if s.join == "" {
+		return nil
+	}
+
+	// We already have a node ID so were already part of a cluster,
+	// don't join again so we can use our existing state.
+	if s.id != 0 {
+		s.Logger.Printf("skipping join: already member of cluster: nodeId=%v raftEnabled=%v raftNodes=%v",
+			s.id, raft.PeerContained(s.peers, s.Addr.String()), s.peers)
+		return nil
+	}
+
+	s.Logger.Printf("joining cluster at: %v", s.join)
+	for {
+		for _, join := range strings.Split(s.join, ",") {
+			res, err := s.rpc.join(s.Addr.String(), join)
+			if err != nil {
+				s.Logger.Printf("join failed: %v", err)
+				continue
+			}
+
+			s.Logger.Printf("joined remote node %v", join)
+			s.Logger.Printf("nodeId=%v raftEnabled=%v raftNodes=%v", res.NodeID, res.RaftEnabled, res.RaftNodes)
+
+			s.peers = res.RaftNodes
+			s.id = res.NodeID
+
+			if err := s.writeNodeID(res.NodeID); err != nil {
+				s.Logger.Printf("write node id failed: %v", err)
+				break
+			}
+
+			if !res.RaftEnabled {
+				// Shutdown our local raft and transition to a remote raft state
+				if err := s.enableRemoteRaft(); err != nil {
+					s.Logger.Printf("enable remote raft failed: %v", err)
+					break
+				}
+			}
+			return nil
+		}
+
+		s.Logger.Printf("join failed: retrying...")
+		time.Sleep(time.Second)
+	}
+}
+
+func (s *Store) enableLocalRaft() error {
+	if _, ok := s.raftState.(*localRaft); ok {
+		return nil
+	}
+	s.Logger.Printf("switching to local raft")
+
+	lr := &localRaft{store: s}
+	return s.changeState(lr)
+}
+
+func (s *Store) enableRemoteRaft() error {
+	if _, ok := s.raftState.(*remoteRaft); ok {
+		return nil
+	}
+
+	s.Logger.Printf("switching to remote raft")
+	rr := &remoteRaft{store: s}
+	return s.changeState(rr)
+}
+
+func (s *Store) changeState(state raftState) error {
+	if err := s.raftState.close(); err != nil {
+		return err
+	}
+
+	// Clear out any persistent state
+	if err := s.raftState.remove(); err != nil {
+		return err
+	}
+
+	s.raftState = state
+
+	if err := s.raftState.open(); err != nil {
+		return err
 	}
 
 	return nil
@@ -404,10 +494,6 @@ func (s *Store) Snapshot() error {
 // WaitForLeader sleeps until a leader is found or a timeout occurs.
 // timeout == 0 means to wait forever.
 func (s *Store) WaitForLeader(timeout time.Duration) error {
-	if s.Leader() != "" {
-		return nil
-	}
-
 	// Begin timeout timer.
 	timer := time.NewTimer(timeout)
 	defer timer.Stop()
@@ -452,6 +538,9 @@ func (s *Store) IsLeader() bool {
 func (s *Store) Leader() string {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
+	if s.raftState == nil {
+		return ""
+	}
 	return s.raftState.leader()
 }
 
@@ -466,10 +555,10 @@ func (s *Store) AddPeer(addr string) error {
 }
 
 // Peers returns the list of peers in the cluster.
-func (s *Store) Peers() []string {
+func (s *Store) Peers() ([]string, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	return s.peers
+	return s.raftState.peers()
 }
 
 // serveExecListener processes remote exec connections.

--- a/meta/store.go
+++ b/meta/store.go
@@ -383,11 +383,15 @@ func (s *Store) Close() error {
 // WaitForDataChanged will block the current goroutine until the metastore index has
 // be updated.
 func (s *Store) WaitForDataChanged() error {
+	s.mu.RLock()
+	changed := s.changed
+	s.mu.RUnlock()
+
 	for {
 		select {
 		case <-s.closing:
 			return errors.New("closing")
-		case <-s.changed:
+		case <-changed:
 			return nil
 		}
 	}

--- a/meta/store.go
+++ b/meta/store.go
@@ -276,7 +276,7 @@ func (s *Store) Open() error {
 
 // openRaft initializes the raft store.
 func (s *Store) openRaft() error {
-	return s.raftState.openRaft()
+	return s.raftState.open()
 }
 
 // initialize attempts to bootstrap the raft store if there are no committed entries.

--- a/meta/store_test.go
+++ b/meta/store_test.go
@@ -1025,7 +1025,7 @@ func MustOpenCluster(n int) *Cluster {
 
 func (c *Cluster) Join() error {
 	config := NewConfig(filepath.Join(c.path, strconv.Itoa(len(c.Stores))))
-	config.Join = c.Stores[0].Addr.String()
+	config.Peers = []string{c.Stores[0].Addr.String()}
 	s := NewStore(config)
 	if err := s.Open(); err != nil {
 		return err


### PR DESCRIPTION
## Overview

This PR is a follow up to #3372 and implements more the of functionality for #2966.  Specifically, it allows servers to become raft peers when joining.  This allows single node cluster to be expanded to larger clusters and automatically use a large number of nodes for raft consensus to provide better availability.  By default, this is still hard-code to 3 nodes max, but could be made configurable.  The first three nodes added to the cluster will become raft peer members.  The remaining are data-only nodes.

To add a new member to the cluster, you should start `influxd` with the `-join` flag.  The `-join` flag tags a `host:port` value.  Multiple `host:ports` can be specific by comma separating them.  For example:

```
influxd -join host1:8088,host2:8088,host3:8088
```

The port should be the cluster port (default `8088`).  Not the API port (default `8086`).

The existing `[meta].Peers` config var can also be used and is equivalent to the `-join` flag.  If a both are specified, the `-join` flag override the config value.

If nodes are restarted that have previously joined a cluster, their existing cluster state on disk will be used and any join or config variable will be ignored.  

Additionally, the `SHOW SERVERS` statement now has a `raft` column that indicates whether the node is running raft or not.

## Not implemented

* Leaving the cluster - The infrastructure is in place to remove a raft peer, but is not currently exposed.  Removing a non-raft peer is not supported at this time.
* Promoting/demoting  raft peers - The infrastructure to promote/demote nodes to become raft peers is in place but not exposed or wired up currently.
* Changing hostnames - The hostname:port used when joining the cluster can't be changed after the fact.  This will be addressed in #3421 