### PR TITLE
Bugfix for #3429 String representations of RegexLiterals generated in…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 - [#4354](https://github.com/influxdb/influxdb/pull/4353): Fully lock node queues during hinted handoff. Fixes one cause of missing data on clusters.
 - [#4357](https://github.com/influxdb/influxdb/issues/4357): Fix similar float values encoding overflow Thanks @dgryski!
 - [#4344](https://github.com/influxdb/influxdb/issues/4344): Make client.Write default to client.precision if none is given.
+- [#3429](https://github.com/influxdb/influxdb/issues/3429)): Incorrect parsing of regex containing '/'
 
 ## v0.9.4 [2015-09-14]
 

--- a/cmd/influxd/run/server_test.go
+++ b/cmd/influxd/run/server_test.go
@@ -1258,6 +1258,9 @@ func TestServer_Query_Tags(t *testing.T) {
 
 		fmt.Sprintf("cpu3,company=acme01 value=100 %d", mustParseTime(time.RFC3339Nano, "2015-02-28T01:03:36.703820946Z").UnixNano()),
 		fmt.Sprintf("cpu3 value=200 %d", mustParseTime(time.RFC3339Nano, "2012-02-28T01:03:38.703820946Z").UnixNano()),
+
+		fmt.Sprintf("status_code,url=http://www.example.com value=404 %d", mustParseTime(time.RFC3339Nano, "2015-07-22T08:13:54.929026672Z").UnixNano()),
+		fmt.Sprintf("status_code,url=https://influxdb.com value=418 %d", mustParseTime(time.RFC3339Nano, "2015-07-22T09:52:24.914395083Z").UnixNano()),
 	}
 
 	test := NewTest("db0", "rp0")
@@ -1378,6 +1381,16 @@ func TestServer_Query_Tags(t *testing.T) {
 			name:    "single field (regex tag match)",
 			command: `SELECT value FROM db0.rp0.cpu3 WHERE company !~ /acme[23]/`,
 			exp:     `{"results":[{"series":[{"name":"cpu3","columns":["time","value"],"values":[["2012-02-28T01:03:38.703820946Z",200],["2015-02-28T01:03:36.703820946Z",100]]}]}]}`,
+		},
+		&Query{
+			name:    "single field (regex tag match with escaping)",
+			command: `SELECT value FROM db0.rp0.status_code WHERE url !~ /https\:\/\/influxdb\.com/`,
+			exp:     `{"results":[{"series":[{"name":"status_code","columns":["time","value"],"values":[["2015-07-22T08:13:54.929026672Z",404]]}]}]}`,
+		},
+		&Query{
+			name:    "single field (regex tag match with escaping)",
+			command: `SELECT value FROM db0.rp0.status_code WHERE url =~ /https\:\/\/influxdb\.com/`,
+			exp:     `{"results":[{"series":[{"name":"status_code","columns":["time","value"],"values":[["2015-07-22T09:52:24.914395083Z",418]]}]}]}`,
 		},
 	}...)
 

--- a/influxql/ast.go
+++ b/influxql/ast.go
@@ -2635,7 +2635,7 @@ type RegexLiteral struct {
 // String returns a string representation of the literal.
 func (r *RegexLiteral) String() string {
 	if r.Val != nil {
-		return fmt.Sprintf("/%s/", r.Val.String())
+		return fmt.Sprintf("/%s/", strings.Replace(r.Val.String(), `/`, `\/`, -1))
 	}
 	return ""
 }

--- a/influxql/parser_test.go
+++ b/influxql/parser_test.go
@@ -1778,11 +1778,11 @@ func TestParser_ParseExpr(t *testing.T) {
 
 		// Binary expression with quoted '/' regex.
 		{
-      s: `url =~ /http\:\/\/www\.example\.com/`,
+			s: `url =~ /http\:\/\/www\.example\.com/`,
 			expr: &influxql.BinaryExpr{
 				Op:  influxql.EQREGEX,
 				LHS: &influxql.VarRef{Val: "url"},
-        RHS: &influxql.RegexLiteral{Val: regexp.MustCompile(`http\://www\.example\.com`)},
+				RHS: &influxql.RegexLiteral{Val: regexp.MustCompile(`http\://www\.example\.com`)},
 			},
 		},
 

--- a/influxql/parser_test.go
+++ b/influxql/parser_test.go
@@ -1768,11 +1768,21 @@ func TestParser_ParseExpr(t *testing.T) {
 
 		// Binary expression with regex.
 		{
-			s: "region =~ /us.*/",
+			s: `region =~ /us.*/`,
 			expr: &influxql.BinaryExpr{
 				Op:  influxql.EQREGEX,
 				LHS: &influxql.VarRef{Val: "region"},
 				RHS: &influxql.RegexLiteral{Val: regexp.MustCompile(`us.*`)},
+			},
+		},
+
+		// Binary expression with quoted '/' regex.
+		{
+      s: `url =~ /http\:\/\/www\.example\.com/`,
+			expr: &influxql.BinaryExpr{
+				Op:  influxql.EQREGEX,
+				LHS: &influxql.VarRef{Val: "url"},
+        RHS: &influxql.RegexLiteral{Val: regexp.MustCompile(`http\://www\.example\.com`)},
 			},
 		},
 

--- a/influxql/scanner_test.go
+++ b/influxql/scanner_test.go
@@ -276,6 +276,7 @@ func TestScanRegex(t *testing.T) {
 		{in: `/foo\/bar/`, tok: influxql.REGEX, lit: `foo/bar`},
 		{in: `/foo\\/bar/`, tok: influxql.REGEX, lit: `foo\/bar`},
 		{in: `/foo\\bar/`, tok: influxql.REGEX, lit: `foo\\bar`},
+		{in: `/http\:\/\/www\.example\.com/`, tok: influxql.REGEX, lit: `http\://www\.example\.com`},
 	}
 
 	for i, tt := range tests {

--- a/services/httpd/handler_test.go
+++ b/services/httpd/handler_test.go
@@ -157,6 +157,25 @@ func TestHandler_Query(t *testing.T) {
 	}
 }
 
+
+// Ensure the handler returns results from a query (including nil results).
+func TestHandler_QueryRegex(t *testing.T) {
+	h := NewHandler(false)
+	h.QueryExecutor.ExecuteQueryFn = func(q *influxql.Query, db string, chunkSize int) (<-chan *influxql.Result, error) {
+		if q.String() != `SELECT * FROM test WHERE url =~ /http\:\/\/www.akamai\.com/` {
+			t.Fatalf("unexpected query: %s", q.String())
+		} else if db != `test` {
+			t.Fatalf("unexpected db: %s", db)
+		}
+		return NewResultChan(
+			nil,
+		), nil
+	}
+
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, MustNewRequest("GET", "/query?db=test&q=SELECT%20%2A%20FROM%20test%20WHERE%20url%20%3D~%20%2Fhttp%5C%3A%5C%2F%5C%2Fwww.akamai%5C.com%2F", nil))
+}
+
 // Ensure the handler merges results from the same statement.
 func TestHandler_Query_MergeResults(t *testing.T) {
 	h := NewHandler(false)

--- a/services/httpd/handler_test.go
+++ b/services/httpd/handler_test.go
@@ -157,7 +157,6 @@ func TestHandler_Query(t *testing.T) {
 	}
 }
 
-
 // Ensure the handler returns results from a query (including nil results).
 func TestHandler_QueryRegex(t *testing.T) {
 	h := NewHandler(false)


### PR DESCRIPTION
Fix for bug #3429
corrected issue where string representations of RegexLiterals generated in influxql/ast.go added the / char as a start/end delimiter, but did not escape any / characters that may exist with the regex.

- [x] CHANGELOG.md updated
- [x] Rebased/mergable
- [x] Tests pass
- [x] Sign [CLA](http://influxdb.com/community/cla.html) (if not already signed)