### PR TITLE
Fix panic in hinted handoff processor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - [#3579](https://github.com/influxdb/influxdb/issues/3579): Revert breaking change to `client.NewClient` function
 - [#3580](https://github.com/influxdb/influxdb/issues/3580): Do not allow wildcards with fields in select statements
 - [#3530](https://github.com/influxdb/influxdb/pull/3530): Aliasing a column no longer works
+- [#3436](https://github.com/influxdb/influxdb/issues/3436): Fix panic in hinted handoff queue processor
 
 ## v0.9.2 [2015-07-24]
 


### PR DESCRIPTION
A short write has occurred and we do not have enough bytes to determine
the size of the payload.  This is corrupted record that we should drop.
Instead of panicing, log the error and advance the queue since the error
at this location is unreoverable currently.

Fixes #3436