### PR TITLE
Consume CQ results on request timeouts

### DIFF
--- a/services/continuous_querier/service.go
+++ b/services/continuous_querier/service.go
@@ -286,6 +286,12 @@ func (s *Service) runContinuousQueryAndWriteResult(cq *ContinuousQuery) error {
 		return err
 	}
 
+	// Drain results
+	defer func() {
+		for _ = range ch {
+		}
+	}()
+
 	// Read all rows from the result channel.
 	for result := range ch {
 		if result.Err != nil {


### PR DESCRIPTION
As a follow-up to #3517, I have been able to isolate the actual issue. When timeouts occur during the execution of a CQ, the result channel is never consumed, which causes a deadlock in the [query_executor](https://github.com/influxdb/influxdb/blob/a09c0065/tsdb/query_executor.go#L276). Because we are stuck in the [executor](https://github.com/influxdb/influxdb/blob/a09c00653c9fb6bfe8e4a28075ea5bbaa6362568/tsdb/executor.go#L451) the mapper is never closed and the read-only transaction is never released, locking all subsequent writes.