### PR TITLE
Change single udp config to support multiple UDP listeners

### DIFF
--- a/cmd/influxd/run/config.go
+++ b/cmd/influxd/run/config.go
@@ -35,7 +35,7 @@ type Config struct {
 	Graphites []graphite.Config `toml:"graphite"`
 	Collectd  collectd.Config   `toml:"collectd"`
 	OpenTSDB  opentsdb.Config   `toml:"opentsdb"`
-	UDP       udp.Config        `toml:"udp"`
+	UDPs      []udp.Config      `toml:"udp"`
 
 	// Snapshot SnapshotConfig `toml:"snapshot"`
 	Monitoring      monitor.Config            `toml:"monitoring"`

--- a/cmd/influxd/run/config_test.go
+++ b/cmd/influxd/run/config_test.go
@@ -38,7 +38,7 @@ bind-address = ":1000"
 [opentsdb]
 bind-address = ":2000"
 
-[udp]
+[[udp]]
 bind-address = ":4444"
 
 [monitoring]
@@ -69,8 +69,8 @@ enabled = true
 		t.Fatalf("unexpected collectd bind address: %s", c.Collectd.BindAddress)
 	} else if c.OpenTSDB.BindAddress != ":2000" {
 		t.Fatalf("unexpected opentsdb bind address: %s", c.OpenTSDB.BindAddress)
-	} else if c.UDP.BindAddress != ":4444" {
-		t.Fatalf("unexpected udp bind address: %s", c.UDP.BindAddress)
+	} else if c.UDPs[0].BindAddress != ":4444" {
+		t.Fatalf("unexpected udp bind address: %s", c.UDPs[0].BindAddress)
 	} else if c.Monitoring.Enabled != true {
 		t.Fatalf("unexpected monitoring enabled: %v", c.Monitoring.Enabled)
 	} else if c.ContinuousQuery.Enabled != true {

--- a/cmd/influxd/run/server.go
+++ b/cmd/influxd/run/server.go
@@ -125,7 +125,9 @@ func NewServer(c *Config, version string) (*Server, error) {
 	if err := s.appendOpenTSDBService(c.OpenTSDB); err != nil {
 		return nil, err
 	}
-	s.appendUDPService(c.UDP)
+	for _, g := range c.UDPs {
+		s.appendUDPService(g)
+	}
 	s.appendRetentionPolicyService(c.Retention)
 	for _, g := range c.Graphites {
 		if err := s.appendGraphiteService(g); err != nil {

--- a/etc/config.sample.toml
+++ b/etc/config.sample.toml
@@ -163,12 +163,12 @@ reporting-disabled = false
   # retention-policy = ""
 
 ###
-### [udp]
+### [[udp]]
 ###
-### Controls the listener for InfluxDB line protocol data via UDP.
+### Controls the listeners for InfluxDB line protocol data via UDP.
 ###
 
-[udp]
+[[udp]]
   enabled = false
   # bind-address = ""
   # database = ""


### PR DESCRIPTION
Resolves #3596

In 0.7.1 multiple udp listeners could be configured. I upgraded to 0.9.2 and this feature appeared to be missing. This, hopefully, adds it back.

It does replace the single TOML configuration for `[udp]` with `[[udp]]`. I'm not sure if/how this should be handled. This may be considered a breaking change, but since the ability to use multiple servers was already lost (a breaking change) … this seems reasonable to add back in.