### PR TITLE
Host renaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [#3478](https://github.com/influxdb/influxdb/pull/3478): Support incremental cluster joins
 - [#3519](https://github.com/influxdb/influxdb/pull/3519): **--BREAKING CHANGE--** Update line protocol to require trailing i for field values that are integers
 - [#3529](https://github.com/influxdb/influxdb/pull/3529): Add TLS support for OpenTSDB plugin. Thanks @nathanielc
+- [#3421](https://github.com/influxdb/influxdb/issues/3421): Should update metastore and cluster if IP or hostname changes
 
 ### Bugfixes
 - [#3405](https://github.com/influxdb/influxdb/pull/3405): Prevent database panic when fields are missing. Thanks @jhorwit2

--- a/cmd/influxd/run/server.go
+++ b/cmd/influxd/run/server.go
@@ -283,6 +283,7 @@ func (s *Server) Open() error {
 			return fmt.Errorf("resolve tcp: addr=%s, err=%s", hostport, err)
 		}
 		s.MetaStore.Addr = addr
+		s.MetaStore.RemoteAddr = &tcpaddr{hostport}
 
 		// Open shared TCP connection.
 		ln, err := net.Listen("tcp", s.BindAddress)
@@ -494,3 +495,8 @@ func stopProfile() {
 		log.Println("mem profile stopped")
 	}
 }
+
+type tcpaddr struct{ host string }
+
+func (a *tcpaddr) Network() string { return "tcp" }
+func (a *tcpaddr) String() string  { return a.host }

--- a/meta/internal/meta.pb.go
+++ b/meta/internal/meta.pb.go
@@ -37,6 +37,7 @@ It has these top-level messages:
 	SetPrivilegeCommand
 	SetDataCommand
 	SetAdminPrivilegeCommand
+	UpdateNodeCommand
 	Response
 	ResponseHeader
 	ErrorResponse
@@ -111,6 +112,7 @@ const (
 	Command_SetPrivilegeCommand              Command_Type = 16
 	Command_SetDataCommand                   Command_Type = 17
 	Command_SetAdminPrivilegeCommand         Command_Type = 18
+	Command_UpdateNodeCommand                Command_Type = 19
 )
 
 var Command_Type_name = map[int32]string{
@@ -132,6 +134,7 @@ var Command_Type_name = map[int32]string{
 	16: "SetPrivilegeCommand",
 	17: "SetDataCommand",
 	18: "SetAdminPrivilegeCommand",
+	19: "UpdateNodeCommand",
 }
 var Command_Type_value = map[string]int32{
 	"CreateNodeCommand":                1,
@@ -152,6 +155,7 @@ var Command_Type_value = map[string]int32{
 	"SetPrivilegeCommand":              16,
 	"SetDataCommand":                   17,
 	"SetAdminPrivilegeCommand":         18,
+	"UpdateNodeCommand":                19,
 }
 
 func (x Command_Type) Enum() *Command_Type {
@@ -1154,6 +1158,38 @@ var E_SetAdminPrivilegeCommand_Command = &proto.ExtensionDesc{
 	Tag:           "bytes,118,opt,name=command",
 }
 
+type UpdateNodeCommand struct {
+	ID               *uint64 `protobuf:"varint,1,req" json:"ID,omitempty"`
+	Host             *string `protobuf:"bytes,2,req" json:"Host,omitempty"`
+	XXX_unrecognized []byte  `json:"-"`
+}
+
+func (m *UpdateNodeCommand) Reset()         { *m = UpdateNodeCommand{} }
+func (m *UpdateNodeCommand) String() string { return proto.CompactTextString(m) }
+func (*UpdateNodeCommand) ProtoMessage()    {}
+
+func (m *UpdateNodeCommand) GetID() uint64 {
+	if m != nil && m.ID != nil {
+		return *m.ID
+	}
+	return 0
+}
+
+func (m *UpdateNodeCommand) GetHost() string {
+	if m != nil && m.Host != nil {
+		return *m.Host
+	}
+	return ""
+}
+
+var E_UpdateNodeCommand_Command = &proto.ExtensionDesc{
+	ExtendedType:  (*Command)(nil),
+	ExtensionType: (*UpdateNodeCommand)(nil),
+	Field:         119,
+	Name:          "internal.UpdateNodeCommand.command",
+	Tag:           "bytes,119,opt,name=command",
+}
+
 type Response struct {
 	OK               *bool   `protobuf:"varint,1,req" json:"OK,omitempty"`
 	Error            *string `protobuf:"bytes,2,opt" json:"Error,omitempty"`
@@ -1381,4 +1417,5 @@ func init() {
 	proto.RegisterExtension(E_SetPrivilegeCommand_Command)
 	proto.RegisterExtension(E_SetDataCommand_Command)
 	proto.RegisterExtension(E_SetAdminPrivilegeCommand_Command)
+	proto.RegisterExtension(E_UpdateNodeCommand_Command)
 }

--- a/meta/internal/meta.proto
+++ b/meta/internal/meta.proto
@@ -99,7 +99,7 @@ message Command {
 		SetPrivilegeCommand              = 16;
 		SetDataCommand                   = 17;
 		SetAdminPrivilegeCommand         = 18;
-        UpdateNodeCommand                = 19;
+		UpdateNodeCommand                = 19;
     }
 
     required Type type = 1;

--- a/meta/internal/meta.proto
+++ b/meta/internal/meta.proto
@@ -99,6 +99,7 @@ message Command {
 		SetPrivilegeCommand              = 16;
 		SetDataCommand                   = 17;
 		SetAdminPrivilegeCommand         = 18;
+        UpdateNodeCommand                = 19;
     }
 
     required Type type = 1;
@@ -249,6 +250,14 @@ message SetAdminPrivilegeCommand {
     }
     required string Username = 1;
     required bool Admin = 2;
+}
+
+message UpdateNodeCommand {
+    extend Command {
+        optional UpdateNodeCommand command = 119;
+    }
+    required uint64 ID = 1;
+    required string Host = 2;
 }
 
 message Response {

--- a/meta/state.go
+++ b/meta/state.go
@@ -162,7 +162,9 @@ func (r *localRaft) open() error {
 func (r *localRaft) close() error {
 	// Shutdown raft.
 	if r.raft != nil {
-		r.raft.Shutdown()
+		if err := r.raft.Shutdown().Error(); err != nil {
+			return err
+		}
 		r.raft = nil
 	}
 	if r.transport != nil {

--- a/meta/statement_executor.go
+++ b/meta/statement_executor.go
@@ -133,9 +133,9 @@ func (e *StatementExecutor) executeShowServersStatement(q *influxql.ShowServersS
 		return &influxql.Result{Err: err}
 	}
 
-	row := &influxql.Row{Columns: []string{"id", "url", "raft"}}
+	row := &influxql.Row{Columns: []string{"id", "cluster_addr", "raft"}}
 	for _, ni := range nis {
-		row.Values = append(row.Values, []interface{}{ni.ID, "http://" + ni.Host, contains(peers, ni.Host)})
+		row.Values = append(row.Values, []interface{}{ni.ID, ni.Host, contains(peers, ni.Host)})
 	}
 	return &influxql.Result{Series: []*influxql.Row{row}}
 }

--- a/meta/statement_executor_test.go
+++ b/meta/statement_executor_test.go
@@ -129,10 +129,10 @@ func TestStatementExecutor_ExecuteStatement_ShowServers(t *testing.T) {
 		t.Fatal(res.Err)
 	} else if !reflect.DeepEqual(res.Series, influxql.Rows{
 		{
-			Columns: []string{"id", "url", "raft"},
+			Columns: []string{"id", "cluster_addr", "raft"},
 			Values: [][]interface{}{
-				{uint64(1), "http://node0", true},
-				{uint64(2), "http://node1", false},
+				{uint64(1), "node0", true},
+				{uint64(2), "node1", false},
 			},
 		},
 	}) {

--- a/meta/store.go
+++ b/meta/store.go
@@ -34,6 +34,8 @@ const (
 
 	// SaltBytes is the number of bytes used for salts
 	SaltBytes = 32
+
+	DefaultSyncNodeDelay = time.Second
 )
 
 // ExecMagic is the first 4 bytes sent to a remote exec connection to verify
@@ -71,6 +73,7 @@ type Store struct {
 
 	rpc *rpc
 
+	// The address used by other nodes to reach this node.
 	RemoteAddr net.Addr
 
 	raftState raftState
@@ -280,7 +283,7 @@ func (s *Store) syncNodeInfo() error {
 			return nil
 		}(); err != nil {
 			// If we get an error, the cluster has not stabilized so just try again
-			time.Sleep(time.Second)
+			time.Sleep(DefaultSyncNodeDelay)
 			continue
 		}
 		return nil

--- a/meta/store.go
+++ b/meta/store.go
@@ -279,7 +279,7 @@ func (s *Store) syncNodeInfo() error {
 			}
 			return nil
 		}(); err != nil {
-			// If we get an error, the cluster has not stabilized so just retry again
+			// If we get an error, the cluster has not stabilized so just try again
 			time.Sleep(time.Second)
 			continue
 		}
@@ -801,7 +801,7 @@ func (s *Store) CreateNode(host string) (*NodeInfo, error) {
 	return s.NodeByHost(host)
 }
 
-// CreateNode creates a new node in the store.
+// UpdateNode updates an existing node in the store.
 func (s *Store) UpdateNode(id uint64, host string) (*NodeInfo, error) {
 	if err := s.exec(internal.Command_UpdateNodeCommand, internal.E_UpdateNodeCommand_Command,
 		&internal.UpdateNodeCommand{

--- a/meta/store_test.go
+++ b/meta/store_test.go
@@ -735,6 +735,7 @@ func TestStore_Snapshot_And_Restore(t *testing.T) {
 
 	s := MustOpenStore()
 	s.LeaveFiles = true
+	addr := s.RemoteAddr.String()
 
 	// Create a bunch of databases in the Store
 	nDatabases := 5
@@ -748,13 +749,11 @@ func TestStore_Snapshot_And_Restore(t *testing.T) {
 	}
 
 	s.Close()
+	time.Sleep(100 * time.Millisecond)
 
 	// Test restoring the snapshot taken above.
 	existingDataPath := s.Path()
-	s = NewStore(NewConfig(existingDataPath))
-	if err := s.Open(); err != nil {
-		panic(err)
-	}
+	s = MustOpenStoreWithPath(addr, existingDataPath)
 	defer s.Close()
 
 	// Wait until the server is ready.

--- a/meta/store_test.go
+++ b/meta/store_test.go
@@ -934,6 +934,7 @@ func (s *Store) Open() error {
 	}
 	s.Addr = ln.Addr()
 	s.Listener = ln
+	s.RemoteAddr = s.Addr
 
 	// Wrap listener in a muxer.
 	mux := tcp.NewMux()

--- a/meta/store_test.go
+++ b/meta/store_test.go
@@ -749,6 +749,8 @@ func TestStore_Snapshot_And_Restore(t *testing.T) {
 	}
 
 	s.Close()
+
+	// Allow the kernel to free up the port so we can re-use it again
 	time.Sleep(100 * time.Millisecond)
 
 	// Test restoring the snapshot taken above.


### PR DESCRIPTION
This PR allows the `-hostname` flag to update an existing nodes hostname in the cluster without having to rebuild the cluster.  Hostname changes need to work for both raft consensus members as well as non-raft members.  

The non-raft members change is straightforward and just updates it's hostname after startup through normal raft remote exec commands. 

Updating a raft member's hostname turned out to be far more complicated because the cluster must have an elected leader to apply the change. In addition to updating the meta stores `NodeInfo`, we also need to update the raft peers.  This latter change is very problematic and requires manual intervention by an administrator.  In the case that a raft peers hostname is changed, the server will abort startup if it detects that the `meta/peers.json` is out of sync with the hostname being used.  The administrator will need to manually update the `meta/peers.json` on all raft peers and start the other nodes before starting the node with the updated hostname.

## Example

Start a single node that defaults to hostname of `localhost`.
```
$ influxd
no configuration provided, using default settings
[continuous_querier] 2015/08/05 10:47:15 starting continuous query service
[metastore] 2015/08/05 10:47:16 created local node: id=1, host=localhost:8088
[admin] 2015/08/05 10:47:16 listening on HTTP: [::]:8083
[httpd] 2015/08/05 10:47:16 authentication enabled: false
[httpd] 2015/08/05 10:47:16 listening on HTTP: [::]:8086
2015/08/05 10:47:16 InfluxDB starting, version 0.9, commit unknown
2015/08/05 10:47:16 GOMAXPROCS set to 8
[run] 2015/08/05 10:47:16 listening for signals
2015/08/05 10:47:16 Sending anonymous usage statistics to m.influxdb.com 
```

Verify with `SHOW SERVERS`:
```
influxdb:meta jason$ echo "SHOW SERVERS" | influx
Connected to http://localhost:8086 version 0.9
InfluxDB shell 0.9
id	cluster_addr	raft
1	localhost:8088	true
```

Restart with a new hostname of `inflxudb.local`.   The server detects that its hostname is not in sync with its raft peers and aborts with an error.  Since this single node is a raft peer, we need to manually update the `peers.json` file first.

```
$ influxd -hostname influxdb.local
no configuration provided, using default settings
[continuous_querier] 2015/08/05 10:48:21 starting continuous query service
[metastore] 2015/08/05 10:48:22 influxdb.local:8088 is not in the list of raft peers. Please update /Users/jason/.influxdb/meta/peers.json on all raft nodes to have the same contents.
run: open server: open meta store: raft: peers out of sync: influxdb.local:8088 not in [localhost:8088]
```

Update `meta/peers.json`:
```
sed -i '' 's/localhost/influxdb.local/' /Users/jason/.influxdb/meta/peers.json
```

Restart with new hostname:
```
$ influxd -hostname influxdb.local
no configuration provided, using default settings
[continuous_querier] 2015/08/05 10:53:36 starting continuous query service
[metastore] 2015/08/05 10:53:36 read local node id: 1
[metastore] 2015/08/05 10:53:36 skipping join: already member of cluster: nodeId=1 raftEnabled=true raftNodes=[influxdb.local:8088]
[admin] 2015/08/05 10:53:36 listening on HTTP: [::]:8083
[httpd] 2015/08/05 10:53:36 authentication enabled: false
[httpd] 2015/08/05 10:53:36 listening on HTTP: [::]:8086
2015/08/05 10:53:36 InfluxDB starting, version 0.9, commit unknown
2015/08/05 10:53:36 GOMAXPROCS set to 8
[run] 2015/08/05 10:53:36 listening for signals
[metastore] 2015/08/05 10:53:38 updated node id=1 hostname=influxdb.local:8088
2015/08/05 10:53:38 Sending anonymous usage statistics to m.influxdb.com
```

Verify with `SHOW SERVERS`:
```
influxdb:meta jason$ echo "SHOW SERVERS" | influx
Connected to http://localhost:8086 version 0.9
InfluxDB shell 0.9
id	cluster_addr		raft
1	influxdb.local:8088	true
````
 


