### PR TITLE
Mapper refactor

### DIFF
--- a/build-docker.sh
+++ b/build-docker.sh
@@ -1,7 +1,9 @@
-#!/bin/sh -x -e
+#!/bin/sh
+
+set -e -x
 
 GO_VER=${GO_VER:-1.5}
 
-docker run -it -v "$GOPATH":/gopath -v "$(pwd)":/app -e "GOPATH=/gopath" -w /app golang:$GO_VER sh -c 'CGO_ENABLED=0 go build -a --installsuffix cgo --ldflags="-s" -o influxd ./cmd/influxd'
+docker run -it -v "${GOPATH}":/gopath -v "$(pwd)":/app -e "GOPATH=/gopath" -w /app golang:$GO_VER sh -c 'CGO_ENABLED=0 go build -a --installsuffix cgo --ldflags="-s" -o influxd ./cmd/influxd'
 
 docker build -t influxdb .

--- a/cluster/service.go
+++ b/cluster/service.go
@@ -259,6 +259,7 @@ func (s *Service) processMapShardRequest(w io.Writer, buf []byte) error {
 		if err != nil {
 			return fmt.Errorf("next chunk: %s", err)
 		}
+
 		if chunk != nil {
 			b, err := json.Marshal(chunk)
 			if err != nil {
@@ -269,11 +270,12 @@ func (s *Service) processMapShardRequest(w io.Writer, buf []byte) error {
 
 		// Write to connection.
 		resp.SetCode(0)
+		v := chunk.(*tsdb.MapperOutput)
 		if err := writeMapShardResponseMessage(w, &resp); err != nil {
 			return err
 		}
 
-		if chunk == nil {
+		if v == nil {
 			// All mapper data sent.
 			return nil
 		}

--- a/cluster/service.go
+++ b/cluster/service.go
@@ -260,6 +260,9 @@ func (s *Service) processMapShardRequest(w io.Writer, buf []byte) error {
 			return fmt.Errorf("next chunk: %s", err)
 		}
 
+		// NOTE: Even if the chunk is nil, we still need to send one
+		// empty response to let the other side know we're out of data.
+
 		if chunk != nil {
 			b, err := json.Marshal(chunk)
 			if err != nil {
@@ -270,12 +273,11 @@ func (s *Service) processMapShardRequest(w io.Writer, buf []byte) error {
 
 		// Write to connection.
 		resp.SetCode(0)
-		v := chunk.(*tsdb.MapperOutput)
 		if err := writeMapShardResponseMessage(w, &resp); err != nil {
 			return err
 		}
 
-		if v == nil {
+		if chunk == nil {
 			// All mapper data sent.
 			return nil
 		}

--- a/cluster/shard_mapper_test.go
+++ b/cluster/shard_mapper_test.go
@@ -77,9 +77,13 @@ func TestShardWriter_RemoteMapper_Success(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to get next chunk from mapper: %s", err.Error())
 	}
-	output, ok := chunk.(*tsdb.MapperOutput)
+	b, ok := chunk.([]byte)
 	if !ok {
 		t.Fatal("chunk is not of expected type")
+	}
+	output := &tsdb.MapperOutput{}
+	if err := json.Unmarshal(b, output); err != nil {
+		t.Fatal(err)
 	}
 	if output.Name != "cpu" {
 		t.Fatalf("received output incorrect, exp: %v, got %v", expOutput, output)

--- a/tsdb/executor.go
+++ b/tsdb/executor.go
@@ -24,6 +24,7 @@ const (
 // Mapper is the interface all Mapper types must implement.
 type Mapper interface {
 	Open() error
+	SetRemote(m Mapper) error
 	TagSets() []string
 	Fields() []string
 	NextChunk() (interface{}, error)

--- a/tsdb/mapper.go
+++ b/tsdb/mapper.go
@@ -271,7 +271,10 @@ func (lm *LocalMapper) NextChunk() (interface{}, error) {
 		b, err := lm.remote.NextChunk()
 		if err != nil {
 			return nil, err
+		} else if b == nil {
+			return nil, nil
 		}
+
 		mo := &MapperOutput{}
 		if err := json.Unmarshal(b.([]byte), mo); err != nil {
 			return nil, err
@@ -293,7 +296,7 @@ func (lm *LocalMapper) NextChunk() (interface{}, error) {
 // nextChunkRaw returns the next chunk of data. Data comes in the same order as the
 // tags return by TagSets. A chunk never contains data for more than 1 tagset.
 // If there is no more data for any tagset, nil will be returned.
-func (lm *LocalMapper) nextChunkRaw() (*MapperOutput, error) {
+func (lm *LocalMapper) nextChunkRaw() (interface{}, error) {
 	var output *MapperOutput
 	for {
 		if lm.currCursorIndex == len(lm.cursors) {
@@ -335,7 +338,7 @@ func (lm *LocalMapper) nextChunkRaw() (*MapperOutput, error) {
 // for the current tagset. Tagsets are always processed in the same order as that
 // returned by AvailTagsSets(). When there is no more data for any tagset nil
 // is returned.
-func (lm *LocalMapper) nextChunkAgg() (*MapperOutput, error) {
+func (lm *LocalMapper) nextChunkAgg() (interface{}, error) {
 	var output *MapperOutput
 	for {
 		if lm.currCursorIndex == len(lm.cursors) {


### PR DESCRIPTION
This PR refactors remote shard mapping and fixes a couple bugs.

- Change `RemoteMapper` to be more generic and reusable by other types of mappers.
- Change `LocalMapper` to use a `RemoteMapper` to retrieve chunks from remote shards. Before this change, executors used `RemoteMapper` directly.
- Fix bug where select fields weren't being returned by `RemoteMapper`. (caused panic)
- Fix bug causing `processMapShardRequest` to spew unused responses over the network.