### PR TITLE
Remove unused buffer allocation

### DIFF
--- a/tsdb/engine/bz1/bz1.go
+++ b/tsdb/engine/bz1/bz1.go
@@ -598,7 +598,6 @@ func (tx *Tx) Cursor(key string) tsdb.Cursor {
 
 	c := &Cursor{
 		cursor: b.Cursor(),
-		buf:    make([]byte, DefaultBlockSize),
 	}
 
 	return tsdb.MultiCursor(walCursor, c)


### PR DESCRIPTION
The buffer allocation in bz1 was unused and I'm fairly certain that it
was harmful to performance if used. For queries that run through a bz1
block, needing to hold on to a 64kb block is expensive. Better to churn
on the allocator and have the blocks be released when they are unused
than to have 64kb hanging around for each series regardless of size.

Thanks to @jwilder for brainstorming this issue with me.