### PR TITLE
Optimize Point.unescape

### DIFF
--- a/tsdb/points.go
+++ b/tsdb/points.go
@@ -905,10 +905,38 @@ func escapeString(in string) string {
 }
 
 func unescape(in []byte) []byte {
-	for b, esc := range escapeCodes {
-		in = bytes.Replace(in, esc, []byte{b}, -1)
+	i := 0
+	inLen := len(in)
+	var out []byte
+
+	for {
+		if i >= inLen {
+			break
+		}
+		if in[i] == '\\' && i+1 < inLen {
+			switch in[i+1] {
+			case ',':
+				out = append(out, ',')
+				i += 2
+				continue
+			case '"':
+				out = append(out, '"')
+				i += 2
+				continue
+			case ' ':
+				out = append(out, ' ')
+				i += 2
+				continue
+			case '=':
+				out = append(out, '=')
+				i += 2
+				continue
+			}
+		}
+		out = append(out, in[i])
+		i += 1
 	}
-	return in
+	return out
 }
 
 func unescapeString(in string) string {


### PR DESCRIPTION
This func show up in profiling.  It's called frequently from multiple places and
can be made more efficient.  The previous implementation looped over the input
slice 4 times updating and returning a new slice each time.  This changes it to loop
once and create one result slice.

With influx_stress

Before:

  Wrote 10000000 points at average rate of 241750
  Average response time:  187.78968ms

After:

  Wrote 10000000 points at average rate of 254618
  Average response time:  172.235028ms