### PR TITLE
check error when opening shard DBs.

### DIFF
--- a/tsdb/store.go
+++ b/tsdb/store.go
@@ -237,7 +237,10 @@ func (s *Store) loadShards() error {
 				}
 
 				shard := NewShard(s.databaseIndexes[db], path, s.EngineOptions)
-				shard.Open()
+				err = shard.Open()
+				if err != nil {
+					return fmt.Errorf("failed to open shard %d: %s", shardID, err)
+				}
 				s.shards[shardID] = shard
 			}
 		}


### PR DESCRIPTION
Doing the initial work on #3516, I suspect that it's an issue where
we're throwing away an opening error and then accessing the database
to cause the panic. Since we threw away this error before, let's log
it so that we can see what's happening.

It doesn't fix the error proper, since the shard will still not be
accessible, but it will give us a better idea what's going on.