### PR TITLE
Shutdown raft transport and layer first

### DIFF
--- a/meta/state.go
+++ b/meta/state.go
@@ -201,6 +201,16 @@ func (r *localRaft) close() error {
 	close(r.closing)
 	r.wg.Wait()
 
+	if r.transport != nil {
+		r.transport.Close()
+		r.transport = nil
+	}
+
+	if r.raftLayer != nil {
+		r.raftLayer.Close()
+		r.raftLayer = nil
+	}
+
 	// Shutdown raft.
 	if r.raft != nil {
 		if err := r.raft.Shutdown().Error(); err != nil {
@@ -208,10 +218,7 @@ func (r *localRaft) close() error {
 		}
 		r.raft = nil
 	}
-	if r.transport != nil {
-		r.transport.Close()
-		r.transport = nil
-	}
+
 	if r.raftStore != nil {
 		r.raftStore.Close()
 		r.raftStore = nil


### PR DESCRIPTION
The raft.Shutdown() call was deadlocking if operations were still
being applied to the log sometimes.  Change the shutdown behavior to
match how consul shuts down raft:

https://github.com/hashicorp/consul/blob/e37b5ecb692b4154927e3386e40e745436c78c93/consul/server.go#L471-L477