### PR TITLE
Remove unused in-memory index hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ There are breaking changes in this release. Please see the *Features* section be
 - [#3517](https://github.com/influxdb/influxdb/pull/3517): Batch CQ writes to avoid timeouts. Thanks @dim.
 - [#3522](https://github.com/influxdb/influxdb/pull/3522): Consume CQ results on request timeouts. Thanks @dim.
 - [#3646](https://github.com/influxdb/influxdb/pull/3646): Fix nil FieldCodec panic.
+- [#3672](https://github.com/influxdb/influxdb/pull/3672): Reduce in-memory index by 20%-30%
 
 ## v0.9.2 [2015-07-24]
 

--- a/tsdb/meta.go
+++ b/tsdb/meta.go
@@ -298,7 +298,6 @@ type Measurement struct {
 	index      *DatabaseIndex
 
 	// in-memory index fields
-	series              map[string]*Series // sorted tagset string to the series object
 	seriesByID          map[uint64]*Series // lookup table for series by their id
 	measurement         *Measurement
 	seriesByTagKeyValue map[string]map[string]SeriesIDs // map from tag key to value to sorted set of series ids
@@ -312,7 +311,6 @@ func NewMeasurement(name string, idx *DatabaseIndex) *Measurement {
 		fieldNames: make(map[string]struct{}),
 		index:      idx,
 
-		series:              make(map[string]*Series),
 		seriesByID:          make(map[uint64]*Series),
 		seriesByTagKeyValue: make(map[string]map[string]SeriesIDs),
 		seriesIDs:           make(SeriesIDs, 0),
@@ -382,8 +380,6 @@ func (m *Measurement) AddSeries(s *Series) bool {
 		return false
 	}
 	m.seriesByID[s.id] = s
-	tagset := string(MarshalTags(s.Tags))
-	m.series[tagset] = s
 	m.seriesIDs = append(m.seriesIDs, s.id)
 
 	// the series ID should always be higher than all others because it's a new
@@ -421,10 +417,6 @@ func (m *Measurement) DropSeries(seriesID uint64) {
 	if _, ok := m.seriesByID[seriesID]; !ok {
 		return
 	}
-	s := m.seriesByID[seriesID]
-	tagset := string(MarshalTags(s.Tags))
-
-	delete(m.series, tagset)
 	delete(m.seriesByID, seriesID)
 
 	var ids []uint64


### PR DESCRIPTION
The series map on Measurement was updated and deleted but never
actually used.  Series keys can be very big since they are the
string representation of the measurement plus sorted tags.

Locally I see ~20%-30% reduction in memory usage with 1M series.