### PR TITLE
Use 4KB default block size for bz1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@ Please see the *Features* section below for full details.
 - [#3778](https://github.com/influxdb/influxdb/pull/3778): Don't panic if SELECT on time.
 - [#3824](https://github.com/influxdb/influxdb/issues/3824): tsdb.Point.MarshalBinary needs to support all number types
 - [#3828](https://github.com/influxdb/influxdb/pull/3828): Support all number types when decoding a point
+- [#3853](https://github.com/influxdb/influxdb/pull/3853): Use 4KB default block size for bz1
 
 ## v0.9.2 [2015-07-24]
 

--- a/tsdb/engine/bz1/bz1.go
+++ b/tsdb/engine/bz1/bz1.go
@@ -35,7 +35,7 @@ func init() {
 
 const (
 	// DefaultBlockSize is the default size of uncompressed points blocks.
-	DefaultBlockSize = 64 * 1024 // 64KB
+	DefaultBlockSize = 4 * 1024 // 4KB
 )
 
 // Ensure Engine implements the interface.


### PR DESCRIPTION
## Overview

This commit changes the default block size from 64KB to 4KB for `bz1`. This was lowered because small blocks were being uncompressed, merged, recompressed, and inserted for a large portion of updates. This became slower and slower over time until it reached the 64KB threshold. We moved to the 4KB threshold in order to lower the impact of this recompression.