### PR TITLE
Force all values to float64 for math

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - [#3436](https://github.com/influxdb/influxdb/issues/3436): Fix panic in hinted handoff queue processor
 - [#3401](https://github.com/influxdb/influxdb/issues/3401): Derivative on non-numeric fields panics db
 - [#3583](https://github.com/influxdb/influxdb/issues/3583): Inserting value in scientific notation with a trailing i causes panic
+- [#3611](https://github.com/influxdb/influxdb/pull/3611): Fix query arithmetic with integers
 
 ## v0.9.2 [2015-07-24]
 

--- a/influxql/result.go
+++ b/influxql/result.go
@@ -166,12 +166,8 @@ func newBinaryExprEvaluator(op Token, lhs, rhs Processor) Processor {
 		return func(values []interface{}) interface{} {
 			l := lhs(values)
 			r := rhs(values)
-			if lv, ok := l.(float64); ok {
-				if rv, ok := r.(float64); ok {
-					if rv != 0 {
-						return lv + rv
-					}
-				}
+			if lf, rf, ok := processorValuesAsFloat64(l, r); ok {
+				return lf + rf
 			}
 			return nil
 		}
@@ -179,12 +175,8 @@ func newBinaryExprEvaluator(op Token, lhs, rhs Processor) Processor {
 		return func(values []interface{}) interface{} {
 			l := lhs(values)
 			r := rhs(values)
-			if lv, ok := l.(float64); ok {
-				if rv, ok := r.(float64); ok {
-					if rv != 0 {
-						return lv - rv
-					}
-				}
+			if lf, rf, ok := processorValuesAsFloat64(l, r); ok {
+				return lf - rf
 			}
 			return nil
 		}
@@ -192,12 +184,8 @@ func newBinaryExprEvaluator(op Token, lhs, rhs Processor) Processor {
 		return func(values []interface{}) interface{} {
 			l := lhs(values)
 			r := rhs(values)
-			if lv, ok := l.(float64); ok {
-				if rv, ok := r.(float64); ok {
-					if rv != 0 {
-						return lv * rv
-					}
-				}
+			if lf, rf, ok := processorValuesAsFloat64(l, r); ok {
+				return lf * rf
 			}
 			return nil
 		}
@@ -205,12 +193,8 @@ func newBinaryExprEvaluator(op Token, lhs, rhs Processor) Processor {
 		return func(values []interface{}) interface{} {
 			l := lhs(values)
 			r := rhs(values)
-			if lv, ok := l.(float64); ok {
-				if rv, ok := r.(float64); ok {
-					if rv != 0 {
-						return lv / rv
-					}
-				}
+			if lf, rf, ok := processorValuesAsFloat64(l, r); ok {
+				return lf / rf
 			}
 			return nil
 		}
@@ -220,4 +204,28 @@ func newBinaryExprEvaluator(op Token, lhs, rhs Processor) Processor {
 			return nil
 		}
 	}
+}
+
+func processorValuesAsFloat64(lhs interface{}, rhs interface{}) (float64, float64, bool) {
+	var lf float64
+	var rf float64
+	var ok bool
+
+	lf, ok = lhs.(float64)
+	if !ok {
+		var li int64
+		if li, ok = lhs.(int64); !ok {
+			return 0, 0, false
+		}
+		lf = float64(li)
+	}
+	rf, ok = rhs.(float64)
+	if !ok {
+		var ri int64
+		if ri, ok = rhs.(int64); !ok {
+			return 0, 0, false
+		}
+		rf = float64(ri)
+	}
+	return lf, rf, true
 }


### PR DESCRIPTION
Fixes issue #3000

Any literal values in a math query e.g. the '2' in 'value * 2' are stored as float64 by the parser, so all other values must be cast to this type. This does mean that precision may be lost if the integer values are greater than 2^53.
