### PR TITLE
Silence snapshotter logger for testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ There are breaking changes in this release. Please see the *Features* section be
 - [#3638](https://github.com/influxdb/influxdb/pull/3638): Cluster config fixes and removal of meta.peers config field
 - [#3640](https://github.com/influxdb/influxdb/pull/3640): Shutdown Graphite service when signal received.
 - [#3632](https://github.com/influxdb/influxdb/issues/3632): Make single-node host renames more seamless
+- [#3656](https://github.com/influxdb/influxdb/issues/3656): Silence snapshotter logger for testing
 
 ## v0.9.2 [2015-07-24]
 

--- a/services/snapshotter/service.go
+++ b/services/snapshotter/service.go
@@ -58,6 +58,11 @@ func (s *Service) Close() error {
 	return nil
 }
 
+// SetLogger sets the internal logger to the logger passed in.
+func (s *Service) SetLogger(l *log.Logger) {
+	s.Logger = l
+}
+
 // Err returns a channel for fatal out-of-band errors.
 func (s *Service) Err() <-chan error { return s.err }
 


### PR DESCRIPTION
Added `SetLogger` to the snapshotter service so it can be silenced for tests.