### PR TITLE
Add initial WAL implementation and tests

### DIFF
--- a/cmd/influx_stress/influx_stress.go
+++ b/cmd/influx_stress/influx_stress.go
@@ -1,0 +1,155 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"math/rand"
+	"net/url"
+	"runtime"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/influxdb/influxdb/client"
+)
+
+var (
+	batchSize     = flag.Int("batchsize", 5000, "number of points per batch")
+	seriesCount   = flag.Int("series", 10000, "number of unique series to create")
+	pointCount    = flag.Int("points", 100, "number of points per series to create")
+	concurrency   = flag.Int("concurrency", 1, "number of simultaneous writes to run")
+	batchInterval = flag.Duration("batchinterval", 0*time.Second, "duration between batches")
+	database      = flag.String("database", "stress", "name of database")
+	address       = flag.String("addr", "localhost:8086", "IP address and port of database (e.g., localhost:8086)")
+)
+
+func main() {
+	flag.Parse()
+	runtime.GOMAXPROCS(runtime.NumCPU())
+
+	startTime := time.Now()
+	counter := NewConcurrencyLimiter(*concurrency)
+
+	u, _ := url.Parse(fmt.Sprintf("http://%s", *address))
+	c, err := client.NewClient(client.Config{URL: *u})
+	if err != nil {
+		panic(err)
+	}
+
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+	responseTimes := make([]int, 0)
+
+	totalPoints := 0
+
+	for i := 1; i <= *pointCount; i++ {
+		batch := &client.BatchPoints{
+			Database:         *database,
+			WriteConsistency: "any",
+			Time:             time.Now(),
+			Precision:        "n",
+		}
+
+		for j := 1; j <= *seriesCount; j++ {
+			p := client.Point{
+				Measurement: "cpu",
+				Tags:        map[string]string{"region": "uswest", "host": fmt.Sprintf("host-%d", j)},
+				Fields:      map[string]interface{}{"value": rand.Float64()},
+			}
+			batch.Points = append(batch.Points, p)
+			if len(batch.Points) >= *batchSize {
+				wg.Add(1)
+				counter.Increment()
+				totalPoints += len(batch.Points)
+				go func(b *client.BatchPoints, total int) {
+					fmt.Println("WRITING: ", len(b.Points))
+					st := time.Now()
+					if _, err := c.Write(*batch); err != nil {
+						fmt.Println("ERROR: ", err.Error())
+					} else {
+						mu.Lock()
+						responseTimes = append(responseTimes, int(time.Since(st).Nanoseconds()))
+						mu.Unlock()
+					}
+					wg.Done()
+					counter.Decrement()
+					if total%1000000 == 0 {
+						fmt.Printf("%d total points. %d in %s\n", total, *batchSize, time.Since(st))
+					}
+				}(batch, totalPoints)
+
+				batch = &client.BatchPoints{
+					Database:         *database,
+					WriteConsistency: "any",
+					Precision:        "n",
+				}
+			}
+		}
+	}
+
+	wg.Wait()
+	sort.Sort(sort.Reverse(sort.IntSlice(responseTimes)))
+
+	total := int64(0)
+	for _, t := range responseTimes {
+		total += int64(t)
+	}
+	mean := total / int64(len(responseTimes))
+
+	fmt.Printf("Wrote %d points at average rate of %.0f\n", totalPoints, float64(totalPoints)/time.Since(startTime).Seconds())
+	fmt.Println("Average response time: ", time.Duration(mean))
+	fmt.Println("Slowest response times:")
+	for _, r := range responseTimes[:100] {
+		fmt.Println(time.Duration(r))
+	}
+}
+
+// ConcurrencyLimiter is a go routine safe struct that can be used to
+// ensure that no more than a specifid max number of goroutines are
+// executing.
+type ConcurrencyLimiter struct {
+	inc   chan chan struct{}
+	dec   chan struct{}
+	max   int
+	count int
+}
+
+// NewConcurrencyLimiter returns a configured limiter that will
+// ensure that calls to Increment will block if the max is hit.
+func NewConcurrencyLimiter(max int) *ConcurrencyLimiter {
+	c := &ConcurrencyLimiter{
+		inc: make(chan chan struct{}),
+		dec: make(chan struct{}, max),
+		max: max,
+	}
+	go c.handleLimits()
+	return c
+}
+
+// Increment will increase the count of running goroutines by 1.
+// if the number is currently at the max, the call to Increment
+// will block until another goroutine decrements.
+func (c *ConcurrencyLimiter) Increment() {
+	r := make(chan struct{})
+	c.inc <- r
+	<-r
+}
+
+// Decrement will reduce the count of running goroutines by 1
+func (c *ConcurrencyLimiter) Decrement() {
+	c.dec <- struct{}{}
+}
+
+// handleLimits runs in a goroutine to manage the count of
+// running goroutines.
+func (c *ConcurrencyLimiter) handleLimits() {
+	for {
+		r := <-c.inc
+		if c.count >= c.max {
+			<-c.dec
+			c.count--
+		}
+		c.count++
+		r <- struct{}{}
+	}
+}

--- a/cmd/influx_stress/influx_stress.go
+++ b/cmd/influx_stress/influx_stress.go
@@ -15,7 +15,7 @@ import (
 
 var (
 	batchSize     = flag.Int("batchsize", 5000, "number of points per batch")
-	seriesCount   = flag.Int("series", 10000, "number of unique series to create")
+	seriesCount   = flag.Int("series", 100000, "number of unique series to create")
 	pointCount    = flag.Int("points", 100, "number of points per series to create")
 	concurrency   = flag.Int("concurrency", 10, "number of simultaneous writes to run")
 	batchInterval = flag.Duration("batchinterval", 0*time.Second, "duration between batches")

--- a/cmd/influx_stress/influx_stress.go
+++ b/cmd/influx_stress/influx_stress.go
@@ -17,7 +17,7 @@ var (
 	batchSize     = flag.Int("batchsize", 5000, "number of points per batch")
 	seriesCount   = flag.Int("series", 10000, "number of unique series to create")
 	pointCount    = flag.Int("points", 100, "number of points per series to create")
-	concurrency   = flag.Int("concurrency", 1, "number of simultaneous writes to run")
+	concurrency   = flag.Int("concurrency", 10, "number of simultaneous writes to run")
 	batchInterval = flag.Duration("batchinterval", 0*time.Second, "duration between batches")
 	database      = flag.String("database", "stress", "name of database")
 	address       = flag.String("addr", "localhost:8086", "IP address and port of database (e.g., localhost:8086)")
@@ -62,9 +62,8 @@ func main() {
 				counter.Increment()
 				totalPoints += len(batch.Points)
 				go func(b *client.BatchPoints, total int) {
-					fmt.Println("WRITING: ", len(b.Points))
 					st := time.Now()
-					if _, err := c.Write(*batch); err != nil {
+					if _, err := c.Write(*b); err != nil {
 						fmt.Println("ERROR: ", err.Error())
 					} else {
 						mu.Lock()

--- a/cmd/influxd/run/server.go
+++ b/cmd/influxd/run/server.go
@@ -68,6 +68,9 @@ type Server struct {
 // NewServer returns a new instance of Server built from a config.
 func NewServer(c *Config, version string) (*Server, error) {
 	// Construct base meta store and data store.
+	tsdbStore := tsdb.NewStore(c.Data.Dir)
+	tsdbStore.EngineOptions.Config = c.Data
+
 	s := &Server{
 		version: version,
 		err:     make(chan error),
@@ -77,7 +80,7 @@ func NewServer(c *Config, version string) (*Server, error) {
 		BindAddress: c.Meta.BindAddress,
 
 		MetaStore: meta.NewStore(c.Meta),
-		TSDBStore: tsdb.NewStore(c.Data.Dir),
+		TSDBStore: tsdbStore,
 
 		reportingDisabled: c.ReportingDisabled,
 	}

--- a/cmd/influxd/run/server_helpers_test.go
+++ b/cmd/influxd/run/server_helpers_test.go
@@ -35,6 +35,7 @@ func NewServer(c *run.Config) *Server {
 		Server: srv,
 		Config: c,
 	}
+	s.TSDBStore.EngineOptions.Config = c.Data
 	configureLogging(&s)
 	return &s
 }
@@ -155,6 +156,7 @@ func NewConfig() *run.Config {
 	c.Meta.CommitTimeout = toml.Duration(5 * time.Millisecond)
 
 	c.Data.Dir = MustTempFile()
+	c.Data.WALDir = MustTempFile()
 
 	c.HintedHandoff.Dir = MustTempFile()
 

--- a/etc/config.sample.toml
+++ b/etc/config.sample.toml
@@ -36,9 +36,36 @@ reporting-disabled = false
 
 [data]
   dir = "/var/opt/influxdb/data"
+
+  # The following WAL settings are for the b1 storage engine used in 0.9.2. They won't
+  # apply to any new shards created after upgrading to a version > 0.9.3.
   max-wal-size = 104857600 # Maximum size the WAL can reach before a flush. Defaults to 100MB.
   wal-flush-interval = "10m" # Maximum time data can sit in WAL before a flush.
   wal-partition-flush-delay = "2s" # The delay time between each WAL partition being flushed.
+
+  # These are the WAL settings for the storage engine >= 0.9.3
+  wal-dir = "/var/opt/influxdb/wal"
+  wal-enable-logging = true
+
+  # When a series in the WAL in-memory cache reaches this size in bytes it is marked as ready to
+  # flush to the index
+  # wal-ready-series-size = 25600
+
+  # Flush and compact a partition once this ratio of series are over the ready size
+  # wal-compaction-threshold = 0.6
+
+  # Force a flush and compaction if any series in a partition gets above this size in bytes
+  # wal-max-series-size = 2097152
+
+  # Force a flush of all series and full compaction if there have been no writes in this
+  # amount of time. This is useful for ensuring that shards that are cold for writes don't
+  # keep a bunch of data cached in memory and in the WAL.
+  # wal-flush-cold-interval = "10m"
+
+  # Force a partition to flush its largest series if it reaches this approximate size in
+  # bytes. Remember there are 5 partitions so you'll need at least 5x this amount of memory.
+  # The more memory you have, the bigger this can be.
+  # wal-partition-size-threshold = 20971520
 
 ###
 ### [cluster]

--- a/services/httpd/handler.go
+++ b/services/httpd/handler.go
@@ -81,7 +81,7 @@ func NewHandler(requireAuthentication, loggingEnabled, writeTrace bool) *Handler
 		mux: pat.New(),
 		requireAuthentication: requireAuthentication,
 		Logger:                log.New(os.Stderr, "[http] ", log.LstdFlags),
-		loggingEnabled:        loggingEnabled,
+		loggingEnabled:        false,
 		WriteTrace:            writeTrace,
 	}
 

--- a/services/httpd/handler.go
+++ b/services/httpd/handler.go
@@ -81,7 +81,7 @@ func NewHandler(requireAuthentication, loggingEnabled, writeTrace bool) *Handler
 		mux: pat.New(),
 		requireAuthentication: requireAuthentication,
 		Logger:                log.New(os.Stderr, "[http] ", log.LstdFlags),
-		loggingEnabled:        false,
+		loggingEnabled:        loggingEnabled,
 		WriteTrace:            writeTrace,
 	}
 

--- a/tsdb/config.go
+++ b/tsdb/config.go
@@ -30,7 +30,7 @@ const (
 
 	// DefaultFlushColdInterval specifies how long after a partition has been cold
 	// for writes that a full flush and compaction are forced
-	DefaultFlushColdInterval = 20 * time.Second
+	DefaultFlushColdInterval = 5 * time.Minute
 
 	// DefaultParititionSizeThreshold specifies when a partition gets to this size in
 	// memory, we should slow down writes until it gets a chance to compact.

--- a/tsdb/config.go
+++ b/tsdb/config.go
@@ -16,13 +16,48 @@ const (
 
 	// DefaultWALPartitionFlushDelay is the sleep time between WAL partition flushes.
 	DefaultWALPartitionFlushDelay = 2 * time.Second
+
+	// tsdb/engine/wal configuration options
+
+	// DefaultReadySeriesSize of 32KB specifies when a series is eligible to be flushed
+	DefaultReadySeriesSize = 30 * 1024
+
+	// DefaultCompactionThreshold flush and compact a partition once this ratio of keys are over the flush size
+	DefaultCompactionThreshold = 0.5
+
+	// DefaultMaxSeriesSize specifies the size at which a series will be forced to flush
+	DefaultMaxSeriesSize = 1024 * 1024
+
+	// DefaultFlushColdInterval specifies how long after a partition has been cold
+	// for writes that a full flush and compaction are forced
+	DefaultFlushColdInterval = 20 * time.Second
+
+	// DefaultParititionSizeThreshold specifies when a partition gets to this size in
+	// memory, we should slow down writes until it gets a chance to compact.
+	// This will force clients to get backpressure if they're writing too fast. We need
+	// this because the WAL can take writes much faster than the index. So eventually
+	// we'll need to create backpressure, otherwise we'll fill up the memory and die.
+	// This number multiplied by the parition count is roughly the max possible memory
+	// size for the in-memory WAL cache.
+	DefaultPartitionSizeThreshold = 20 * 1024 * 1024 // 20MB
 )
 
 type Config struct {
-	Dir                    string        `toml:"dir"`
+	Dir string `toml:"dir"`
+
+	// WAL config options for b1 (introduced in 0.9.2)
 	MaxWALSize             int           `toml:"max-wal-size"`
 	WALFlushInterval       toml.Duration `toml:"wal-flush-interval"`
 	WALPartitionFlushDelay toml.Duration `toml:"wal-partition-flush-delay"`
+
+	// WAL configuration options for bz1 (introduced in 0.9.3)
+	WALDir                    string        `toml:"wal-dir"`
+	WALEnableLogging          bool          `toml:"wal-enable-logging"`
+	WALReadySeriesSize        int           `toml:"wal-ready-series-size"`
+	WALCompactionThreshold    float64       `toml:"wal-compaction-threshold"`
+	WALMaxSeriesSize          int           `toml:"wal-max-series-size"`
+	WALFlushColdInterval      toml.Duration `toml:"wal-flush-cold-interval"`
+	WALPartitionSizeThreshold uint64        `toml:"wal-partition-size-threshold"`
 }
 
 func NewConfig() Config {
@@ -30,5 +65,12 @@ func NewConfig() Config {
 		MaxWALSize:             DefaultMaxWALSize,
 		WALFlushInterval:       toml.Duration(DefaultWALFlushInterval),
 		WALPartitionFlushDelay: toml.Duration(DefaultWALPartitionFlushDelay),
+
+		WALEnableLogging:          true,
+		WALReadySeriesSize:        DefaultReadySeriesSize,
+		WALCompactionThreshold:    DefaultCompactionThreshold,
+		WALMaxSeriesSize:          DefaultMaxSeriesSize,
+		WALFlushColdInterval:      toml.Duration(DefaultFlushColdInterval),
+		WALPartitionSizeThreshold: DefaultPartitionSizeThreshold,
 	}
 }

--- a/tsdb/engine.go
+++ b/tsdb/engine.go
@@ -102,6 +102,8 @@ type EngineOptions struct {
 	MaxWALSize             int
 	WALFlushInterval       time.Duration
 	WALPartitionFlushDelay time.Duration
+
+	Config Config
 }
 
 // NewEngineOptions returns the default options.
@@ -111,6 +113,7 @@ func NewEngineOptions() EngineOptions {
 		MaxWALSize:             DefaultMaxWALSize,
 		WALFlushInterval:       DefaultWALFlushInterval,
 		WALPartitionFlushDelay: DefaultWALPartitionFlushDelay,
+		Config:                 NewConfig(),
 	}
 }
 

--- a/tsdb/engine.go
+++ b/tsdb/engine.go
@@ -16,7 +16,7 @@ var (
 )
 
 // DefaultEngine is the default engine used by the shard when initializing.
-const DefaultEngine = "b1"
+const DefaultEngine = "bz1"
 
 // Engine represents a swappable storage engine for the shard.
 type Engine interface {
@@ -52,7 +52,7 @@ func RegisterEngine(name string, fn NewEngineFunc) {
 func NewEngine(path string, options EngineOptions) (Engine, error) {
 	// Create a new engine
 	if _, err := os.Stat(path); os.IsNotExist(err) {
-		return newEngineFuncs[DefaultEngine](path, options), nil
+		return newEngineFuncs[options.EngineVersion](path, options), nil
 	}
 
 	// Only bolt-based backends are currently supported so open it and check the format.
@@ -96,6 +96,7 @@ func NewEngine(path string, options EngineOptions) (Engine, error) {
 
 // EngineOptions represents the options used to initialize the engine.
 type EngineOptions struct {
+	EngineVersion          string
 	MaxWALSize             int
 	WALFlushInterval       time.Duration
 	WALPartitionFlushDelay time.Duration
@@ -104,6 +105,7 @@ type EngineOptions struct {
 // NewEngineOptions returns the default options.
 func NewEngineOptions() EngineOptions {
 	return EngineOptions{
+		EngineVersion:          DefaultEngine,
 		MaxWALSize:             DefaultMaxWALSize,
 		WALFlushInterval:       DefaultWALFlushInterval,
 		WALPartitionFlushDelay: DefaultWALPartitionFlushDelay,

--- a/tsdb/engine/b1/b1.go
+++ b/tsdb/engine/b1/b1.go
@@ -194,7 +194,7 @@ func (e *Engine) LoadMetadataIndex(index *tsdb.DatabaseIndex, measurementFields 
 		meta = tx.Bucket([]byte("series"))
 		c = meta.Cursor()
 		for k, v := c.First(); k != nil; k, v = c.Next() {
-			series := &tsdb.Series{}
+			series := tsdb.NewSeries("", nil)
 			if err := series.UnmarshalBinary(v); err != nil {
 				return err
 			}

--- a/tsdb/engine/b1/b1_test.go
+++ b/tsdb/engine/b1/b1_test.go
@@ -22,7 +22,7 @@ func TestEngine_WritePoints(t *testing.T) {
 	mf := &tsdb.MeasurementFields{Fields: make(map[string]*tsdb.Field)}
 	mf.CreateFieldIfNotExists("value", influxql.Float)
 	seriesToCreate := []*tsdb.SeriesCreate{
-		{Series: &tsdb.Series{Key: string(tsdb.MakeKey([]byte("temperature"), nil))}},
+		{Series: tsdb.NewSeries(string(tsdb.MakeKey([]byte("temperature"), nil)), nil)},
 	}
 
 	// Parse point.

--- a/tsdb/engine/bz1/bz1.go
+++ b/tsdb/engine/bz1/bz1.go
@@ -277,7 +277,6 @@ func (e *Engine) writeIndex(tx *bolt.Tx, key string, a [][]byte) error {
 	}
 
 	// Create or retrieve series bucket.
-	fmt.Println("WRITE: ", key, len(key))
 	bkt, err := tx.Bucket([]byte("points")).CreateBucketIfNotExists([]byte(key))
 	if err != nil {
 		return fmt.Errorf("create series bucket: %s", err)
@@ -471,7 +470,6 @@ type Tx struct {
 
 // Cursor returns an iterator for a key.
 func (tx *Tx) Cursor(key string) tsdb.Cursor {
-	fmt.Println("CURSOR: ", key)
 	walCursor := tx.wal.Cursor(key)
 
 	// Retrieve points bucket. Ignore if there is no bucket.
@@ -499,7 +497,6 @@ type Cursor struct {
 func (c *Cursor) Seek(seek []byte) (key, value []byte) {
 	// Move cursor to appropriate block and set to buffer.
 	_, v := c.cursor.Seek(seek)
-	fmt.Println("SEEK: ", key, v)
 	c.setBuf(v)
 
 	// Read current block up to seek position.
@@ -559,7 +556,6 @@ func (c *Cursor) setBuf(block []byte) {
 		c.buf = c.buf[0:0]
 		log.Printf("block decode error: %s", err)
 	}
-	fmt.Println("setBuf: ", buf)
 	c.buf, c.off = buf, 0
 }
 
@@ -573,7 +569,6 @@ func (c *Cursor) read() (key, value []byte) {
 	// Otherwise read the current entry.
 	buf := c.buf[c.off:]
 	dataSize := entryDataSize(buf)
-	fmt.Println("read: ", buf, dataSize, len(buf), entryHeaderSize, entryHeaderSize+dataSize)
 	return buf[0:8], buf[entryHeaderSize : entryHeaderSize+dataSize]
 }
 

--- a/tsdb/engine/bz1/bz1.go
+++ b/tsdb/engine/bz1/bz1.go
@@ -28,10 +28,6 @@ var (
 const (
 	// Format is the file format name of this engine.
 	Format = "bz1"
-
-	// WALDir is the suffixe that is put on the path for
-	// where the WAL files should be kept for a given shard.
-	WALDir = "_wal"
 )
 
 func init() {
@@ -72,7 +68,14 @@ type WAL interface {
 // NewEngine returns a new instance of Engine.
 func NewEngine(path string, opt tsdb.EngineOptions) tsdb.Engine {
 	// create the writer with a directory of the same name as the shard, but with the wal extension
-	w := wal.NewLog(filepath.Join(filepath.Dir(path), filepath.Base(path)+WALDir))
+	w := wal.NewLog(filepath.Join(opt.Config.WALDir, filepath.Base(path)))
+
+	w.ReadySeriesSize = opt.Config.WALReadySeriesSize
+	w.FlushColdInterval = time.Duration(opt.Config.WALFlushColdInterval)
+	w.MaxSeriesSize = opt.Config.WALMaxSeriesSize
+	w.CompactionThreshold = opt.Config.WALCompactionThreshold
+	w.PartitionSizeThreshold = opt.Config.WALPartitionSizeThreshold
+	w.ReadySeriesSize = opt.Config.WALReadySeriesSize
 
 	e := &Engine{
 		path: path,

--- a/tsdb/engine/bz1/bz1.go
+++ b/tsdb/engine/bz1/bz1.go
@@ -170,9 +170,18 @@ func (e *Engine) LoadMetadataIndex(index *tsdb.DatabaseIndex, measurementFields 
 		if err != nil {
 			return err
 		}
-		for k, series := range series {
-			series.InitializeShards()
-			index.CreateSeriesIndexIfNotExists(tsdb.MeasurementFromSeriesKey(string(k)), series)
+
+		// Load the series into the in-memory index in sorted order to ensure
+		// it's always consistent for testing purposes
+		a := make([]string, 0, len(series))
+		for k, _ := range series {
+			a = append(a, k)
+		}
+		sort.Strings(a)
+		for _, key := range a {
+			s := series[key]
+			s.InitializeShards()
+			index.CreateSeriesIndexIfNotExists(tsdb.MeasurementFromSeriesKey(string(key)), s)
 		}
 		return nil
 	}); err != nil {

--- a/tsdb/engine/bz1/bz1_test.go
+++ b/tsdb/engine/bz1/bz1_test.go
@@ -324,7 +324,7 @@ func NewEngine(opt tsdb.EngineOptions) *Engine {
 	e := &Engine{
 		Engine: bz1.NewEngine(f.Name(), opt).(*bz1.Engine),
 	}
-	e.Engine.PointsWriter = &e.PointsWriter
+	e.Engine.WAL = &e.PointsWriter
 	return e
 }
 
@@ -364,6 +364,20 @@ type EnginePointsWriter struct {
 func (w *EnginePointsWriter) WritePoints(points []tsdb.Point) error {
 	return w.WritePointsFn(points)
 }
+
+func (w *EnginePointsWriter) Open() error { return nil }
+
+func (w *EnginePointsWriter) Close() error { return nil }
+
+func (w *EnginePointsWriter) Cursor(key string) tsdb.Cursor { return &Cursor{} }
+
+// Cursor represents a mock that implements tsdb.Curosr.
+type Cursor struct {
+}
+
+func (c *Cursor) Seek(key []byte) ([]byte, []byte) { return nil, nil }
+
+func (c *Cursor) Next() ([]byte, []byte) { return nil, nil }
 
 // Points represents a set of encoded points by key. Implements quick.Generator.
 type Points map[string][][]byte

--- a/tsdb/engine/wal/wal.go
+++ b/tsdb/engine/wal/wal.go
@@ -1,0 +1,1013 @@
+package wal
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"hash/fnv"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/golang/snappy"
+	"github.com/influxdb/influxdb/tsdb"
+)
+
+const (
+	DefaultSegmentSize         = 2 * 1024 * 1024 // 2MB, default size of a segment file in a partitions
+	DefaultReadySeriesSize     = 32 * 1024       // 32KB, series is ready to flush once it reaches this size
+	DefaultCompactionThreshold = 0.5             // flush and compact a partition once this ratio of keys are over the flush size
+	DefaultMaxSeriesSize       = 2 * 1024 * 1024 // if any key in a WAL partition reaches this size, we'll force compaction of the partition
+
+	// if there have been no writes to a partition in this amount of time, we'll force a full flush
+	DefaultFlushInterval = 30 * time.Minute
+
+	// When a partition gets to this size in memory, we should slow down writes until it gets a chance to compact.
+	// This will force clients to get backpressure if they're writing too fast. We need this because the WAL can
+	// take writes much faster than the index. So eventually we'll need to create backpressure, otherwise we'll fill
+	// up the memory and die. This number multiplied by the parition count is roughly the max possible memory size for the in-memory WAL cache.
+	DefaultPartitionSizeThreshold = 200 * 1024 * 1024
+
+	DefaultPartitionCount = 10
+
+	// the file extension we expect for wal segments
+	FileExtension = "wal"
+
+	// flushes are triggered automatically by different criteria. check on this interval
+	flushCheckInterval = 500 * time.Millisecond
+)
+
+var (
+	// ErrCompactionRunning to return if we attempt to run a compaction on a partition that is currently running one
+	ErrCompactionRunning = errors.New("compaction running")
+
+	// ErrCompactionBlock gets returned if we're reading a compressed block and its a file compaction description
+	ErrCompactionBlock = errors.New("compaction description")
+
+	// within a segment file, it could be a compaction file, which has parts in it that
+	// indicate a file name that was compacted. We use this sequence to identify those sections
+	CompactSequence = []byte{0xFF, 0xFF}
+)
+
+type Log struct {
+	path           string
+	walSegmentSize int
+	flushSize      int
+
+	flush           chan int    // signals a background flush on the given partition
+	flushCheckTimer *time.Timer // check this often to see if a background flush should happen
+
+	// These coordinate closing and waiting for running goroutines.
+	wg      sync.WaitGroup
+	closing chan struct{}
+
+	// Used for out-of-band error messages.
+	logger *log.Logger
+
+	mu         sync.RWMutex
+	partitions map[uint8]*partition
+
+	// The writer used by the logger.
+	LogOutput     io.Writer
+	FlushInterval time.Duration
+	SegmentSize   int
+
+	// Settings that control when a partition should get flushed to index and compacted
+	// flush if any series in the partition has exceeded this size threshold
+	MaxSeriesSize int
+	// a series is ready to flush once it has this much data in it
+	ReadySeriesSize int
+	// a partition is ready to flush if this percentage of series has hit the readySeriesSize or greater
+	CompactionThreshold float64
+	// a partition should be flushed if it has reached this size in memory
+	PartitionSizeThreshold uint64
+	// the number of separate partitions to create for the WAL. Compactions happen per partition. So this number
+	// will affect what percentage of the WAL gets compacted at a time. For instance, a setting of 10 means
+	// we generally will be compacting about 10% of the WAL at a time.
+	PartitionCount uint64
+
+	IndexWriter indexWriter
+}
+
+// indexWriter is an interface for the indexed database the WAL flushes data to
+type indexWriter interface {
+	// time ascending points where each byte array is:
+	//   int64 time
+	//   data
+	WriteIndex(pointsByKey map[string][][]byte) error
+}
+
+func NewLog(path string) *Log {
+	return &Log{
+		path:  path,
+		flush: make(chan int, 1),
+
+		// these options should be overriden by any options in the config
+		LogOutput:              os.Stderr,
+		FlushInterval:          DefaultFlushInterval,
+		SegmentSize:            DefaultSegmentSize,
+		MaxSeriesSize:          DefaultMaxSeriesSize,
+		CompactionThreshold:    DefaultCompactionThreshold,
+		PartitionSizeThreshold: DefaultPartitionSizeThreshold,
+		ReadySeriesSize:        DefaultReadySeriesSize,
+		PartitionCount:         DefaultPartitionCount,
+	}
+}
+
+// Open opens and initializes the Log. Will recover from previous unclosed shutdowns
+func (w *Log) Open() error {
+	// open the partitions
+	w.partitions = make(map[uint8]*partition)
+	for i := uint64(1); i <= w.PartitionCount; i++ {
+		p, err := newPartition(uint8(i), w.path, w.SegmentSize)
+		if err != nil {
+			return err
+		}
+		w.partitions[uint8(i)] = p
+	}
+	if err := w.openPartitionFiles(); err != nil {
+		return err
+	}
+
+	w.logger = log.New(w.LogOutput, "[wal] ", log.LstdFlags)
+
+	w.flushCheckTimer = time.NewTimer(flushCheckInterval)
+
+	// Start background goroutines.
+	w.wg = *&sync.WaitGroup{}
+	w.wg.Add(1)
+	w.closing = make(chan struct{})
+	go w.autoflusher(w.closing)
+
+	return nil
+}
+
+// Cursor will return a cursor object to Seek and iterate with Next for the WAL cache for the given
+func (w *Log) Cursor(key string) tsdb.Cursor {
+	w.mu.RLock()
+	defer w.mu.RUnlock()
+
+	p := w.walPartition([]byte(key))
+
+	return p.cursor(key)
+}
+
+// partition is a set of files for a partition of the WAL. We use multiple partitions so when compactions occur
+// only a portion of the WAL must be flushed and compacted
+type partition struct {
+	id                 uint8
+	path               string
+	mu                 sync.Mutex
+	currentSegmentFile *os.File
+	currentSegmentSize int
+	currentSegmentID   uint32
+	lastFileID         uint32
+	totalSize          uint64
+	lastWrite          time.Time
+	maxSegmentSize     int
+	cache              map[string][][]byte
+	// this cache is a temporary placeholder to keep data while its being flushed
+	// and compacted. It's for cursors to combine the cache and this if a flush is occuring
+	flushCache        map[string][][]byte
+	cacheDirtySort    map[string]bool // will be true if the key needs to be sorted
+	cacheSizes        map[string]int
+	compactionRunning bool
+}
+
+func newPartition(id uint8, path string, segmentSize int) (*partition, error) {
+	return &partition{
+		id:             id,
+		path:           path,
+		maxSegmentSize: segmentSize,
+		lastWrite:      time.Now(),
+		cache:          make(map[string][][]byte),
+		cacheDirtySort: make(map[string]bool),
+		cacheSizes:     make(map[string]int),
+	}, nil
+}
+
+// Close resets the caches and closes the currently open segment file
+func (p *partition) Close() error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	p.cache = nil
+	p.cacheDirtySort = nil
+	p.cacheSizes = nil
+	if err := p.currentSegmentFile.Close(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// write will write a compressed block of the points to the current segment file. If the segment
+// file is larger than the max size, it will roll over to a new file before performing the write.
+// This method will also add the points to the in memory cache
+func (p *partition) write(points []tsdb.Point) error {
+	block := make([]byte, 0)
+	for _, pp := range points {
+		block = append(block, marshalWALEntry(pp.Key(), pp.UnixNano(), pp.Data())...)
+	}
+	b := snappy.Encode(nil, block)
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	// rotate to a new file if we've gone over our limit
+	if p.currentSegmentFile == nil || p.currentSegmentSize > p.maxSegmentSize {
+		err := p.newSegmentFile()
+		if err != nil {
+			return err
+		}
+	}
+
+	if n, err := p.currentSegmentFile.Write(u64tob(uint64(len(b)))); err != nil {
+		return err
+	} else if n != 8 {
+		return fmt.Errorf("expected to write %d bytes but wrote %d", 8, n)
+	}
+
+	if n, err := p.currentSegmentFile.Write(b); err != nil {
+		return err
+	} else if n != len(b) {
+		return fmt.Errorf("expected to write %d bytes but wrote %d", len(b), n)
+	}
+
+	if err := p.currentSegmentFile.Sync(); err != nil {
+		return err
+	}
+
+	p.currentSegmentSize += (8 + len(b))
+	p.lastWrite = time.Now()
+
+	for _, pp := range points {
+		p.addToCache(pp.Key(), pp.Data(), pp.UnixNano())
+	}
+	return nil
+}
+
+// newSegmentFile will close the current segment file and open a new one, updating bookkeeping info on the partition
+func (p *partition) newSegmentFile() error {
+	p.currentSegmentID += 1
+	if p.currentSegmentFile != nil {
+		if err := p.currentSegmentFile.Close(); err != nil {
+			return err
+		}
+	}
+
+	fileName := p.fileNameForSegment(p.currentSegmentID)
+
+	ff, err := os.OpenFile(fileName, os.O_CREATE|os.O_RDWR, 0600)
+	if err != nil {
+		return err
+	}
+	p.currentSegmentFile = ff
+	return nil
+}
+
+// fileNameForSegment will return the full path and filename for a given segment ID
+func (p *partition) fileNameForSegment(id uint32) string {
+	return filepath.Join(p.path, fmt.Sprintf("%02d.%06d.%s", p.id, id, FileExtension))
+}
+
+// compactionFileName will return the file name that should be used for a conmpaction onthis partition
+func (p *partition) compactionFileName() string {
+	return filepath.Join(p.path, fmt.Sprintf("%02d.%06d.CPT", p.id, 1))
+}
+
+// fileIDFromName will return the segment ID from the file name
+func (p *partition) fileIDFromName(name string) (uint32, error) {
+	parts := strings.Split(filepath.Base(name), ".")
+	if len(parts) != 3 {
+		return 0, fmt.Errorf("file name doesn't follow wal format: %s", name)
+	}
+	id, err := strconv.ParseUint(parts[1], 10, 32)
+	if err != nil {
+		return 0, err
+	}
+	return uint32(id), nil
+}
+
+// shouldFlush returns true if a partition should be flushed. The criteria are
+// maxSeriesSize - flush if any series in the partition has exceeded this size threshold
+// readySeriesSize - a series is ready to flush once it has this much data in it
+// compactionThreshold - a partition is ready to flush if this percentage of series has hit the readySeriesSize or greater
+// partitionSizeThreshold - a partition should be flushed if it has reached this size in memory
+func (p *partition) shouldFlush(maxSeriesSize, readySeriesSize int, compactionThreshold float64, partitionSizeThreshold uint64) bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.totalSize > partitionSizeThreshold {
+		return true
+	}
+
+	countReady := float64(0)
+	for _, s := range p.cacheSizes {
+		if s > maxSeriesSize {
+			return true
+		} else if s > readySeriesSize {
+			countReady += 1
+		}
+	}
+
+	if countReady/float64(len(p.cacheSizes)) > compactionThreshold {
+		return true
+	}
+
+	return false
+}
+
+// flushAndCompact will flush any series that are over their threshold and then read in all old segment files and
+// write the data that was not flushed to a new file
+func (p *partition) flushAndCompact(idx indexWriter, maxSeriesSize, readySeriesSize int) error {
+	seriesToFlush := make(map[string][][]byte)
+	sizeOfFlush := 0
+	var compactFilesLessThan uint32
+
+	if err := func() error {
+		p.mu.Lock()
+		defer p.mu.Unlock()
+
+		if p.compactionRunning {
+			return ErrCompactionRunning
+		}
+		p.compactionRunning = true
+
+		for k, s := range p.cacheSizes {
+			// if the series is over the threshold, save it in the map to flush later
+			if s >= maxSeriesSize || s >= readySeriesSize {
+				sizeOfFlush += s
+				seriesToFlush[k] = p.cache[k]
+				delete(p.cacheSizes, k)
+				delete(p.cache, k)
+
+				// always hand the index data that is sorted
+				if p.cacheDirtySort[k] {
+					sort.Sort(byteSlices(seriesToFlush[k]))
+					delete(p.cacheDirtySort, k)
+				}
+			}
+		}
+		p.flushCache = seriesToFlush
+
+		// roll over a new segment file so we can compact all the old ones
+		if err := p.newSegmentFile(); err != nil {
+			return err
+		}
+		compactFilesLessThan = p.currentSegmentID
+
+		return nil
+	}(); err == ErrCompactionRunning {
+		return nil
+	} else if err != nil {
+		return err
+	}
+
+	// write the data to the index first
+	if err := idx.WriteIndex(seriesToFlush); err != nil {
+		// if we can't write the index, we should just bring down the server hard
+		panic(fmt.Sprintf("error writing the wal to the index: %s", err.Error()))
+	}
+
+	// clear the flush cache
+	p.mu.Lock()
+	p.flushCache = nil
+	p.mu.Unlock()
+
+	// now compact all the old data
+	fileNames, err := p.segmentFileNames()
+	if err != nil {
+		return err
+	}
+
+	// all compacted data from the segments will go into this file
+	compactionFile, err := os.OpenFile(p.compactionFileName(), os.O_CREATE|os.O_RDWR, 0600)
+	if err != nil {
+		return err
+	}
+
+	for _, n := range fileNames {
+		id, err := p.idFromFileName(n)
+		if err != nil {
+			return err
+		}
+
+		// only compact files that are older than the segment that became active when we started the flush
+		if id >= compactFilesLessThan {
+			break
+		}
+
+		f, err := os.OpenFile(n, os.O_RDONLY, 0600)
+		if err != nil {
+			return err
+		}
+
+		sf := newSegmentFile(f)
+		var entries []*entry
+		for {
+			a, err := sf.readCompressedBlock()
+
+			if err == ErrCompactionBlock {
+				continue
+			} else if err != nil {
+				return err
+			}
+
+			if a == nil {
+				break
+			}
+
+			// only compact the entries from series that haven't been flushed
+			for _, e := range a {
+				if _, ok := seriesToFlush[string(e.key)]; !ok {
+					entries = append(entries, e)
+				}
+			}
+		}
+
+		if err := p.writeCompactionEntry(compactionFile, entries); err != nil {
+			return err
+		}
+
+		// now close and delete the file
+		if err := f.Close(); err != nil {
+			return err
+		}
+		os.Remove(n)
+	}
+
+	if err := compactionFile.Close(); err != nil {
+		return err
+	}
+
+	// close the compaction file and rename it so that it will appear as the very first segment
+	compactionFile.Close()
+	os.Rename(compactionFile.Name(), p.fileNameForSegment(1))
+
+	// and mark the compaction as done
+	p.mu.Lock()
+	p.compactionRunning = false
+	p.mu.Unlock()
+
+	return nil
+}
+
+// writeCompactionEntry will write a marker for the beginning of the file we're compacting, a compressed block
+// for all entries, then a marker for the end of the file
+func (p *partition) writeCompactionEntry(f *os.File, entries []*entry) error {
+	if err := p.writeCompactionFileName(f); err != nil {
+		return err
+	}
+
+	block := make([]byte, 0)
+	for _, e := range entries {
+		block = append(block, marshalWALEntry(e.key, e.timestamp, e.data)...)
+	}
+	b := snappy.Encode(nil, block)
+
+	if n, err := f.Write(u64tob(uint64(len(b)))); err != nil {
+		return err
+	} else if n != 8 {
+		return fmt.Errorf("compaction expected to write %d bytes but wrote %d", 8, n)
+	}
+
+	if n, err := f.Write(b); err != nil {
+		return err
+	} else if n != len(b) {
+		return fmt.Errorf("compaction expected to write %d bytes but wrote %d", len(b), n)
+	}
+
+	if err := p.writeCompactionFileName(f); err != nil {
+		return err
+	}
+
+	return f.Sync()
+}
+
+// writeCompactionFileName will write a compaction log length entry and the name of the file that is compacted
+func (p *partition) writeCompactionFileName(f *os.File) error {
+	name := []byte(f.Name())
+	length := u64tob(uint64(len(name)))
+
+	// the beginning of the length has two bytes to indicate that this is a compaction log entry
+	length[0] = 0xFF
+	length[1] = 0xFF
+
+	if n, err := f.Write(length); err != nil {
+		return err
+	} else if n != 8 {
+		return fmt.Errorf("compaction expected to write %d bytes but wrote %d", 8, n)
+	}
+
+	if n, err := f.Write(name); err != nil {
+		return err
+	} else if n != len(name) {
+		return fmt.Errorf("compaction expected to write %d bytes but wrote %d", len(name), n)
+	}
+
+	return nil
+}
+
+// readFile will read a segment file and marshal its entries into the cache
+func (p *partition) readFile(path string) (entries []*entry, err error) {
+	id, err := p.fileIDFromName(path)
+	if err != nil {
+		return nil, err
+	}
+
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0600)
+	if err != nil {
+		return nil, err
+	}
+
+	sf := newSegmentFile(f)
+	for {
+		a, err := sf.readCompressedBlock()
+
+		if err == ErrCompactionBlock {
+			continue
+		} else if err != nil {
+			return nil, err
+		} else if a == nil {
+			break
+		}
+
+		entries = append(entries, a...)
+	}
+
+	// if this is the highest segment file, it'll be the one we use, otherwise close it out now that we're done reading
+	if id > p.currentSegmentID {
+		p.currentSegmentID = id
+		p.currentSegmentFile = f
+		p.currentSegmentSize = sf.size
+	} else {
+		if err := f.Close(); err != nil {
+			return nil, err
+		}
+	}
+	return
+}
+
+// addToCache will marshal the entry and add it to the in memory cache. It will also mark if this key will need sorting later
+func (p *partition) addToCache(key, data []byte, timestamp int64) {
+	// Generate in-memory cache entry of <timestamp,data>.
+	v := MarshalEntry(timestamp, data)
+	p.totalSize += uint64(len(v))
+	// Determine if we'll need to sort the values for this key later
+	a := p.cache[string(key)]
+	needSort := !(len(a) == 0 || bytes.Compare(a[len(a)-1], v) == -1)
+	p.cacheDirtySort[string(key)] = needSort
+
+	// Append to cache list.
+	p.cache[string(key)] = append(a, v)
+	p.cacheSizes[string(key)] += len(v)
+}
+
+// cursor will combine the in memory cache and flush cache (if a flush is currently happening) to give a single ordered cursor for the key
+func (p *partition) cursor(key string) *cursor {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	cache := p.cache[key]
+	if cache == nil {
+		return &cursor{}
+	}
+
+	// if we're in the middle of a flush, combine the previous cache
+	// with this one for the cursor
+	if fc, ok := p.flushCache[key]; ok {
+		c := make([][]byte, len(fc), len(fc)+len(cache))
+		copy(c, fc)
+		c = append(c, cache...)
+		sort.Sort(byteSlices(c))
+		return &cursor{cache: c, position: -1}
+	}
+
+	if p.cacheDirtySort[key] {
+		sort.Sort(byteSlices(cache))
+		delete(p.cacheDirtySort, key)
+	}
+
+	return &cursor{cache: cache, position: -1}
+}
+
+// idFromFileName parses the segment file ID from its name
+func (p *partition) idFromFileName(name string) (uint32, error) {
+	parts := strings.Split(name, ".")
+	if len(parts) != 3 {
+		return 0, fmt.Errorf("file %s has wrong name format to be a segment file", name)
+	}
+
+	id, err := strconv.ParseUint(parts[1], 10, 32)
+
+	return uint32(id), err
+}
+
+// segmentFileNames returns all the segment files names for the partition
+func (p *partition) segmentFileNames() ([]string, error) {
+	path := filepath.Join(p.path, fmt.Sprintf("%02d.*.%s", p.id, FileExtension))
+	fileNames, err := filepath.Glob(path)
+	return fileNames, err
+}
+
+// segmentFile is a struct for reading in segment files from the WAL. Used on startup only while loading
+type segmentFile struct {
+	f      *os.File
+	block  []byte
+	length []byte
+	size   int
+}
+
+func newSegmentFile(f *os.File) *segmentFile {
+	return &segmentFile{
+		length: make([]byte, 8),
+		f:      f,
+	}
+}
+
+// readCompressedBlock will read the next compressed block from the file and marshal the entries.
+// if we've hit the end of the file or corruption the entry array will be nil
+func (s *segmentFile) readCompressedBlock() (entries []*entry, err error) {
+	n, err := s.f.Read(s.length)
+	if err == io.EOF {
+		return nil, nil
+	} else if err != nil {
+		return nil, err
+	}
+	s.size += n
+
+	if n != len(s.length) {
+		log.Println("unable to read the size of a data block from file: ", s.f.Name())
+		// seek back before this length so we can start overwriting the file from here
+		s.f.Seek(-int64(n), 1)
+		return nil, nil
+	}
+
+	// Compacted WAL files will have a magic byte sequence that indicate the next part is a file name
+	// instead of a compressed block. We can ignore these bytes and the ensuing file name to get to the next block.
+	isCompactionFileNameBlock := false
+	if bytes.Compare(s.length[0:2], CompactSequence) == 0 {
+		s.length[0] = 0x00
+		s.length[1] = 0x00
+		isCompactionFileNameBlock = true
+	}
+
+	dataLength := btou64(s.length)
+
+	// make sure we haven't hit the end of data. trailing end of file can be zero bytes
+	if dataLength == 0 {
+		s.f.Seek(-int64(len(s.length)), 1)
+		return nil, nil
+	}
+
+	if len(s.block) < int(dataLength) {
+		s.block = make([]byte, dataLength)
+	}
+
+	n, err = s.f.Read(s.block[:dataLength])
+	if err != nil {
+		return nil, err
+	}
+	s.size += n
+
+	// read the compressed block and decompress it. if partial or corrupt,
+	// overwrite with zeroes so we can start over on this wal file
+	if n != int(dataLength) {
+		log.Println("partial compressed block in file: ", s.f.Name())
+
+		// seek back to before this block and its size so we can overwrite the corrupt data
+		s.f.Seek(-int64(len(s.length)+n), 1)
+		if err := s.zeroRestOfFile(); err != nil {
+			return nil, err
+		}
+
+		return nil, nil
+	}
+
+	// skip the rest if this is just the filename from a compaction
+	if isCompactionFileNameBlock {
+		return nil, ErrCompactionBlock
+	}
+
+	buf, err := snappy.Decode(nil, s.block[:dataLength])
+
+	// if there was an error decoding, this is a corrupt block so we zero out the rest of the file
+	if err != nil {
+		log.Println("corrupt compressed block in file: ", err.Error(), s.f.Name())
+
+		// go back to the start of this block and zero out the rest of the file
+		s.f.Seek(-int64(len(s.length)+n), 1)
+		if err := s.zeroRestOfFile(); err != nil {
+			return nil, err
+		}
+
+		return nil, nil
+	}
+
+	// read in the individual data points from the decompressed wal block
+	bytesRead := 0
+	for {
+		if bytesRead >= len(buf) {
+			break
+		}
+		n, key, timestamp, data := unmarshalWALEntry(buf[bytesRead:])
+		bytesRead += n
+		entries = append(entries, &entry{key: key, data: data, timestamp: timestamp})
+	}
+
+	return
+}
+
+// zeroRestOfFile will write zeroes for the rest of the segment file. This is used if for some reason a partial write occured.
+// it basically resets the rest of the segment file so we can continue to use it
+func (s *segmentFile) zeroRestOfFile() error {
+	buf := make([]byte, 1024*512)
+	bytesToOverwrite := int64(0)
+	for {
+		n, err := s.f.Read(buf)
+		bytesToOverwrite += int64(n)
+		if err != nil || n == 0 {
+			break
+		}
+	}
+	if _, err := s.f.Seek(-bytesToOverwrite, 1); err != nil {
+		return err
+	}
+	for i := int64(0); i < bytesToOverwrite; i++ {
+		if _, err := s.f.Write([]byte{0x00}); err != nil {
+			return err
+		}
+	}
+	if err := s.f.Sync(); err != nil {
+		return err
+	}
+	_, err := s.f.Seek(-bytesToOverwrite, 1)
+	return err
+}
+
+// entry is used as a temporary object when reading data from segment files
+type entry struct {
+	key       []byte
+	data      []byte
+	timestamp int64
+}
+
+// cursor is a forward cursor for a given entry in the cache
+type cursor struct {
+	cache    [][]byte
+	position int
+}
+
+// Seek will point the cursor to the given time (or key)
+func (c *cursor) Seek(seek []byte) (key, value []byte) {
+	for i, p := range c.cache {
+		if bytes.Compare(seek, p[0:8]) >= 0 {
+			c.position = i
+			return p[0:8], p[8:]
+		}
+	}
+	return nil, nil
+}
+
+// Next moves the cursor to the next key/value. will return nil if at the end
+func (c *cursor) Next() (key, value []byte) {
+	pos := c.position + 1
+	if pos < len(c.cache) {
+		c.position = pos
+		v := c.cache[c.position]
+		return v[0:8], v[8:]
+	}
+	return nil, nil
+}
+
+func (w *Log) WritePoints(points []tsdb.Point) error {
+	partitionsToWrite := w.pointsToPartitions(points)
+
+	// get it to disk
+	if err := func() error {
+		w.mu.RLock()
+		defer w.mu.RUnlock()
+
+		for p, points := range partitionsToWrite {
+			if err := p.write(points); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (l *Log) Flush() error {
+	return fmt.Errorf("explicit call to flush isn't implemented yet")
+}
+
+// pointsToPartitions returns a map that organizes the points into the partitions they should be mapped to
+func (w *Log) pointsToPartitions(points []tsdb.Point) map[*partition][]tsdb.Point {
+	m := make(map[*partition][]tsdb.Point)
+	for _, p := range points {
+		pp := w.walPartition(p.Key())
+		m[pp] = append(m[pp], p)
+	}
+	return m
+}
+
+// openPartitionFiles will open all partitions and read their segment files
+func (w *Log) openPartitionFiles() error {
+	results := make(chan error, len(w.partitions))
+	for _, p := range w.partitions {
+
+		go func(p *partition) {
+			fileNames, err := p.segmentFileNames()
+			if err != nil {
+				results <- err
+				return
+			}
+			for _, n := range fileNames {
+				entries, err := p.readFile(n)
+				if err != nil {
+					results <- err
+					return
+				}
+				for _, e := range entries {
+					p.addToCache(e.key, e.data, e.timestamp)
+				}
+			}
+			results <- nil
+		}(p)
+	}
+
+	for i := 0; i < len(w.partitions); i++ {
+		err := <-results
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Close will finish any flush that is currently in process and close file handles
+func (w *Log) Close() error {
+	// stop the autoflushing process so it doesn't try to kick another one off
+	if w.closing != nil {
+		close(w.closing)
+		w.closing = nil
+	}
+
+	w.wg.Wait()
+
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	// clear the cache
+	w.partitions = nil
+
+	return w.close()
+}
+
+// close all the open Log partitions and file handles
+func (w *Log) close() error {
+	for _, p := range w.partitions {
+		if err := p.Close(); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// triggerAutoFlush will flush and compact any partitions that have hit the thresholds for compaction
+func (l *Log) triggerAutoFlush() {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	for _, p := range l.partitions {
+		if p.shouldFlush(l.MaxSeriesSize, l.ReadySeriesSize, l.CompactionThreshold, l.PartitionSizeThreshold) {
+			if err := p.flushAndCompact(l.IndexWriter, l.MaxSeriesSize, l.ReadySeriesSize); err != nil {
+				l.logger.Printf("error flushing partition %d: %s\n", p.id, err)
+			}
+		}
+	}
+}
+
+// autoflusher waits for notification of a flush and kicks it off in the background.
+// This method runs in a separate goroutine.
+func (w *Log) autoflusher(closing chan struct{}) {
+	defer w.wg.Done()
+
+	for {
+		// Wait for close or flush signal.
+		select {
+		case <-closing:
+			return
+		case <-w.flushCheckTimer.C:
+			w.triggerAutoFlush()
+		case <-w.flush:
+			if err := w.Flush(); err != nil {
+				w.logger.Printf("flush error: %s", err)
+			}
+		}
+	}
+}
+
+// walPartition returns the partition number that key belongs to.
+func (l *Log) walPartition(key []byte) *partition {
+	h := fnv.New64a()
+	h.Write(key)
+	id := uint8(h.Sum64()%l.PartitionCount + 1)
+	p := l.partitions[id]
+	if p == nil {
+		if p, err := newPartition(id, l.path, l.SegmentSize); err != nil {
+			panic(err)
+
+		} else {
+			l.partitions[id] = p
+		}
+	}
+	return p
+}
+
+// marshalWALEntry encodes point data into a single byte slice.
+//
+// The format of the byte slice is:
+//
+//     uint64 timestamp
+//     uint32 key length
+//     uint32 data length
+//     []byte key
+//     []byte data
+//
+func marshalWALEntry(key []byte, timestamp int64, data []byte) []byte {
+	v := make([]byte, 8+4+4, 8+4+4+len(key)+len(data))
+	binary.BigEndian.PutUint64(v[0:8], uint64(timestamp))
+	binary.BigEndian.PutUint32(v[8:12], uint32(len(key)))
+	binary.BigEndian.PutUint32(v[12:16], uint32(len(data)))
+
+	v = append(v, key...)
+	v = append(v, data...)
+
+	return v
+}
+
+// unmarshalWALEntry decodes a WAL entry into it's separate parts.
+// Returned byte slices point to the original slice.
+func unmarshalWALEntry(v []byte) (bytesRead int, key []byte, timestamp int64, data []byte) {
+	timestamp = int64(binary.BigEndian.Uint64(v[0:8]))
+	keyLen := binary.BigEndian.Uint32(v[8:12])
+	dataLen := binary.BigEndian.Uint32(v[12:16])
+
+	key = v[16 : 16+keyLen]
+	data = v[16+keyLen : 16+keyLen+dataLen]
+	bytesRead = 16 + int(keyLen) + int(dataLen)
+	return
+}
+
+// marshalCacheEntry encodes the timestamp and data to a single byte slice.
+//
+// The format of the byte slice is:
+//
+//     uint64 timestamp
+//     []byte data
+//
+func MarshalEntry(timestamp int64, data []byte) []byte {
+	buf := make([]byte, 8+len(data))
+	binary.BigEndian.PutUint64(buf[0:8], uint64(timestamp))
+	copy(buf[8:], data)
+	return buf
+}
+
+// unmarshalCacheEntry returns the timestamp and data from an encoded byte slice.
+func UnmarshalEntry(buf []byte) (timestamp int64, data []byte) {
+	timestamp = int64(binary.BigEndian.Uint64(buf[0:8]))
+	data = buf[8:]
+	return
+}
+
+// u64tob converts a uint64 into an 8-byte slice.
+func u64tob(v uint64) []byte {
+	b := make([]byte, 8)
+	binary.BigEndian.PutUint64(b, v)
+	return b
+}
+
+func btou64(b []byte) uint64 {
+	return binary.BigEndian.Uint64(b)
+}
+
+// byteSlices represents a sortable slice of byte slices.
+type byteSlices [][]byte
+
+func (a byteSlices) Len() int           { return len(a) }
+func (a byteSlices) Less(i, j int) bool { return bytes.Compare(a[i], a[j]) == -1 }
+func (a byteSlices) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }

--- a/tsdb/engine/wal/wal.go
+++ b/tsdb/engine/wal/wal.go
@@ -220,7 +220,6 @@ func (l *Log) Cursor(key string) tsdb.Cursor {
 }
 
 func (l *Log) WritePoints(points []tsdb.Point) error {
-	fmt.Println("WRITING: ", len(points))
 	partitionsToWrite := l.pointsToPartitions(points)
 
 	// get it to disk

--- a/tsdb/engine/wal/wal.go
+++ b/tsdb/engine/wal/wal.go
@@ -248,9 +248,6 @@ func (l *Log) Flush() error {
 func (l *Log) pointsToPartitions(points []tsdb.Point) map[*Partition][]tsdb.Point {
 	m := make(map[*Partition][]tsdb.Point)
 	for _, p := range points {
-		if "cpu,host=host-5008,region=uswest" == string(p.Key()) {
-			fmt.Println("POINT: ", p.String())
-		}
 		pp := l.partition(p.Key())
 		m[pp] = append(m[pp], p)
 	}

--- a/tsdb/engine/wal/wal_test.go
+++ b/tsdb/engine/wal/wal_test.go
@@ -524,7 +524,7 @@ func TestWAL_SeriesAndFieldsGetPersisted(t *testing.T) {
 
 	s := idx.Series("cpu,host=A")
 	if s == nil {
-		t.Fatal("expected to find series cpu,host=A in index %v", idx)
+		t.Fatal("expected to find series cpu,host=A in index")
 	}
 
 	s = idx.Series("cpu,host=B")

--- a/tsdb/engine/wal/wal_test.go
+++ b/tsdb/engine/wal/wal_test.go
@@ -16,9 +16,7 @@ import (
 func TestWAL_WritePoints(t *testing.T) {
 	log := openTestWAL()
 	defer log.Close()
-	defer func() {
-		os.RemoveAll(log.path)
-	}()
+	defer os.RemoveAll(log.path)
 
 	if err := log.Open(); err != nil {
 		t.Fatalf("couldn't open wal: %s", err.Error())
@@ -123,9 +121,7 @@ func TestWAL_WritePoints(t *testing.T) {
 func TestWAL_CorruptDataLengthSize(t *testing.T) {
 	log := openTestWAL()
 	defer log.Close()
-	defer func() {
-		os.RemoveAll(log.path)
-	}()
+	defer os.RemoveAll(log.path)
 
 	if err := log.Open(); err != nil {
 		t.Fatalf("couldn't open wal: %s", err.Error())
@@ -204,9 +200,7 @@ func TestWAL_CorruptDataLengthSize(t *testing.T) {
 func TestWAL_CorruptDataBlock(t *testing.T) {
 	log := openTestWAL()
 	defer log.Close()
-	defer func() {
-		os.RemoveAll(log.path)
-	}()
+	defer os.RemoveAll(log.path)
 
 	if err := log.Open(); err != nil {
 		t.Fatalf("couldn't open wal: %s", err.Error())
@@ -292,13 +286,11 @@ func TestWAL_CorruptDataBlock(t *testing.T) {
 // it with enough data to flush
 func TestWAL_CompactAfterPercentageThreshold(t *testing.T) {
 	log := openTestWAL()
-	log.PartitionCount = 2
+	log.partitionCount = 2
 	log.CompactionThreshold = 0.7
 
 	defer log.Close()
-	defer func() {
-		os.RemoveAll(log.path)
-	}()
+	defer os.RemoveAll(log.path)
 
 	if err := log.Open(); err != nil {
 		t.Fatalf("couldn't open wal: %s", err.Error())
@@ -313,7 +305,7 @@ func TestWAL_CompactAfterPercentageThreshold(t *testing.T) {
 	})
 
 	points := make([]map[string][][]byte, 0)
-	log.IndexWriter = &testIndexWriter{fn: func(pointsByKey map[string][][]byte) error {
+	log.Index = &testIndexWriter{fn: func(pointsByKey map[string][][]byte) error {
 		points = append(points, pointsByKey)
 		return nil
 	}}
@@ -359,7 +351,7 @@ func TestWAL_CompactAfterPercentageThreshold(t *testing.T) {
 		t.Fatal("expected partition 1 to return true from shouldFlush")
 	}
 
-	if err := log.partitions[1].flushAndCompact(log.IndexWriter, DefaultMaxSeriesSize, readySize); err != nil {
+	if err := log.partitions[1].flushAndCompact(log.Index, DefaultMaxSeriesSize, readySize); err != nil {
 		t.Fatalf("error flushing and compacting: %s", err.Error())
 	}
 

--- a/tsdb/engine/wal/wal_test.go
+++ b/tsdb/engine/wal/wal_test.go
@@ -8,10 +8,10 @@ import (
 	"math/rand"
 	"os"
 	"testing"
+	"time"
 
 	// "runtime"
 	// "sync"
-	// "time"
 
 	"github.com/influxdb/influxdb/influxql"
 	"github.com/influxdb/influxdb/tsdb"
@@ -293,6 +293,9 @@ func TestWAL_CompactAfterPercentageThreshold(t *testing.T) {
 	log.partitionCount = 2
 	log.CompactionThreshold = 0.7
 	log.ReadySeriesSize = 1024
+
+	// set this high so that a flush doesn't automatically kick in and mess up our test
+	log.flushCheckInterval = time.Minute
 
 	defer log.Close()
 	defer os.RemoveAll(log.path)

--- a/tsdb/engine/wal/wal_test.go
+++ b/tsdb/engine/wal/wal_test.go
@@ -334,7 +334,7 @@ func TestWAL_CompactAfterPercentageThreshold(t *testing.T) {
 			buf.WriteString(fmt.Sprintf("cpu,host=A,region=useast3 value=%.3f %d\n", rand.Float64(), i))
 
 			// ensure that as a whole its not ready for flushing yet
-			if log.partitions[1].shouldFlush(DefaultMaxSeriesSize, DefaultCompactionThreshold) != noFlush {
+			if log.partitions[1].shouldFlush(tsdb.DefaultMaxSeriesSize, tsdb.DefaultCompactionThreshold) != noFlush {
 				t.Fatal("expected partition 1 to return false from shouldFlush")
 			}
 		}
@@ -354,7 +354,7 @@ func TestWAL_CompactAfterPercentageThreshold(t *testing.T) {
 	}
 
 	// ensure it is marked as should flush because of the threshold
-	if log.partitions[1].shouldFlush(DefaultMaxSeriesSize, DefaultCompactionThreshold) != thresholdFlush {
+	if log.partitions[1].shouldFlush(tsdb.DefaultMaxSeriesSize, tsdb.DefaultCompactionThreshold) != thresholdFlush {
 		t.Fatal("expected partition 1 to return true from shouldFlush")
 	}
 
@@ -451,7 +451,7 @@ func TestWAL_CompactAfterTimeWithoutWrite(t *testing.T) {
 	time.Sleep(700 * time.Millisecond)
 
 	// ensure that as a whole its not ready for flushing yet
-	if f := log.partitions[1].shouldFlush(DefaultMaxSeriesSize, DefaultCompactionThreshold); f != noFlush {
+	if f := log.partitions[1].shouldFlush(tsdb.DefaultMaxSeriesSize, tsdb.DefaultCompactionThreshold); f != noFlush {
 		t.Fatalf("expected partition 1 to return noFlush from shouldFlush %v", f)
 	}
 

--- a/tsdb/engine/wal/wal_test.go
+++ b/tsdb/engine/wal/wal_test.go
@@ -1,0 +1,512 @@
+package wal
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"io/ioutil"
+	"math/rand"
+	"os"
+	"testing"
+
+	"github.com/influxdb/influxdb/influxql"
+	"github.com/influxdb/influxdb/tsdb"
+)
+
+func TestWAL_WritePoints(t *testing.T) {
+	log := openTestWAL()
+	defer log.Close()
+	defer func() {
+		os.RemoveAll(log.path)
+	}()
+
+	if err := log.Open(); err != nil {
+		t.Fatalf("couldn't open wal: %s", err.Error())
+	}
+
+	codec := tsdb.NewFieldCodec(map[string]*tsdb.Field{
+		"value": {
+			ID:   uint8(1),
+			Name: "value",
+			Type: influxql.Float,
+		},
+	})
+
+	// test that we can write to two different series
+	p1 := parsePoint("cpu,host=A value=23.2 1", codec)
+	p2 := parsePoint("cpu,host=A value=25.3 4", codec)
+	p3 := parsePoint("cpu,host=B value=1.0 1", codec)
+	if err := log.WritePoints([]tsdb.Point{p1, p2, p3}); err != nil {
+		t.Fatalf("failed to write points: %s", err.Error())
+	}
+
+	verify := func() {
+		c := log.Cursor("cpu,host=A")
+		k, v := c.Seek(inttob(1))
+
+		// ensure the series are there and points are in order
+		if bytes.Compare(v, p1.Data()) != 0 {
+			t.Fatalf("expected to seek to first point but got key and value: %v %v", k, v)
+		}
+
+		k, v = c.Next()
+		if bytes.Compare(v, p2.Data()) != 0 {
+			t.Fatalf("expected to seek to first point but got key and value: %v %v", k, v)
+		}
+
+		k, v = c.Next()
+		if k != nil {
+			t.Fatalf("expected nil on last seek: %v %v", k, v)
+		}
+
+		c = log.Cursor("cpu,host=B")
+		k, v = c.Next()
+		if bytes.Compare(v, p3.Data()) != 0 {
+			t.Fatalf("expected to seek to first point but got key and value: %v %v", k, v)
+		}
+	}
+
+	verify()
+
+	// ensure that we can close and re-open the log with points still there
+	log.Close()
+	log.Open()
+
+	verify()
+
+	// ensure we can write new points into the series
+	p4 := parsePoint("cpu,host=A value=1.0 7", codec)
+	// ensure we can write an all new series
+	p5 := parsePoint("cpu,host=C value=1.4 2", codec)
+	// ensure we can write a point out of order and get it back
+	p6 := parsePoint("cpu,host=A value=1.3 2", codec)
+	// // ensure we can write to a new partition
+	// p7 := parsePoint("cpu,region=west value=2.2", codec)
+	if err := log.WritePoints([]tsdb.Point{p4, p5, p6}); err != nil {
+		t.Fatalf("failed to write points: %s", err.Error())
+	}
+
+	verify2 := func() {
+		c := log.Cursor("cpu,host=A")
+		k, v := c.Next()
+		if bytes.Compare(v, p1.Data()) != 0 {
+			t.Fatalf("order wrong, expected p1, %v %v %v", v, k, p1.Data())
+		}
+		_, v = c.Next()
+		if bytes.Compare(v, p6.Data()) != 0 {
+			t.Fatal("order wrong, expected p6")
+		}
+		_, v = c.Next()
+		if bytes.Compare(v, p2.Data()) != 0 {
+			t.Fatal("order wrong, expected p6")
+		}
+		_, v = c.Next()
+		if bytes.Compare(v, p4.Data()) != 0 {
+			t.Fatal("order wrong, expected p6")
+		}
+
+		c = log.Cursor("cpu,host=C")
+		_, v = c.Next()
+		if bytes.Compare(v, p5.Data()) != 0 {
+			t.Fatal("order wrong, expected p6")
+		}
+	}
+
+	verify2()
+
+	log.Close()
+	log.Open()
+
+	verify2()
+}
+
+func TestWAL_CorruptDataLengthSize(t *testing.T) {
+	log := openTestWAL()
+	defer log.Close()
+	defer func() {
+		os.RemoveAll(log.path)
+	}()
+
+	if err := log.Open(); err != nil {
+		t.Fatalf("couldn't open wal: %s", err.Error())
+	}
+
+	codec := tsdb.NewFieldCodec(map[string]*tsdb.Field{
+		"value": {
+			ID:   uint8(1),
+			Name: "value",
+			Type: influxql.Float,
+		},
+	})
+
+	// test that we can write to two different series
+	p1 := parsePoint("cpu,host=A value=23.2 1", codec)
+	p2 := parsePoint("cpu,host=A value=25.3 4", codec)
+	if err := log.WritePoints([]tsdb.Point{p1, p2}); err != nil {
+		t.Fatalf("failed to write points: %s", err.Error())
+	}
+
+	verify := func() {
+		c := log.Cursor("cpu,host=A")
+		_, v := c.Next()
+		if bytes.Compare(v, p1.Data()) != 0 {
+			t.Fatal("p1 value wrong")
+		}
+		_, v = c.Next()
+		if bytes.Compare(v, p2.Data()) != 0 {
+			t.Fatal("p2 value wrong")
+		}
+		_, v = c.Next()
+		if v != nil {
+			t.Fatal("expected cursor to return nil")
+		}
+	}
+
+	verify()
+
+	// now write junk data and ensure that we can close, re-open and read
+	f := log.partitions[1].currentSegmentFile
+	f.Write([]byte{0x23, 0x12})
+	f.Sync()
+	log.Close()
+	log.Open()
+
+	verify()
+
+	// now write new data and ensure it's all good
+	p3 := parsePoint("cpu,host=A value=29.2 6", codec)
+	if err := log.WritePoints([]tsdb.Point{p3}); err != nil {
+		t.Fatalf("failed to write point: %s", err.Error())
+	}
+
+	verify = func() {
+		c := log.Cursor("cpu,host=A")
+		_, v := c.Next()
+		if bytes.Compare(v, p1.Data()) != 0 {
+			t.Fatal("p1 value wrong")
+		}
+		_, v = c.Next()
+		if bytes.Compare(v, p2.Data()) != 0 {
+			t.Fatal("p2 value wrong")
+		}
+		_, v = c.Next()
+		if bytes.Compare(v, p3.Data()) != 0 {
+			t.Fatal("p3 value wrong")
+		}
+	}
+
+	verify()
+	log.Close()
+	log.Open()
+	verify()
+}
+
+func TestWAL_CorruptDataBlock(t *testing.T) {
+	log := openTestWAL()
+	defer log.Close()
+	defer func() {
+		os.RemoveAll(log.path)
+	}()
+
+	if err := log.Open(); err != nil {
+		t.Fatalf("couldn't open wal: %s", err.Error())
+	}
+
+	codec := tsdb.NewFieldCodec(map[string]*tsdb.Field{
+		"value": {
+			ID:   uint8(1),
+			Name: "value",
+			Type: influxql.Float,
+		},
+	})
+
+	// test that we can write to two different series
+	p1 := parsePoint("cpu,host=A value=23.2 1", codec)
+	p2 := parsePoint("cpu,host=A value=25.3 4", codec)
+	if err := log.WritePoints([]tsdb.Point{p1, p2}); err != nil {
+		t.Fatalf("failed to write points: %s", err.Error())
+	}
+
+	verify := func() {
+		c := log.Cursor("cpu,host=A")
+		_, v := c.Next()
+		if bytes.Compare(v, p1.Data()) != 0 {
+			t.Fatal("p1 value wrong")
+		}
+		_, v = c.Next()
+		if bytes.Compare(v, p2.Data()) != 0 {
+			t.Fatal("p2 value wrong")
+		}
+		_, v = c.Next()
+		if v != nil {
+			t.Fatal("expected cursor to return nil")
+		}
+	}
+
+	verify()
+
+	// now write junk data and ensure that we can close, re-open and read
+
+	f := log.partitions[1].currentSegmentFile
+	f.Write(u64tob(23))
+	// now write a bunch of garbage
+	for i := 0; i < 1000; i++ {
+		f.Write([]byte{0x23, 0x78, 0x11, 0x33})
+	}
+	f.Sync()
+
+	log.Close()
+	log.Open()
+
+	verify()
+
+	// now write new data and ensure it's all good
+	p3 := parsePoint("cpu,host=A value=29.2 6", codec)
+	if err := log.WritePoints([]tsdb.Point{p3}); err != nil {
+		t.Fatalf("failed to write point: %s", err.Error())
+	}
+
+	verify = func() {
+		c := log.Cursor("cpu,host=A")
+		_, v := c.Next()
+		if bytes.Compare(v, p1.Data()) != 0 {
+			t.Fatal("p1 value wrong")
+		}
+		_, v = c.Next()
+		if bytes.Compare(v, p2.Data()) != 0 {
+			t.Fatal("p2 value wrong")
+		}
+		_, v = c.Next()
+		if bytes.Compare(v, p3.Data()) != 0 {
+			t.Fatal("p3 value wrong", p3.Data(), v)
+		}
+	}
+
+	verify()
+	log.Close()
+	log.Open()
+	verify()
+}
+
+// Ensure the wal flushes and compacts after a partition has enough series in
+// it with enough data to flush
+func TestWAL_CompactAfterPercentageThreshold(t *testing.T) {
+	log := openTestWAL()
+	log.PartitionCount = 2
+	log.CompactionThreshold = 0.7
+
+	defer log.Close()
+	defer func() {
+		os.RemoveAll(log.path)
+	}()
+
+	if err := log.Open(); err != nil {
+		t.Fatalf("couldn't open wal: %s", err.Error())
+	}
+
+	codec := tsdb.NewFieldCodec(map[string]*tsdb.Field{
+		"value": {
+			ID:   uint8(1),
+			Name: "value",
+			Type: influxql.Float,
+		},
+	})
+
+	points := make([]map[string][][]byte, 0)
+	log.IndexWriter = &testIndexWriter{fn: func(pointsByKey map[string][][]byte) error {
+		points = append(points, pointsByKey)
+		return nil
+	}}
+
+	readySize := 1024
+
+	numSeries := 100
+	b := make([]byte, 70*5000)
+	for i := 1; i <= 100; i++ {
+		buf := bytes.NewBuffer(b)
+		for j := 1; j <= numSeries; j++ {
+			buf.WriteString(fmt.Sprintf("cpu,host=A,region=uswest%d value=%.3f %d\n", j, rand.Float64(), i))
+		}
+
+		// ensure that before we go over the threshold it isn't marked for flushing
+		if i < 50 {
+			// interleave data for some series that won't be ready to flush
+			buf.WriteString(fmt.Sprintf("cpu,host=A,region=useast1 value=%.3f %d\n", rand.Float64(), i))
+			buf.WriteString(fmt.Sprintf("cpu,host=A,region=useast3 value=%.3f %d\n", rand.Float64(), i))
+
+			// ensure that as a whole its not ready for flushing yet
+			if log.partitions[1].shouldFlush(DefaultMaxSeriesSize, readySize, DefaultCompactionThreshold, DefaultPartitionSizeThreshold) {
+				t.Fatal("expected partition 1 to return false from shouldFlush")
+			}
+		}
+
+		// write the batch out
+		if err := log.WritePoints(parsePoints(buf.String(), codec)); err != nil {
+			t.Fatalf("failed to write points: %s", err.Error())
+		}
+		buf = bytes.NewBuffer(b)
+	}
+
+	// ensure we have some data
+	c := log.Cursor("cpu,host=A,region=uswest23")
+	k, v := c.Next()
+	if btou64(k) != 1 {
+		fmt.Println("expected data ", k, v)
+	}
+
+	// ensure it is marked as should flush because of the threshold
+	if !log.partitions[1].shouldFlush(DefaultMaxSeriesSize, readySize, DefaultCompactionThreshold, DefaultPartitionSizeThreshold) {
+		t.Fatal("expected partition 1 to return true from shouldFlush")
+	}
+
+	if err := log.partitions[1].flushAndCompact(log.IndexWriter, DefaultMaxSeriesSize, readySize); err != nil {
+		t.Fatalf("error flushing and compacting: %s", err.Error())
+	}
+
+	// should be nil
+	c = log.Cursor("cpu,host=A,region=uswest23")
+	k, v = c.Next()
+	if k != nil || v != nil {
+		t.Fatal("expected cache to be nil after flush: ", k, v)
+	}
+
+	c = log.Cursor("cpu,host=A,region=useast1")
+	k, v = c.Next()
+	if btou64(k) != 1 {
+		t.Fatal("expected cache to be there after flush and compact: ", k, v)
+	}
+
+	if len(points) == 0 {
+		t.Fatal("expected points to be flushed to index")
+	}
+
+	// now close and re-open the wal and ensure the compacted data is gone and other data is still there
+	log.Close()
+	log.Open()
+
+	c = log.Cursor("cpu,host=A,region=uswest23")
+	k, v = c.Next()
+	if k != nil || v != nil {
+		t.Fatal("expected cache to be nil after flush and re-open: ", k, v)
+	}
+
+	c = log.Cursor("cpu,host=A,region=useast1")
+	k, v = c.Next()
+	if btou64(k) != 1 {
+		t.Fatal("expected cache to be there after flush and compact: ", k, v)
+	}
+}
+
+// test that partitions get compacted and flushed when number of series hits compaction threshold
+// test that partitions get compacted and flushed when a single series hits the compaction threshold
+// test that writes slow down when the partition size threshold is hit
+
+// func TestWAL_MultipleSegments(t *testing.T) {
+// 	runtime.GOMAXPROCS(8)
+
+// 	log := openTestWAL()
+// 	defer log.Close()
+// 	// defer func() {
+// 	// 	os.RemoveAll(log.path)
+// 	// }()
+
+// 	if err := log.Open(); err != nil {
+// 		t.Fatalf("couldn't open wal: ", err.Error())
+// 	}
+
+// 	codec := tsdb.NewFieldCodec(map[string]*tsdb.Field{
+// 		"value": {
+// 			ID:   uint8(1),
+// 			Name: "value",
+// 			Type: influxql.Float,
+// 		},
+// 	})
+
+// 	startTime := time.Now()
+// 	numSeries := 250000
+// 	perPost := 5000
+// 	b := make([]byte, 70*5000)
+// 	for i := 1; i <= 100; i++ {
+// 		fmt.Println("WRITING: ", i*numSeries)
+// 		n := 0
+// 		buf := bytes.NewBuffer(b)
+// 		var wg sync.WaitGroup
+// 		for j := 1; j <= numSeries; j++ {
+// 			n += 1
+// 			buf.WriteString(fmt.Sprintf("cpu,host=A,region=uswest%d value=%.3f %d\n", j, rand.Float64(), i))
+// 			if n >= perPost {
+// 				go func(b string) {
+// 					wg.Add(1)
+// 					if err := log.WritePoints(parsePoints(b, codec)); err != nil {
+// 						t.Fatalf("failed to write points: %s", err.Error())
+// 					}
+// 					wg.Done()
+// 				}(buf.String())
+// 				buf = bytes.NewBuffer(b)
+// 				n = 0
+// 			}
+// 		}
+// 		wg.Wait()
+// 	}
+// 	fmt.Println("PATH: ", log.path)
+// 	fmt.Println("TIME TO WRITE: ", time.Now().Sub(startTime))
+// 	for _, p := range log.partitions {
+// 		fmt.Println("SIZE: ", p.totalSize/1024/1024)
+// 	}
+
+// 	fmt.Println("CLOSING")
+// 	log.Close()
+// 	fmt.Println("TEST OPENING")
+// 	startTime = time.Now()
+// 	log.Open()
+// 	fmt.Println("TIME TO OPEN: ", time.Now().Sub(startTime))
+// 	for _, p := range log.partitions {
+// 		fmt.Println("SIZE: ", p.totalSize)
+// 	}
+
+// 	c := log.Cursor("cpu,host=A,region=uswest10")
+// 	k, v := c.Seek(inttob(23))
+// 	fmt.Println("VALS: ", k, v)
+// 	time.Sleep(time.Minute)
+// }
+
+type testIndexWriter struct {
+	fn func(pointsByKey map[string][][]byte) error
+}
+
+func (t *testIndexWriter) WriteIndex(pointsByKey map[string][][]byte) error {
+	return t.fn(pointsByKey)
+}
+
+func openTestWAL() *Log {
+	dir, err := ioutil.TempDir("", "wal-test")
+	if err != nil {
+		panic("couldn't get temp dir")
+	}
+	return NewLog(dir)
+}
+
+func parsePoints(buf string, codec *tsdb.FieldCodec) []tsdb.Point {
+	points, err := tsdb.ParsePointsString(buf)
+	if err != nil {
+		panic(fmt.Sprintf("couldn't parse points: %s", err.Error()))
+	}
+	for _, p := range points {
+		b, err := codec.EncodeFields(p.Fields())
+		if err != nil {
+			panic(fmt.Sprintf("couldn't encode fields: %s", err.Error()))
+		}
+		p.SetData(b)
+	}
+	return points
+}
+
+func parsePoint(buf string, codec *tsdb.FieldCodec) tsdb.Point {
+	return parsePoints(buf, codec)[0]
+}
+
+func inttob(v int) []byte {
+	b := make([]byte, 8)
+	binary.BigEndian.PutUint64(b, uint64(v))
+	return b
+}

--- a/tsdb/executor_test.go
+++ b/tsdb/executor_test.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"math"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -947,6 +948,8 @@ func testStore() *tsdb.Store {
 	path, _ := ioutil.TempDir("", "")
 
 	store := tsdb.NewStore(path)
+
+	store.EngineOptions.Config.WALDir = filepath.Join(path, "wal")
 	err := store.Open()
 	if err != nil {
 		panic(err)

--- a/tsdb/mapper_test.go
+++ b/tsdb/mapper_test.go
@@ -494,7 +494,7 @@ func TestShardMapper_LocalMapperTagSets(t *testing.T) {
 func mustCreateShard(dir string) *tsdb.Shard {
 	tmpShard := path.Join(dir, "shard")
 	index := tsdb.NewDatabaseIndex()
-	sh := tsdb.NewShard(index, tmpShard, tsdb.NewEngineOptions())
+	sh := tsdb.NewShard(1, index, tmpShard, tsdb.NewEngineOptions())
 	if err := sh.Open(); err != nil {
 		panic(fmt.Sprintf("error opening shard: %s", err.Error()))
 	}

--- a/tsdb/mapper_test.go
+++ b/tsdb/mapper_test.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -494,7 +495,9 @@ func TestShardMapper_LocalMapperTagSets(t *testing.T) {
 func mustCreateShard(dir string) *tsdb.Shard {
 	tmpShard := path.Join(dir, "shard")
 	index := tsdb.NewDatabaseIndex()
-	sh := tsdb.NewShard(1, index, tmpShard, tsdb.NewEngineOptions())
+	opts := tsdb.NewEngineOptions()
+	opts.Config.WALDir = filepath.Join(dir, "wal")
+	sh := tsdb.NewShard(1, index, tmpShard, opts)
 	if err := sh.Open(); err != nil {
 		panic(fmt.Sprintf("error opening shard: %s", err.Error()))
 	}

--- a/tsdb/meta.go
+++ b/tsdb/meta.go
@@ -1018,6 +1018,10 @@ func (s *Series) UnmarshalBinary(buf []byte) error {
 	return nil
 }
 
+func (s *Series) InitializeShards() {
+	s.shardIDs = make(map[uint64]bool)
+}
+
 // match returns true if all tags match the series' tags.
 func (s *Series) match(tags map[string]string) bool {
 	for k, v := range tags {

--- a/tsdb/meta.go
+++ b/tsdb/meta.go
@@ -980,6 +980,16 @@ type Series struct {
 
 	id          uint64
 	measurement *Measurement
+	shardIDs    map[uint64]bool // shards that have this series defined
+}
+
+// NewSeries returns an initialized series struct
+func NewSeries(key string, tags map[string]string) *Series {
+	return &Series{
+		Key:      key,
+		Tags:     tags,
+		shardIDs: make(map[uint64]bool),
+	}
 }
 
 // MarshalBinary encodes the object to a binary format.

--- a/tsdb/meta_test.go
+++ b/tsdb/meta_test.go
@@ -182,10 +182,7 @@ func genTestSeries(mCnt, tCnt, vCnt int) []*TestSeries {
 		for _, ts := range tagSets {
 			series = append(series, &TestSeries{
 				Measurement: m,
-				Series: &tsdb.Series{
-					Key:  fmt.Sprintf("%s:%s", m, string(tsdb.MarshalTags(ts))),
-					Tags: ts,
-				},
+				Series:      tsdb.NewSeries(fmt.Sprintf("%s:%s", m, string(tsdb.MarshalTags(ts))), ts),
 			})
 		}
 	}

--- a/tsdb/query_executor_test.go
+++ b/tsdb/query_executor_test.go
@@ -54,7 +54,9 @@ func TestWritePointsAndExecuteQuery(t *testing.T) {
 	}
 
 	store.Close()
+	conf := store.EngineOptions.Config
 	store = tsdb.NewStore(store.Path())
+	store.EngineOptions.Config = conf
 	if err := store.Open(); err != nil {
 		t.Fatalf(err.Error())
 	}
@@ -84,7 +86,9 @@ func TestWritePointsAndExecuteQuery_Update(t *testing.T) {
 
 	// Restart store.
 	store.Close()
+	conf := store.EngineOptions.Config
 	store = tsdb.NewStore(store.Path())
+	store.EngineOptions.Config = conf
 	if err := store.Open(); err != nil {
 		t.Fatalf(err.Error())
 	}
@@ -145,7 +149,9 @@ func TestDropSeriesStatement(t *testing.T) {
 	}
 
 	store.Close()
+	conf := store.EngineOptions.Config
 	store = tsdb.NewStore(store.Path())
+	store.EngineOptions.Config = conf
 	store.Open()
 	executor.Store = store
 
@@ -215,7 +221,9 @@ func TestDropMeasurementStatement(t *testing.T) {
 
 	validateDrop()
 	store.Close()
+	conf := store.EngineOptions.Config
 	store = tsdb.NewStore(store.Path())
+	store.EngineOptions.Config = conf
 	store.Open()
 	executor.Store = store
 	validateDrop()
@@ -279,7 +287,9 @@ func TestDropDatabase(t *testing.T) {
 	}
 
 	store.Close()
+	conf := store.EngineOptions.Config
 	store = tsdb.NewStore(store.Path())
+	store.EngineOptions.Config = conf
 	store.Open()
 	executor.Store = store
 	executor.ShardMapper = &testShardMapper{store: store}
@@ -344,6 +354,8 @@ func testStoreAndExecutor() (*tsdb.Store, *tsdb.QueryExecutor) {
 	path, _ := ioutil.TempDir("", "")
 
 	store := tsdb.NewStore(path)
+	store.EngineOptions.Config.WALDir = filepath.Join(path, "wal")
+
 	err := store.Open()
 	if err != nil {
 		panic(err)

--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -149,7 +149,6 @@ type SeriesCreate struct {
 
 // WritePoints will write the raw data points and any new metadata to the index in the shard
 func (s *Shard) WritePoints(points []Point) error {
-	fmt.Println("SHARD: ", len(points))
 	seriesToCreate, fieldsToCreate, err := s.validateSeriesAndFields(points)
 	if err != nil {
 		return err

--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -149,6 +149,7 @@ type SeriesCreate struct {
 
 // WritePoints will write the raw data points and any new metadata to the index in the shard
 func (s *Shard) WritePoints(points []Point) error {
+	fmt.Println("SHARD: ", len(points))
 	seriesToCreate, fieldsToCreate, err := s.validateSeriesAndFields(points)
 	if err != nil {
 		return err

--- a/tsdb/shard_test.go
+++ b/tsdb/shard_test.go
@@ -20,7 +20,7 @@ func TestShardWriteAndIndex(t *testing.T) {
 	tmpShard := path.Join(tmpDir, "shard")
 
 	index := tsdb.NewDatabaseIndex()
-	sh := tsdb.NewShard(index, tmpShard, tsdb.NewEngineOptions())
+	sh := tsdb.NewShard(1, index, tmpShard, tsdb.NewEngineOptions())
 	if err := sh.Open(); err != nil {
 		t.Fatalf("error openeing shard: %s", err.Error())
 	}
@@ -66,7 +66,7 @@ func TestShardWriteAndIndex(t *testing.T) {
 	sh.Close()
 
 	index = tsdb.NewDatabaseIndex()
-	sh = tsdb.NewShard(index, tmpShard, tsdb.NewEngineOptions())
+	sh = tsdb.NewShard(1, index, tmpShard, tsdb.NewEngineOptions())
 	if err := sh.Open(); err != nil {
 		t.Fatalf("error openeing shard: %s", err.Error())
 	}
@@ -87,7 +87,7 @@ func TestShardWriteAddNewField(t *testing.T) {
 	tmpShard := path.Join(tmpDir, "shard")
 
 	index := tsdb.NewDatabaseIndex()
-	sh := tsdb.NewShard(index, tmpShard, tsdb.NewEngineOptions())
+	sh := tsdb.NewShard(1, index, tmpShard, tsdb.NewEngineOptions())
 	if err := sh.Open(); err != nil {
 		t.Fatalf("error openeing shard: %s", err.Error())
 	}
@@ -143,7 +143,7 @@ func TestShard_Autoflush(t *testing.T) {
 	defer os.RemoveAll(path)
 
 	// Open shard with a really low size threshold, high flush interval.
-	sh := tsdb.NewShard(tsdb.NewDatabaseIndex(), filepath.Join(path, "shard"), tsdb.EngineOptions{
+	sh := tsdb.NewShard(1, tsdb.NewDatabaseIndex(), filepath.Join(path, "shard"), tsdb.EngineOptions{
 		EngineVersion:          b1.Format,
 		MaxWALSize:             1024, // 1KB
 		WALFlushInterval:       1 * time.Hour,
@@ -183,7 +183,7 @@ func TestShard_Autoflush_FlushInterval(t *testing.T) {
 	defer os.RemoveAll(path)
 
 	// Open shard with a high size threshold, small time threshold.
-	sh := tsdb.NewShard(tsdb.NewDatabaseIndex(), filepath.Join(path, "shard"), tsdb.EngineOptions{
+	sh := tsdb.NewShard(1, tsdb.NewDatabaseIndex(), filepath.Join(path, "shard"), tsdb.EngineOptions{
 		EngineVersion:          b1.Format,
 		MaxWALSize:             10 * 1024 * 1024, // 10MB
 		WALFlushInterval:       100 * time.Millisecond,
@@ -266,7 +266,7 @@ func benchmarkWritePoints(b *testing.B, mCnt, tkCnt, tvCnt, pntCnt int) {
 	for n := 0; n < b.N; n++ {
 		tmpDir, _ := ioutil.TempDir("", "shard_test")
 		tmpShard := path.Join(tmpDir, "shard")
-		shard := tsdb.NewShard(index, tmpShard, tsdb.NewEngineOptions())
+		shard := tsdb.NewShard(1, index, tmpShard, tsdb.NewEngineOptions())
 		shard.Open()
 
 		b.StartTimer()
@@ -301,7 +301,7 @@ func benchmarkWritePointsExistingSeries(b *testing.B, mCnt, tkCnt, tvCnt, pntCnt
 	tmpDir, _ := ioutil.TempDir("", "")
 	defer os.RemoveAll(tmpDir)
 	tmpShard := path.Join(tmpDir, "shard")
-	shard := tsdb.NewShard(index, tmpShard, tsdb.NewEngineOptions())
+	shard := tsdb.NewShard(1, index, tmpShard, tsdb.NewEngineOptions())
 	shard.Open()
 	defer shard.Close()
 	chunkedWrite(shard, points)

--- a/tsdb/shard_test.go
+++ b/tsdb/shard_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/influxdb/influxdb/tsdb"
+	"github.com/influxdb/influxdb/tsdb/engine/b1"
 )
 
 func TestShardWriteAndIndex(t *testing.T) {
@@ -143,6 +144,7 @@ func TestShard_Autoflush(t *testing.T) {
 
 	// Open shard with a really low size threshold, high flush interval.
 	sh := tsdb.NewShard(tsdb.NewDatabaseIndex(), filepath.Join(path, "shard"), tsdb.EngineOptions{
+		EngineVersion:          b1.Format,
 		MaxWALSize:             1024, // 1KB
 		WALFlushInterval:       1 * time.Hour,
 		WALPartitionFlushDelay: 1 * time.Millisecond,
@@ -182,6 +184,7 @@ func TestShard_Autoflush_FlushInterval(t *testing.T) {
 
 	// Open shard with a high size threshold, small time threshold.
 	sh := tsdb.NewShard(tsdb.NewDatabaseIndex(), filepath.Join(path, "shard"), tsdb.EngineOptions{
+		EngineVersion:          b1.Format,
 		MaxWALSize:             10 * 1024 * 1024, // 10MB
 		WALFlushInterval:       100 * time.Millisecond,
 		WALPartitionFlushDelay: 1 * time.Millisecond,

--- a/tsdb/shard_test.go
+++ b/tsdb/shard_test.go
@@ -20,7 +20,10 @@ func TestShardWriteAndIndex(t *testing.T) {
 	tmpShard := path.Join(tmpDir, "shard")
 
 	index := tsdb.NewDatabaseIndex()
-	sh := tsdb.NewShard(1, index, tmpShard, tsdb.NewEngineOptions())
+	opts := tsdb.NewEngineOptions()
+	opts.Config.WALDir = filepath.Join(tmpDir, "wal")
+
+	sh := tsdb.NewShard(1, index, tmpShard, opts)
 	if err := sh.Open(); err != nil {
 		t.Fatalf("error openeing shard: %s", err.Error())
 	}
@@ -66,7 +69,7 @@ func TestShardWriteAndIndex(t *testing.T) {
 	sh.Close()
 
 	index = tsdb.NewDatabaseIndex()
-	sh = tsdb.NewShard(1, index, tmpShard, tsdb.NewEngineOptions())
+	sh = tsdb.NewShard(1, index, tmpShard, opts)
 	if err := sh.Open(); err != nil {
 		t.Fatalf("error openeing shard: %s", err.Error())
 	}
@@ -87,7 +90,10 @@ func TestShardWriteAddNewField(t *testing.T) {
 	tmpShard := path.Join(tmpDir, "shard")
 
 	index := tsdb.NewDatabaseIndex()
-	sh := tsdb.NewShard(1, index, tmpShard, tsdb.NewEngineOptions())
+	opts := tsdb.NewEngineOptions()
+	opts.Config.WALDir = filepath.Join(tmpDir, "wal")
+
+	sh := tsdb.NewShard(1, index, tmpShard, opts)
 	if err := sh.Open(); err != nil {
 		t.Fatalf("error openeing shard: %s", err.Error())
 	}

--- a/tsdb/store.go
+++ b/tsdb/store.go
@@ -82,7 +82,7 @@ func (s *Store) CreateShard(database, retentionPolicy string, shardID uint64) er
 	}
 
 	shardPath := filepath.Join(s.path, database, retentionPolicy, strconv.FormatUint(shardID, 10))
-	shard := NewShard(db, shardPath, s.EngineOptions)
+	shard := NewShard(shardID, db, shardPath, s.EngineOptions)
 	if err := shard.Open(); err != nil {
 		return err
 	}
@@ -236,7 +236,7 @@ func (s *Store) loadShards() error {
 					continue
 				}
 
-				shard := NewShard(s.databaseIndexes[db], path, s.EngineOptions)
+				shard := NewShard(shardID, s.databaseIndexes[db], path, s.EngineOptions)
 				err = shard.Open()
 				if err != nil {
 					return fmt.Errorf("failed to open shard %d: %s", shardID, err)

--- a/tsdb/store.go
+++ b/tsdb/store.go
@@ -14,9 +14,12 @@ import (
 )
 
 func NewStore(path string) *Store {
+	opts := NewEngineOptions()
+	opts.Config = NewConfig()
+
 	return &Store{
 		path:          path,
-		EngineOptions: NewEngineOptions(),
+		EngineOptions: opts,
 		Logger:        log.New(os.Stderr, "[store] ", log.LstdFlags),
 	}
 }

--- a/tsdb/store_test.go
+++ b/tsdb/store_test.go
@@ -22,6 +22,7 @@ func TestStoreOpen(t *testing.T) {
 	}
 
 	s := tsdb.NewStore(dir)
+	s.EngineOptions.Config.WALDir = filepath.Join(dir, "wal")
 	if err := s.Open(); err != nil {
 		t.Fatalf("Store.Open() failed: %v", err)
 	}
@@ -49,6 +50,7 @@ func TestStoreOpenShard(t *testing.T) {
 	}
 
 	s := tsdb.NewStore(dir)
+	s.EngineOptions.Config.WALDir = filepath.Join(dir, "wal")
 	if err := s.Open(); err != nil {
 		t.Fatalf("Store.Open() failed: %v", err)
 	}
@@ -82,6 +84,7 @@ func TestStoreOpenShardCreateDelete(t *testing.T) {
 	}
 
 	s := tsdb.NewStore(dir)
+	s.EngineOptions.Config.WALDir = filepath.Join(dir, "wal")
 	if err := s.Open(); err != nil {
 		t.Fatalf("Store.Open() failed: %v", err)
 	}
@@ -129,6 +132,7 @@ func TestStoreOpenNotDatabaseDir(t *testing.T) {
 	}
 
 	s := tsdb.NewStore(dir)
+	s.EngineOptions.Config.WALDir = filepath.Join(dir, "wal")
 	if err := s.Open(); err != nil {
 		t.Fatalf("Store.Open() failed: %v", err)
 	}
@@ -159,6 +163,7 @@ func TestStoreOpenNotRPDir(t *testing.T) {
 	}
 
 	s := tsdb.NewStore(dir)
+	s.EngineOptions.Config.WALDir = filepath.Join(dir, "wal")
 	if err := s.Open(); err != nil {
 		t.Fatalf("Store.Open() failed: %v", err)
 	}
@@ -195,6 +200,7 @@ func TestStoreOpenShardBadShardPath(t *testing.T) {
 	}
 
 	s := tsdb.NewStore(dir)
+	s.EngineOptions.Config.WALDir = filepath.Join(dir, "wal")
 	if err := s.Open(); err != nil {
 		t.Fatalf("Store.Open() failed: %v", err)
 	}
@@ -221,6 +227,7 @@ func TestStoreEnsureSeriesPersistedInNewShards(t *testing.T) {
 	defer os.RemoveAll(dir)
 
 	s := tsdb.NewStore(dir)
+	s.EngineOptions.Config.WALDir = filepath.Join(dir, "wal")
 	if err := s.Open(); err != nil {
 		t.Fatalf("Store.Open() failed: %v", err)
 	}
@@ -255,6 +262,7 @@ func TestStoreEnsureSeriesPersistedInNewShards(t *testing.T) {
 	s.Close()
 
 	s = tsdb.NewStore(dir)
+	s.EngineOptions.Config.WALDir = filepath.Join(dir, "wal")
 	if err := s.Open(); err != nil {
 		t.Fatalf("Store.Open() failed: %v", err)
 	}

--- a/tsdb/store_test.go
+++ b/tsdb/store_test.go
@@ -213,6 +213,61 @@ func TestStoreOpenShardBadShardPath(t *testing.T) {
 
 }
 
+func TestStoreEnsureSeriesPersistedInNewShards(t *testing.T) {
+	dir, err := ioutil.TempDir("", "store_test")
+	if err != nil {
+		t.Fatalf("Store.Open() failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(dir)
+
+	s := tsdb.NewStore(dir)
+	if err := s.Open(); err != nil {
+		t.Fatalf("Store.Open() failed: %v", err)
+	}
+
+	if err := s.CreateShard("foo", "default", 1); err != nil {
+		t.Fatalf("error creating shard: %v", err)
+	}
+
+	p, _ := tsdb.ParsePoints([]byte("cpu val=1"))
+	if err := s.WriteToShard(1, p); err != nil {
+		t.Fatalf("error writing to shard: %v", err)
+	}
+
+	if err := s.CreateShard("foo", "default", 2); err != nil {
+		t.Fatalf("error creating shard: %v", err)
+	}
+
+	if err := s.WriteToShard(2, p); err != nil {
+		t.Fatalf("error writing to shard: %v", err)
+	}
+
+	d := s.DatabaseIndex("foo")
+	if d == nil {
+		t.Fatal("expected to have database index for foo")
+	}
+	if d.Series("cpu") == nil {
+		t.Fatal("expected series cpu to be in the index")
+	}
+
+	// delete the shard, close the store and reopen it and confirm the measurement is still there
+	s.DeleteShard(1)
+	s.Close()
+
+	s = tsdb.NewStore(dir)
+	if err := s.Open(); err != nil {
+		t.Fatalf("Store.Open() failed: %v", err)
+	}
+
+	d = s.DatabaseIndex("foo")
+	if d == nil {
+		t.Fatal("expected to have database index for foo")
+	}
+	if d.Series("cpu") == nil {
+		t.Fatal("expected series cpu to be in the index")
+	}
+}
+
 func BenchmarkStoreOpen_200KSeries_100Shards(b *testing.B) { benchmarkStoreOpen(b, 64, 5, 5, 1, 100) }
 
 func benchmarkStoreOpen(b *testing.B, mCnt, tkCnt, tvCnt, pntCnt, shardCnt int) {


### PR DESCRIPTION
This implements a WAL that is backed by the filesystem and disconnected from BoltDB.

Partitions
------------
The WAL is broken into different partitions. The default number of partitions is 5. Each partition consists of a number of segment files. By default these files will get up to 2MB in size before a new segment file is opened. The files are numbered and start at 1. The number indicates the order in which the files should be read on startup to ensure data is recovered in the same order it was written.

Partitions are flushed and compacted individually. One of the goals with having multiple partitions was to be able to flush only a portion of the WAL at a time.

Compaction
----------------
The WAL does not flush everything in a partition when it comes time. It will only flush series that are over a given threshold (30kb by default). Here's the order of steps for compaction:

1.  Lock the partition to determine which series will be flush and move these series to a flush cache. This is against in memory structures and should be very fast.
2.  Start a new segment file so that all the old files can be compacted without blocking writes to this partition.
3. Write any series that are over the flush threshold to the index (BoltDB)
4.  Read all the old segment files pulling out entries that are in series that weren't flushed to the index and write them to a temporary compaction file
5.  Delete the old segment files as they are read
6.  Rename the compaction file so that it is segment file number 1

The reason for having a flush cache and the regular cache is so that queries can be answered while a compaction is occurring. Also, writes can come into the series that are in the middle of being flushed. They will simply get written into the new segment file and added to the in-memory cache for the next flush.

Task List
------------
- [x] WAL writes to disk
- [x] Keep entries in memory cache with a method to get a `Cursor` on them
- [x] Read WAL segments from disk on startup to populate cache
- [x] Recover from corrupted WAL segment files
- [x] Periodically compact WAL based on max series size, percentage of series ready to flush, or max partition size
- [x] Gradually delay writes when the WAL is getting backed up
- [x] Force flush on max memory size for WAL partitions
- [x] Force flush if no writes have happened in some configurable interval of time
- [x] Integrate with BZ engine
- [x] Ensure that two points in the same series can't have the same time in the WAL
- [x] Add saving series and fields to WAL and update bz1 to store metadata in compressed format
- [x] Recover from incomplete compaction
- [ ] Add option to force flush on startup
- [x] Add logging options
- [x] Make default WAL directory different than shard dir
