### PR TITLE
SELECT solely on time should return error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ Please see the *Features* section below for full details.
 - [#3736](https://github.com/influxdb/influxdb/pull/3736): Update shard group duration with retention policy changes. Thanks for the report @papylhomme
 - [#3539](https://github.com/influxdb/influxdb/issues/3539): parser incorrectly accepts NaN as numerical value, but not always
 - [#3790](https://github.com/influxdb/influxdb/pull/3790): Fix line protocol parsing equals in measurements and NaN values
+- [#3778](https://github.com/influxdb/influxdb/pull/3778): Don't panic if SELECT on time.
 
 ## v0.9.2 [2015-07-24]
 

--- a/cmd/influxd/run/server_test.go
+++ b/cmd/influxd/run/server_test.go
@@ -1394,6 +1394,11 @@ func TestServer_Query_Common(t *testing.T) {
 			exp:     fmt.Sprintf(`{"results":[{"series":[{"name":"cpu","columns":["time","value"],"values":[["%s",1]]}]}]}`, now.Format(time.RFC3339Nano)),
 		},
 		&Query{
+			name:    "explicitly selecting time and a valid measurement and field should succeed",
+			command: `SELECT time,value FROM db0.rp0.cpu`,
+			exp:     fmt.Sprintf(`{"results":[{"series":[{"name":"cpu","columns":["time","value"],"values":[["%s",1]]}]}]}`, now.Format(time.RFC3339Nano)),
+		},
+		&Query{
 			name:    "selecting a measurement that doesn't exist should result in empty set",
 			command: `SELECT value FROM db0.rp0.idontexist`,
 			exp:     `{"results":[{}]}`,

--- a/influxql/ast.go
+++ b/influxql/ast.go
@@ -1013,10 +1013,9 @@ func (s *SelectStatement) validate(tr targetRequirement) error {
 }
 
 func (s *SelectStatement) validateFields() error {
-	for _, f := range s.NamesInSelect() {
-		if f == "time" {
-			return fmt.Errorf("'time' is an invalid field for SELECT")
-		}
+	ns := s.NamesInSelect()
+	if len(ns) == 1 && ns[0] == "time" {
+		return fmt.Errorf("at least 1 non-time field must be queried")
 	}
 	return nil
 }

--- a/influxql/ast.go
+++ b/influxql/ast.go
@@ -985,6 +985,10 @@ func (s *SelectStatement) hasTimeDimensions(node Node) bool {
 }
 
 func (s *SelectStatement) validate(tr targetRequirement) error {
+	if err := s.validateFields(); err != nil {
+		return err
+	}
+
 	if err := s.validateDistinct(); err != nil {
 		return err
 	}
@@ -1005,6 +1009,15 @@ func (s *SelectStatement) validate(tr targetRequirement) error {
 		return err
 	}
 
+	return nil
+}
+
+func (s *SelectStatement) validateFields() error {
+	for _, f := range s.NamesInSelect() {
+		if f == "time" {
+			return fmt.Errorf("'time' is an invalid field for SELECT")
+		}
+	}
 	return nil
 }
 

--- a/influxql/parser_test.go
+++ b/influxql/parser_test.go
@@ -1206,7 +1206,7 @@ func TestParser_ParseStatement(t *testing.T) {
 		// Errors
 		{s: ``, err: `found EOF, expected SELECT, DELETE, SHOW, CREATE, DROP, GRANT, REVOKE, ALTER, SET at line 1, char 1`},
 		{s: `SELECT`, err: `found EOF, expected identifier, string, number, bool at line 1, char 8`},
-		{s: `SELECT time FROM myserie`, err: `'time' is an invalid field for SELECT`},
+		{s: `SELECT time FROM myseries`, err: `at least 1 non-time field must be queried`},
 		{s: `blah blah`, err: `found blah, expected SELECT, DELETE, SHOW, CREATE, DROP, GRANT, REVOKE, ALTER, SET at line 1, char 1`},
 		{s: `SELECT field1 X`, err: `found X, expected FROM at line 1, char 15`},
 		{s: `SELECT field1 FROM "series" WHERE X +;`, err: `found ;, expected identifier, string, number, bool at line 1, char 38`},

--- a/influxql/parser_test.go
+++ b/influxql/parser_test.go
@@ -1206,6 +1206,7 @@ func TestParser_ParseStatement(t *testing.T) {
 		// Errors
 		{s: ``, err: `found EOF, expected SELECT, DELETE, SHOW, CREATE, DROP, GRANT, REVOKE, ALTER, SET at line 1, char 1`},
 		{s: `SELECT`, err: `found EOF, expected identifier, string, number, bool at line 1, char 8`},
+		{s: `SELECT time FROM myserie`, err: `'time' is an invalid field for SELECT`},
 		{s: `blah blah`, err: `found blah, expected SELECT, DELETE, SHOW, CREATE, DROP, GRANT, REVOKE, ALTER, SET at line 1, char 1`},
 		{s: `SELECT field1 X`, err: `found X, expected FROM at line 1, char 15`},
 		{s: `SELECT field1 FROM "series" WHERE X +;`, err: `found ;, expected identifier, string, number, bool at line 1, char 38`},


### PR DESCRIPTION
Fixes #3010.

Simply check for `time` in the `SELECT` clause, and kick it back if the query contains it. Should this be a case-insensitive check?