### PR TITLE
Allow queries to be looped

### DIFF
--- a/cmd/influxd/run/server_helpers_test.go
+++ b/cmd/influxd/run/server_helpers_test.go
@@ -232,6 +232,7 @@ type Query struct {
 	exp, act string
 	pattern  bool
 	skip     bool
+	repeat   int
 }
 
 // Execute runs the command and returns an err if it fails


### PR DESCRIPTION
Some queries may be subject to race conditions. This variable allows the
test to request that a query is executed multiple times, increasing the
chance that any race will be exposed.