### PR TITLE
Fix panic parsing measurement with large number of tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - [#3404](https://github.com/influxdb/influxdb/pull/3404): Added support for escaped single quotes in query string. Thanks @jhorwit2
 - [#3414](https://github.com/influxdb/influxdb/issues/3414): Shard mappers perform query re-writing
 - [#3525](https://github.com/influxdb/influxdb/pull/3525): check if fields are valid during parse time.
+- [#3511](https://github.com/influxdb/influxdb/issues/3511): Sending a large number of tag causes panic
 
 ## v0.9.2 [2015-07-24]
 

--- a/tsdb/points.go
+++ b/tsdb/points.go
@@ -254,6 +254,13 @@ func scanKey(buf []byte, i int) (int, []byte, error) {
 				return i, buf[start:i], fmt.Errorf("missing tag value")
 			}
 			i += 1
+
+			// grow our indices slice if we have too many tags
+			if commas >= len(indices) {
+				newIndics := make([]int, cap(indices)*2)
+				copy(newIndics, indices)
+				indices = newIndics
+			}
 			indices[commas] = i
 			commas += 1
 
@@ -273,6 +280,14 @@ func scanKey(buf []byte, i int) (int, []byte, error) {
 			if equals > 0 && commas-1 != equals-1 {
 				return i, buf[start:i], fmt.Errorf("missing tag value")
 			}
+
+			// grow our indices slice if we have too many tags
+			if commas >= len(indices) {
+				newIndics := make([]int, cap(indices)*2)
+				copy(newIndics, indices)
+				indices = newIndics
+			}
+
 			indices[commas] = i + 1
 			break
 		}

--- a/tsdb/points_test.go
+++ b/tsdb/points_test.go
@@ -857,7 +857,22 @@ func TestNewPointNaN(t *testing.T) {
 			},
 			time.Unix(1, 0)),
 	)
+}
 
+func TestNewPointLargeNumberOfTags(t *testing.T) {
+	tags := ""
+	for i := 0; i < 255; i++ {
+		tags += fmt.Sprintf(",tag%d=value%d", i, i)
+	}
+
+	pt, err := tsdb.ParsePointsString(fmt.Sprintf("cpu%s value=1", tags))
+	if err != nil {
+		t.Fatalf("ParsePoints() with max tags failed: %v", err)
+	}
+
+	if len(pt[0].Tags()) != 255 {
+		t.Fatalf("ParsePoints() with max tags failed: %v", err)
+	}
 }
 
 func TestParsePointIntsFloats(t *testing.T) {


### PR DESCRIPTION
Defaults to handling measurements with up to 100 tags and will
now grow the slice if there are more instead of panicing.

Fixes #3511