### PR TITLE
Fix line protocol parsing equals in measurements and NaN values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,8 @@ Please see the *Features* section below for full details.
 - [#3681](https://github.com/influxdb/influxdb/issues/3682): Fix inserting string value with backslashes
 - [#3735](https://github.com/influxdb/influxdb/issues/3735): Append to small bz1 blocks
 - [#3736](https://github.com/influxdb/influxdb/pull/3736): Update shard group duration with retention policy changes. Thanks for the report @papylhomme
+- [#3539](https://github.com/influxdb/influxdb/issues/3539): parser incorrectly accepts NaN as numerical value, but not always
+- [#3790](https://github.com/influxdb/influxdb/pull/3790): Fix line protocol parsing equals in measurements and NaN values
 
 ## v0.9.2 [2015-07-24]
 

--- a/tsdb/points.go
+++ b/tsdb/points.go
@@ -615,14 +615,13 @@ func scanNumber(buf []byte, i int) (int, error) {
 		}
 
 		// NaN is a valid float
-		if i+3 < len(buf) && (buf[i] == 'N' || buf[i] == 'n') {
+		if i+2 < len(buf) && (buf[i] == 'N' || buf[i] == 'n') {
 			if (buf[i+1] == 'a' || buf[i+1] == 'A') && (buf[i+2] == 'N' || buf[i+2] == 'n') {
 				i += 3
 				continue
 			}
 			return i, fmt.Errorf("invalid number")
 		}
-
 		if !isNumeric(buf[i]) {
 			return i, fmt.Errorf("invalid number")
 		}

--- a/tsdb/points.go
+++ b/tsdb/points.go
@@ -257,7 +257,9 @@ func scanKey(buf []byte, i int) (int, []byte, error) {
 			break
 		}
 
-		if buf[i] == '=' {
+		// equals is special in the tags section.  It must be escaped if part of a tag name or value.
+		// It does not need to be escaped if part of the measurement.
+		if buf[i] == '=' && commas > 0 {
 			if i-1 < 0 || i-2 < 0 {
 				return i, buf[start:i], fmt.Errorf("missing tag name")
 			}

--- a/tsdb/points_test.go
+++ b/tsdb/points_test.go
@@ -632,6 +632,18 @@ func TestParsePointUnescape(t *testing.T) {
 			},
 			time.Unix(0, 0)))
 
+	// measurement, tag and tag value with equals
+	test(t, `cpu=load,equals\=foo=tag\=value value=1i`,
+		tsdb.NewPoint(
+			"cpu=load", // Not escaped
+			tsdb.Tags{
+				"equals=foo": "tag=value", // Tag and value unescaped
+			},
+			tsdb.Fields{
+				"value": 1,
+			},
+			time.Unix(0, 0)))
+
 }
 
 func TestParsePointWithTags(t *testing.T) {

--- a/tsdb/points_test.go
+++ b/tsdb/points_test.go
@@ -991,6 +991,17 @@ func TestNewPointNaN(t *testing.T) {
 			},
 			time.Unix(1, 0)),
 	)
+
+	test(t, `nan value=NaN`,
+		tsdb.NewPoint(
+			"nan",
+			tsdb.Tags{},
+			tsdb.Fields{
+				"value": math.NaN(),
+			},
+			time.Unix(0, 0)),
+	)
+
 }
 
 func TestNewPointLargeNumberOfTags(t *testing.T) {


### PR DESCRIPTION
Fixes a regression where measurement names with `=` would fail to parse.  Also fixes a bug where `NaN` could no be parsed if a timestamp was not also included in the line.  The `NaN` change only fixes the parsing.  There is still an issue querying for `NaN` values though.

Fixes #3539 