### PR TITLE
Make the WAL cursor create a copy of the cache

### DIFF
--- a/tsdb/engine/wal/wal.go
+++ b/tsdb/engine/wal/wal.go
@@ -1309,7 +1309,10 @@ func (p *Partition) cursor(key string) *cursor {
 		entry.isDirtySort = false
 	}
 
-	return &cursor{cache: entry.points}
+	// build a copy so modifications to the partition don't change the result set
+	a := make([][]byte, len(entry.points))
+	copy(a, entry.points)
+	return &cursor{cache: a}
 }
 
 // idFromFileName parses the segment file ID from its name


### PR DESCRIPTION
I think this will fix the problem @jwilder and @jhorwit2 were mentioning about some inconsistent query results. Thoughts?