### PR TITLE
Initial docker support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - [#3502](https://github.com/influxdb/influxdb/pull/3502): Importer for 0.8.9 data via the CLI
 - [#3564](https://github.com/influxdb/influxdb/pull/3564): Fix alias, maintain column sort order
 - [#3585](https://github.com/influxdb/influxdb/pull/3585): Additional test coverage for non-existent fields
+- [#3246](https://github.com/influxdb/influxdb/issues/3246): Allow overriding of configuration parameters using environment variables
 
 ### Bugfixes
 - [#3405](https://github.com/influxdb/influxdb/pull/3405): Prevent database panic when fields are missing. Thanks @jhorwit2

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -1,7 +1,7 @@
 # Docker Setup
 ========================
 
-This document describes how to buidl and run a minimal InfluxDB container under Docker.   It has currently only be tested for local development and assumes that you have a working docker environment already.
+This document describes how to build and run a minimal InfluxDB container under Docker.   Currently, it has only been tested for local development and assumes that you have a working docker environment.
 
 ## Building Image
 
@@ -23,7 +23,7 @@ Available version can be found [here](https://hub.docker.com/_/golang/).
 
 ## Single Node Container
 
-This will start a interactive, single-node, that publishes the containers port `8086` and `8088` to the hosts ports `8086` and `8088` respectively.  This is identical to starting `influxd` manually.
+This will start an interactive, single-node, that publishes the containers port `8086` and `8088` to the hosts ports `8086` and `8088` respectively.  This is identical to starting `influxd` manually.
 
 ```
 $ docker run -it -p 8086:8086 -p 8088:8088 influxdb

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -1,0 +1,44 @@
+# Docker Setup
+========================
+
+This document describes how to buidl and run a minimal InfluxDB container under Docker.   It has currently only be tested for local development and assumes that you have a working docker environment already.
+
+## Building Image
+
+To build a docker image for InfluxDB from your current checkout, run the following:
+
+```
+$ ./build-docker.sh
+```
+
+This script uses the `golang:1.5` image to build a fully static binary of `influxd` and then adds it to a minimal `scratch` image.
+
+To build the image using a different version of go:
+
+```
+$ GO_VER=1.4.2 ./build-docker.sh
+```
+
+Available version can be found [here](https://hub.docker.com/_/golang/).
+
+## Single Node Container
+
+This will start a interactive, single-node, that publishes the containers port `8086` and `8088` to the hosts ports `8086` and `8088` respectively.  This is identical to starting `influxd` manually.
+
+```
+$ docker run -it -p 8086:8086 -p 8088:8088 influxdb
+```
+
+## Multi-Node Cluster
+
+This will create a simple 3-node cluster.  The data is stored within the container and will be lost when the container is removed.  This is only useful for test clusters.
+
+The `HOST_IP` env variable should be your host IP if running under linux or the virtualbox VM IP if running under OSX.  On OSX, this would be something like: `$(docker-machine ip dev)` or `$(boot2docker ip)` depending on which docker tool you are using.
+
+```
+$ export HOST_IP=<your host/VM IP>
+$ docker run -it -p 8086:8088 -p 8088:8088 influxdb -hostname $HOST_IP:8088
+$ docker run -it -p 8186:8088 -p 8188:8088 influxdb -hostname $HOST_IP:8188 -join $HOST_IP:8088
+$ docker run -it -p 8286:8088 -p 8288:8088 influxdb -hostname $HOST_IP:8288 -join $HOST_IP:8088
+```
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM busybox:ubuntu-14.04
+
+MAINTAINER Jason Wilder "<jason@influxdb.com>"
+
+# admin, http, udp, cluster, graphite, opentsdb, collectd
+EXPOSE 8083 8086 8086/udp 8088 2003 4242 25826
+
+WORKDIR /app
+
+# copy binary into image
+COPY influxd /app/
+
+# Add influxd to the PATH
+ENV PATH=/app:$PATH
+
+# Generate a default config
+RUN influxd config > /etc/influxdb.toml
+
+# Use /data for all disk storage
+RUN sed -i 's/dir = "\/.*influxdb/dir = "\/data/' /etc/influxdb.toml
+
+VOLUME ["/data"]
+
+ENTRYPOINT ["influxd", "--config", "/etc/influxdb.toml"]

--- a/build-docker.sh
+++ b/build-docker.sh
@@ -1,0 +1,7 @@
+#!/bin/sh -x -e
+
+GO_VER=${GO_VER:-1.5}
+
+docker run -it -v "$GOPATH":/gopath -v "$(pwd)":/app -e "GOPATH=/gopath" -w /app golang:$GO_VER sh -c 'CGO_ENABLED=0 go build -a --installsuffix cgo --ldflags="-s" -o influxd ./cmd/influxd'
+
+docker build -t influxdb .

--- a/cmd/influxd/run/command.go
+++ b/cmd/influxd/run/command.go
@@ -78,6 +78,11 @@ func (cmd *Command) Run(args ...string) error {
 		return fmt.Errorf("parse config: %s", err)
 	}
 
+	// Apply any environment variables on top of the parsed config
+	if err := config.ApplyEnvOverrides(); err != nil {
+		return fmt.Errorf("apply env config: %v", err)
+	}
+
 	// Override config hostname if specified in the command line args.
 	if options.Hostname != "" {
 		config.Meta.Hostname = options.Hostname

--- a/cmd/influxd/run/config.go
+++ b/cmd/influxd/run/config.go
@@ -118,7 +118,7 @@ func (c *Config) Validate() error {
 }
 
 func (c *Config) ApplyEnvOverrides() error {
-	return c.applyEnvOverrides("", reflect.ValueOf(c))
+	return c.applyEnvOverrides("INFLUXDB", reflect.ValueOf(c))
 }
 
 func (c *Config) applyEnvOverrides(prefix string, spec reflect.Value) error {

--- a/cmd/influxd/run/config.go
+++ b/cmd/influxd/run/config.go
@@ -3,6 +3,7 @@ package run
 import (
 	"errors"
 	"fmt"
+	"os"
 	"os/user"
 	"path/filepath"
 
@@ -73,15 +74,20 @@ func NewConfig() *Config {
 func NewDemoConfig() (*Config, error) {
 	c := NewConfig()
 
+	var homeDir string
 	// By default, store meta and data files in current users home directory
 	u, err := user.Current()
-	if err != nil {
+	if err == nil {
+		homeDir = u.HomeDir
+	} else if os.Getenv("HOME") != "" {
+		homeDir = os.Getenv("HOME")
+	} else {
 		return nil, fmt.Errorf("failed to determine current user for storage")
 	}
 
-	c.Meta.Dir = filepath.Join(u.HomeDir, ".influxdb/meta")
-	c.Data.Dir = filepath.Join(u.HomeDir, ".influxdb/data")
-	c.HintedHandoff.Dir = filepath.Join(u.HomeDir, ".influxdb/hh")
+	c.Meta.Dir = filepath.Join(homeDir, ".influxdb/meta")
+	c.Data.Dir = filepath.Join(homeDir, ".influxdb/data")
+	c.HintedHandoff.Dir = filepath.Join(homeDir, ".influxdb/hh")
 
 	c.Admin.Enabled = true
 	c.Monitoring.Enabled = false

--- a/cmd/influxd/run/config.go
+++ b/cmd/influxd/run/config.go
@@ -6,6 +6,10 @@ import (
 	"os"
 	"os/user"
 	"path/filepath"
+	"reflect"
+	"strconv"
+	"strings"
+	"time"
 
 	"github.com/influxdb/influxdb/cluster"
 	"github.com/influxdb/influxdb/meta"
@@ -108,6 +112,107 @@ func (c *Config) Validate() error {
 	for _, g := range c.Graphites {
 		if err := g.Validate(); err != nil {
 			return fmt.Errorf("invalid graphite config: %v", err)
+		}
+	}
+	return nil
+}
+
+func (c *Config) ApplyEnvOverrides() error {
+	return c.applyEnvOverrides("", reflect.ValueOf(c))
+}
+
+func (c *Config) applyEnvOverrides(prefix string, spec reflect.Value) error {
+	// If we have a pointer, dereference it
+	s := spec
+	if spec.Kind() == reflect.Ptr {
+		s = spec.Elem()
+	}
+
+	typeOfSpec := s.Type()
+	for i := 0; i < s.NumField(); i++ {
+		f := s.Field(i)
+		// Get the toml tag to determine what env var name to use
+		configName := typeOfSpec.Field(i).Tag.Get("toml")
+		// Replace hyphens with underscores to avoid issues with shells
+		configName = strings.Replace(configName, "-", "_", -1)
+		fieldName := typeOfSpec.Field(i).Name
+
+		// Skip any fields that we cannot set
+		if f.CanSet() || f.Kind() == reflect.Slice {
+
+			// Use the upper-case prefix and toml name for the env var
+			key := strings.ToUpper(configName)
+			if prefix != "" {
+				key = strings.ToUpper(fmt.Sprintf("%s_%s", prefix, configName))
+			}
+			value := os.Getenv(key)
+
+			// If the type is s slice, apply to each using the index as a suffix
+			// e.g. GRAPHITE_0
+			if f.Kind() == reflect.Slice || f.Kind() == reflect.Array {
+				for i := 0; i < f.Len(); i++ {
+					if err := c.applyEnvOverrides(fmt.Sprintf("%s_%d", key, i), f.Index(i)); err != nil {
+						return err
+					}
+				}
+				continue
+			}
+
+			// If it's a sub-config, recursively apply
+			if f.Kind() == reflect.Struct || f.Kind() == reflect.Ptr {
+				if err := c.applyEnvOverrides(key, f); err != nil {
+					return err
+				}
+				continue
+			}
+
+			// Skip any fields we don't have a value to set
+			if value == "" {
+				continue
+			}
+
+			switch f.Kind() {
+			case reflect.String:
+				f.SetString(value)
+			case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+
+				var intValue int64
+
+				// Handle toml.Duration
+				if f.Type().Name() == "Duration" {
+					dur, err := time.ParseDuration(value)
+					if err != nil {
+						return fmt.Errorf("failed to apply %v to %v using type %v and value '%v'", key, fieldName, f.Type().String(), value)
+					}
+					intValue = dur.Nanoseconds()
+				} else {
+					var err error
+					intValue, err = strconv.ParseInt(value, 0, f.Type().Bits())
+					if err != nil {
+						return fmt.Errorf("failed to apply %v to %v using type %v and value '%v'", key, fieldName, f.Type().String(), value)
+					}
+				}
+
+				f.SetInt(intValue)
+			case reflect.Bool:
+				boolValue, err := strconv.ParseBool(value)
+				if err != nil {
+					return fmt.Errorf("failed to apply %v to %v using type %v and value '%v'", key, fieldName, f.Type().String(), value)
+
+				}
+				f.SetBool(boolValue)
+			case reflect.Float32, reflect.Float64:
+				floatValue, err := strconv.ParseFloat(value, f.Type().Bits())
+				if err != nil {
+					return fmt.Errorf("failed to apply %v to %v using type %v and value '%v'", key, fieldName, f.Type().String(), value)
+
+				}
+				f.SetFloat(floatValue)
+			default:
+				if err := c.applyEnvOverrides(key, f); err != nil {
+					return err
+				}
+			}
 		}
 	}
 	return nil


### PR DESCRIPTION
This PR adds some features to make it easier to run `influxd` in a docker container.  Mostly the changes are allowing configuration details to be passed through the environment or command-line options instead of only through a config file which is problematic for docker images.

Specifically it adds:

* Allowing `-hostname` to override the remote address port in addition to the hostname.  If a port is not specified, the `BindAddress` port is used as before.
* Allow overriding of config variables via environment variables #3246 
* Some basic instructions and scripts to build a small influxdb images based off of `busybox` and built using `golang:1.5`. (~18MB)

The image has only been tested locally and still needs some additional updates to make it suitable for a production deployment.  The image has not been push to docker hub since it's still being tweaked.