### PR TITLE
Set sensible Graphite batching defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ There are breaking changes in this release. Please see the *Features* section be
 - [#3326](https://github.com/influxdb/influxdb/issues/3326): simple regex query fails with cryptic error
 - [#3618](https://github.com/influxdb/influxdb/pull/3618): Fix collectd stats panic on i386. Thanks @richterger
 - [#3625](https://github.com/influxdb/influxdb/pull/3625): Don't panic when aggregate and raw queries are in a single statement
+- [#3629](https://github.com/influxdb/influxdb/pull/3629): Use sensible batching defaults for Graphite.
 
 ## v0.9.2 [2015-07-24]
 

--- a/services/graphite/config.go
+++ b/services/graphite/config.go
@@ -3,6 +3,7 @@ package graphite
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/influxdb/influxdb/toml"
 	"github.com/influxdb/influxdb/tsdb"
@@ -24,6 +25,12 @@ const (
 	// DefaultSeparator is the default join character to use when joining multiple
 	// measurment parts in a template.
 	DefaultSeparator = "."
+
+	// DefaultBatchSize is the default Graphite batch size.
+	DefaultBatchSize = 1000
+
+	// DefaultBatchTimeout is the default Graphite batch timeout.
+	DefaultBatchTimeout = time.Second
 )
 
 // Config represents the configuration for Graphite endpoints.
@@ -46,6 +53,8 @@ func NewConfig() Config {
 		BindAddress:      DefaultBindAddress,
 		Database:         DefaultDatabase,
 		Protocol:         DefaultProtocol,
+		BatchSize:        DefaultBatchSize,
+		BatchTimeout:     toml.Duration(DefaultBatchTimeout),
 		ConsistencyLevel: DefaultConsistencyLevel,
 		Separator:        DefaultSeparator,
 	}


### PR DESCRIPTION
The sample config file that comes with InfluxDB implies that Graphite uses this default batching config. But it actually doesn't -- Graphite does no batching by default. This change fixes that.