### PR TITLE
Fix regex queries regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - [#3401](https://github.com/influxdb/influxdb/issues/3401): Derivative on non-numeric fields panics db
 - [#3583](https://github.com/influxdb/influxdb/issues/3583): Inserting value in scientific notation with a trailing i causes panic
 - [#3611](https://github.com/influxdb/influxdb/pull/3611): Fix query arithmetic with integers
+- [#3326](https://github.com/influxdb/influxdb/issues/3326): simple regex query fails with cryptic error
 
 ## v0.9.2 [2015-07-24]
 

--- a/tsdb/meta.go
+++ b/tsdb/meta.go
@@ -349,7 +349,7 @@ func (m *Measurement) ValidateGroupBy(stmt *influxql.SelectStatement) error {
 	for _, d := range stmt.Dimensions {
 		switch e := d.Expr.(type) {
 		case *influxql.VarRef:
-			if !m.HasTagKey(e.Val) {
+			if m.HasField(e.Val) {
 				return fmt.Errorf("can not use field in GROUP BY clause: %s", e.Val)
 			}
 		}


### PR DESCRIPTION
ValidateGroupBy was returning an error if a tag does not exist
but it appears that function was supposed to be validating that
a field name was not used as a group by field.

Fixes #3326