### PR TITLE
Fix invalid time stamp in graphite metric causes panic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 With this release InfluxDB is moving to Go 1.5.
 
 ### Features
+- [#3771](https://github.com/influxdb/influxdb/pull/3771): Close idle Graphite TCP connections
 - [#3755](https://github.com/influxdb/influxdb/issues/3755): Add option to build script. Thanks @fg2it
 - [#3863](https://github.com/influxdb/influxdb/pull/3863): Move to Go 1.5
 - [#3892](https://github.com/influxdb/influxdb/pull/3892): Support IF NOT EXISTS for CREATE DATABASE
@@ -16,6 +17,7 @@ With this release InfluxDB is moving to Go 1.5.
 - [#3996](https://github.com/influxdb/influxdb/pull/3996): Add statistics to httpd package
 
 ### Bugfixes
+- [#3785](https://github.com/influxdb/influxdb/issues/3785): Invalid time stamp in graphite metric causes panic
 - [#3804](https://github.com/influxdb/influxdb/pull/3804): init.d script fixes, fixes issue 3803.
 - [#3823](https://github.com/influxdb/influxdb/pull/3823): Deterministic ordering for first() and last()
 - [#3869](https://github.com/influxdb/influxdb/issues/3869): Seemingly deadlocked when ingesting metrics via graphite plugin

--- a/services/graphite/parser.go
+++ b/services/graphite/parser.go
@@ -11,7 +11,11 @@ import (
 	"github.com/influxdb/influxdb/tsdb"
 )
 
-var defaultTemplate *template
+var (
+	defaultTemplate *template
+	MinDate         = time.Date(1901, 12, 13, 0, 0, 0, 0, time.UTC)
+	MaxDate         = time.Date(2038, 1, 19, 0, 0, 0, 0, time.UTC)
+)
 
 func init() {
 	var err error
@@ -124,6 +128,9 @@ func (p *Parser) Parse(line string) (tsdb.Point, error) {
 		if unixTime != float64(-1) {
 			// Check if we have fractional seconds
 			timestamp = time.Unix(int64(unixTime), int64((unixTime-math.Floor(unixTime))*float64(time.Second)))
+			if timestamp.Before(MinDate) || timestamp.After(MaxDate) {
+				return nil, fmt.Errorf("timestamp out of range")
+			}
 		}
 	}
 


### PR DESCRIPTION
If a timestamp larger than the max epoch value was sent via
graphite it would cause the timestamp to overflow when it was
marshaled/unmarshaled back from the raft log.  The overflow caused
the shard group to get created with the wrong timestamp which caused
a panic when writing the point.  The panic was caused because the
timestamp that were supposed to exists in a map created by MapShards
did not actually exist so a nil ShardGroup was used.

The change prevents creating the point with an invalid timestamp.  Since
graphite using a timestamp in seconds, the maximum range is known and
can be prevented.  This also adds a check for the minimum range as well.

Fixes #3785