### PR TITLE
Memomize tagset cursor's key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ There are breaking changes in this release. Please see the *Features* section be
 - [#3646](https://github.com/influxdb/influxdb/pull/3646): Fix nil FieldCodec panic.
 - [#3672](https://github.com/influxdb/influxdb/pull/3672): Reduce in-memory index by 20%-30%
 - [#3673](https://github.com/influxdb/influxdb/pull/3673): Improve query performance by removing unnecessary tagset sorting.
+- [#3676](https://github.com/influxdb/influxdb/pull/3676): Improve query performance by memomizing mapper output keys.
 
 ## v0.9.2 [2015-07-24]
 

--- a/tsdb/executor.go
+++ b/tsdb/executor.go
@@ -269,8 +269,9 @@ func (e *Executor) executeRaw(out chan *influxql.Row) {
 			// Add up to the index to the values
 			if chunkedOutput == nil {
 				chunkedOutput = &MapperOutput{
-					Name: m.bufferedChunk.Name,
-					Tags: m.bufferedChunk.Tags,
+					Name:      m.bufferedChunk.Name,
+					Tags:      m.bufferedChunk.Tags,
+					cursorKey: m.bufferedChunk.key(),
 				}
 				chunkedOutput.Values = m.bufferedChunk.Values[:ind]
 			} else {


### PR DESCRIPTION
CPU profiling shows that computing the tagset-based key of each point is significant CPU cost (`formMeasurementTagSetKey`). These keys actually don't change per cursor, so precompute per tagset cursor, and then tack this value onto mapper outputs.

Before this change the cursor tagset-based key was getting computed for every point emitted by that cursor, which involved marshalling tags ever time a point was emitted.

With this change in place, on my machine, a partner's test query execution time was reduced by 30-40%.
