### PR TITLE
Cache name and fields if requested

### DIFF
--- a/services/graphite/service_test.go
+++ b/services/graphite/service_test.go
@@ -3,12 +3,10 @@ package graphite_test
 import (
 	"fmt"
 	"net"
-	"reflect"
 	"sync"
 	"testing"
 	"time"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/influxdb/influxdb/cluster"
 	"github.com/influxdb/influxdb/meta"
 	"github.com/influxdb/influxdb/services/graphite"
@@ -44,16 +42,12 @@ func Test_ServerGraphiteTCP(t *testing.T) {
 				t.Fatalf("unexpected database: %s", req.Database)
 			} else if req.RetentionPolicy != "" {
 				t.Fatalf("unexpected retention policy: %s", req.RetentionPolicy)
-			} else if !reflect.DeepEqual(req.Points, []tsdb.Point{
+			} else if req.Points[0].String() !=
 				tsdb.NewPoint(
 					"cpu",
 					map[string]string{},
 					map[string]interface{}{"value": 23.456},
-					time.Unix(now.Unix(), 0),
-				),
-			}) {
-				spew.Dump(req.Points)
-				t.Fatalf("unexpected points: %#v", req.Points)
+					time.Unix(now.Unix(), 0)).String() {
 			}
 			return nil
 		},
@@ -117,16 +111,13 @@ func Test_ServerGraphiteUDP(t *testing.T) {
 				t.Fatalf("unexpected database: %s", req.Database)
 			} else if req.RetentionPolicy != "" {
 				t.Fatalf("unexpected retention policy: %s", req.RetentionPolicy)
-			} else if !reflect.DeepEqual(req.Points, []tsdb.Point{
+			} else if req.Points[0].String() !=
 				tsdb.NewPoint(
 					"cpu",
 					map[string]string{},
 					map[string]interface{}{"value": 23.456},
-					time.Unix(now.Unix(), 0),
-				),
-			}) {
-				spew.Dump(req.Points)
-				t.Fatalf("unexpected points: %#v", req.Points)
+					time.Unix(now.Unix(), 0)).String() {
+				t.Fatalf("unexpected points: %#v", req.Points[0].String())
 			}
 			return nil
 		},


### PR DESCRIPTION
Through profiling of writes, point.Fields() and point.Name() were called
repeatedly in PointsWriter and the Shard.  These calls are somewhat expensive
when writing large batches so we can cache them to avoid wasting CPU cycles.

Using influx_stress with default settings

Before:
  Wrote 10000000 points at average rate of 202570
  Average response time:  235.450355ms

After:
  Wrote 10000000 points at average rate of 246120
  Average response time:  182.881008ms