### PR TITLE
Apply env overrideds for config command

### DIFF
--- a/cmd/influxd/run/config_command.go
+++ b/cmd/influxd/run/config_command.go
@@ -42,9 +42,19 @@ func (cmd *PrintConfigCommand) Run(args ...string) error {
 		return fmt.Errorf("parse config: %s", err)
 	}
 
+	// Apply any environment variables on top of the parsed config
+	if err := config.ApplyEnvOverrides(); err != nil {
+		return fmt.Errorf("apply env config: %v", err)
+	}
+
 	// Override config properties.
 	if *hostname != "" {
 		config.Meta.Hostname = *hostname
+	}
+
+	// Validate the configuration.
+	if err := config.Validate(); err != nil {
+		return fmt.Errorf("%s. To generate a valid configuration file run `influxd config > influxdb.generated.conf`.", err)
 	}
 
 	toml.NewEncoder(cmd.Stdout).Encode(config)


### PR DESCRIPTION
Matches the behavior of the run command and lets you test env var override values more easily.