### PR TITLE
Remove unused Database index names and sorting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bugfixes
 - [#3804](https://github.com/influxdb/influxdb/pull/3804): init.d script fixes, fixes issue 3803.
 - [#3823](https://github.com/influxdb/influxdb/pull/3823): Deterministic ordering for first() and last()
+- [#3869](https://github.com/influxdb/influxdb/issues/3869): Seemingly deadlocked when ingesting metrics via graphite plugin 
 
 ## v0.9.3 [2015-08-26]
 

--- a/tsdb/meta.go
+++ b/tsdb/meta.go
@@ -27,7 +27,6 @@ type DatabaseIndex struct {
 	mu           sync.RWMutex
 	measurements map[string]*Measurement // measurement name to object and index
 	series       map[string]*Series      // map series key to the Series object
-	names        []string                // sorted list of the measurement names
 	lastID       uint64                  // last used series ID. They're in memory only for this shard
 }
 
@@ -35,15 +34,7 @@ func NewDatabaseIndex() *DatabaseIndex {
 	return &DatabaseIndex{
 		measurements: make(map[string]*Measurement),
 		series:       make(map[string]*Series),
-		names:        make([]string, 0),
 	}
-}
-
-// Names returns a sorted list of measurement names.
-func (d *DatabaseIndex) Names() []string {
-	d.mu.RLock()
-	defer d.mu.RUnlock()
-	return d.names
 }
 
 // Series returns a series by key.
@@ -106,8 +97,6 @@ func (s *DatabaseIndex) CreateMeasurementIndexIfNotExists(name string) *Measurem
 	if m == nil {
 		m = NewMeasurement(name, s)
 		s.measurements[name] = m
-		s.names = append(s.names, name)
-		sort.Strings(s.names)
 	}
 	return m
 }
@@ -275,14 +264,6 @@ func (db *DatabaseIndex) DropMeasurement(name string) {
 	for _, s := range m.seriesByID {
 		delete(db.series, s.Key)
 	}
-
-	var names []string
-	for _, n := range db.names {
-		if n != name {
-			names = append(names, n)
-		}
-	}
-	db.names = names
 }
 
 // DropSeries removes the series keys and their tags from the index

--- a/tsdb/shard_test.go
+++ b/tsdb/shard_test.go
@@ -48,9 +48,6 @@ func TestShardWriteAndIndex(t *testing.T) {
 	}
 
 	validateIndex := func() {
-		if !reflect.DeepEqual(index.Names(), []string{"cpu"}) {
-			t.Fatalf("measurement names in shard didn't match")
-		}
 		if index.SeriesN() != 1 {
 			t.Fatalf("series wasn't in index")
 		}
@@ -125,9 +122,6 @@ func TestShardWriteAddNewField(t *testing.T) {
 		t.Fatalf(err.Error())
 	}
 
-	if !reflect.DeepEqual(index.Names(), []string{"cpu"}) {
-		t.Fatalf("measurement names in shard didn't match")
-	}
 	if index.SeriesN() != 1 {
 		t.Fatalf("series wasn't in index")
 	}


### PR DESCRIPTION
Writes could timeout and when adding new measurement names to the
index if the sort took a long time.  The names slice was never
actually used (except a test) so keeping it in the index wastes memory
and sorting it wastes CPU and increases lock contention.  The sorting
was happening while the shard held a write-lock.

Fixes #3869