### PR TITLE
Fix duplicate points in b1/cursor

### DIFF
--- a/tsdb/engine/b1/b1.go
+++ b/tsdb/engine/b1/b1.go
@@ -563,6 +563,9 @@ type Cursor struct {
 	// Cache and current cache index.
 	cache [][]byte
 	index int
+
+	// Previously read key.
+	prev []byte
 }
 
 // Seek moves the cursor to a position and returns the closest key/value pair.
@@ -577,46 +580,42 @@ func (c *Cursor) Seek(seek []byte) (key, value []byte) {
 		return bytes.Compare(c.cache[i][0:8], seek) != -1
 	})
 
+	c.prev = nil
 	return c.read()
 }
 
 // Next returns the next key/value pair from the cursor.
 func (c *Cursor) Next() (key, value []byte) {
-	// Read next bolt key/value if not bufferred.
-	if c.buf.key == nil && c.cursor != nil {
-		c.buf.key, c.buf.value = c.cursor.Next()
-	}
-
 	return c.read()
 }
 
 // read returns the next key/value in the cursor buffer or cache.
 func (c *Cursor) read() (key, value []byte) {
-	// If neither a buffer or cache exists then return nil.
-	if c.buf.key == nil && c.index >= len(c.cache) {
-		return nil, nil
-	}
-
-	// Use the buffer if it exists and there's no cache or if it is lower than the cache.
-	if c.buf.key != nil && (c.index >= len(c.cache) || bytes.Compare(c.buf.key, c.cache[c.index][0:8]) == -1) {
-		key, value = c.buf.key, c.buf.value
-		c.buf.key, c.buf.value = nil, nil
-		return
-	}
-
-	// Otherwise read from the cache.
 	// Continue skipping ahead through duplicate keys in the cache list.
 	for {
-		// Read the current cache key/value pair.
-		key, value = c.cache[c.index][0:8], c.cache[c.index][8:]
-		c.index++
+		// Read next value from the cursor.
+		if c.buf.key == nil && c.cursor != nil {
+			c.buf.key, c.buf.value = c.cursor.Next()
+		}
+
+		// Read from the buffer or cache, which ever is lower.
+		if c.buf.key != nil && (c.index >= len(c.cache) || bytes.Compare(c.buf.key, c.cache[c.index][0:8]) == -1) {
+			key, value = c.buf.key, c.buf.value
+			c.buf.key, c.buf.value = nil, nil
+		} else if c.index < len(c.cache) {
+			key, value = c.cache[c.index][0:8], c.cache[c.index][8:]
+			c.index++
+		} else {
+			key, value = nil, nil
+		}
 
 		// Exit loop if we're at the end of the cache or the next key is different.
-		if c.index >= len(c.cache) || !bytes.Equal(key, c.cache[c.index][0:8]) {
+		if key == nil || !bytes.Equal(key, c.prev) {
 			break
 		}
 	}
 
+	c.prev = key
 	return
 }
 

--- a/tsdb/engine/b1/b1.go
+++ b/tsdb/engine/b1/b1.go
@@ -86,6 +86,9 @@ func NewEngine(path string, opt tsdb.EngineOptions) tsdb.Engine {
 	return e
 }
 
+// Path returns the path the engine was initialized with.
+func (e *Engine) Path() string { return e.path }
+
 // Open opens and initializes the engine.
 func (e *Engine) Open() error {
 	if err := func() error {

--- a/tsdb/engine/b1/b1_test.go
+++ b/tsdb/engine/b1/b1_test.go
@@ -40,6 +40,11 @@ func TestEngine_WritePoints(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// Flush to disk.
+	if err := e.Flush(0); err != nil {
+		t.Fatal(err)
+	}
+
 	// Parse new point.
 	points, err = tsdb.ParsePointsWithPrecision([]byte("temperature value=200 1434059627"), time.Now().UTC(), "s")
 	if err != nil {
@@ -65,7 +70,7 @@ func TestEngine_WritePoints(t *testing.T) {
 	} else if m, err := mf.Codec.DecodeFieldsWithNames(v); err != nil {
 		t.Fatal(err)
 	} else if m["value"] != float64(200) {
-		t.Fatalf("unexpected value: %#v", m)
+		t.Errorf("unexpected value: %#v", m)
 	}
 
 	if k, v := c.Next(); k != nil {

--- a/tsdb/engine/b1/b1_test.go
+++ b/tsdb/engine/b1/b1_test.go
@@ -1,0 +1,129 @@
+package b1_test
+
+import (
+	"bytes"
+	"encoding/binary"
+	"io/ioutil"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/influxdb/influxdb/influxql"
+	"github.com/influxdb/influxdb/tsdb"
+	"github.com/influxdb/influxdb/tsdb/engine/b1"
+)
+
+// Ensure points can be written to the engine and queried.
+func TestEngine_WritePoints(t *testing.T) {
+	e := OpenDefaultEngine()
+	defer e.Close()
+
+	// Create metadata.
+	mf := &tsdb.MeasurementFields{Fields: make(map[string]*tsdb.Field)}
+	mf.CreateFieldIfNotExists("value", influxql.Float)
+	seriesToCreate := []*tsdb.SeriesCreate{
+		{Series: &tsdb.Series{Key: string(tsdb.MakeKey([]byte("temperature"), nil))}},
+	}
+
+	// Parse point.
+	points, err := tsdb.ParsePointsWithPrecision([]byte("temperature value=100 1434059627"), time.Now().UTC(), "s")
+	if err != nil {
+		t.Fatal(err)
+	} else if data, err := mf.Codec.EncodeFields(points[0].Fields()); err != nil {
+		t.Fatal(err)
+	} else {
+		points[0].SetData(data)
+	}
+
+	// Write original value.
+	if err := e.WritePoints(points, map[string]*tsdb.MeasurementFields{"temperature": mf}, seriesToCreate); err != nil {
+		t.Fatal(err)
+	}
+
+	// Parse new point.
+	points, err = tsdb.ParsePointsWithPrecision([]byte("temperature value=200 1434059627"), time.Now().UTC(), "s")
+	if err != nil {
+		t.Fatal(err)
+	} else if data, err := mf.Codec.EncodeFields(points[0].Fields()); err != nil {
+		t.Fatal(err)
+	} else {
+		points[0].SetData(data)
+	}
+
+	// Update existing value.
+	if err := e.WritePoints(points, nil, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	// Ensure only the updated value is read.
+	tx := e.MustBegin(false)
+	defer tx.Rollback()
+
+	c := tx.Cursor("temperature")
+	if k, v := c.Seek([]byte{0}); !bytes.Equal(k, u64tob(uint64(time.Unix(1434059627, 0).UnixNano()))) {
+		t.Fatalf("unexpected key: %#v", k)
+	} else if m, err := mf.Codec.DecodeFieldsWithNames(v); err != nil {
+		t.Fatal(err)
+	} else if m["value"] != float64(200) {
+		t.Fatalf("unexpected value: %#v", m)
+	}
+
+	if k, v := c.Next(); k != nil {
+		t.Fatalf("unexpected key/value: %#v / %#v", k, v)
+	}
+}
+
+// Engine represents a test wrapper for b1.Engine.
+type Engine struct {
+	*b1.Engine
+}
+
+// NewEngine returns a new instance of Engine.
+func NewEngine(opt tsdb.EngineOptions) *Engine {
+	// Generate temporary file.
+	f, _ := ioutil.TempFile("", "b1-")
+	f.Close()
+	os.Remove(f.Name())
+
+	return &Engine{
+		Engine: b1.NewEngine(f.Name(), opt).(*b1.Engine),
+	}
+}
+
+// OpenEngine returns an opened instance of Engine. Panic on error.
+func OpenEngine(opt tsdb.EngineOptions) *Engine {
+	e := NewEngine(opt)
+	if err := e.Open(); err != nil {
+		panic(err)
+	}
+	return e
+}
+
+// OpenDefaultEngine returns an open Engine with default options.
+func OpenDefaultEngine() *Engine { return OpenEngine(tsdb.NewEngineOptions()) }
+
+// Close closes the engine and removes all data.
+func (e *Engine) Close() error {
+	e.Engine.Close()
+	os.RemoveAll(e.Path())
+	return nil
+}
+
+// MustBegin returns a new tranaction. Panic on error.
+func (e *Engine) MustBegin(writable bool) tsdb.Tx {
+	tx, err := e.Begin(writable)
+	if err != nil {
+		panic(err)
+	}
+	return tx
+}
+
+func u64tob(v uint64) []byte {
+	b := make([]byte, 8)
+	binary.BigEndian.PutUint64(b, v)
+	return b
+}
+
+func btou64(b []byte) uint64 {
+	return binary.BigEndian.Uint64(b)
+}

--- a/tsdb/mapper_test.go
+++ b/tsdb/mapper_test.go
@@ -419,7 +419,7 @@ func TestShardMapper_WriteAndSingleMapperAggregateQuery(t *testing.T) {
 		for i := range tt.expected {
 			got := aggIntervalAsJson(t, mapper)
 			if got != tt.expected[i] {
-				t.Errorf("test '%s'\n\tgot      %s\n\texpected %s", tt.stmt, got, tt.expected[i])
+				t.Fatalf("test '%s'\n\tgot      %s\n\texpected %s", tt.stmt, got, tt.expected[i])
 				break
 			}
 		}

--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -299,7 +299,7 @@ func (s *Shard) createFieldsAndMeasurements(fieldsToCreate []*FieldCreate) (map[
 		measurementsToSave[f.Measurement] = m
 
 		// add the field to the in memory index
-		if err := m.createFieldIfNotExists(f.Field.Name, f.Field.Type); err != nil {
+		if err := m.CreateFieldIfNotExists(f.Field.Name, f.Field.Type); err != nil {
 			return nil, err
 		}
 
@@ -391,10 +391,10 @@ func (m *MeasurementFields) UnmarshalBinary(buf []byte) error {
 	return nil
 }
 
-// createFieldIfNotExists creates a new field with an autoincrementing ID.
+// CreateFieldIfNotExists creates a new field with an autoincrementing ID.
 // Returns an error if 255 fields have already been created on the measurement or
 // the fields already exists with a different type.
-func (m *MeasurementFields) createFieldIfNotExists(name string, typ influxql.DataType) error {
+func (m *MeasurementFields) CreateFieldIfNotExists(name string, typ influxql.DataType) error {
 	// Ignore if the field already exists.
 	if f := m.Fields[name]; f != nil {
 		if f.Type != typ {


### PR DESCRIPTION
## Overview

This pull request fixes the `b1` cursor so that reads from either the cache or bolt buffer will check against the previously read key to ensure that two of the same keys are not returned.

This is not an issue that will effect `bz1` because it will use the `tsdb.MultiCursor` which dedupes keys properly.

Fixes #3571.
