### PR TITLE
Fix nil FieldCodec panic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ There are breaking changes in this release. Please see the *Features* section be
 - [#3651](https://github.com/influxdb/influxdb/pull/3651): Fully remove series when dropped.
 - [#3517](https://github.com/influxdb/influxdb/pull/3517): Batch CQ writes to avoid timeouts. Thanks @dim.
 - [#3522](https://github.com/influxdb/influxdb/pull/3522): Consume CQ results on request timeouts. Thanks @dim.
+- [#3646](https://github.com/influxdb/influxdb/pull/3646): Fix nil FieldCodec panic.
 
 ## v0.9.2 [2015-07-24]
 

--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -130,7 +130,7 @@ func (s *Shard) FieldCodec(measurementName string) *FieldCodec {
 	defer s.mu.RUnlock()
 	m := s.measurementFields[measurementName]
 	if m == nil {
-		return nil
+		return NewFieldCodec(nil)
 	}
 	return m.Codec
 }


### PR DESCRIPTION
## Overview

This pull request changes `FieldCodec` to always be non-nil. Normally it should always be non-nil, however, if metadata is not persisted correctly or consistently then it could be missing. A `nil` `FieldCodec` causes queries to panic.

Fixes #3535