### PR TITLE
Add build branch to version information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ There are breaking changes in this release. Please see the *Features* section be
 - [#3599](https://github.com/influxdb/influxdb/pull/3599): **--BREAKING CHANGE--** Support multiple UDP inputs. Thanks @tpitale
 - [#3636](https://github.com/influxdb/influxdb/pull/3639): Cap auto-created retention policy replica count at 3
 - [#3641](https://github.com/influxdb/influxdb/pull/3641): Logging enhancements and single-node rename
+- [#3635](https://github.com/influxdb/influxdb/pull/3635): Add build branch to version output.
 
 ### Bugfixes
 - [#3405](https://github.com/influxdb/influxdb/pull/3405): Prevent database panic when fields are missing. Thanks @jhorwit2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -156,10 +156,10 @@ go install ./...
 To set the version and commit flags during the build pass the following to the build command:
 
 ```bash
--ldflags="-X main.version $VERSION -X main.commit $COMMIT"
+-ldflags="-X main.version $VERSION -X main.branch $BRANCH -X main.commit $COMMIT"
 ```
 
-where `$VERSION` is the version, and `$COMMIT` is the git commit hash.
+where `$VERSION` is the version, `$BRANCH` is the branch, and `$COMMIT` is the git commit hash.
 
 To run the tests, execute the following command:
 

--- a/cmd/influxd/main.go
+++ b/cmd/influxd/main.go
@@ -22,12 +22,16 @@ import (
 var (
 	version string = "0.9"
 	commit  string
+	branch  string
 )
 
 func init() {
-	// If commit not set, make that clear.
+	// If commit or branch are not set, make that clear.
 	if commit == "" {
 		commit = "unknown"
+	}
+	if branch == "" {
+		branch = "unknown"
 	}
 }
 
@@ -72,6 +76,7 @@ func (m *Main) Run(args ...string) error {
 		// Tell the server the build details.
 		cmd.Version = version
 		cmd.Commit = commit
+		cmd.Branch = branch
 
 		if err := cmd.Run(args...); err != nil {
 			return fmt.Errorf("run: %s", err)
@@ -183,7 +188,7 @@ func (cmd *VersionCommand) Run(args ...string) error {
 	}
 
 	// Print version info.
-	fmt.Fprintf(cmd.Stdout, "InfluxDB v%s (git: %s)\n", version, commit)
+	fmt.Fprintf(cmd.Stdout, "InfluxDB v%s (git: %s %s)\n", version, branch, commit)
 
 	return nil
 }
@@ -191,5 +196,5 @@ func (cmd *VersionCommand) Run(args ...string) error {
 var versionUsage = `
 usage: version
 
-	version displays the InfluxDB version and build git commit hash
+	version displays the InfluxDB version, build branch and git commit hash
 `

--- a/cmd/influxd/run/command.go
+++ b/cmd/influxd/run/command.go
@@ -30,6 +30,7 @@ const logo = `
 // Command represents the command executed by "influxd run".
 type Command struct {
 	Version string
+	Branch  string
 	Commit  string
 
 	closing chan struct{}
@@ -110,7 +111,7 @@ func (cmd *Command) Run(args ...string) error {
 	cmd.Server = s
 
 	// Mark start-up in log.
-	log.Printf("InfluxDB starting, version %s, commit %s", cmd.Version, cmd.Commit)
+	log.Printf("InfluxDB starting, version %s, branch %s, commit %s", cmd.Version, cmd.Branch, cmd.Commit)
 	log.Println("GOMAXPROCS set to", runtime.GOMAXPROCS(0))
 
 	// Begin monitoring the server's error channel.

--- a/package.sh
+++ b/package.sh
@@ -184,12 +184,13 @@ do_build() {
     git checkout $TARGET_BRANCH # go get switches to master, so ensure we're back.
     version=$1
     commit=`git rev-parse HEAD`
+    branch=`current_branch`
     if [ $? -ne 0 ]; then
         echo "Unable to retrieve current commit -- aborting"
         cleanup_exit 1
     fi
 
-    go install -a -ldflags="-X main.version $version -X main.commit $commit" ./...
+    go install -a -ldflags="-X main.version $version -X main.branch $branch -X main.commit $commit" ./...
     if [ $? -ne 0 ]; then
         echo "Build failed, unable to create package -- aborting"
         cleanup_exit 1


### PR DESCRIPTION
Enhance the information displayed by the `version` command, to minimize any confusion about built code.