### PR TITLE
Close idle Graphite TCP connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## v0.9.4 [unreleased]
 
+### Features
+- [#3771](https://github.com/influxdb/influxdb/pull/3771): Close idle Graphite TCP connections
+
+### Bugfixes
+
 ## v0.9.3 [unreleased]
 
 ### Release Notes

--- a/etc/config.sample.toml
+++ b/etc/config.sample.toml
@@ -132,11 +132,14 @@ reporting-disabled = false
   # name-separator = "."
 
   # These next lines control how batching works. You should have this enabled
-  # otherwise you could get dropped metrics or poor performance. Batching 
+  # otherwise you could get dropped metrics or poor performance. Batching
   # will buffer points in memory if you have many coming in.
 
   # batch-size = 1000 # will flush if this many points get buffered
   # batch-timeout = "1s" # will flush at least this often even if we haven't hit buffer limit
+
+  # Time after which idle TCP connections will be closed. 0s for no timeout.
+  # tcp-conn-timeout = "900s"
 
   ## "name-schema" configures tag names for parsing the metric name from graphite protocol;
   ## separated by `name-separator`.

--- a/services/graphite/config.go
+++ b/services/graphite/config.go
@@ -31,6 +31,11 @@ const (
 
 	// DefaultBatchTimeout is the default Graphite batch timeout.
 	DefaultBatchTimeout = time.Second
+
+	// DefaultTCPConnTimeout is the time after which if no data is received on
+	// a TCP connection, the connection will close. Only applies when the protocol
+	// is TCP. 0 means no timeout.
+	DefaultTCPConnTimeout = 15 * time.Minute
 )
 
 // Config represents the configuration for Graphite endpoints.
@@ -41,6 +46,7 @@ type Config struct {
 	Protocol         string        `toml:"protocol"`
 	BatchSize        int           `toml:"batch-size"`
 	BatchTimeout     toml.Duration `toml:"batch-timeout"`
+	TCPTimeout       toml.Duration `toml:"tcp-conn-timeout"`
 	ConsistencyLevel string        `toml:"consistency-level"`
 	Templates        []string      `toml:"templates"`
 	Tags             []string      `toml:"tags"`
@@ -55,6 +61,7 @@ func NewConfig() Config {
 		Protocol:         DefaultProtocol,
 		BatchSize:        DefaultBatchSize,
 		BatchTimeout:     toml.Duration(DefaultBatchTimeout),
+		TCPTimeout:       toml.Duration(DefaultTCPConnTimeout),
 		ConsistencyLevel: DefaultConsistencyLevel,
 		Separator:        DefaultSeparator,
 	}

--- a/services/graphite/config_test.go
+++ b/services/graphite/config_test.go
@@ -18,6 +18,7 @@ enabled = true
 protocol = "tcp"
 batch-size=100
 batch-timeout="1s"
+tcp-conn-timeout="5s"
 consistency-level="one"
 templates=["servers.* .host.measurement*"]
 tags=["region=us-east"]
@@ -38,6 +39,8 @@ tags=["region=us-east"]
 		t.Fatalf("unexpected graphite batch size: %d", c.BatchSize)
 	} else if time.Duration(c.BatchTimeout) != time.Second {
 		t.Fatalf("unexpected graphite batch timeout: %v", c.BatchTimeout)
+	} else if time.Duration(c.TCPTimeout) != 5*time.Second {
+		t.Fatalf("unexpected idle TCP connection timeout: %v", c.TCPTimeout)
 	} else if c.ConsistencyLevel != "one" {
 		t.Fatalf("unexpected graphite consistency setting: %s", c.ConsistencyLevel)
 	}

--- a/services/graphite/service_test.go
+++ b/services/graphite/service_test.go
@@ -2,6 +2,7 @@ package graphite_test
 
 import (
 	"fmt"
+	"io"
 	"net"
 	"reflect"
 	"sync"
@@ -86,6 +87,52 @@ func Test_ServerGraphiteTCP(t *testing.T) {
 	}
 
 	wg.Wait()
+}
+
+func Test_ServerGraphiteTCPTimeout(t *testing.T) {
+	t.Parallel()
+
+	config := graphite.NewConfig()
+	config.Database = "graphitedb"
+	config.BindAddress = ":0"
+	config.TCPTimeout = toml.Duration(100 * time.Millisecond)
+
+	service, err := graphite.NewService(config)
+	if err != nil {
+		t.Fatalf("failed to create Graphite service: %s", err.Error())
+	}
+
+	pointsWriter := PointsWriter{
+		WritePointsFn: func(req *cluster.WritePointsRequest) error {
+			return nil
+		},
+	}
+	service.PointsWriter = &pointsWriter
+	dbCreator := DatabaseCreator{}
+	service.MetaStore = &dbCreator
+
+	if err := service.Open(); err != nil {
+		t.Fatalf("failed to open Graphite service: %s", err.Error())
+	}
+
+	if !dbCreator.Created {
+		t.Fatalf("failed to create target database")
+	}
+
+	// Connect to the graphite endpoint we just spun up
+	_, port, _ := net.SplitHostPort(service.Addr().String())
+	conn, err := net.Dial("tcp", "127.0.0.1:"+port)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// The only way to be sure a connection has closed is to try reading from it.
+	time.Sleep(200 * time.Millisecond)
+	data := make([]byte, 256)
+	_, err = conn.Read(data)
+	if err != io.EOF {
+		t.Fatal("expected Graphite write timeout error")
+	}
 }
 
 func Test_ServerGraphiteUDP(t *testing.T) {


### PR DESCRIPTION
With this change, idle TCP Graphite connections are closed. This frees up resources, if a sender has gone idle.

This timeout can be completely disabled if necessary.