### PR TITLE
Prevent 'p' parameter of OPTIONS requests being logged.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ There are breaking changes in this release. Please see the *Features* section be
 - [#3672](https://github.com/influxdb/influxdb/pull/3672): Reduce in-memory index by 20%-30%
 - [#3673](https://github.com/influxdb/influxdb/pull/3673): Improve query performance by removing unnecessary tagset sorting.
 - [#3676](https://github.com/influxdb/influxdb/pull/3676): Improve query performance by memomizing mapper output keys.
+- [#3686](https://github.com/influxdb/influxdb/pull/3686): Ensure 'p' parameter is not logged, even on OPTIONS requests.
 - [#3687](https://github.com/influxdb/influxdb/issues/3687): Fix panic: runtime error: makeslice: len out of range in hinted handoff
 - [#3697](https://github.com/influxdb/influxdb/issues/3697):  Correctly merge non-chunked results for same series. Fix issue #3242.
 

--- a/services/httpd/handler.go
+++ b/services/httpd/handler.go
@@ -601,8 +601,6 @@ func parseCredentials(r *http.Request) (string, string, error) {
 	q := r.URL.Query()
 
 	if u, p := q.Get("u"), q.Get("p"); u != "" && p != "" {
-		q.Set("p", "[REDACTED]")
-		r.URL.RawQuery = q.Encode()
 		return u, p, nil
 	}
 	if u, p, ok := r.BasicAuth(); ok {

--- a/services/httpd/response_logger.go
+++ b/services/httpd/response_logger.go
@@ -58,11 +58,23 @@ func (l *responseLogger) Size() int {
 	return l.size
 }
 
+// redact any occurrence of a password parameter, 'p'
+func redactPassword(r *http.Request) {
+	q := r.URL.Query()
+	if p := q.Get("p"); p != "" {
+		q.Set("p", "[REDACTED]")
+		r.URL.RawQuery = q.Encode()
+	}
+}
+
 // Common Log Format: http://en.wikipedia.org/wiki/Common_Log_Format
 
 // buildLogLine creates a common log format
 // in addition to the common fields, we also append referrer, user agent and request ID
 func buildLogLine(l *responseLogger, r *http.Request, start time.Time) string {
+
+	redactPassword(r)
+
 	username := parseUsername(r)
 
 	host, _, err := net.SplitHostPort(r.RemoteAddr)


### PR DESCRIPTION
Previously, OPTIONS requests were logged without passwords being redacted.

This occurred because password redaction is performed by the authentication
handler and a) the serveOptions handler did not have the parameter
that forces the authentication handler to be put on the request path and b)
the CORS handler returns early for OPTIONS requests
before the authentication handler is invoked.

With this commit, OPTIONS requests are also subject to the authentication handler
and the responsibility for the early return on OPTIONS request is moved from
the CORS handler to the authentication handler.

Signed-off-by: Jon Seymour <jon@wildducktheories.com>