### PR TITLE
Logging enhancements and single-node rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ There are breaking changes in this release. Please see the *Features* section be
 - [#3246](https://github.com/influxdb/influxdb/issues/3246): Allow overriding of configuration parameters using environment variables
 - [#3599](https://github.com/influxdb/influxdb/pull/3599): **--BREAKING CHANGE--** Support multiple UDP inputs. Thanks @tpitale
 - [#3636](https://github.com/influxdb/influxdb/pull/3639): Cap auto-created retention policy replica count at 3
+- [#3641](https://github.com/influxdb/influxdb/pull/3641): Logging enhancements and single-node rename
 
 ### Bugfixes
 - [#3405](https://github.com/influxdb/influxdb/pull/3405): Prevent database panic when fields are missing. Thanks @jhorwit2
@@ -42,6 +43,7 @@ There are breaking changes in this release. Please see the *Features* section be
 - [#3629](https://github.com/influxdb/influxdb/pull/3629): Use sensible batching defaults for Graphite.
 - [#3638](https://github.com/influxdb/influxdb/pull/3638): Cluster config fixes and removal of meta.peers config field
 - [#3640](https://github.com/influxdb/influxdb/pull/3640): Shutdown Graphite service when signal received.
+- [#3632](https://github.com/influxdb/influxdb/issues/3632): Make single-node host renames more seamless
 
 ## v0.9.2 [2015-07-24]
 

--- a/cluster/service.go
+++ b/cluster/service.go
@@ -54,7 +54,7 @@ func NewService(c Config) *Service {
 // Open opens the network listener and begins serving requests.
 func (s *Service) Open() error {
 
-	s.Logger.Println("Staring cluster service")
+	s.Logger.Println("Starting cluster service")
 	// Begin serving conections.
 	s.wg.Add(1)
 	go s.serve()

--- a/cluster/service.go
+++ b/cluster/service.go
@@ -53,6 +53,8 @@ func NewService(c Config) *Service {
 
 // Open opens the network listener and begins serving requests.
 func (s *Service) Open() error {
+
+	s.Logger.Println("Staring cluster service")
 	// Begin serving conections.
 	s.wg.Add(1)
 	go s.serve()

--- a/cmd/influxd/main.go
+++ b/cmd/influxd/main.go
@@ -79,12 +79,12 @@ func (m *Main) Run(args ...string) error {
 
 		signalCh := make(chan os.Signal, 1)
 		signal.Notify(signalCh, os.Interrupt, syscall.SIGTERM)
-		m.Logger.Println("listening for signals")
+		m.Logger.Println("Listening for signals")
 
 		// Block until one of the signals above is received
 		select {
 		case <-signalCh:
-			m.Logger.Println("signal received, initializing clean shutdown...")
+			m.Logger.Println("Signal received, initializing clean shutdown...")
 			go func() {
 				cmd.Close()
 			}()
@@ -92,7 +92,7 @@ func (m *Main) Run(args ...string) error {
 
 		// Block again until another signal is received, a shutdown timeout elapses,
 		// or the Command is gracefully closed
-		m.Logger.Println("waiting for clean shutdown...")
+		m.Logger.Println("Waiting for clean shutdown...")
 		select {
 		case <-signalCh:
 			m.Logger.Println("second signal received, initializing hard shutdown")

--- a/cmd/influxd/run/command.go
+++ b/cmd/influxd/run/command.go
@@ -189,7 +189,7 @@ func (cmd *Command) ParseConfig(path string) (*Config, error) {
 		return NewDemoConfig()
 	}
 
-	fmt.Fprintf(cmd.Stdout, "using configuration at: %s\n", path)
+	fmt.Fprintf(cmd.Stdout, "Using configuration at: %s\n", path)
 
 	config := NewConfig()
 	if _, err := toml.DecodeFile(path, &config); err != nil {

--- a/services/admin/service.go
+++ b/services/admin/service.go
@@ -38,7 +38,6 @@ func NewService(c Config) *Service {
 
 // Open starts the service
 func (s *Service) Open() error {
-
 	s.logger.Printf("Starting admin service")
 
 	// Open listener.

--- a/services/admin/service.go
+++ b/services/admin/service.go
@@ -38,6 +38,9 @@ func NewService(c Config) *Service {
 
 // Open starts the service
 func (s *Service) Open() error {
+
+	s.logger.Printf("Starting admin service")
+
 	// Open listener.
 	if s.https {
 		cert, err := tls.LoadX509KeyPair(s.cert, s.cert)
@@ -52,7 +55,7 @@ func (s *Service) Open() error {
 			return err
 		}
 
-		s.logger.Println("listening on HTTPS:", listener.Addr().String())
+		s.logger.Println("Listening on HTTPS:", listener.Addr().String())
 		s.listener = listener
 	} else {
 		listener, err := net.Listen("tcp", s.addr)
@@ -60,7 +63,7 @@ func (s *Service) Open() error {
 			return err
 		}
 
-		s.logger.Println("listening on HTTP:", listener.Addr().String())
+		s.logger.Println("Listening on HTTP:", listener.Addr().String())
 		s.listener = listener
 	}
 

--- a/services/collectd/service.go
+++ b/services/collectd/service.go
@@ -57,8 +57,7 @@ func NewService(c Config) *Service {
 
 // Open starts the service.
 func (s *Service) Open() error {
-
-	s.Logger.Printf("Starting collected service")
+	s.Logger.Printf("Starting collectd service")
 
 	if s.Config.BindAddress == "" {
 		return fmt.Errorf("bind address is blank")

--- a/services/continuous_querier/service.go
+++ b/services/continuous_querier/service.go
@@ -71,12 +71,14 @@ func NewService(c Config) *Service {
 		lastRuns:       map[string]time.Time{},
 	}
 
-	s.Logger.Println("starting continuous query service")
 	return s
 }
 
 // Open starts the service.
 func (s *Service) Open() error {
+
+	s.Logger.Println("Starting continuous query service")
+
 	if s.stop != nil {
 		return nil
 	}

--- a/services/graphite/service.go
+++ b/services/graphite/service.go
@@ -85,16 +85,17 @@ func NewService(c Config) (*Service, error) {
 
 // Open starts the Graphite input processing data.
 func (s *Service) Open() error {
+	s.logger.Println("Starting graphite service")
+
 	if err := s.MetaStore.WaitForLeader(leaderWaitTimeout); err != nil {
-		s.logger.Printf("failed to detect a cluster leader: %s", err.Error())
+		s.logger.Printf("Failed to detect a cluster leader: %s", err.Error())
 		return err
 	}
 
 	if _, err := s.MetaStore.CreateDatabaseIfNotExists(s.database); err != nil {
-		s.logger.Printf("failed to ensure target database %s exists: %s", s.database, err.Error())
+		s.logger.Printf("Failed to ensure target database %s exists: %s", s.database, err.Error())
 		return err
 	}
-	s.logger.Printf("ensured target database %s exists", s.database)
 
 	s.batcher = tsdb.NewPointBatcher(s.batchSize, s.batchTimeout)
 	s.batcher.Start()
@@ -115,7 +116,7 @@ func (s *Service) Open() error {
 		return err
 	}
 
-	s.logger.Printf("%s Graphite input opened on %s", s.protocol, s.addr.String())
+	s.logger.Printf("Listening on %s: %s", strings.ToUpper(s.protocol), s.addr.String())
 	return nil
 }
 

--- a/services/hh/service.go
+++ b/services/hh/service.go
@@ -47,16 +47,21 @@ func NewService(c Config, w shardWriter) *Service {
 	if err != nil {
 		s.Logger.Fatalf("Failed to start hinted handoff processor: %v", err)
 	}
+
 	processor.Logger = s.Logger
 	s.HintedHandoff = processor
 	return s
 }
 
 func (s *Service) Open() error {
+	s.Logger.Printf("Starting hinted handoff service")
+
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	s.closing = make(chan struct{})
+
+	s.Logger.Printf("Using data dir: %v", s.cfg.Dir)
 
 	s.wg.Add(2)
 	go s.retryWrites()

--- a/services/httpd/service.go
+++ b/services/httpd/service.go
@@ -43,7 +43,8 @@ func NewService(c Config) *Service {
 
 // Open starts the service
 func (s *Service) Open() error {
-	s.Logger.Println("authentication enabled:", s.Handler.requireAuthentication)
+	s.Logger.Println("Starting HTTP service")
+	s.Logger.Println("Authentication enabled:", s.Handler.requireAuthentication)
 
 	// Open listener.
 	if s.https {
@@ -59,7 +60,7 @@ func (s *Service) Open() error {
 			return err
 		}
 
-		s.Logger.Println("listening on HTTPS:", listener.Addr().String())
+		s.Logger.Println("Listening on HTTPS:", listener.Addr().String())
 		s.ln = listener
 	} else {
 		listener, err := net.Listen("tcp", s.addr)
@@ -67,7 +68,7 @@ func (s *Service) Open() error {
 			return err
 		}
 
-		s.Logger.Println("listening on HTTP:", listener.Addr().String())
+		s.Logger.Println("Listening on HTTP:", listener.Addr().String())
 		s.ln = listener
 	}
 

--- a/services/opentsdb/service.go
+++ b/services/opentsdb/service.go
@@ -70,16 +70,17 @@ func NewService(c Config) (*Service, error) {
 
 // Open starts the service
 func (s *Service) Open() error {
+	s.Logger.Println("Starting OpenTSDB service")
+
 	if err := s.MetaStore.WaitForLeader(leaderWaitTimeout); err != nil {
-		s.Logger.Printf("failed to detect a cluster leader: %s", err.Error())
+		s.Logger.Printf("Failed to detect a cluster leader: %s", err.Error())
 		return err
 	}
 
 	if _, err := s.MetaStore.CreateDatabaseIfNotExists(s.Database); err != nil {
-		s.Logger.Printf("failed to ensure target database %s exists: %s", s.Database, err.Error())
+		s.Logger.Printf("Failed to ensure target database %s exists: %s", s.Database, err.Error())
 		return err
 	}
-	s.Logger.Printf("ensured target database %s exists", s.Database)
 
 	// Open listener.
 	if s.tls {
@@ -95,7 +96,7 @@ func (s *Service) Open() error {
 			return err
 		}
 
-		s.Logger.Println("listening on TLS:", listener.Addr().String())
+		s.Logger.Println("Listening on TLS:", listener.Addr().String())
 		s.ln = listener
 	} else {
 		listener, err := net.Listen("tcp", s.BindAddress)
@@ -103,7 +104,7 @@ func (s *Service) Open() error {
 			return err
 		}
 
-		s.Logger.Println("listening on:", listener.Addr().String())
+		s.Logger.Println("Listening on:", listener.Addr().String())
 		s.ln = listener
 	}
 	s.httpln = newChanListener(s.ln.Addr())

--- a/services/precreator/service.go
+++ b/services/precreator/service.go
@@ -44,6 +44,8 @@ func (s *Service) Open() error {
 		return nil
 	}
 
+	s.Logger.Println("Starting precreation service")
+
 	s.done = make(chan struct{})
 
 	s.wg.Add(1)
@@ -81,7 +83,7 @@ func (s *Service) runPrecreation() {
 				s.Logger.Printf("failed to precreate shards: %s", err.Error())
 			}
 		case <-s.done:
-			s.Logger.Println("precreation service terminating")
+			s.Logger.Println("Precreation service terminating")
 			return
 		}
 	}

--- a/services/retention/service.go
+++ b/services/retention/service.go
@@ -40,6 +40,7 @@ func NewService(c Config) *Service {
 
 // Open starts retention policy enforcement.
 func (s *Service) Open() error {
+	s.logger.Println("Starting rentention policy enforcement service")
 	s.wg.Add(2)
 	go s.deleteShardGroups()
 	go s.deleteShards()

--- a/services/snapshotter/service.go
+++ b/services/snapshotter/service.go
@@ -42,6 +42,8 @@ func NewService() *Service {
 
 // Open starts the service.
 func (s *Service) Open() error {
+	s.Logger.Println("Starting snapshot service")
+
 	s.wg.Add(1)
 	go s.serve()
 	return nil

--- a/services/udp/service.go
+++ b/services/udp/service.go
@@ -66,7 +66,7 @@ func (s *Service) Open() (err error) {
 		return err
 	}
 
-	s.Logger.Printf("Started listening on %s", s.config.BindAddress)
+	s.Logger.Printf("Started listening on UDP: %s", s.config.BindAddress)
 
 	s.wg.Add(2)
 	go s.serve()

--- a/tsdb/store.go
+++ b/tsdb/store.go
@@ -256,6 +256,8 @@ func (s *Store) Open() error {
 	s.shards = map[uint64]*Shard{}
 	s.databaseIndexes = map[string]*DatabaseIndex{}
 
+	s.Logger.Printf("Using data dir: %v", s.Path())
+
 	// Create directory.
 	if err := os.MkdirAll(s.path, 0777); err != nil {
 		return err


### PR DESCRIPTION
This PR makes it more seamless to rename a single-node cluster.  Renaming a raft peer in a multiple node cluster still requires operator intervention.

This also cleans up the logging to add more consistency to what and how things are logged.  Specifically:
* Capitalize first letter of message
* Log all services starting consistently
* Remove some extraneous log statements in meta.Store
* Log data dirs for meta, data and hinted handoff
* Log raft leadership changes