### PR TITLE
protect engine points cache from concurrent modifications.

### DIFF
--- a/tsdb/engine/b1/b1.go
+++ b/tsdb/engine/b1/b1.go
@@ -37,7 +37,7 @@ var _ tsdb.Engine = &Engine{}
 
 // Engine represents a version 1 storage engine.
 type Engine struct {
-	mu sync.Mutex
+	mu sync.RWMutex
 
 	path string   // path to data file
 	db   *bolt.DB // underlying database
@@ -533,6 +533,9 @@ type Tx struct {
 func (tx *Tx) Cursor(key string) tsdb.Cursor {
 	// Retrieve key bucket.
 	b := tx.Bucket([]byte(key))
+
+	tx.engine.mu.RLock()
+	defer tx.engine.mu.RUnlock()
 
 	// Ignore if there is no bucket or points in the cache.
 	partitionID := WALPartition([]byte(key))


### PR DESCRIPTION
Creating a cursor would access the engine cache concurrently with
writes, causing data races. Fix by adding a mutex around cache
accesses.