### PR TITLE
Adds support for logrus logger.

### DIFF
--- a/client/example_test.go
+++ b/client/example_test.go
@@ -2,7 +2,7 @@ package client_test
 
 import (
 	"fmt"
-	"log"
+	log "github.com/Sirupsen/logrus"
 	"math/rand"
 	"net/url"
 	"os"

--- a/cluster/points_writer.go
+++ b/cluster/points_writer.go
@@ -3,11 +3,11 @@ package cluster
 import (
 	"errors"
 	"fmt"
-	"log"
-	"os"
 	"strings"
 	"sync"
 	"time"
+
+	log "github.com/Sirupsen/logrus"
 
 	"github.com/influxdb/influxdb"
 	"github.com/influxdb/influxdb/meta"
@@ -68,7 +68,7 @@ type PointsWriter struct {
 	mu           sync.RWMutex
 	closing      chan struct{}
 	WriteTimeout time.Duration
-	Logger       *log.Logger
+	Logger       log.StdLogger
 
 	MetaStore interface {
 		NodeID() uint64
@@ -97,7 +97,7 @@ func NewPointsWriter() *PointsWriter {
 	return &PointsWriter{
 		closing:      make(chan struct{}),
 		WriteTimeout: DefaultWriteTimeout,
-		Logger:       log.New(os.Stderr, "[write] ", log.LstdFlags),
+		Logger:       log.New().WithField("service", "write"),
 	}
 }
 

--- a/cluster/service.go
+++ b/cluster/service.go
@@ -5,11 +5,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"net"
-	"os"
 	"strings"
 	"sync"
+
+	log "github.com/Sirupsen/logrus"
 
 	"github.com/influxdb/influxdb/meta"
 	"github.com/influxdb/influxdb/tsdb"
@@ -40,14 +40,14 @@ type Service struct {
 		CreateMapper(shardID uint64, query string, chunkSize int) (tsdb.Mapper, error)
 	}
 
-	Logger *log.Logger
+	Logger log.StdLogger
 }
 
 // NewService returns a new instance of Service.
 func NewService(c Config) *Service {
 	return &Service{
 		closing: make(chan struct{}),
-		Logger:  log.New(os.Stderr, "[tcp] ", log.LstdFlags),
+		Logger:  log.New().WithField("service", "tcp"),
 	}
 }
 
@@ -61,7 +61,7 @@ func (s *Service) Open() error {
 }
 
 // SetLogger sets the internal logger to the logger passed in.
-func (s *Service) SetLogger(l *log.Logger) {
+func (s *Service) SetLogger(l log.StdLogger) {
 	s.Logger = l
 }
 

--- a/cmd/influxd/backup/backup.go
+++ b/cmd/influxd/backup/backup.go
@@ -6,9 +6,10 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"log"
 	"net"
 	"os"
+
+	log "github.com/Sirupsen/logrus"
 
 	"github.com/influxdb/influxdb/services/snapshotter"
 	"github.com/influxdb/influxdb/snapshot"
@@ -20,7 +21,7 @@ const Suffix = ".pending"
 // Command represents the program execution for "influxd backup".
 type Command struct {
 	// The logger passed to the ticker during execution.
-	Logger *log.Logger
+	Logger log.StdLogger
 
 	// Standard input/output, overridden for testing.
 	Stderr io.Writer
@@ -36,7 +37,7 @@ func NewCommand() *Command {
 // Run executes the program.
 func (cmd *Command) Run(args ...string) error {
 	// Set up logger.
-	cmd.Logger = log.New(cmd.Stderr, "", log.LstdFlags)
+	cmd.Logger = log.New()
 	cmd.Logger.Printf("influxdb backup")
 
 	// Parse command line arguments.

--- a/cmd/influxd/main.go
+++ b/cmd/influxd/main.go
@@ -4,13 +4,14 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"log"
 	"math/rand"
 	"os"
 	"os/signal"
 	"strings"
 	"syscall"
 	"time"
+
+	log "github.com/Sirupsen/logrus"
 
 	"github.com/influxdb/influxdb/cmd/influxd/backup"
 	"github.com/influxdb/influxdb/cmd/influxd/help"
@@ -43,7 +44,7 @@ func main() {
 
 // Main represents the program execution.
 type Main struct {
-	Logger *log.Logger
+	Logger log.StdLogger
 
 	Stdin  io.Reader
 	Stdout io.Writer
@@ -53,7 +54,7 @@ type Main struct {
 // NewMain return a new instance of Main.
 func NewMain() *Main {
 	return &Main{
-		Logger: log.New(os.Stderr, "[run] ", log.LstdFlags),
+		Logger: log.New().WithField("service", "run"),
 		Stdin:  os.Stdin,
 		Stdout: os.Stdout,
 		Stderr: os.Stderr,

--- a/cmd/influxd/run/command.go
+++ b/cmd/influxd/run/command.go
@@ -5,12 +5,13 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strconv"
 	"strings"
+
+	log "github.com/Sirupsen/logrus"
 
 	"github.com/BurntSushi/toml"
 )
@@ -125,7 +126,7 @@ func (cmd *Command) Close() error {
 }
 
 func (cmd *Command) monitorServerErrors() {
-	logger := log.New(cmd.Stderr, "", log.LstdFlags)
+	logger := log.New()
 	for {
 		select {
 		case err := <-cmd.Server.Err():

--- a/cmd/influxd/run/server.go
+++ b/cmd/influxd/run/server.go
@@ -3,7 +3,7 @@ package run
 import (
 	"bytes"
 	"fmt"
-	"log"
+	log "github.com/Sirupsen/logrus"
 	"net"
 	"net/http"
 	"os"

--- a/cmd/influxd/run/server_helpers_test.go
+++ b/cmd/influxd/run/server_helpers_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
 	"math"
 	"net/http"
 	"net/url"
@@ -15,6 +14,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	log "github.com/Sirupsen/logrus"
 
 	"github.com/influxdb/influxdb/cmd/influxd/run"
 	"github.com/influxdb/influxdb/meta"
@@ -294,9 +295,10 @@ func configureLogging(s *Server) {
 	// Set the logger to discard unless verbose is on
 	if !testing.Verbose() {
 		type logSetter interface {
-			SetLogger(*log.Logger)
+			SetLogger(log.StdLogger)
 		}
-		nullLogger := log.New(ioutil.Discard, "", 0)
+		nullLogger := log.NewEntry(log.New())
+		nullLogger.Logger.Out = ioutil.Discard
 		s.MetaStore.Logger = nullLogger
 		s.TSDBStore.Logger = nullLogger
 		for _, service := range s.Services {

--- a/etc/burn-in/burn-in.rb
+++ b/etc/burn-in/burn-in.rb
@@ -2,7 +2,7 @@ require "influxdb"
 require "colorize"
 require "benchmark"
 
-require_relative "log"
+require_relative log "github.com/Sirupsen/logrus"
 require_relative "random_gaussian"
 
 BATCH_SIZE = 10_000

--- a/meta/rpc.go
+++ b/meta/rpc.go
@@ -6,9 +6,10 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
 	"net"
 	"time"
+
+	log "github.com/Sirupsen/logrus"
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/raft"
@@ -23,7 +24,7 @@ const (
 
 // rpc handles request/response style messaging between cluster nodes
 type rpc struct {
-	logger         *log.Logger
+	logger         log.StdLogger
 	tracingEnabled bool
 
 	store interface {

--- a/meta/state.go
+++ b/meta/state.go
@@ -6,10 +6,13 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"math/rand"
 	"os"
 	"path/filepath"
 	"time"
+
+	"github.com/Sirupsen/logrus"
 
 	"github.com/hashicorp/raft"
 	"github.com/hashicorp/raft-boltdb"
@@ -100,7 +103,7 @@ func (r *localRaft) open() error {
 	config.LogOutput = ioutil.Discard
 
 	if s.clusterTracingEnabled {
-		config.Logger = s.Logger
+		config.Logger = log.New(logrus.New().WithField("service", "metastore").Logger.Out, "", log.LstdFlags)
 	}
 	config.HeartbeatTimeout = s.HeartbeatTimeout
 	config.ElectionTimeout = s.ElectionTimeout

--- a/meta/store.go
+++ b/meta/store.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
 	"math/rand"
 	"net"
 	"os"
@@ -18,6 +17,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	log "github.com/Sirupsen/logrus"
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/raft"
@@ -120,7 +121,7 @@ type Store struct {
 	// Returns an error if the password is invalid or a hash cannot be generated.
 	hashPassword HashPasswordFn
 
-	Logger *log.Logger
+	Logger log.StdLogger
 }
 
 type authUser struct {
@@ -151,7 +152,7 @@ func NewStore(c *Config) *Store {
 		hashPassword: func(password string) ([]byte, error) {
 			return bcrypt.GenerateFromPassword([]byte(password), BcryptCost)
 		},
-		Logger: log.New(os.Stderr, "[metastore] ", log.LstdFlags),
+		Logger: log.New().WithField("service", "metastore"),
 	}
 
 	s.raftState = &localRaft{store: s}

--- a/meta/store_test.go
+++ b/meta/store_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"net"
 	"os"
 	"path/filepath"
@@ -13,6 +12,8 @@ import (
 	"strconv"
 	"testing"
 	"time"
+
+	log "github.com/Sirupsen/logrus"
 
 	"github.com/influxdb/influxdb/meta"
 	"github.com/influxdb/influxdb/tcp"
@@ -890,7 +891,7 @@ func NewStore(c *meta.Config) *Store {
 	s := &Store{
 		Store: meta.NewStore(c),
 	}
-	s.Logger = log.New(&s.Stderr, "", log.LstdFlags)
+	s.Logger = log.NewEntry(log.New())
 	s.SetHashPasswordFn(mockHashPassword)
 	return s
 }

--- a/services/admin/service.go
+++ b/services/admin/service.go
@@ -3,11 +3,11 @@ package admin
 import (
 	"crypto/tls"
 	"fmt"
-	"log"
 	"net"
 	"net/http"
-	"os"
 	"strings"
+
+	log "github.com/Sirupsen/logrus"
 
 	// Register static assets via statik.
 	_ "github.com/influxdb/influxdb/statik"
@@ -22,7 +22,7 @@ type Service struct {
 	cert     string
 	err      chan error
 
-	logger *log.Logger
+	logger log.StdLogger
 }
 
 // NewService returns a new instance of Service.
@@ -32,7 +32,7 @@ func NewService(c Config) *Service {
 		https:  c.HttpsEnabled,
 		cert:   c.HttpsCertificate,
 		err:    make(chan error),
-		logger: log.New(os.Stderr, "[admin] ", log.LstdFlags),
+		logger: log.New().WithField("service", "admin"),
 	}
 }
 
@@ -78,7 +78,7 @@ func (s *Service) Close() error {
 }
 
 // SetLogger sets the internal logger to the logger passed in.
-func (s *Service) SetLogger(l *log.Logger) {
+func (s *Service) SetLogger(l log.StdLogger) {
 	s.logger = l
 }
 

--- a/services/collectd/service.go
+++ b/services/collectd/service.go
@@ -2,11 +2,11 @@ package collectd
 
 import (
 	"fmt"
-	"log"
 	"net"
-	"os"
 	"sync"
 	"time"
+
+	log "github.com/Sirupsen/logrus"
 
 	"github.com/influxdb/influxdb/cluster"
 	"github.com/influxdb/influxdb/meta"
@@ -33,7 +33,7 @@ type Service struct {
 	Config       *Config
 	MetaStore    metaStore
 	PointsWriter pointsWriter
-	Logger       *log.Logger
+	Logger       log.StdLogger
 
 	wg      sync.WaitGroup
 	err     chan error
@@ -48,7 +48,7 @@ type Service struct {
 func NewService(c Config) *Service {
 	s := &Service{
 		Config: &c,
-		Logger: log.New(os.Stderr, "[collectd] ", log.LstdFlags),
+		Logger: log.New().WithField("service", "collectd"),
 		err:    make(chan error),
 	}
 
@@ -138,7 +138,7 @@ func (s *Service) Close() error {
 }
 
 // SetLogger sets the internal logger to the logger passed in.
-func (s *Service) SetLogger(l *log.Logger) {
+func (s *Service) SetLogger(l log.StdLogger) {
 	s.Logger = l
 }
 

--- a/services/collectd/service_test.go
+++ b/services/collectd/service_test.go
@@ -4,10 +4,11 @@ import (
 	"encoding/hex"
 	"errors"
 	"io/ioutil"
-	"log"
 	"net"
 	"testing"
 	"time"
+
+	log "github.com/Sirupsen/logrus"
 
 	"github.com/influxdb/influxdb/cluster"
 	"github.com/influxdb/influxdb/meta"
@@ -202,7 +203,9 @@ func newTestService(batchSize int, batchDuration time.Duration) *testService {
 	}
 
 	if !testing.Verbose() {
-		s.Logger = log.New(ioutil.Discard, "", log.LstdFlags)
+		logger := log.New()
+		logger.Out = ioutil.Discard
+		s.Logger = logger
 	}
 
 	return s

--- a/services/continuous_querier/service.go
+++ b/services/continuous_querier/service.go
@@ -3,11 +3,11 @@ package continuous_querier
 import (
 	"errors"
 	"fmt"
-	"log"
-	"os"
 	"strings"
 	"sync"
 	"time"
+
+	log "github.com/Sirupsen/logrus"
 
 	"github.com/influxdb/influxdb/cluster"
 	"github.com/influxdb/influxdb/influxql"
@@ -52,7 +52,7 @@ type Service struct {
 	RunInterval   time.Duration
 	// RunCh can be used by clients to signal service to run CQs.
 	RunCh          chan struct{}
-	Logger         *log.Logger
+	Logger         log.StdLogger
 	loggingEnabled bool
 	// lastRuns maps CQ name to last time it was run.
 	lastRuns map[string]time.Time
@@ -67,7 +67,7 @@ func NewService(c Config) *Service {
 		RunInterval:    time.Second,
 		RunCh:          make(chan struct{}),
 		loggingEnabled: c.LogEnabled,
-		Logger:         log.New(os.Stderr, "[continuous_querier] ", log.LstdFlags),
+		Logger:         log.New().WithField("service", "continuos_querier"),
 		lastRuns:       map[string]time.Time{},
 	}
 
@@ -105,7 +105,7 @@ func (s *Service) Close() error {
 }
 
 // SetLogger sets the internal logger to the logger passed in.
-func (s *Service) SetLogger(l *log.Logger) {
+func (s *Service) SetLogger(l log.StdLogger) {
 	s.Logger = l
 }
 

--- a/services/continuous_querier/service_test.go
+++ b/services/continuous_querier/service_test.go
@@ -4,10 +4,11 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"sync"
 	"testing"
 	"time"
+
+	log "github.com/Sirupsen/logrus"
 
 	"github.com/influxdb/influxdb/cluster"
 	"github.com/influxdb/influxdb/influxql"
@@ -244,7 +245,9 @@ func NewTestService(t *testing.T) *Service {
 
 	// Set Logger to write to dev/null so stdout isn't polluted.
 	if !testing.Verbose() {
-		s.Logger = log.New(ioutil.Discard, "", log.LstdFlags)
+		logger := log.New()
+		logger.Out = ioutil.Discard
+		s.Logger = logger
 	}
 
 	// Add a couple test databases and CQs.

--- a/services/graphite/service.go
+++ b/services/graphite/service.go
@@ -3,13 +3,13 @@ package graphite
 import (
 	"bufio"
 	"fmt"
-	"log"
 	"math"
 	"net"
-	"os"
 	"strings"
 	"sync"
 	"time"
+
+	log "github.com/Sirupsen/logrus"
 
 	"github.com/influxdb/influxdb/cluster"
 	"github.com/influxdb/influxdb/meta"
@@ -32,7 +32,7 @@ type Service struct {
 	batcher *tsdb.PointBatcher
 	parser  *Parser
 
-	logger *log.Logger
+	logger log.StdLogger
 
 	ln   net.Listener
 	addr net.Addr
@@ -60,7 +60,7 @@ func NewService(c Config) (*Service, error) {
 		protocol:     d.Protocol,
 		batchSize:    d.BatchSize,
 		batchTimeout: time.Duration(d.BatchTimeout),
-		logger:       log.New(os.Stderr, "[graphite] ", log.LstdFlags),
+		logger:       log.New().WithField("service", "graphite"),
 		done:         make(chan struct{}),
 	}
 
@@ -132,7 +132,7 @@ func (s *Service) Close() error {
 }
 
 // SetLogger sets the internal logger to the logger passed in.
-func (s *Service) SetLogger(l *log.Logger) {
+func (s *Service) SetLogger(l log.StdLogger) {
 	s.logger = l
 }
 

--- a/services/hh/processor.go
+++ b/services/hh/processor.go
@@ -4,12 +4,13 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"os"
 	"path/filepath"
 	"strconv"
 	"sync"
 	"time"
+
+	log "github.com/Sirupsen/logrus"
 
 	"github.com/influxdb/influxdb/tsdb"
 )
@@ -24,7 +25,7 @@ type Processor struct {
 
 	queues map[uint64]*queue
 	writer shardWriter
-	Logger *log.Logger
+	Logger log.StdLogger
 }
 
 type ProcessorOptions struct {
@@ -37,7 +38,7 @@ func NewProcessor(dir string, writer shardWriter, options ProcessorOptions) (*Pr
 		dir:    dir,
 		queues: map[uint64]*queue{},
 		writer: writer,
-		Logger: log.New(os.Stderr, "[handoff] ", log.LstdFlags),
+		Logger: log.New().WithField("service", "handoff"),
 	}
 	p.setOptions(options)
 

--- a/services/hh/service.go
+++ b/services/hh/service.go
@@ -3,10 +3,10 @@ package hh
 import (
 	"fmt"
 	"io"
-	"log"
-	"os"
 	"sync"
 	"time"
+
+	log "github.com/Sirupsen/logrus"
 
 	"github.com/influxdb/influxdb/tsdb"
 )
@@ -18,7 +18,7 @@ type Service struct {
 	wg      sync.WaitGroup
 	closing chan struct{}
 
-	Logger *log.Logger
+	Logger log.StdLogger
 	cfg    Config
 
 	ShardWriter shardWriter
@@ -38,7 +38,7 @@ type shardWriter interface {
 func NewService(c Config, w shardWriter) *Service {
 	s := &Service{
 		cfg:    c,
-		Logger: log.New(os.Stderr, "[handoff] ", log.LstdFlags),
+		Logger: log.New().WithField("service", "handoff"),
 	}
 	processor, err := NewProcessor(c.Dir, w, ProcessorOptions{
 		MaxSize:        c.MaxSize,
@@ -77,7 +77,7 @@ func (s *Service) Close() error {
 }
 
 // SetLogger sets the internal logger to the logger passed in.
-func (s *Service) SetLogger(l *log.Logger) {
+func (s *Service) SetLogger(l log.StdLogger) {
 	s.Logger = l
 }
 

--- a/services/httpd/handler.go
+++ b/services/httpd/handler.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
 	"net/http"
 	"net/http/pprof"
-	"os"
 	"strconv"
 	"strings"
 	"time"
+
+	log "github.com/Sirupsen/logrus"
 
 	"github.com/bmizerany/pat"
 	"github.com/influxdb/influxdb"
@@ -70,7 +70,7 @@ type Handler struct {
 
 	ContinuousQuerier continuous_querier.ContinuousQuerier
 
-	Logger         *log.Logger
+	Logger         log.StdLogger
 	loggingEnabled bool // Log every HTTP access.
 	WriteTrace     bool // Detailed logging of write path
 }
@@ -80,7 +80,7 @@ func NewHandler(requireAuthentication, loggingEnabled, writeTrace bool) *Handler
 	h := &Handler{
 		mux: pat.New(),
 		requireAuthentication: requireAuthentication,
-		Logger:                log.New(os.Stderr, "[http] ", log.LstdFlags),
+		Logger:                log.New().WithField("service", "http"),
 		loggingEnabled:        loggingEnabled,
 		WriteTrace:            writeTrace,
 	}
@@ -723,7 +723,7 @@ func requestID(inner http.Handler) http.Handler {
 	})
 }
 
-func logging(inner http.Handler, name string, weblog *log.Logger) http.Handler {
+func logging(inner http.Handler, name string, weblog log.StdLogger) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		start := time.Now()
 		l := &responseLogger{w: w}
@@ -733,7 +733,7 @@ func logging(inner http.Handler, name string, weblog *log.Logger) http.Handler {
 	})
 }
 
-func recovery(inner http.Handler, name string, weblog *log.Logger) http.Handler {
+func recovery(inner http.Handler, name string, weblog log.StdLogger) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		start := time.Now()
 		l := &responseLogger{w: w}

--- a/services/httpd/service.go
+++ b/services/httpd/service.go
@@ -3,11 +3,11 @@ package httpd
 import (
 	"crypto/tls"
 	"fmt"
-	"log"
 	"net"
 	"net/http"
-	"os"
 	"strings"
+
+	log "github.com/Sirupsen/logrus"
 )
 
 // Service manages the listener and handler for an HTTP endpoint.
@@ -20,7 +20,7 @@ type Service struct {
 
 	Handler *Handler
 
-	Logger *log.Logger
+	Logger log.StdLogger
 }
 
 // NewService returns a new instance of Service.
@@ -35,7 +35,7 @@ func NewService(c Config) *Service {
 			c.LogEnabled,
 			c.WriteTracing,
 		),
-		Logger: log.New(os.Stderr, "[httpd] ", log.LstdFlags),
+		Logger: log.New().WithField("service", "httpd"),
 	}
 	s.Handler.Logger = s.Logger
 	return s
@@ -85,7 +85,7 @@ func (s *Service) Close() error {
 }
 
 // SetLogger sets the internal logger to the logger passed in.
-func (s *Service) SetLogger(l *log.Logger) {
+func (s *Service) SetLogger(l log.StdLogger) {
 	s.Logger = l
 }
 

--- a/services/opentsdb/handler.go
+++ b/services/opentsdb/handler.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
-	"log"
+	log "github.com/Sirupsen/logrus"
 	"net"
 	"net/http"
 	"time"
@@ -25,7 +25,7 @@ type Handler struct {
 		WritePoints(p *cluster.WritePointsRequest) error
 	}
 
-	Logger *log.Logger
+	Logger log.StdLogger
 }
 
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {

--- a/services/opentsdb/service.go
+++ b/services/opentsdb/service.go
@@ -5,15 +5,15 @@ import (
 	"bytes"
 	"crypto/tls"
 	"io"
-	"log"
 	"net"
 	"net/http"
 	"net/textproto"
-	"os"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
+
+	log "github.com/Sirupsen/logrus"
 
 	"github.com/influxdb/influxdb/cluster"
 	"github.com/influxdb/influxdb/meta"
@@ -45,7 +45,7 @@ type Service struct {
 		CreateDatabaseIfNotExists(name string) (*meta.DatabaseInfo, error)
 	}
 
-	Logger *log.Logger
+	Logger log.StdLogger
 }
 
 // NewService returns a new instance of Service.
@@ -63,7 +63,7 @@ func NewService(c Config) (*Service, error) {
 		Database:         c.Database,
 		RetentionPolicy:  c.RetentionPolicy,
 		ConsistencyLevel: consistencyLevel,
-		Logger:           log.New(os.Stderr, "[opentsdb] ", log.LstdFlags),
+		Logger:           log.New().WithField("service", "opentsdb"),
 	}
 	return s, nil
 }
@@ -127,7 +127,7 @@ func (s *Service) Close() error {
 }
 
 // SetLogger sets the internal logger to the logger passed in.
-func (s *Service) SetLogger(l *log.Logger) { s.Logger = l }
+func (s *Service) SetLogger(l log.StdLogger) { s.Logger = l }
 
 // Err returns a channel for fatal errors that occur on the listener.
 func (s *Service) Err() <-chan error { return s.err }

--- a/services/opentsdb/service_test.go
+++ b/services/opentsdb/service_test.go
@@ -2,7 +2,6 @@ package opentsdb_test
 
 import (
 	"io/ioutil"
-	"log"
 	"net"
 	"net/http"
 	"reflect"
@@ -10,6 +9,8 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	log "github.com/Sirupsen/logrus"
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/influxdb/influxdb/cluster"
@@ -140,7 +141,9 @@ func NewService(database string) *Service {
 	s.Service.MetaStore = &DatabaseCreator{}
 
 	if !testing.Verbose() {
-		s.Logger = log.New(ioutil.Discard, "", log.LstdFlags)
+		logger := log.New()
+		log.SetOutput(ioutil.Discard)
+		s.Logger = logger
 	}
 
 	return s

--- a/services/precreator/service.go
+++ b/services/precreator/service.go
@@ -1,17 +1,17 @@
 package precreator
 
 import (
-	"log"
-	"os"
 	"sync"
 	"time"
+
+	log "github.com/Sirupsen/logrus"
 )
 
 type Service struct {
 	checkInterval time.Duration
 	advancePeriod time.Duration
 
-	Logger *log.Logger
+	Logger log.StdLogger
 
 	done chan struct{}
 	wg   sync.WaitGroup
@@ -27,14 +27,14 @@ func NewService(c Config) (*Service, error) {
 	s := Service{
 		checkInterval: time.Duration(c.CheckInterval),
 		advancePeriod: time.Duration(c.AdvancePeriod),
-		Logger:        log.New(os.Stderr, "[shard-precreation] ", log.LstdFlags),
+		Logger:        log.New().WithField("service", "shard-precreation"),
 	}
 
 	return &s, nil
 }
 
 // SetLogger sets the internal logger to the logger passed in.
-func (s *Service) SetLogger(l *log.Logger) {
+func (s *Service) SetLogger(l log.StdLogger) {
 	s.Logger = l
 }
 

--- a/services/retention/service.go
+++ b/services/retention/service.go
@@ -1,10 +1,10 @@
 package retention
 
 import (
-	"log"
-	"os"
 	"sync"
 	"time"
+
+	log "github.com/Sirupsen/logrus"
 
 	"github.com/influxdb/influxdb/meta"
 )
@@ -26,7 +26,7 @@ type Service struct {
 	wg            sync.WaitGroup
 	done          chan struct{}
 
-	logger *log.Logger
+	logger log.StdLogger
 }
 
 // NewService returns a configure retention policy enforcement service.
@@ -34,7 +34,7 @@ func NewService(c Config) *Service {
 	return &Service{
 		checkInterval: time.Duration(c.CheckInterval),
 		done:          make(chan struct{}),
-		logger:        log.New(os.Stderr, "[retention] ", log.LstdFlags),
+		logger:        log.New().WithField("service", "retention"),
 	}
 }
 
@@ -54,7 +54,7 @@ func (s *Service) Close() error {
 }
 
 // SetLogger sets the internal logger to the logger passed in.
-func (s *Service) SetLogger(l *log.Logger) {
+func (s *Service) SetLogger(l log.StdLogger) {
 	s.logger = l
 }
 

--- a/services/snapshotter/service.go
+++ b/services/snapshotter/service.go
@@ -4,11 +4,11 @@ import (
 	"encoding"
 	"encoding/json"
 	"fmt"
-	"log"
 	"net"
-	"os"
 	"strings"
 	"sync"
+
+	log "github.com/Sirupsen/logrus"
 
 	"github.com/influxdb/influxdb/snapshot"
 	"github.com/influxdb/influxdb/tsdb"
@@ -29,14 +29,14 @@ type Service struct {
 	TSDBStore *tsdb.Store
 
 	Listener net.Listener
-	Logger   *log.Logger
+	Logger   log.StdLogger
 }
 
 // NewService returns a new instance of Service.
 func NewService() *Service {
 	return &Service{
 		err:    make(chan error),
-		Logger: log.New(os.Stderr, "[snapshot] ", log.LstdFlags),
+		Logger: log.New().WithField("service", "snapshot"),
 	}
 }
 

--- a/services/udp/service.go
+++ b/services/udp/service.go
@@ -2,11 +2,11 @@ package udp
 
 import (
 	"errors"
-	"log"
 	"net"
-	"os"
 	"sync"
 	"time"
+
+	log "github.com/Sirupsen/logrus"
 
 	"github.com/influxdb/influxdb/cluster"
 	"github.com/influxdb/influxdb/tsdb"
@@ -34,7 +34,7 @@ type Service struct {
 		WritePoints(p *cluster.WritePointsRequest) error
 	}
 
-	Logger *log.Logger
+	Logger log.StdLogger
 }
 
 func NewService(c Config) *Service {
@@ -42,7 +42,7 @@ func NewService(c Config) *Service {
 		config:  c,
 		done:    make(chan struct{}),
 		batcher: tsdb.NewPointBatcher(c.BatchSize, time.Duration(c.BatchTimeout)),
-		Logger:  log.New(os.Stderr, "[udp] ", log.LstdFlags),
+		Logger:  log.New().WithField("service", "udp"),
 	}
 }
 
@@ -150,7 +150,7 @@ func (s *Service) Close() error {
 }
 
 // SetLogger sets the internal logger to the logger passed in.
-func (s *Service) SetLogger(l *log.Logger) {
+func (s *Service) SetLogger(l log.StdLogger) {
 	s.Logger = l
 }
 

--- a/tcp/mux.go
+++ b/tcp/mux.go
@@ -4,10 +4,10 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
 	"net"
-	"os"
 	"time"
+
+	log "github.com/Sirupsen/logrus"
 )
 
 const (
@@ -24,7 +24,7 @@ type Mux struct {
 	Timeout time.Duration
 
 	// Out-of-band error logger
-	Logger *log.Logger
+	Logger log.StdLogger
 }
 
 // NewMux returns a new instance of Mux for ln.
@@ -32,7 +32,7 @@ func NewMux() *Mux {
 	return &Mux{
 		m:       make(map[byte]*listener),
 		Timeout: DefaultTimeout,
-		Logger:  log.New(os.Stderr, "", log.LstdFlags),
+		Logger:  log.New(),
 	}
 }
 

--- a/tcp/mux_test.go
+++ b/tcp/mux_test.go
@@ -3,14 +3,14 @@ package tcp_test
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
-	"log"
 	"net"
 	"strings"
 	"sync"
 	"testing"
 	"testing/quick"
 	"time"
+
+	log "github.com/Sirupsen/logrus"
 
 	"github.com/influxdb/influxdb/tcp"
 )
@@ -39,7 +39,7 @@ func TestMux(t *testing.T) {
 		mux := tcp.NewMux()
 		mux.Timeout = 200 * time.Millisecond
 		if !testing.Verbose() {
-			mux.Logger = log.New(ioutil.Discard, "", 0)
+			mux.Logger = log.New()
 		}
 		for i := uint8(0); i < n; i++ {
 			ln := mux.Listen(byte(i))

--- a/tsdb/engine/b1/b1.go
+++ b/tsdb/engine/b1/b1.go
@@ -7,11 +7,12 @@ import (
 	"fmt"
 	"hash/fnv"
 	"io"
-	"log"
 	"os"
 	"sort"
 	"sync"
 	"time"
+
+	log "github.com/Sirupsen/logrus"
 
 	"github.com/boltdb/bolt"
 	"github.com/influxdb/influxdb/tsdb"
@@ -53,7 +54,7 @@ type Engine struct {
 	closing chan struct{}
 
 	// Used for out-of-band error messages.
-	logger *log.Logger
+	logger log.StdLogger
 
 	// The maximum size and time thresholds for flushing the WAL.
 	MaxWALSize             int
@@ -122,7 +123,7 @@ func (e *Engine) Open() error {
 		e.flushTimer = time.NewTimer(e.WALFlushInterval)
 
 		// Initialize logger.
-		e.logger = log.New(e.LogOutput, "[b1] ", log.LstdFlags)
+		e.logger = log.New().WithField("service", "b1")
 
 		// Start background goroutines.
 		e.wg.Add(1)

--- a/tsdb/query_executor.go
+++ b/tsdb/query_executor.go
@@ -3,11 +3,11 @@ package tsdb
 import (
 	"errors"
 	"fmt"
-	"log"
-	"os"
 	"sort"
 	"strings"
 	"time"
+
+	log "github.com/Sirupsen/logrus"
 
 	"github.com/influxdb/influxdb/influxql"
 	"github.com/influxdb/influxdb/meta"
@@ -41,7 +41,7 @@ type QueryExecutor struct {
 		CreateMapper(shard meta.ShardInfo, stmt string, chunkSize int) (Mapper, error)
 	}
 
-	Logger *log.Logger
+	Logger log.StdLogger
 
 	// the local data store
 	Store *Store
@@ -51,7 +51,7 @@ type QueryExecutor struct {
 func NewQueryExecutor(store *Store) *QueryExecutor {
 	return &QueryExecutor{
 		Store:  store,
-		Logger: log.New(os.Stderr, "[query] ", log.LstdFlags),
+		Logger: log.New().WithField("service", "query"),
 	}
 }
 

--- a/tsdb/store.go
+++ b/tsdb/store.go
@@ -3,12 +3,13 @@ package tsdb
 import (
 	"fmt"
 	"io/ioutil"
-	"log"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
+
+	log "github.com/Sirupsen/logrus"
 
 	"github.com/influxdb/influxdb/influxql"
 )
@@ -17,7 +18,7 @@ func NewStore(path string) *Store {
 	return &Store{
 		path:          path,
 		EngineOptions: NewEngineOptions(),
-		Logger:        log.New(os.Stderr, "[store] ", log.LstdFlags),
+		Logger:        log.New().WithField("service", "store"),
 	}
 }
 
@@ -33,7 +34,7 @@ type Store struct {
 	shards          map[uint64]*Shard
 
 	EngineOptions EngineOptions
-	Logger        *log.Logger
+	Logger        log.StdLogger
 }
 
 // Path returns the store's root path.


### PR DESCRIPTION
Several mayor Go projects (like Docker and RunC) decided to use [logrus](https://github.com/Sirupsen/logrus)
mainly for two reasons

- It provides the same API as the default Golang stdlib
- Features which allow better handling of logs produced by the
application like Hooks, formatters etc.

Hopefully you'll find this interesting enough to merge

Signed-off-by: Marcos Lilljedahl <marcosnils@gmail.com>