### PR TITLE
Add shell option to start the daemon on CentOS

### DIFF
--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -151,7 +151,7 @@ case $1 in
         if which start-stop-daemon > /dev/null 2>&1; then
             start-stop-daemon --chuid $GROUP:$USER --start --quiet --pidfile $PIDFILE --exec $DAEMON -- -pidfile $PIDFILE -config $CONFIG $INFLUXD_OPTS >>$STDOUT 2>>$STDERR &
         else
-            su -c "nohup $DAEMON -pidfile $PIDFILE -config $CONFIG $INFLUXD_OPTS >>$STDOUT 2>>$STDERR &" $USER
+            su -s /bin/sh -c "nohup $DAEMON -pidfile $PIDFILE -config $CONFIG $INFLUXD_OPTS >>$STDOUT 2>>$STDERR &" $USER
         fi
         log_success_msg "$NAME process was started"
         ;;


### PR DESCRIPTION
Unless a valid shell for the user running influxdb, the command su fails with
the error:
 This account is currently not available.

The user shouldn't have a valid shell although the package creates influxdb
user with /bin/bash