### PR TITLE
A gigabyte parsing testing only requires 2GB

### DIFF
--- a/toml/toml_test.go
+++ b/toml/toml_test.go
@@ -1,7 +1,6 @@
 package toml_test
 
 import (
-	"reflect"
 	"testing"
 
 	"github.com/influxdb/influxdb/toml"
@@ -19,14 +18,10 @@ func TestSize_UnmarshalText_MB(t *testing.T) {
 
 // Ensure that gigabyte sizes can be parsed.
 func TestSize_UnmarshalText_GB(t *testing.T) {
-	if typ := reflect.TypeOf(0); typ.Size() != 8 {
-		t.Skip("large gigabyte parsing on 64-bit arch only")
-	}
-
 	var s toml.Size
-	if err := s.UnmarshalText([]byte("10g")); err != nil {
+	if err := s.UnmarshalText([]byte("2g")); err != nil {
 		t.Fatalf("unexpected error: %s", err)
-	} else if s != 10*(1<<30) {
+	} else if s != 2147483648 {
 		t.Fatalf("unexpected size: %d", s)
 	}
 }


### PR DESCRIPTION
Fixes issue #3732.