### PR TITLE
Move to Go 1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 ## v0.9.4 [unreleased]
 
+### Release Notes
+With this release InfluxDB is moving to Go 1.5.
+
 ### Features
+-[#3863](https://github.com/influxdb/influxdb/pull/3863): Move to Go 1.5
 
 ### Bugfixes
 - [#3804](https://github.com/influxdb/influxdb/pull/3804): init.d script fixes, fixes issue 3803.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,7 +79,7 @@ second to sign our CLA, which can be found
 
 Installing Go
 -------------
-InfluxDB requires Go 1.4 or greater.
+InfluxDB requires Go 1.5 or greater.
 
 At InfluxDB we find gvm, a Go version manager, useful for installing Go. For instructions
 on how to install it see [the gvm page on github](https://github.com/moovweb/gvm).
@@ -87,8 +87,8 @@ on how to install it see [the gvm page on github](https://github.com/moovweb/gvm
 After installing gvm you can install and set the default go version by
 running the following:
 
-    gvm install go1.4
-    gvm use go1.4 --default
+    gvm install go1.5
+    gvm use go1.5 --default
 
 Revision Control Systems
 ------
@@ -156,7 +156,7 @@ go install ./...
 To set the version and commit flags during the build pass the following to the build command:
 
 ```bash
--ldflags="-X main.version $VERSION -X main.branch $BRANCH -X main.commit $COMMIT"
+-ldflags="-X main.version $VERSION -X main.branch=$BRANCH -X main.commit=$COMMIT"
 ```
 
 where `$VERSION` is the version, `$BRANCH` is the branch, and `$COMMIT` is the git commit hash.

--- a/Dockerfile_test_ubuntu32
+++ b/Dockerfile_test_ubuntu32
@@ -1,7 +1,7 @@
 FROM 32bit/ubuntu:14.04
 
 RUN apt-get update && apt-get install -y python-software-properties software-properties-common git
-RUN add-apt-repository ppa:evarlast/golang1.4
+RUN add-apt-repository ppa:evarlast/golang1.5
 RUN apt-get update && apt-get install -y golang-go
 
 ENV GOPATH=/root/go

--- a/Dockerfile_test_ubuntu32
+++ b/Dockerfile_test_ubuntu32
@@ -2,7 +2,7 @@ FROM 32bit/ubuntu:14.04
 
 RUN apt-get update && apt-get install -y python-software-properties software-properties-common git
 RUN add-apt-repository ppa:evarlast/golang1.5
-RUN apt-get update && apt-get install -y golang-go
+RUN apt-get update && apt-get install -y -o Dpkg::Options::="--force-overwrite" golang-go
 
 ENV GOPATH=/root/go
 RUN mkdir -p /root/go/src/github.com/influxdb/influxdb

--- a/circle-test.sh
+++ b/circle-test.sh
@@ -5,7 +5,7 @@
 # build process for InfluxDB.
 
 BUILD_DIR=$HOME/influxdb-build
-GO_VERSION=go1.4.2
+GO_VERSION=go1.5
 PARALLELISM="-parallel 256"
 TIMEOUT="-timeout 480s"
 

--- a/circle.yml
+++ b/circle.yml
@@ -3,7 +3,7 @@ machine:
         - docker
     pre:
         - bash < <(curl -s -S -L https://raw.githubusercontent.com/moovweb/gvm/master/binscripts/gvm-installer)
-        - source $HOME/.gvm/scripts/gvm; gvm install go1.4.2 --binary
+        - source $HOME/.gvm/scripts/gvm; gvm install go1.5 --binary
 
 dependencies:
     override:

--- a/client/influxdb_test.go
+++ b/client/influxdb_test.go
@@ -517,8 +517,8 @@ func TestClient_Timeout(t *testing.T) {
 	_, err = c.Query(query)
 	if err == nil {
 		t.Fatalf("unexpected success.  expected timeout error")
-	} else if !strings.Contains(err.Error(), "use of closed network connection") {
-		t.Fatalf("unexpected error.  expected 'use of closed network connection' error, got %v", err)
+	} else if !strings.Contains(err.Error(), "request canceled") {
+		t.Fatalf("unexpected error.  expected 'request canceled' error, got %v", err)
 	}
 
 	confignotimeout := client.Config{URL: *u}

--- a/cmd/influxd/run/command.go
+++ b/cmd/influxd/run/command.go
@@ -71,9 +71,6 @@ func (cmd *Command) Run(args ...string) error {
 		return fmt.Errorf("write pid file: %s", err)
 	}
 
-	// Set parallelism.
-	runtime.GOMAXPROCS(runtime.NumCPU())
-
 	// Turn on block profiling to debug stuck databases
 	runtime.SetBlockProfileRate(int(1 * time.Second))
 

--- a/package.sh
+++ b/package.sh
@@ -57,7 +57,7 @@ if [ -z "$FPM" ]; then
     FPM=`which fpm`
 fi
 
-GO_VERSION="go1.4.2"
+GO_VERSION="go1.5"
 GOPATH_INSTALL=
 BINS=(
     influxd
@@ -190,7 +190,7 @@ do_build() {
         cleanup_exit 1
     fi
 
-    go install -a -ldflags="-X main.version $version -X main.branch $branch -X main.commit $commit" ./...
+    go install -a -ldflags="-X main.version $version -X main.branch=$branch -X main.commit=$commit" ./...
     if [ $? -ne 0 ]; then
         echo "Build failed, unable to create package -- aborting"
         cleanup_exit 1


### PR DESCRIPTION
This patch migrates InfluxDB to Go 1.5.

Very little had to change. The most significant change was to some unit test code, in which an interaction with Go's race detector was exposed. This was addressed using some explicit synchronization. The unit test was also split in two for clarity.

Only one small change to production code was required -- the explicit configuration of GOMAXPROCS.