### PR TITLE
Enforce predictable order for first() and last()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bugfixes
 - [#3804](https://github.com/influxdb/influxdb/pull/3804): init.d script fixes, fixes issue 3803.
+- [#3823](https://github.com/influxdb/influxdb/pull/3823): Deterministic ordering for first() and last()
 
 ## v0.9.3 [unreleased]
 

--- a/influxql/functions.go
+++ b/influxql/functions.go
@@ -949,6 +949,8 @@ func MapFirst(itr Iterator) interface{} {
 		if k < out.Time {
 			out.Time = k
 			out.Val = v
+		} else if k == out.Time && greaterThan(v, out.Val) {
+			out.Val = v
 		}
 	}
 	if pointsYielded {
@@ -976,6 +978,8 @@ func ReduceFirst(values []interface{}) interface{} {
 		if val.Time < out.Time {
 			out.Time = val.Time
 			out.Val = val.Val
+		} else if val.Time == out.Time && greaterThan(val.Val, out.Val) {
+			out.Val = val.Val
 		}
 	}
 	if pointsYielded {
@@ -998,6 +1002,8 @@ func MapLast(itr Iterator) interface{} {
 		}
 		if k > out.Time {
 			out.Time = k
+			out.Val = v
+		} else if k == out.Time && greaterThan(v, out.Val) {
 			out.Val = v
 		}
 	}
@@ -1026,6 +1032,8 @@ func ReduceLast(values []interface{}) interface{} {
 		}
 		if val.Time > out.Time {
 			out.Time = val.Time
+			out.Val = val.Val
+		} else if val.Time == out.Time && greaterThan(val.Val, out.Val) {
 			out.Val = val.Val
 		}
 	}
@@ -1112,3 +1120,17 @@ type rawOutputs []*rawQueryMapOutput
 func (a rawOutputs) Len() int           { return len(a) }
 func (a rawOutputs) Less(i, j int) bool { return a[i].Time < a[j].Time }
 func (a rawOutputs) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+
+func greaterThan(a, b interface{}) bool {
+	switch t := a.(type) {
+	case int64:
+		return t > b.(int64)
+	case float64:
+		return t > b.(float64)
+	case string:
+		return t > b.(string)
+	case bool:
+		return t == true
+	}
+	return false
+}


### PR DESCRIPTION
When two or more points have the same timestamp during first() and last() aggregations, the tie is broken by taking the one with the larger value.

Solution thanks to @jwilder 