### PR TITLE
Shutdown Graphite listener first during Close()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ There are breaking changes in this release. Please see the *Features* section be
 - [#3625](https://github.com/influxdb/influxdb/pull/3625): Don't panic when aggregate and raw queries are in a single statement
 - [#3629](https://github.com/influxdb/influxdb/pull/3629): Use sensible batching defaults for Graphite.
 - [#3638](https://github.com/influxdb/influxdb/pull/3638): Cluster config fixes and removal of meta.peers config field
+- [#3640](https://github.com/influxdb/influxdb/pull/3640): Shutdown Graphite service when signal received.
 
 ## v0.9.2 [2015-07-24]
 

--- a/services/graphite/service.go
+++ b/services/graphite/service.go
@@ -121,13 +121,15 @@ func (s *Service) Open() error {
 
 // Close stops all data processing on the Graphite input.
 func (s *Service) Close() error {
-	s.batcher.Flush()
-	close(s.done)
-	s.wg.Wait()
-	s.done = nil
 	if s.ln != nil {
 		s.ln.Close()
 	}
+
+	s.batcher.Stop()
+	close(s.done)
+	s.wg.Wait()
+	s.done = nil
+
 	return nil
 }
 


### PR DESCRIPTION
InfluxDB did not shut down in response to CNTRL-C when Graphite was enabled.

Without this change the WaitGroup was not fully decremented as the Accept() call on the listener never exited, and then Wait() never returned.