### PR TITLE
Fix deadlock in metastore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,7 @@ Please see the *Features* section below for full details.
 - [#3824](https://github.com/influxdb/influxdb/issues/3824): tsdb.Point.MarshalBinary needs to support all number types
 - [#3828](https://github.com/influxdb/influxdb/pull/3828): Support all number types when decoding a point
 - [#3853](https://github.com/influxdb/influxdb/pull/3853): Use 4KB default block size for bz1
+- [#3607](https://github.com/influxdb/influxdb/issues/3607): Fix unable to query influxdb due to deadlock in metastore.  Thanks @ccutrer!
 
 ## v0.9.2 [2015-07-24]
 

--- a/meta/state.go
+++ b/meta/state.go
@@ -334,8 +334,6 @@ func (r *localRaft) leader() string {
 }
 
 func (r *localRaft) isLeader() bool {
-	r.store.mu.RLock()
-	defer r.store.mu.RUnlock()
 	if r.raft == nil {
 		return false
 	}


### PR DESCRIPTION
The interaction of continuous query service, the meta-store loading
and initializing raft state, and syncing node info could cause a
deadlock in some instances.  There was an extra read-lock taken by isLeader()
when it already had a read-lock.  Removing this extra lock fixes the startup
deadlock.

Fixes #3607