### PR TITLE
adjust granularity of block profile

### DIFF
--- a/cmd/influxd/run/command.go
+++ b/cmd/influxd/run/command.go
@@ -75,7 +75,7 @@ func (cmd *Command) Run(args ...string) error {
 	runtime.GOMAXPROCS(runtime.NumCPU())
 
 	// Turn on block profiling to debug stuck databases
-	runtime.SetBlockProfileRate(int(10 * time.Second))
+	runtime.SetBlockProfileRate(int(1 * time.Second))
 
 	// Parse config
 	config, err := cmd.ParseConfig(options.ConfigPath)


### PR DESCRIPTION
32bit int platforms can't handle a constant this high, so cap it at
1 second instead.