### PR TITLE
turn on block profiling

### DIFF
--- a/cmd/influxd/run/command.go
+++ b/cmd/influxd/run/command.go
@@ -11,6 +11,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/BurntSushi/toml"
 )
@@ -72,6 +73,9 @@ func (cmd *Command) Run(args ...string) error {
 
 	// Set parallelism.
 	runtime.GOMAXPROCS(runtime.NumCPU())
+
+	// Turn on block profiling to debug stuck databases
+	runtime.SetBlockProfileRate(int(10 * time.Second))
 
 	// Parse config
 	config, err := cmd.ParseConfig(options.ConfigPath)


### PR DESCRIPTION
This should help us figure out where exactly a database is hung when
it happens.