### PR TITLE
Add TLS support to the OpenTSDB plugin

### DIFF
--- a/services/opentsdb/config.go
+++ b/services/opentsdb/config.go
@@ -20,6 +20,8 @@ type Config struct {
 	Database         string `toml:"database"`
 	RetentionPolicy  string `toml:"retention-policy"`
 	ConsistencyLevel string `toml:"consistency-level"`
+	TLSEnabled       bool   `toml:"tls-enabled"`
+	Certificate      string `toml:"certificate"`
 }
 
 func NewConfig() Config {
@@ -28,5 +30,7 @@ func NewConfig() Config {
 		Database:         DefaultDatabase,
 		RetentionPolicy:  DefaultRetentionPolicy,
 		ConsistencyLevel: DefaultConsistencyLevel,
+		TLSEnabled:       false,
+		Certificate:      "/etc/ssl/influxdb.pem",
 	}
 }

--- a/services/opentsdb/config_test.go
+++ b/services/opentsdb/config_test.go
@@ -15,6 +15,8 @@ enabled = true
 bind-address = ":9000"
 database = "xxx"
 consistency-level ="all"
+tls-enabled = true
+certificate = "/etc/ssl/cert.pem"
 `, &c); err != nil {
 		t.Fatal(err)
 	}
@@ -27,6 +29,10 @@ consistency-level ="all"
 	} else if c.Database != "xxx" {
 		t.Fatalf("unexpected database: %s", c.Database)
 	} else if c.ConsistencyLevel != "all" {
-		t.Fatalf("unexpected database: %s", c.ConsistencyLevel)
+		t.Fatalf("unexpected consistency-level: %s", c.ConsistencyLevel)
+	} else if c.TLSEnabled != true {
+		t.Fatalf("unexpected tls-enabled: %s", c.TLSEnabled)
+	} else if c.Certificate != "/etc/ssl/cert.pem" {
+		t.Fatalf("unexpected certificate: %s", c.Certificate)
 	}
 }


### PR DESCRIPTION
Adds TLS support to the OpenTSDB plugin. I updated the config tests to reflect the new config as well. Defaults are backwards compatible.