### PR TITLE
Precompute cursor keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ There are breaking changes in this release. Please see the *Features* section be
 - [#3646](https://github.com/influxdb/influxdb/pull/3646): Fix nil FieldCodec panic.
 - [#3672](https://github.com/influxdb/influxdb/pull/3672): Reduce in-memory index by 20%-30%
 - [#3673](https://github.com/influxdb/influxdb/pull/3673): Improve query performance by removing unnecessary tagset sorting.
+- [#3675](https://github.com/influxdb/influxdb/pull/3675): Improve query performance by precomputing cursor tagset-based keys.
 
 ## v0.9.2 [2015-07-24]
 

--- a/tsdb/mapper.go
+++ b/tsdb/mapper.go
@@ -73,6 +73,7 @@ func NewLocalMapper(shard *Shard, stmt influxql.Statement, chunkSize int) *Local
 		shard:     shard,
 		stmt:      stmt,
 		chunkSize: chunkSize,
+		cursors:   make([]*tagSetCursor, 0),
 	}
 }
 


### PR DESCRIPTION
CPU profiling shows that computing the tagset-based key of each point is significant CPU cost. These keys actually don't change per cursor, so precompute once at mapper-open time, and then use those values as points are drained from the cursor.

Before this change the cursor tag was getting computed on every point, which involved marshalling tags.

With this change in place, on my machine, a partner's test query went from 52 seconds to 13 seconds.
