### PR TITLE
Prevent out of memory range slices from being created

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ There are breaking changes in this release. Please see the *Features* section be
 - [#3672](https://github.com/influxdb/influxdb/pull/3672): Reduce in-memory index by 20%-30%
 - [#3673](https://github.com/influxdb/influxdb/pull/3673): Improve query performance by removing unnecessary tagset sorting.
 - [#3676](https://github.com/influxdb/influxdb/pull/3676): Improve query performance by memomizing mapper output keys.
+- [#3687](https://github.com/influxdb/influxdb/issues/3687): Fix panic: runtime error: makeslice: len out of range in hinted handoff
 
 ## v0.9.2 [2015-07-24]
 

--- a/services/hh/queue.go
+++ b/services/hh/queue.go
@@ -496,6 +496,10 @@ func (l *segment) current() ([]byte, error) {
 	}
 	l.currentSize = int64(sz)
 
+	if int64(sz) > l.maxSize {
+		return nil, fmt.Errorf("record size out of range: max %d: got %d", l.maxSize, sz)
+	}
+
 	b := make([]byte, sz)
 	if err := l.readBytes(b); err != nil {
 		return nil, err


### PR DESCRIPTION
If the hinted handoff segment is corrupt, the size read could be
invalid and attempting to create a slice using that size causes
a panic.  Ideally, we'd have a checksum on the seqment record but
for now just return an error when the size is larger than the
segment file.

Fixes #3687