### PR TITLE
Run 32bit tests in CircleCI + Added script to run them separately

### DIFF
--- a/Dockerfile_test_ubuntu32
+++ b/Dockerfile_test_ubuntu32
@@ -1,0 +1,12 @@
+FROM 32bit/ubuntu:14.04
+
+RUN apt-get update && apt-get install -y python-software-properties software-properties-common git
+RUN add-apt-repository ppa:evarlast/golang1.4
+RUN apt-get update && apt-get install -y golang-go
+
+ENV GOPATH=/root/go
+RUN mkdir -p /root/go/src/github.com/influxdb/influxdb
+RUN mkdir -p /tmp/artifacts
+
+VOLUME /root/go/src/github.com/influxdb/influxdb
+VOLUME /tmp/artifacts

--- a/circle-test.sh
+++ b/circle-test.sh
@@ -53,6 +53,17 @@ case $CIRCLE_NODE_INDEX in
     0)
         go test $PARALLELISM $TIMEOUT -v ./... 2>&1 | tee $CIRCLE_ARTIFACTS/test_logs.txt
         rc=${PIPESTATUS[0]}
+        if [[ $rc != 0 ]]; then
+            exit $rc
+        fi
+
+        # 32bit tests. (Could be run on a separate node instead)
+        exit_if_fail docker build -f Dockerfile_test_ubuntu32 -t ubuntu-32-influxdb-test .
+        docker run -v $(pwd):/root/go/src/github.com/influxdb/influxdb \
+                        -v ${CIRCLE_ARTIFACTS}:/tmp/artifacts \
+                        -t ubuntu-32-influxdb-test bash \
+                        -c "cd /root/go/src/github.com/influxdb/influxdb && go get -t -d -v ./... && go build -v ./... && go test ${PARALLELISM} ${TIMEOUT} -v ./... 2>&1 | tee /tmp/artifacts/test_logs_i386.txt && exit \${PIPESTATUS[0]}"
+        rc=$?
         ;;
     1)
        GORACE="halt_on_error=1" go test $PARALLELISM $TIMEOUT -v -race ./... 2>&1 | tee $CIRCLE_ARTIFACTS/test_logs_race.txt

--- a/circle.yml
+++ b/circle.yml
@@ -1,4 +1,6 @@
 machine:
+    services:
+        - docker
     pre:
         - bash < <(curl -s -S -L https://raw.githubusercontent.com/moovweb/gvm/master/binscripts/gvm-installer)
         - source $HOME/.gvm/scripts/gvm; gvm install go1.4.2 --binary
@@ -6,6 +8,11 @@ machine:
 dependencies:
     override:
         - echo "Dummy override, so no Circle dependencies execute"
+        - if [[ -e ~/docker/image.tar ]]; then docker load -i ~/docker/image.tar; fi
+        - docker build -f Dockerfile_test_ubuntu32 -t ubuntu-32-influxdb-test .
+        - mkdir -p ~/docker; docker save ubuntu-32-influxdb-test > ~/docker/image.tar
+    cache_directories:
+        - "~/docker"
 test:
     override:
         - bash circle-test.sh:

--- a/test-32bit-docker.sh
+++ b/test-32bit-docker.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+docker build -f Dockerfile_test_ubuntu32 -t ubuntu-32-influxdb-test .
+docker run -v $(pwd):/root/go/src/github.com/influxdb/influxdb -t ubuntu-32-influxdb-test bash -c "cd /root/go/src/github.com/influxdb/influxdb && go get -t -d -v ./... && go build -v ./... && go test -v ./..."


### PR DESCRIPTION
I couldn't find any features on the CircleCI documentation to test on 32bit.

I have written a small script that uses a container to test on i386. Would you consider to add it to CircleCI?

I can do it myself if you guys want.

//cc @otoolep 