### PR TITLE
Cluster config fixes and removal of meta.peers config field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ There are breaking changes in this release. Please see the *Features* section be
 - [#3618](https://github.com/influxdb/influxdb/pull/3618): Fix collectd stats panic on i386. Thanks @richterger
 - [#3625](https://github.com/influxdb/influxdb/pull/3625): Don't panic when aggregate and raw queries are in a single statement
 - [#3629](https://github.com/influxdb/influxdb/pull/3629): Use sensible batching defaults for Graphite.
+- [#3638](https://github.com/influxdb/influxdb/pull/3638): Cluster config fixes and removal of meta.peers config field
 
 ## v0.9.2 [2015-07-24]
 

--- a/cmd/influxd/run/config.go
+++ b/cmd/influxd/run/config.go
@@ -128,6 +128,11 @@ func (c *Config) applyEnvOverrides(prefix string, spec reflect.Value) error {
 		s = spec.Elem()
 	}
 
+	// Make sure we have struct
+	if s.Kind() != reflect.Struct {
+		return nil
+	}
+
 	typeOfSpec := s.Type()
 	for i := 0; i < s.NumField(); i++ {
 		f := s.Field(i)

--- a/cmd/influxd/run/server.go
+++ b/cmd/influxd/run/server.go
@@ -460,7 +460,7 @@ func (s *Server) hostAddr() (string, string, error) {
 	host := s.Hostname
 
 	// See if we might have a port that will override the BindAddress port
-	if host != "" && host[len(host)-1] >= '0' && host[len(host)-1] <= '9' {
+	if host != "" && host[len(host)-1] >= '0' && host[len(host)-1] <= '9' && strings.Contains(host, ":") {
 		hostArg, portArg, err := net.SplitHostPort(s.Hostname)
 		if err != nil {
 			return "", "", err

--- a/meta/config.go
+++ b/meta/config.go
@@ -31,7 +31,7 @@ type Config struct {
 	Dir                 string        `toml:"dir"`
 	Hostname            string        `toml:"hostname"`
 	BindAddress         string        `toml:"bind-address"`
-	Peers               []string      `toml:"peers"`
+	Peers               []string      `toml:"-"`
 	RetentionAutoCreate bool          `toml:"retention-autocreate"`
 	ElectionTimeout     toml.Duration `toml:"election-timeout"`
 	HeartbeatTimeout    toml.Duration `toml:"heartbeat-timeout"`


### PR DESCRIPTION
This PR fixes a panic and a regression with the `-hostname` flag as well as removes the `[meta].peers` config option to avoid confusion.  The supported method for joining a node to a cluster is using the `-join` flag.