### PR TITLE
Drop /opt from system paths

### DIFF
--- a/etc/config.sample.toml
+++ b/etc/config.sample.toml
@@ -16,7 +16,7 @@ reporting-disabled = false
 ###
 
 [meta]
-  dir = "/var/opt/influxdb/meta"
+  dir = "/var/influxdb/meta"
   hostname = "localhost"
   bind-address = ":8088"
   retention-autocreate = true
@@ -35,7 +35,7 @@ reporting-disabled = false
 ###
 
 [data]
-  dir = "/var/opt/influxdb/data"
+  dir = "/var/influxdb/data"
 
   # The following WAL settings are for the b1 storage engine used in 0.9.2. They won't
   # apply to any new shards created after upgrading to a version > 0.9.3.
@@ -44,7 +44,7 @@ reporting-disabled = false
   wal-partition-flush-delay = "2s" # The delay time between each WAL partition being flushed.
 
   # These are the WAL settings for the storage engine >= 0.9.3
-  wal-dir = "/var/opt/influxdb/wal"
+  wal-dir = "/var/influxdb/wal"
   wal-enable-logging = true
 
   # When a series in the WAL in-memory cache reaches this size in bytes it is marked as ready to
@@ -239,7 +239,7 @@ reporting-disabled = false
 
 [hinted-handoff]
   enabled = true
-  dir = "/var/opt/influxdb/hh"
+  dir = "/var/influxdb/hh"
   max-size = 1073741824
   max-age = "168h"
   retry-rate-limit = 0

--- a/package.sh
+++ b/package.sh
@@ -36,8 +36,8 @@ AWS_FILE=~/aws.conf
 
 INSTALL_ROOT_DIR=/opt/influxdb
 INFLUXDB_LOG_DIR=/var/log/influxdb
-INFLUXDB_DATA_DIR=/var/opt/influxdb
-CONFIG_ROOT_DIR=/etc/opt/influxdb
+INFLUXDB_DATA_DIR=/var/influxdb
+CONFIG_ROOT_DIR=/etc/influxdb
 
 SAMPLE_CONFIGURATION=etc/config.sample.toml
 INITD_SCRIPT=scripts/init.sh

--- a/scripts/influxdb.service
+++ b/scripts/influxdb.service
@@ -9,7 +9,7 @@ User=influxdb
 Group=influxdb
 LimitNOFILE=65536
 EnvironmentFile=-/etc/default/influxdb
-ExecStart=/opt/influxdb/influxd -config /etc/opt/influxdb/influxdb.conf $INFLUXD_OPTS
+ExecStart=/opt/influxdb/influxd -config /etc/influxdb/influxdb.conf $INFLUXD_OPTS
 Restart=on-failure
 
 [Install]

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -38,7 +38,7 @@ DAEMON=/opt/influxdb/influxd
 [ -x $DAEMON ] || exit 5
 
 # Configuration file
-CONFIG=/etc/opt/influxdb/influxdb.conf
+CONFIG=/etc/influxdb/influxdb.conf
 
 # PID file for the daemon
 PIDFILE=/var/run/influxdb/influxd.pid


### PR DESCRIPTION
While this is definitely not a bug I feel like using paths like `/etc/opt/influxdb` and `/var/opt/influxdb` is quite misleading as it is more accepted to simply use `/etc/[program name]` and `/var/[program name]`. I'm not entirely sure if this was a typo (and considering that logs are placed in `/var/log/influxdb` and not `/var/log/opt/influxdb` I'd guess this was a typo of some sort) or done intentionally but if there's no actual reason to add `/opt`, dropping it does look a little bit cleaner.