### PR TITLE
Fix parsing string fields with newlines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - [#3525](https://github.com/influxdb/influxdb/pull/3525): check if fields are valid during parse time.
 - [#3511](https://github.com/influxdb/influxdb/issues/3511): Sending a large number of tag causes panic
 - [#3288](https://github.com/influxdb/influxdb/issues/3288): Run go fuzz on the line-protocol input
+- [#3545](https://github.com/influxdb/influxdb/issues/3545): Fix parsing string fields with newlines
 
 ## v0.9.2 [2015-07-24]
 

--- a/tsdb/points.go
+++ b/tsdb/points.go
@@ -116,7 +116,7 @@ func ParsePointsWithPrecision(buf []byte, defaultTime time.Time, precision strin
 		block []byte
 	)
 	for {
-		pos, block = scanTo(buf, pos, '\n')
+		pos, block = scanLine(buf, pos)
 		pos += 1
 
 		if len(block) == 0 {
@@ -689,6 +689,39 @@ func skipWhitespace(buf []byte, i int) int {
 		break
 	}
 	return i
+}
+
+// scanLine returns the end position in buf and the next line found within
+// buf.
+func scanLine(buf []byte, i int) (int, []byte) {
+	start := i
+	quoted := false
+	for {
+		// reached the end of buf?
+		if i >= len(buf) {
+			break
+		}
+
+		// If we see a double quote, makes sure it is not escaped
+		if buf[i] == '"' && buf[i-1] != '\\' {
+			i += 1
+			quoted = !quoted
+			continue
+		}
+
+		if buf[i] == '\\' {
+			i += 2
+			continue
+		}
+
+		if buf[i] == '\n' && !quoted {
+			break
+		}
+
+		i += 1
+	}
+
+	return i, buf[start:i]
 }
 
 // scanTo returns the end position in buf and the next consecutive block

--- a/tsdb/points_test.go
+++ b/tsdb/points_test.go
@@ -681,6 +681,22 @@ func TestParsePointWithStringWithSpaces(t *testing.T) {
 	)
 }
 
+func TestParsePointWithStringWithNewline(t *testing.T) {
+	test(t, "cpu,host=serverA,region=us-east value=1.0,str=\"foo\nbar\" 1000000000",
+		tsdb.NewPoint(
+			"cpu",
+			tsdb.Tags{
+				"host":   "serverA",
+				"region": "us-east",
+			},
+			tsdb.Fields{
+				"value": 1.0,
+				"str":   "foo\nbar", // newline in string value
+			},
+			time.Unix(1, 0)),
+	)
+}
+
 func TestParsePointWithStringWithCommas(t *testing.T) {
 	// escaped comma
 	test(t, `cpu,host=serverA,region=us-east value=1.0,str="foo\,bar" 1000000000`,


### PR DESCRIPTION
Newlines in a string field would cause the parser to return
the line prematurely causing "unbalanced quotes" errors.  This
makes the line scanning aware of quote fields so that the whole
line is returned.

Fixes #3545