### PR TITLE
Rename v1 engine to b1

### DIFF
--- a/tsdb/engine.go
+++ b/tsdb/engine.go
@@ -16,7 +16,7 @@ var (
 )
 
 // DefaultEngine is the default engine used by the shard when initializing.
-const DefaultEngine = "v1"
+const DefaultEngine = "b1"
 
 // Engine represents a swappable storage engine for the shard.
 type Engine interface {
@@ -68,14 +68,17 @@ func NewEngine(path string, options EngineOptions) (Engine, error) {
 			// Retrieve the meta bucket.
 			b := tx.Bucket([]byte("meta"))
 
-			// If no format is specified then it must be an original v1 database.
+			// If no format is specified then it must be an original b1 database.
 			if b == nil {
-				format = "v1"
+				format = "b1"
 				return nil
 			}
 
 			// Save the format.
 			format = string(b.Get([]byte("format")))
+			if format == "v1" {
+				format = "b1"
+			}
 			return nil
 		})
 	}(); err != nil {

--- a/tsdb/engine/b1/b1.go
+++ b/tsdb/engine/b1/b1.go
@@ -1,4 +1,4 @@
-package v1
+package b1
 
 import (
 	"bytes"
@@ -18,7 +18,7 @@ import (
 )
 
 // Format is the file format name of this engine.
-const Format = "v1"
+const Format = "b1"
 
 func init() {
 	tsdb.RegisterEngine(Format, NewEngine)
@@ -122,7 +122,7 @@ func (e *Engine) Open() error {
 		e.flushTimer = time.NewTimer(e.WALFlushInterval)
 
 		// Initialize logger.
-		e.logger = log.New(e.LogOutput, "[v1] ", log.LstdFlags)
+		e.logger = log.New(e.LogOutput, "[b1] ", log.LstdFlags)
 
 		// Start background goroutines.
 		e.wg.Add(1)

--- a/tsdb/engine/engine.go
+++ b/tsdb/engine/engine.go
@@ -1,5 +1,5 @@
 package engine
 
 import (
-	_ "github.com/influxdb/influxdb/tsdb/engine/v1"
+	_ "github.com/influxdb/influxdb/tsdb/engine/b1"
 )


### PR DESCRIPTION
## Overview

This pull request changes the 'v1' engine to 'b1' to represent "bolt v1".

This change was part of the compression PR but that PR is being reverted and merged into the `b1` engine type.