### PR TITLE
Cap auto-created retention policy replica count at 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ There are breaking changes in this release. Please see the *Features* section be
 - [#3585](https://github.com/influxdb/influxdb/pull/3585): Additional test coverage for non-existent fields
 - [#3246](https://github.com/influxdb/influxdb/issues/3246): Allow overriding of configuration parameters using environment variables
 - [#3599](https://github.com/influxdb/influxdb/pull/3599): **--BREAKING CHANGE--** Support multiple UDP inputs. Thanks @tpitale
+- [#3636](https://github.com/influxdb/influxdb/pull/3639): Cap auto-created retention policy replica count at 3
 
 ### Bugfixes
 - [#3405](https://github.com/influxdb/influxdb/pull/3405): Prevent database panic when fields are missing. Thanks @jhorwit2

--- a/meta/data.go
+++ b/meta/data.go
@@ -141,8 +141,8 @@ func (data *Data) CreateRetentionPolicy(database string, rpi *RetentionPolicyInf
 	// Validate retention policy.
 	if rpi.Name == "" {
 		return ErrRetentionPolicyNameRequired
-	} else if rpi.ReplicaN != len(data.Nodes) {
-		return ErrReplicationFactorMismatch
+	} else if rpi.ReplicaN < 1 {
+		return ErrReplicationFactorTooLow
 	}
 
 	// Find database.

--- a/meta/data_test.go
+++ b/meta/data_test.go
@@ -127,14 +127,10 @@ func TestData_CreateRetentionPolicy_ErrNameRequired(t *testing.T) {
 	}
 }
 
-// Ensure that creating a policy with a replication factor that doesn't match
-// the number of nodes in the cluster will return an error. This is a temporary
-// restriction until v0.9.1 is released.
-func TestData_CreateRetentionPolicy_ErrReplicationFactorMismatch(t *testing.T) {
-	data := meta.Data{
-		Nodes: []meta.NodeInfo{{ID: 1}, {ID: 2}, {ID: 3}},
-	}
-	if err := data.CreateRetentionPolicy("db0", &meta.RetentionPolicyInfo{Name: "rp0", ReplicaN: 2}); err != meta.ErrReplicationFactorMismatch {
+// Ensure that creating a policy with a replication factor less than 1 returns an error.
+func TestData_CreateRetentionPolicy_ErrReplicationFactorTooLow(t *testing.T) {
+	data := meta.Data{Nodes: []meta.NodeInfo{{ID: 1}}}
+	if err := data.CreateRetentionPolicy("db0", &meta.RetentionPolicyInfo{Name: "rp0", ReplicaN: 0}); err != meta.ErrReplicationFactorTooLow {
 		t.Fatalf("unexpected error: %s", err)
 	}
 }
@@ -152,10 +148,10 @@ func TestData_CreateRetentionPolicy_ErrRetentionPolicyExists(t *testing.T) {
 	var data meta.Data
 	if err := data.CreateDatabase("db0"); err != nil {
 		t.Fatal(err)
-	} else if err = data.CreateRetentionPolicy("db0", &meta.RetentionPolicyInfo{Name: "rp0"}); err != nil {
+	} else if err = data.CreateRetentionPolicy("db0", &meta.RetentionPolicyInfo{Name: "rp0", ReplicaN: 1}); err != nil {
 		t.Fatal(err)
 	}
-	if err := data.CreateRetentionPolicy("db0", &meta.RetentionPolicyInfo{Name: "rp0"}); err != meta.ErrRetentionPolicyExists {
+	if err := data.CreateRetentionPolicy("db0", &meta.RetentionPolicyInfo{Name: "rp0", ReplicaN: 1}); err != meta.ErrRetentionPolicyExists {
 		t.Fatalf("unexpected error: %s", err)
 	}
 }
@@ -165,7 +161,7 @@ func TestData_UpdateRetentionPolicy(t *testing.T) {
 	var data meta.Data
 	if err := data.CreateDatabase("db0"); err != nil {
 		t.Fatal(err)
-	} else if err = data.CreateRetentionPolicy("db0", &meta.RetentionPolicyInfo{Name: "rp0"}); err != nil {
+	} else if err = data.CreateRetentionPolicy("db0", &meta.RetentionPolicyInfo{Name: "rp0", ReplicaN: 1}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -194,7 +190,7 @@ func TestData_DropRetentionPolicy(t *testing.T) {
 	var data meta.Data
 	if err := data.CreateDatabase("db0"); err != nil {
 		t.Fatal(err)
-	} else if err = data.CreateRetentionPolicy("db0", &meta.RetentionPolicyInfo{Name: "rp0"}); err != nil {
+	} else if err = data.CreateRetentionPolicy("db0", &meta.RetentionPolicyInfo{Name: "rp0", ReplicaN: 1}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -229,9 +225,9 @@ func TestData_RetentionPolicy(t *testing.T) {
 	var data meta.Data
 	if err := data.CreateDatabase("db0"); err != nil {
 		t.Fatal(err)
-	} else if err = data.CreateRetentionPolicy("db0", &meta.RetentionPolicyInfo{Name: "rp0"}); err != nil {
+	} else if err = data.CreateRetentionPolicy("db0", &meta.RetentionPolicyInfo{Name: "rp0", ReplicaN: 1}); err != nil {
 		t.Fatal(err)
-	} else if err = data.CreateRetentionPolicy("db0", &meta.RetentionPolicyInfo{Name: "rp1"}); err != nil {
+	} else if err = data.CreateRetentionPolicy("db0", &meta.RetentionPolicyInfo{Name: "rp1", ReplicaN: 1}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -240,6 +236,7 @@ func TestData_RetentionPolicy(t *testing.T) {
 	} else if !reflect.DeepEqual(rpi, &meta.RetentionPolicyInfo{
 		Name:               "rp0",
 		ShardGroupDuration: 604800000000000,
+		ReplicaN:           1,
 	}) {
 		t.Fatalf("unexpected value: %#v", rpi)
 	}
@@ -258,7 +255,7 @@ func TestData_SetDefaultRetentionPolicy(t *testing.T) {
 	var data meta.Data
 	if err := data.CreateDatabase("db0"); err != nil {
 		t.Fatal(err)
-	} else if err = data.CreateRetentionPolicy("db0", &meta.RetentionPolicyInfo{Name: "rp0"}); err != nil {
+	} else if err = data.CreateRetentionPolicy("db0", &meta.RetentionPolicyInfo{Name: "rp0", ReplicaN: 1}); err != nil {
 		t.Fatal(err)
 	}
 

--- a/meta/errors.go
+++ b/meta/errors.go
@@ -58,10 +58,9 @@ var (
 	ErrRetentionPolicyDurationTooLow = errors.New(fmt.Sprintf("retention policy duration must be at least %s",
 		RetentionPolicyMinDuration))
 
-	// ErrReplicationFactorMismatch is returned when the replication factor
-	// does not match the number of nodes in the cluster. This is a temporary
-	// restriction until v0.9.1 is released.
-	ErrReplicationFactorMismatch = errors.New("replication factor must match cluster size; this limitation will be lifted in v0.9.1")
+	// ErrReplicationFactorTooLow is returned when the replication factor is not in an
+	// acceptable range.
+	ErrReplicationFactorTooLow = errors.New("replication factor must be greater than 0")
 )
 
 var (

--- a/meta/store.go
+++ b/meta/store.go
@@ -47,6 +47,10 @@ const (
 	AutoCreateRetentionPolicyName   = "default"
 	AutoCreateRetentionPolicyPeriod = 0
 	RetentionPolicyMinDuration      = time.Hour
+
+	// MaxAutoCreatedRetentionPolicyReplicaN is the maximum replication factor that will
+	// be set for auto-created retention policies.
+	MaxAutoCreatedRetentionPolicyReplicaN = 3
 )
 
 // Raft configuration.
@@ -866,6 +870,10 @@ func (s *Store) CreateDatabase(name string) (*DatabaseInfo, error) {
 			return nil
 		}); err != nil {
 			return nil, fmt.Errorf("read: %s", err)
+		}
+
+		if nodeN > MaxAutoCreatedRetentionPolicyReplicaN {
+			nodeN = MaxAutoCreatedRetentionPolicyReplicaN
 		}
 
 		// Create a retention policy.


### PR DESCRIPTION
Defaulting to the number of nodes in the cluster is doesn't make
sense with larger clusters. (e.g. 10 nodes = RF 10)