### PR TITLE
BZ1 Pt. II

### DIFF
--- a/tsdb/engine/bz1/bz1.go
+++ b/tsdb/engine/bz1/bz1.go
@@ -30,7 +30,7 @@ func init() {
 
 const (
 	// DefaultBlockSize is the default size of uncompressed points blocks.
-	DefaultBlockSize = 4 * 1024 * 1024 // 4MB
+	DefaultBlockSize = 32 * 1024 // 32KB
 )
 
 // Ensure Engine implements the interface.
@@ -340,6 +340,20 @@ func (e *Engine) Begin(writable bool) (tsdb.Tx, error) {
 		return nil, err
 	}
 	return &Tx{Tx: tx, engine: e}, nil
+}
+
+// Stats returns internal statistics for the engine.
+func (e *Engine) Stats() (stats Stats, err error) {
+	err = e.db.View(func(tx *bolt.Tx) error {
+		stats.Size = tx.Size()
+		return nil
+	})
+	return stats, err
+}
+
+// Stats represents internal engine statistics.
+type Stats struct {
+	Size int64 // BoltDB data size
 }
 
 // Tx represents a transaction.

--- a/tsdb/engine/bz1/bz1.go
+++ b/tsdb/engine/bz1/bz1.go
@@ -1,0 +1,478 @@
+package bz1
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/boltdb/bolt"
+	"github.com/golang/snappy"
+	"github.com/influxdb/influxdb/tsdb"
+)
+
+var (
+	// ErrSeriesExists is returned when writing points to an existing series.
+	ErrSeriesExists = errors.New("series exists")
+)
+
+// Format is the file format name of this engine.
+const Format = "bz1"
+
+func init() {
+	tsdb.RegisterEngine(Format, NewEngine)
+}
+
+const (
+	// DefaultBlockSize is the default size of uncompressed points blocks.
+	DefaultBlockSize = 4 * 1024 * 1024 // 4MB
+)
+
+// Ensure Engine implements the interface.
+var _ tsdb.Engine = &Engine{}
+
+// Engine represents a storage engine with compressed blocks.
+type Engine struct {
+	mu   sync.Mutex
+	path string
+	db   *bolt.DB
+
+	// Size of uncompressed points to write to a block.
+	BlockSize int
+}
+
+// NewEngine returns a new instance of Engine.
+func NewEngine(path string, opt tsdb.EngineOptions) tsdb.Engine {
+	return &Engine{
+		path: path,
+
+		BlockSize: DefaultBlockSize,
+	}
+}
+
+// Path returns the path the engine was opened with.
+func (e *Engine) Path() string { return e.path }
+
+// Open opens and initializes the engine.
+func (e *Engine) Open() error {
+	if err := func() error {
+		e.mu.Lock()
+		defer e.mu.Unlock()
+
+		// Open underlying storage.
+		db, err := bolt.Open(e.path, 0666, &bolt.Options{Timeout: 1 * time.Second})
+		if err != nil {
+			return err
+		}
+		e.db = db
+
+		// Initialize data file.
+		if err := e.db.Update(func(tx *bolt.Tx) error {
+			_, _ = tx.CreateBucketIfNotExists([]byte("series"))
+			_, _ = tx.CreateBucketIfNotExists([]byte("fields"))
+			_, _ = tx.CreateBucketIfNotExists([]byte("points"))
+
+			// Set file format, if not set yet.
+			b, _ := tx.CreateBucketIfNotExists([]byte("meta"))
+			if v := b.Get([]byte("format")); v == nil {
+				if err := b.Put([]byte("format"), []byte(Format)); err != nil {
+					return fmt.Errorf("set format: %s", err)
+				}
+			}
+
+			return nil
+		}); err != nil {
+			return fmt.Errorf("init: %s", err)
+		}
+
+		return nil
+	}(); err != nil {
+		e.close()
+		return err
+	}
+	return nil
+}
+
+// Close closes the engine.
+func (e *Engine) Close() error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.close()
+}
+
+func (e *Engine) close() error {
+	if e.db != nil {
+		return e.db.Close()
+	}
+	return nil
+}
+
+// SetLogOutput is a no-op.
+func (e *Engine) SetLogOutput(w io.Writer) {}
+
+// LoadMetadataIndex loads the shard metadata into memory.
+func (e *Engine) LoadMetadataIndex(index *tsdb.DatabaseIndex, measurementFields map[string]*tsdb.MeasurementFields) error {
+	return e.db.View(func(tx *bolt.Tx) error {
+		// Load measurement metadata
+		meta := tx.Bucket([]byte("fields"))
+		c := meta.Cursor()
+		for k, v := c.First(); k != nil; k, v = c.Next() {
+			m := index.CreateMeasurementIndexIfNotExists(string(k))
+			mf := &tsdb.MeasurementFields{}
+			if err := mf.UnmarshalBinary(v); err != nil {
+				return err
+			}
+			for name, _ := range mf.Fields {
+				m.SetFieldName(name)
+			}
+			mf.Codec = tsdb.NewFieldCodec(mf.Fields)
+			measurementFields[m.Name] = mf
+		}
+
+		// Load series metadata
+		meta = tx.Bucket([]byte("series"))
+		c = meta.Cursor()
+		for k, v := c.First(); k != nil; k, v = c.Next() {
+			series := &tsdb.Series{}
+			if err := series.UnmarshalBinary(v); err != nil {
+				return err
+			}
+			index.CreateSeriesIndexIfNotExists(tsdb.MeasurementFromSeriesKey(string(k)), series)
+		}
+		return nil
+	})
+}
+
+// WritePoints writes metadata and point data into the engine.
+// Returns an error if new points are added to an existing key.
+func (e *Engine) WritePoints(points []tsdb.Point, measurementFieldsToSave map[string]*tsdb.MeasurementFields, seriesToCreate []*tsdb.SeriesCreate) error {
+	if err := e.db.Update(func(tx *bolt.Tx) error {
+		// Write series & field metadata.
+		if err := e.writeSeries(tx, seriesToCreate); err != nil {
+			return fmt.Errorf("write series: %s", err)
+		}
+		if err := e.writeFields(tx, measurementFieldsToSave); err != nil {
+			return fmt.Errorf("write fields: %s", err)
+		}
+
+		// Group points together by key.
+		for key, a := range groupPointsByKey(points) {
+			if err := e.writePoints(tx, key, a); err != nil {
+				return fmt.Errorf("write points: key=%s, err=%s", key, err)
+			}
+		}
+
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// writeSeries writes a list of series to the metadata.
+func (e *Engine) writeSeries(tx *bolt.Tx, a []*tsdb.SeriesCreate) error {
+	// Ignore if there are no series.
+	if len(a) == 0 {
+		return nil
+	}
+
+	// Marshal and insert each series into the metadata.
+	b := tx.Bucket([]byte("series"))
+	for _, sc := range a {
+		// Marshal series into bytes.
+		data, err := sc.Series.MarshalBinary()
+		if err != nil {
+			return fmt.Errorf("marshal series: %s", err)
+		}
+
+		// Insert marshaled data into appropriate key.
+		if err := b.Put([]byte(sc.Series.Key), data); err != nil {
+			return fmt.Errorf("put: %s", err)
+		}
+	}
+
+	return nil
+}
+
+// writeFields writes a list of measurement fields to the metadata.
+func (e *Engine) writeFields(tx *bolt.Tx, m map[string]*tsdb.MeasurementFields) error {
+	// Ignore if there are no fields to save.
+	if len(m) == 0 {
+		return nil
+	}
+
+	// Persist each measurement field in the map.
+	b := tx.Bucket([]byte("fields"))
+	for k, f := range m {
+		// Marshal field into bytes.
+		data, err := f.MarshalBinary()
+		if err != nil {
+			return fmt.Errorf("marshal measurement field: %s", err)
+		}
+
+		// Insert marshaled data into key.
+		if err := b.Put([]byte(k), data); err != nil {
+			return fmt.Errorf("put: %s", err)
+		}
+	}
+
+	return nil
+}
+
+// writePoints writes a set of points for a single key.
+func (e *Engine) writePoints(tx *bolt.Tx, key string, a []tsdb.Point) error {
+	// Ignore if there are no points.
+	if len(a) == 0 {
+		return nil
+	}
+
+	// Ensure points are sorted.
+	sort.Sort(tsdb.Points(a))
+
+	// Group points into blocks by size.
+	blocks := make([][]byte, 1)
+	for _, p := range a {
+		// Add a new block if the last one is too large.
+		if len(blocks[len(blocks)-1]) > e.BlockSize {
+			blocks = append(blocks, nil)
+		}
+
+		// Append point to the end of the block.
+		buf := marshalEntry(p.UnixNano(), p.Data())
+		blocks[len(blocks)-1] = append(blocks[len(blocks)-1], buf...)
+	}
+
+	// Create bucket for key.
+	bkt, err := tx.Bucket([]byte("points")).CreateBucket([]byte(key))
+	if err == bolt.ErrBucketExists {
+		return ErrSeriesExists
+	} else if err != nil {
+		return fmt.Errorf("create series bucket: %s", err)
+	}
+
+	// Write blocks to the bucket.
+	for _, block := range blocks {
+		// Use the first timestamp as the key for the block.
+		timestamp := block[0:8]
+
+		// Compress block using Snappy.
+		value := snappy.Encode(nil, block)
+
+		// Write block to the bucket.
+		if err := bkt.Put(timestamp, value); err != nil {
+			return fmt.Errorf("write block: series=%s, ts=%x, err=%s", timestamp, key, err)
+		}
+	}
+
+	return nil
+}
+
+// groupPointsByKey generates a map of points by key.
+func groupPointsByKey(a []tsdb.Point) map[string][]tsdb.Point {
+	m := make(map[string][]tsdb.Point)
+
+	// Group points by key.
+	for _, p := range a {
+		key := string(p.Key())
+		m[key] = append(m[key], p)
+	}
+
+	return m
+}
+
+// DeleteSeries deletes the series from the engine.
+func (e *Engine) DeleteSeries(keys []string) error {
+	return e.db.Update(func(tx *bolt.Tx) error {
+		for _, k := range keys {
+			if err := tx.Bucket([]byte("series")).Delete([]byte(k)); err != nil {
+				return fmt.Errorf("delete series metadata: %s", err)
+			}
+			if err := tx.Bucket([]byte("points")).DeleteBucket([]byte(k)); err != nil && err != bolt.ErrBucketNotFound {
+				return fmt.Errorf("delete series data: %s", err)
+			}
+		}
+		return nil
+	})
+}
+
+// DeleteMeasurement deletes a measurement and all related series.
+func (e *Engine) DeleteMeasurement(name string, seriesKeys []string) error {
+	return e.db.Update(func(tx *bolt.Tx) error {
+		if err := tx.Bucket([]byte("fields")).Delete([]byte(name)); err != nil {
+			return err
+		}
+
+		for _, k := range seriesKeys {
+			if err := tx.Bucket([]byte("series")).Delete([]byte(k)); err != nil {
+				return fmt.Errorf("delete series metadata: %s", err)
+			}
+			if err := tx.Bucket([]byte("points")).DeleteBucket([]byte(k)); err != nil && err != bolt.ErrBucketNotFound {
+				return fmt.Errorf("delete series data: %s", err)
+			}
+		}
+
+		return nil
+	})
+}
+
+// SeriesCount returns the number of series buckets on the shard.
+func (e *Engine) SeriesCount() (n int, err error) {
+	err = e.db.View(func(tx *bolt.Tx) error {
+		c := tx.Bucket([]byte("points")).Cursor()
+		for k, _ := c.First(); k != nil; k, _ = c.Next() {
+			n++
+		}
+		return nil
+	})
+	return
+}
+
+// Begin starts a new transaction on the engine.
+func (e *Engine) Begin(writable bool) (tsdb.Tx, error) {
+	tx, err := e.db.Begin(writable)
+	if err != nil {
+		return nil, err
+	}
+	return &Tx{Tx: tx, engine: e}, nil
+}
+
+// Tx represents a transaction.
+type Tx struct {
+	*bolt.Tx
+	engine *Engine
+}
+
+// Cursor returns an iterator for a key.
+func (tx *Tx) Cursor(key string) tsdb.Cursor {
+	// Retrieve points bucket. Ignore if there is no bucket.
+	b := tx.Bucket([]byte("points")).Bucket([]byte(key))
+	if b == nil {
+		return nil
+	}
+	return &Cursor{
+		cursor: b.Cursor(),
+		buf:    make([]byte, DefaultBlockSize),
+	}
+}
+
+// Cursor provides ordered iteration across a series.
+type Cursor struct {
+	cursor *bolt.Cursor
+	buf    []byte // uncompressed buffer
+	off    int    // buffer offset
+}
+
+// Seek moves the cursor to a position and returns the closest key/value pair.
+func (c *Cursor) Seek(seek []byte) (key, value []byte) {
+	// Move cursor to appropriate block and set to buffer.
+	_, v := c.cursor.Seek(seek)
+	c.setBuf(v)
+
+	// Read current block up to seek position.
+	c.seekBuf(seek)
+
+	// Return current entry.
+	return c.read()
+}
+
+// seekBuf moves the cursor to a position within the current buffer.
+func (c *Cursor) seekBuf(seek []byte) (key, value []byte) {
+	for {
+		// Slice off the current entry.
+		buf := c.buf[c.off:]
+
+		// Exit if current entry's timestamp is on or after the seek.
+		if len(buf) == 0 || bytes.Compare(buf[0:8], seek) != -1 {
+			return
+		}
+
+		// Otherwise skip ahead to the next entry.
+		c.off += entryHeaderSize + entryDataSize(buf)
+	}
+}
+
+// Next returns the next key/value pair from the cursor.
+func (c *Cursor) Next() (key, value []byte) {
+	// Ignore if there is no buffer.
+	if len(c.buf) == 0 {
+		return nil, nil
+	}
+
+	// Move forward to next entry.
+	c.off += entryHeaderSize + entryDataSize(c.buf[c.off:])
+
+	// If no items left then read first item from next block.
+	if c.off >= len(c.buf) {
+		_, v := c.cursor.Next()
+		c.setBuf(v)
+	}
+
+	return c.read()
+}
+
+// setBuf saves a compressed block to the buffer.
+func (c *Cursor) setBuf(block []byte) {
+	// Clear if the block is empty.
+	if len(block) == 0 {
+		c.buf, c.off = c.buf[0:0], 0
+		return
+	}
+
+	// Otherwise decode block into buffer.
+	buf, err := snappy.Decode(c.buf, block)
+	if err != nil {
+		log.Printf("block decode error: %s", err)
+	}
+	c.buf, c.off = buf, 0
+}
+
+// read reads the current key and value from the current block.
+func (c *Cursor) read() (key, value []byte) {
+	// Return nil if the offset is at the end of the buffer.
+	if c.off >= len(c.buf) {
+		return nil, nil
+	}
+
+	// Otherwise read the current entry.
+	buf := c.buf[c.off:]
+	dataSize := entryDataSize(buf)
+	return buf[0:8], buf[entryHeaderSize : entryHeaderSize+dataSize]
+}
+
+// marshalEntry encodes point data into a single byte slice.
+//
+// The format of the byte slice is:
+//
+//     uint64 timestamp
+//     uint32 data length
+//     []byte data
+//
+func marshalEntry(timestamp int64, data []byte) []byte {
+	v := make([]byte, 8+4, 8+4+len(data))
+	binary.BigEndian.PutUint64(v[0:8], uint64(timestamp))
+	binary.BigEndian.PutUint32(v[8:12], uint32(len(data)))
+	v = append(v, data...)
+	return v
+}
+
+// unmarshalEntry decodes an entry into it's separate parts.
+// Returns the timestamp, data and the number of bytes read.
+// Returned byte slices point to the original slice.
+func unmarshalEntry(v []byte) (timestamp int64, data []byte, n int) {
+	timestamp = int64(binary.BigEndian.Uint64(v[0:8]))
+	dataLen := binary.BigEndian.Uint32(v[8:12])
+	data = v[12+dataLen:]
+	return timestamp, data, 12 + int(dataLen)
+}
+
+// entryHeaderSize is the number of bytes required for the header.
+const entryHeaderSize = 8 + 4
+
+// entryDataSize returns the size of an entry's data field, in bytes.
+func entryDataSize(v []byte) int { return int(binary.BigEndian.Uint32(v[8:12])) }

--- a/tsdb/engine/bz1/bz1_test.go
+++ b/tsdb/engine/bz1/bz1_test.go
@@ -1,0 +1,279 @@
+package bz1_test
+
+import (
+	"encoding/binary"
+	"io/ioutil"
+	"math/rand"
+	"os"
+	"reflect"
+	"sort"
+	"strconv"
+	"testing"
+	"testing/quick"
+	"time"
+
+	"github.com/influxdb/influxdb/tsdb"
+	"github.com/influxdb/influxdb/tsdb/engine/bz1"
+)
+
+// Ensure the engine can write series metadata and reload it.
+func TestEngine_LoadMetadataIndex_Series(t *testing.T) {
+	e := OpenDefaultEngine()
+	defer e.Close()
+
+	// Write series metadata.
+	if err := e.WritePoints(nil, nil, []*tsdb.SeriesCreate{
+		{Series: &tsdb.Series{Key: string(tsdb.MakeKey([]byte("cpu"), map[string]string{"host": "server0"})), Tags: map[string]string{"host": "server0"}}},
+		{Series: &tsdb.Series{Key: string(tsdb.MakeKey([]byte("cpu"), map[string]string{"host": "server1"})), Tags: map[string]string{"host": "server1"}}},
+		{Series: &tsdb.Series{Key: "series with spaces"}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Load metadata index.
+	index := tsdb.NewDatabaseIndex()
+	if err := e.LoadMetadataIndex(index, make(map[string]*tsdb.MeasurementFields)); err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify index is correct.
+	if m := index.Measurement("cpu"); m == nil {
+		t.Fatal("measurement not found")
+	} else if s := m.SeriesByID(1); s.Key != "cpu,host=server0" || !reflect.DeepEqual(s.Tags, map[string]string{"host": "server0"}) {
+		t.Fatalf("unexpected series: %q / %#v", s.Key, s.Tags)
+	} else if s = m.SeriesByID(2); s.Key != "cpu,host=server1" || !reflect.DeepEqual(s.Tags, map[string]string{"host": "server1"}) {
+		t.Fatalf("unexpected series: %q / %#v", s.Key, s.Tags)
+	}
+
+	if m := index.Measurement("series with spaces"); m == nil {
+		t.Fatal("measurement not found")
+	} else if s := m.SeriesByID(3); s.Key != "series with spaces" {
+		t.Fatalf("unexpected series: %q", s.Key)
+	}
+}
+
+// Ensure the engine can write field metadata and reload it.
+func TestEngine_LoadMetadataIndex_Fields(t *testing.T) {
+	e := OpenDefaultEngine()
+	defer e.Close()
+
+	// Write series metadata.
+	if err := e.WritePoints(nil, map[string]*tsdb.MeasurementFields{
+		"cpu": &tsdb.MeasurementFields{
+			Fields: map[string]*tsdb.Field{
+				"value": &tsdb.Field{ID: 0, Name: "value"},
+			},
+		},
+	}, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	// Load metadata index.
+	mfs := make(map[string]*tsdb.MeasurementFields)
+	if err := e.LoadMetadataIndex(tsdb.NewDatabaseIndex(), mfs); err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify measurement field is correct.
+	if mf := mfs["cpu"]; mf == nil {
+		t.Fatal("measurement fields not found")
+	} else if !reflect.DeepEqual(mf.Fields, map[string]*tsdb.Field{"value": &tsdb.Field{ID: 0, Name: "value"}}) {
+		t.Fatalf("unexpected fields: %#v", mf.Fields)
+	}
+}
+
+// Ensure the engine can write points to storage.
+func TestEngine_WritePoints(t *testing.T) {
+	e := OpenDefaultEngine()
+	defer e.Close()
+
+	// Write points against two separate series.
+	if err := e.WritePoints([]tsdb.Point{
+		tsdb.NewPoint("cpu", tsdb.Tags{}, tsdb.Fields{}, time.Unix(0, 1)),
+		tsdb.NewPoint("cpu", tsdb.Tags{}, tsdb.Fields{}, time.Unix(0, 0)),
+		tsdb.NewPoint("cpu", tsdb.Tags{}, tsdb.Fields{}, time.Unix(1, 0)),
+
+		tsdb.NewPoint("cpu", tsdb.Tags{"host": "serverA"}, tsdb.Fields{}, time.Unix(0, 0)),
+	},
+		nil, nil,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	// Iterate over "cpu" series.
+	if keys, err := e.ReadSeriesPointKeys(`cpu`, tsdb.Tags{}); err != nil {
+		t.Fatal(err)
+	} else if !reflect.DeepEqual(keys, [][]byte{
+		{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, // Unix(0, 0)
+		{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01}, // Unix(0, 1)
+		{0x00, 0x00, 0x00, 0x00, 0x3b, 0x9a, 0xca, 0x00}, // Unix(1, 0)
+	}) {
+		t.Fatalf("unexpected series point keys: %v", keys)
+	}
+}
+
+// Ensure the engine read and write randomized points.
+func TestEngine_WritePoints_Quick(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short mode")
+	}
+
+	quick.Check(func(blockSize uint16, points Points) bool {
+		e := OpenDefaultEngine()
+		e.BlockSize = int(blockSize)
+		defer e.Close()
+
+		// Write points against two separate series.
+		if err := e.WritePoints([]tsdb.Point(points), nil, nil); err != nil {
+			t.Fatal(err)
+		}
+
+		// Validate each series.
+		for _, series := range points.Series() {
+			if keys, err := e.ReadSeriesPointKeys(series.Name, series.Tags); err != nil {
+				t.Fatal(err)
+			} else if exp := series.Keys(); !reflect.DeepEqual(exp, keys) {
+				t.Fatalf("series point keys:\n\nexp=%v\n\ngot=%v\n\n", exp, keys)
+			}
+		}
+
+		return true
+	}, nil)
+}
+
+// Engine represents a test wrapper for bz1.Engine.
+type Engine struct {
+	*bz1.Engine
+}
+
+// NewEngine returns a new instance of Engine.
+func NewEngine(opt tsdb.EngineOptions) *Engine {
+	// Generate temporary file.
+	f, _ := ioutil.TempFile("", "bz1-")
+	f.Close()
+	os.Remove(f.Name())
+
+	// Return test wrapper.
+	return &Engine{Engine: bz1.NewEngine(f.Name(), opt).(*bz1.Engine)}
+}
+
+// OpenEngine returns an opened instance of Engine. Panic on error.
+func OpenEngine(opt tsdb.EngineOptions) *Engine {
+	e := NewEngine(opt)
+	if err := e.Open(); err != nil {
+		panic(err)
+	}
+	return e
+}
+
+// OpenDefaultEngine returns an open Engine with default options.
+func OpenDefaultEngine() *Engine { return OpenEngine(tsdb.NewEngineOptions()) }
+
+// Close closes the engine and removes all data.
+func (e *Engine) Close() error {
+	e.Engine.Close()
+	os.RemoveAll(e.Path())
+	return nil
+}
+
+// ReadSeriesPointKeys returns the raw keys for all points store for a series.
+func (e *Engine) ReadSeriesPointKeys(name string, tags tsdb.Tags) ([][]byte, error) {
+	// Open transaction on engine.
+	tx, err := e.Begin(false)
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback()
+
+	// Create a cursor for the series.
+	c := tx.Cursor(string(tsdb.MakeKey([]byte(name), tags)))
+
+	// Collect all the keys.
+	var keys [][]byte
+	for k, _ := c.Seek([]byte{0, 0, 0, 0, 0, 0, 0, 0}); k != nil; k, _ = c.Next() {
+		keys = append(keys, copyBytes(k))
+	}
+
+	return keys, nil
+}
+
+// copyBytes returns a copy of a byte slice.
+func copyBytes(b []byte) []byte {
+	if b == nil {
+		return nil
+	}
+
+	other := make([]byte, len(b))
+	copy(other, b)
+	return other
+}
+
+// Points represents a list of points that implements quick.Generator.
+type Points []tsdb.Point
+
+// Generate generates a random list of point.
+func (Points) Generate(rand *rand.Rand, size int) reflect.Value {
+	points := make([]tsdb.Point, rand.Intn(1000))
+
+	for i := range points {
+		// Generate individual point fields.
+		name := strconv.Itoa(rand.Intn(3))
+		tags := tsdb.Tags{"host": strconv.Itoa(rand.Intn(3))}
+		value, _ := quick.Value(reflect.TypeOf(float64(0)), rand)
+		timestamp := time.Unix(int64(rand.Uint32()), int64(rand.Uint32()))
+
+		// Create point with random data.
+		points[i] = tsdb.NewPoint(name, tags, tsdb.Fields{"value": value}, timestamp)
+	}
+
+	return reflect.ValueOf(points)
+}
+
+// Series returns a list of unique series.
+func (a Points) Series() []Series {
+	m := make(map[string]Series)
+	for _, p := range a {
+		// Retrieve series.
+		key := string(p.Key())
+		s, ok := m[key]
+
+		// If not set already, set name and tags.
+		if !ok {
+			s.Name = p.Name()
+			s.Tags = p.Tags()
+		}
+
+		// Append point to series.
+		s.Points = append(s.Points, p)
+
+		// Update series.
+		m[key] = s
+	}
+
+	// Convert to slice of series and sort points.
+	var other []Series
+	for _, s := range m {
+		sort.Sort(tsdb.Points(s.Points))
+		other = append(other, s)
+	}
+
+	return other
+}
+
+// Series represents a name + tag series. It also includes a list of points.
+type Series struct {
+	Name   string
+	Tags   tsdb.Tags
+	Points []tsdb.Point
+}
+
+// Keys returns byte slice keys for each point.
+func (s *Series) Keys() [][]byte {
+	var a [][]byte
+	for _, p := range s.Points {
+		b := make([]byte, 8)
+		binary.BigEndian.PutUint64(b, uint64(p.UnixNano()))
+		a = append(a, b)
+	}
+	return a
+}

--- a/tsdb/engine/bz1/bz1_test.go
+++ b/tsdb/engine/bz1/bz1_test.go
@@ -1,15 +1,12 @@
 package bz1_test
 
 import (
+	"bytes"
 	"encoding/binary"
 	"io/ioutil"
-	"math/rand"
 	"os"
 	"reflect"
-	"sort"
-	"strconv"
 	"testing"
-	"testing/quick"
 	"time"
 
 	"github.com/influxdb/influxdb/tsdb"
@@ -128,11 +125,11 @@ func TestEngine_WriteIndex_Append(t *testing.T) {
 	// Append points to index.
 	if err := e.WriteIndex(map[string][][]byte{
 		"cpu": [][]byte{
-			append(u64tob(1), []byte{0x10}...),
-			append(u64tob(2), []byte{0x20}...),
+			bz1.MarshalEntry(1, []byte{0x10}),
+			bz1.MarshalEntry(2, []byte{0x20}),
 		},
 		"mem": [][]byte{
-			append(u64tob(0), []byte{0x30}...),
+			bz1.MarshalEntry(0, []byte{0x30}),
 		},
 	}); err != nil {
 		t.Fatal(err)
@@ -146,125 +143,76 @@ func TestEngine_WriteIndex_Append(t *testing.T) {
 	c := tx.Cursor("cpu")
 	if k, v := c.Seek(u64tob(0)); !reflect.DeepEqual(k, []byte{0, 0, 0, 0, 0, 0, 0, 1}) || !reflect.DeepEqual(v, []byte{0x10}) {
 		t.Fatalf("unexpected key/value: %x / %x", k, v)
+	} else if k, v = c.Next(); !reflect.DeepEqual(k, []byte{0, 0, 0, 0, 0, 0, 0, 2}) || !reflect.DeepEqual(v, []byte{0x20}) {
+		t.Fatalf("unexpected key/value: %x / %x", k, v)
+	} else if k, _ = c.Next(); k != nil {
+		t.Fatalf("unexpected key/value: %x / %x", k, v)
+	}
+
+	// Iterate over "mem" series.
+	c = tx.Cursor("mem")
+	if k, v := c.Seek(u64tob(0)); !reflect.DeepEqual(k, []byte{0, 0, 0, 0, 0, 0, 0, 0}) || !reflect.DeepEqual(v, []byte{0x30}) {
+		t.Fatalf("unexpected key/value: %x / %x", k, v)
+	} else if k, _ = c.Next(); k != nil {
+		t.Fatalf("unexpected key/value: %x / %x", k, v)
 	}
 }
 
-// Ensure the engine read and write randomized points.
-func TestEngine_WritePoints_Quick(t *testing.T) {
-	if testing.Short() {
-		t.Skip("short mode")
-	}
-
-	t.Skip("refactoring...")
-
-	quick.Check(func(blockSize uint16, points Points) bool {
-		e := OpenDefaultEngine()
-		e.BlockSize = int(blockSize)
-		defer e.Close()
-
-		// Write points against two separate series.
-		if err := e.WritePoints([]tsdb.Point(points), nil, nil); err != nil {
-			t.Fatal(err)
-		}
-
-		// Validate each series.
-		for _, series := range points.Series() {
-			if keys, err := e.ReadSeriesPointKeys(series.Name, series.Tags); err != nil {
-				t.Fatal(err)
-			} else if exp := series.Keys(); !reflect.DeepEqual(exp, keys) {
-				t.Fatalf("series point keys:\n\nexp=%v\n\ngot=%v\n\n", exp, keys)
-			}
-		}
-
-		return true
-	}, nil)
-}
-
-func BenchmarkEngine_WritePoints_0b_1(b *testing.B)     { benchmarkEngine_WritePoints_0b(b, 1) }
-func BenchmarkEngine_WritePoints_0b_10(b *testing.B)    { benchmarkEngine_WritePoints_0b(b, 10) }
-func BenchmarkEngine_WritePoints_0b_100(b *testing.B)   { benchmarkEngine_WritePoints_0b(b, 100) }
-func BenchmarkEngine_WritePoints_0b_1000(b *testing.B)  { benchmarkEngine_WritePoints_0b(b, 1000) }
-func BenchmarkEngine_WritePoints_0b_10000(b *testing.B) { benchmarkEngine_WritePoints_0b(b, 10000) }
-func benchmarkEngine_WritePoints_0b(b *testing.B, seriesN int) {
-	benchmarkEngine_WritePoints(b, 0, seriesN)
-}
-
-func BenchmarkEngine_WritePoints_512b_100(b *testing.B)   { benchmarkEngine_WritePoints_512b(b, 100) }
-func BenchmarkEngine_WritePoints_512b_1000(b *testing.B)  { benchmarkEngine_WritePoints_512b(b, 1000) }
-func BenchmarkEngine_WritePoints_512b_10000(b *testing.B) { benchmarkEngine_WritePoints_512b(b, 10000) }
-func benchmarkEngine_WritePoints_512b(b *testing.B, seriesN int) {
-	benchmarkEngine_WritePoints(b, 512, seriesN)
-}
-
-func BenchmarkEngine_WritePoints_1KB_100(b *testing.B)   { benchmarkEngine_WritePoints_1KB(b, 100) }
-func BenchmarkEngine_WritePoints_1KB_1000(b *testing.B)  { benchmarkEngine_WritePoints_1KB(b, 1000) }
-func BenchmarkEngine_WritePoints_1KB_10000(b *testing.B) { benchmarkEngine_WritePoints_1KB(b, 10000) }
-func benchmarkEngine_WritePoints_1KB(b *testing.B, seriesN int) {
-	benchmarkEngine_WritePoints(b, 1024, seriesN)
-}
-
-func BenchmarkEngine_WritePoints_2KB_100(b *testing.B)   { benchmarkEngine_WritePoints_2KB(b, 100) }
-func BenchmarkEngine_WritePoints_2KB_1000(b *testing.B)  { benchmarkEngine_WritePoints_2KB(b, 1000) }
-func BenchmarkEngine_WritePoints_2KB_10000(b *testing.B) { benchmarkEngine_WritePoints_2KB(b, 10000) }
-func benchmarkEngine_WritePoints_2KB(b *testing.B, seriesN int) {
-	benchmarkEngine_WritePoints(b, 2*1024, seriesN)
-}
-
-func BenchmarkEngine_WritePoints_4KB_100(b *testing.B)   { benchmarkEngine_WritePoints_4KB(b, 100) }
-func BenchmarkEngine_WritePoints_4KB_1000(b *testing.B)  { benchmarkEngine_WritePoints_4KB(b, 1000) }
-func BenchmarkEngine_WritePoints_4KB_10000(b *testing.B) { benchmarkEngine_WritePoints_4KB(b, 10000) }
-func benchmarkEngine_WritePoints_4KB(b *testing.B, seriesN int) {
-	benchmarkEngine_WritePoints(b, 4*1024, seriesN)
-}
-
-func BenchmarkEngine_WritePoints_8KB_100(b *testing.B)   { benchmarkEngine_WritePoints_8KB(b, 100) }
-func BenchmarkEngine_WritePoints_8KB_1000(b *testing.B)  { benchmarkEngine_WritePoints_8KB(b, 1000) }
-func BenchmarkEngine_WritePoints_8KB_10000(b *testing.B) { benchmarkEngine_WritePoints_8KB(b, 10000) }
-func benchmarkEngine_WritePoints_8KB(b *testing.B, seriesN int) {
-	benchmarkEngine_WritePoints(b, 8*1024, seriesN)
-}
-
-func BenchmarkEngine_WritePoints_16KB_100(b *testing.B)   { benchmarkEngine_WritePoints_16KB(b, 100) }
-func BenchmarkEngine_WritePoints_16KB_1000(b *testing.B)  { benchmarkEngine_WritePoints_16KB(b, 1000) }
-func BenchmarkEngine_WritePoints_16KB_10000(b *testing.B) { benchmarkEngine_WritePoints_16KB(b, 10000) }
-func benchmarkEngine_WritePoints_16KB(b *testing.B, seriesN int) {
-	benchmarkEngine_WritePoints(b, 16*1024, seriesN)
-}
-
-func BenchmarkEngine_WritePoints_32KB_100(b *testing.B)   { benchmarkEngine_WritePoints_32KB(b, 100) }
-func BenchmarkEngine_WritePoints_32KB_1000(b *testing.B)  { benchmarkEngine_WritePoints_32KB(b, 1000) }
-func BenchmarkEngine_WritePoints_32KB_10000(b *testing.B) { benchmarkEngine_WritePoints_32KB(b, 10000) }
-func benchmarkEngine_WritePoints_32KB(b *testing.B, seriesN int) {
-	benchmarkEngine_WritePoints(b, 32*1024, seriesN)
-}
-
-func benchmarkEngine_WritePoints(b *testing.B, blockSize, seriesN int) {
+// Ensure the engine can rewrite blocks that contain the new point range.
+func TestEngine_WriteIndex_Insert(t *testing.T) {
 	e := OpenDefaultEngine()
-	e.BlockSize = blockSize
 	defer e.Close()
 
-	// Generate data.
-	var points []tsdb.Point
-	for i := 0; i < b.N; i++ {
-		points = append(points, tsdb.NewPoint(
-			strconv.Itoa(i/seriesN),
-			tsdb.Tags{},
-			tsdb.Fields{"value": float64(i)},
-			time.Unix(0, 0).Add(time.Duration(i))))
-	}
-	b.ResetTimer()
-
-	// Write points against two separate series.
-	if err := e.WritePoints(points, nil, nil); err != nil {
-		b.Fatal(err)
+	// Write initial points to index.
+	if err := e.WriteIndex(map[string][][]byte{
+		"cpu": [][]byte{
+			bz1.MarshalEntry(10, []byte{0x10}),
+			bz1.MarshalEntry(20, []byte{0x20}),
+			bz1.MarshalEntry(30, []byte{0x30}),
+		},
+	}); err != nil {
+		t.Fatal(err)
 	}
 
-	// Stop timer and measure size per point.
-	b.StopTimer()
-	if stats, err := e.Stats(); err != nil {
-		b.Fatal(err)
-	} else {
-		b.Logf("n=%d, %.1f b/pt", b.N, float64(stats.Size)/float64(b.N))
+	// Write overlapping points to index.
+	if err := e.WriteIndex(map[string][][]byte{
+		"cpu": [][]byte{
+			bz1.MarshalEntry(9, []byte{0x09}),
+			bz1.MarshalEntry(10, []byte{0xFF}),
+			bz1.MarshalEntry(25, []byte{0x25}),
+			bz1.MarshalEntry(31, []byte{0x31}),
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write overlapping points to index again.
+	if err := e.WriteIndex(map[string][][]byte{
+		"cpu": [][]byte{
+			bz1.MarshalEntry(31, []byte{0xFF}),
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Start transaction.
+	tx := e.MustBegin(false)
+	defer tx.Rollback()
+
+	// Iterate over "cpu" series.
+	c := tx.Cursor("cpu")
+	if k, v := c.Seek(u64tob(0)); btou64(k) != 9 || !bytes.Equal(v, []byte{0x09}) {
+		t.Fatalf("unexpected key/value: %x / %x", k, v)
+	} else if k, v = c.Next(); btou64(k) != 10 || !bytes.Equal(v, []byte{0xFF}) {
+		t.Fatalf("unexpected key/value: %x / %x", k, v)
+	} else if k, v = c.Next(); btou64(k) != 20 || !bytes.Equal(v, []byte{0x20}) {
+		t.Fatalf("unexpected key/value: %x / %x", k, v)
+	} else if k, v = c.Next(); btou64(k) != 25 || !bytes.Equal(v, []byte{0x25}) {
+		t.Fatalf("unexpected key/value: %x / %x", k, v)
+	} else if k, v = c.Next(); btou64(k) != 30 || !bytes.Equal(v, []byte{0x30}) {
+		t.Fatalf("unexpected key/value: %x / %x", k, v)
+	} else if k, v = c.Next(); btou64(k) != 31 || !bytes.Equal(v, []byte{0xFF}) {
+		t.Fatalf("unexpected key/value: %x / %x", k, v)
 	}
 }
 
@@ -317,27 +265,6 @@ func (e *Engine) MustBegin(writable bool) tsdb.Tx {
 	return tx
 }
 
-// ReadSeriesPointKeys returns the raw keys for all points store for a series.
-func (e *Engine) ReadSeriesPointKeys(name string, tags tsdb.Tags) ([][]byte, error) {
-	// Open transaction on engine.
-	tx, err := e.Begin(false)
-	if err != nil {
-		return nil, err
-	}
-	defer tx.Rollback()
-
-	// Create a cursor for the series.
-	c := tx.Cursor(string(tsdb.MakeKey([]byte(name), tags)))
-
-	// Collect all the keys.
-	var keys [][]byte
-	for k, _ := c.Seek([]byte{0, 0, 0, 0, 0, 0, 0, 0}); k != nil; k, _ = c.Next() {
-		keys = append(keys, copyBytes(k))
-	}
-
-	return keys, nil
-}
-
 // EnginePointsWriter represents a mock that implements Engine.PointsWriter.
 type EnginePointsWriter struct {
 	WritePointsFn func(points []tsdb.Point) error
@@ -358,79 +285,12 @@ func copyBytes(b []byte) []byte {
 	return other
 }
 
-// Points represents a list of points that implements quick.Generator.
-type Points []tsdb.Point
-
-// Generate generates a random list of point.
-func (Points) Generate(rand *rand.Rand, size int) reflect.Value {
-	points := make([]tsdb.Point, rand.Intn(1000))
-
-	for i := range points {
-		// Generate individual point fields.
-		name := strconv.Itoa(rand.Intn(3))
-		tags := tsdb.Tags{"host": strconv.Itoa(rand.Intn(3))}
-		value, _ := quick.Value(reflect.TypeOf(float64(0)), rand)
-		timestamp := time.Unix(int64(rand.Uint32()), int64(rand.Uint32()))
-
-		// Create point with random data.
-		points[i] = tsdb.NewPoint(name, tags, tsdb.Fields{"value": value}, timestamp)
-	}
-
-	return reflect.ValueOf(points)
-}
-
-// Series returns a list of unique series.
-func (a Points) Series() []Series {
-	m := make(map[string]Series)
-	for _, p := range a {
-		// Retrieve series.
-		key := string(p.Key())
-		s, ok := m[key]
-
-		// If not set already, set name and tags.
-		if !ok {
-			s.Name = p.Name()
-			s.Tags = p.Tags()
-		}
-
-		// Append point to series.
-		s.Points = append(s.Points, p)
-
-		// Update series.
-		m[key] = s
-	}
-
-	// Convert to slice of series and sort points.
-	var other []Series
-	for _, s := range m {
-		sort.Sort(tsdb.Points(s.Points))
-		other = append(other, s)
-	}
-
-	return other
-}
-
-// Series represents a name + tag series. It also includes a list of points.
-type Series struct {
-	Name   string
-	Tags   tsdb.Tags
-	Points []tsdb.Point
-}
-
-// Keys returns byte slice keys for each point.
-func (s *Series) Keys() [][]byte {
-	var a [][]byte
-	for _, p := range s.Points {
-		b := make([]byte, 8)
-		binary.BigEndian.PutUint64(b, uint64(p.UnixNano()))
-		a = append(a, b)
-	}
-	return a
-}
-
 // u64tob converts a uint64 into an 8-byte slice.
 func u64tob(v uint64) []byte {
 	b := make([]byte, 8)
 	binary.BigEndian.PutUint64(b, v)
 	return b
 }
+
+// btou64 converts an 8-byte slice into an uint64.
+func btou64(b []byte) uint64 { return binary.BigEndian.Uint64(b) }

--- a/tsdb/engine/engine.go
+++ b/tsdb/engine/engine.go
@@ -2,4 +2,5 @@ package engine
 
 import (
 	_ "github.com/influxdb/influxdb/tsdb/engine/b1"
+	_ "github.com/influxdb/influxdb/tsdb/engine/bz1"
 )

--- a/tsdb/meta.go
+++ b/tsdb/meta.go
@@ -326,6 +326,13 @@ func (m *Measurement) HasField(name string) bool {
 	return hasField
 }
 
+// SeriesByID returns a series by identifier.
+func (m *Measurement) SeriesByID(id uint64) *Series {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.seriesByID[id]
+}
+
 // SeriesKeys returns the keys of every series in this measurement
 func (m *Measurement) SeriesKeys() []string {
 	m.mu.RLock()

--- a/tsdb/points.go
+++ b/tsdb/points.go
@@ -37,6 +37,13 @@ type Point interface {
 	String() string
 }
 
+// Points represents a sortable list of points by timestamp.
+type Points []Point
+
+func (a Points) Len() int           { return len(a) }
+func (a Points) Less(i, j int) bool { return a[i].Time().Before(a[j].Time()) }
+func (a Points) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+
 // point is the default implementation of Point.
 type point struct {
 	time time.Time
@@ -803,7 +810,7 @@ func unescapeQuoteString(in string) string {
 // NewPoint returns a new point with the given measurement name, tags, fields and timestamp
 func NewPoint(name string, tags Tags, fields Fields, time time.Time) Point {
 	return &point{
-		key:    makeKey([]byte(name), tags),
+		key:    MakeKey([]byte(name), tags),
 		time:   time,
 		fields: fields.MarshalBinary(),
 	}
@@ -833,7 +840,7 @@ func (p *point) Name() string {
 
 // SetName updates the measurement name for the point
 func (p *point) SetName(name string) {
-	p.key = makeKey([]byte(name), p.Tags())
+	p.key = MakeKey([]byte(name), p.Tags())
 }
 
 // Time return the timestamp for the point
@@ -875,20 +882,20 @@ func (p *point) Tags() Tags {
 	return tags
 }
 
-func makeKey(name []byte, tags Tags) []byte {
+func MakeKey(name []byte, tags Tags) []byte {
 	return append(escape(name), tags.HashKey()...)
 }
 
 // SetTags replaces the tags for the point
 func (p *point) SetTags(tags Tags) {
-	p.key = makeKey(p.name(), tags)
+	p.key = MakeKey(p.name(), tags)
 }
 
 // AddTag adds or replaces a tag value for a point
 func (p *point) AddTag(key, value string) {
 	tags := p.Tags()
 	tags[key] = value
-	p.key = makeKey(p.name(), tags)
+	p.key = MakeKey(p.name(), tags)
 }
 
 // Fields returns the fields for the point


### PR DESCRIPTION
## Overview

This pull request is another attempt at the `bz1` engine. The original can be found at https://github.com/influxdb/influxdb/pull/3461.

This approach changes the engine to support an underlying WAL which is being moved out to a separate package. The WAL work is being done by @pauldix. The `bz1` engine now supports a passthrough interface to a `PointsWriter` (which will be the WAL) and implements a function that the WAL periodically  calls back to:

```
func (e *Engine) WriteIndex(pointsByKey map[string][][]byte) error
```

### Implementation

The `WriteIndex()` function supports two separate write paths:

- "append" - Points for a key are all after the last point in the database. This is the fast path and it will simply append additional blocks onto the end.

- "insert" - Points for a key are intermixed with existing points. This is the slow path because it has to read out all the compressed blocks for the time range, combine them with the new points, and then rewrite all the blocks to disk.

There are two separate paths because most of the time users will be writing new data to the end of a series. The slow path mainly exists so that data can be backfilled.


## TODO

- [x] Implement append (fast path)
- [x] Implement insert (slow path)
- [x] Implement `testing/quick` black box testing