### PR TITLE
No need to list, just take map's size

### DIFF
--- a/tsdb/executor.go
+++ b/tsdb/executor.go
@@ -478,7 +478,7 @@ func (e *Executor) executeAggregate(out chan *influxql.Row) {
 		values = e.processDerivative(values)
 
 		// If we have multiple tag sets we'll want to filter out the empty ones
-		if len(availTagSets.list()) > 1 && resultsEmpty(values) {
+		if len(availTagSets) > 1 && resultsEmpty(values) {
 			continue
 		}
 


### PR DESCRIPTION
A particular test query goes from 2 minutes 40 seconds to 1 minute 25 seconds. This code simply needed to know the size of the string set, so can take the length of the map. There is no need to make a sorted string out of the map's keys.