### PR TITLE
Revert breaking change to `client.NewClient` function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - [#3511](https://github.com/influxdb/influxdb/issues/3511): Sending a large number of tag causes panic
 - [#3288](https://github.com/influxdb/influxdb/issues/3288): Run go fuzz on the line-protocol input
 - [#3545](https://github.com/influxdb/influxdb/issues/3545): Fix parsing string fields with newlines
+- [#3579](https://github.com/influxdb/influxdb/issues/3579): Revert breaking change to `client.NewClient` function
 
 ## v0.9.2 [2015-07-24]
 

--- a/client/example_test.go
+++ b/client/example_test.go
@@ -20,7 +20,7 @@ func ExampleNewClient() {
 
 	// NOTE: this assumes you've setup a user and have setup shell env variables,
 	// namely INFLUX_USER/INFLUX_PWD. If not just ommit Username/Password below.
-	conf := &client.Config{
+	conf := client.Config{
 		URL:      *host,
 		Username: os.Getenv("INFLUX_USER"),
 		Password: os.Getenv("INFLUX_PWD"),
@@ -37,7 +37,7 @@ func ExampleClient_Ping() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	con, err := client.NewClient(&client.Config{URL: *host})
+	con, err := client.NewClient(client.Config{URL: *host})
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -54,7 +54,7 @@ func ExampleClient_Query() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	con, err := client.NewClient(&client.Config{URL: *host})
+	con, err := client.NewClient(client.Config{URL: *host})
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -73,7 +73,7 @@ func ExampleClient_Write() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	con, err := client.NewClient(&client.Config{URL: *host})
+	con, err := client.NewClient(client.Config{URL: *host})
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/client/influxdb.go
+++ b/client/influxdb.go
@@ -83,8 +83,8 @@ type Config struct {
 }
 
 // NewConfig will create a config to be used in connecting to the client
-func NewConfig() *Config {
-	return &Config{
+func NewConfig() Config {
+	return Config{
 		Timeout: DefaultTimeout,
 	}
 }
@@ -106,7 +106,7 @@ const (
 )
 
 // NewClient will instantiate and return a connected client to issue commands to the server.
-func NewClient(c *Config) (*Client, error) {
+func NewClient(c Config) (*Client, error) {
 	client := Client{
 		url:        c.URL,
 		username:   c.Username,

--- a/client/influxdb_test.go
+++ b/client/influxdb_test.go
@@ -84,7 +84,7 @@ func BenchmarkUnmarshalJSON10Tags(b *testing.B) {
 }
 
 func TestNewClient(t *testing.T) {
-	config := &client.Config{}
+	config := client.Config{}
 	_, err := client.NewClient(config)
 	if err != nil {
 		t.Fatalf("unexpected error.  expected %v, actual %v", nil, err)
@@ -96,7 +96,7 @@ func TestClient_Ping(t *testing.T) {
 	defer ts.Close()
 
 	u, _ := url.Parse(ts.URL)
-	config := &client.Config{URL: *u}
+	config := client.Config{URL: *u}
 	c, err := client.NewClient(config)
 	if err != nil {
 		t.Fatalf("unexpected error.  expected %v, actual %v", nil, err)
@@ -122,7 +122,7 @@ func TestClient_Query(t *testing.T) {
 	defer ts.Close()
 
 	u, _ := url.Parse(ts.URL)
-	config := &client.Config{URL: *u}
+	config := client.Config{URL: *u}
 	c, err := client.NewClient(config)
 	if err != nil {
 		t.Fatalf("unexpected error.  expected %v, actual %v", nil, err)
@@ -154,7 +154,7 @@ func TestClient_BasicAuth(t *testing.T) {
 
 	u, _ := url.Parse(ts.URL)
 	u.User = url.UserPassword("username", "password")
-	config := &client.Config{URL: *u, Username: "username", Password: "password"}
+	config := client.Config{URL: *u, Username: "username", Password: "password"}
 	c, err := client.NewClient(config)
 	if err != nil {
 		t.Fatalf("unexpected error.  expected %v, actual %v", nil, err)
@@ -175,7 +175,7 @@ func TestClient_Write(t *testing.T) {
 	defer ts.Close()
 
 	u, _ := url.Parse(ts.URL)
-	config := &client.Config{URL: *u}
+	config := client.Config{URL: *u}
 	c, err := client.NewClient(config)
 	if err != nil {
 		t.Fatalf("unexpected error.  expected %v, actual %v", nil, err)
@@ -226,7 +226,7 @@ func TestClient_UserAgent(t *testing.T) {
 
 	for _, test := range tests {
 		u, _ := url.Parse(ts.URL)
-		config := &client.Config{URL: *u, UserAgent: test.userAgent}
+		config := client.Config{URL: *u, UserAgent: test.userAgent}
 		c, err := client.NewClient(config)
 		if err != nil {
 			t.Fatalf("unexpected error.  expected %v, actual %v", nil, err)
@@ -507,7 +507,7 @@ func TestClient_Timeout(t *testing.T) {
 	defer ts.Close()
 
 	u, _ := url.Parse(ts.URL)
-	config := &client.Config{URL: *u, Timeout: 500 * time.Millisecond}
+	config := client.Config{URL: *u, Timeout: 500 * time.Millisecond}
 	c, err := client.NewClient(config)
 	if err != nil {
 		t.Fatalf("unexpected error.  expected %v, actual %v", nil, err)
@@ -521,7 +521,7 @@ func TestClient_Timeout(t *testing.T) {
 		t.Fatalf("unexpected error.  expected 'use of closed network connection' error, got %v", err)
 	}
 
-	confignotimeout := &client.Config{URL: *u}
+	confignotimeout := client.Config{URL: *u}
 	cnotimeout, err := client.NewClient(confignotimeout)
 	_, err = cnotimeout.Query(query)
 	if err != nil {

--- a/cmd/influx/main_test.go
+++ b/cmd/influx/main_test.go
@@ -101,7 +101,7 @@ func TestParseCommand_Insert(t *testing.T) {
 	defer ts.Close()
 
 	u, _ := url.Parse(ts.URL)
-	config := &client.Config{URL: *u}
+	config := client.Config{URL: *u}
 	c, err := client.NewClient(config)
 	if err != nil {
 		t.Fatalf("unexpected error.  expected %v, actual %v", nil, err)
@@ -138,7 +138,7 @@ func TestParseCommand_InsertInto(t *testing.T) {
 	defer ts.Close()
 
 	u, _ := url.Parse(ts.URL)
-	config := &client.Config{URL: *u}
+	config := client.Config{URL: *u}
 	c, err := client.NewClient(config)
 	if err != nil {
 		t.Fatalf("unexpected error.  expected %v, actual %v", nil, err)


### PR DESCRIPTION
In this commit: 

https://github.com/influxdb/influxdb/commit/30a0ca0130f578275758876edc81794dcfc279e2#diff-12d7ec39292af18c588a073414f3e853R110

I made a breaking change for apparently no reason.  Reverting back.