### PR TITLE
Fix two panics in the WAL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ With this release InfluxDB is moving to Go 1.5.
 - [#3823](https://github.com/influxdb/influxdb/pull/3823): Deterministic ordering for first() and last()
 - [#3869](https://github.com/influxdb/influxdb/issues/3869): Seemingly deadlocked when ingesting metrics via graphite plugin
 - [#3856](https://github.com/influxdb/influxdb/pull/3856): Minor changes to retention enforcement.
+- [#3884](https://github.com/influxdb/influxdb/pull/3884): Fix two panics in WAL that can happen at server startup
 
 ## v0.9.3 [2015-08-26]
 

--- a/tsdb/engine/wal/wal.go
+++ b/tsdb/engine/wal/wal.go
@@ -177,12 +177,12 @@ func NewLog(path string) *Log {
 		ReadySeriesSize:        tsdb.DefaultReadySeriesSize,
 		partitionCount:         PartitionCount,
 		flushCheckInterval:     defaultFlushCheckInterval,
+		logger:                 log.New(os.Stderr, "[wal] ", log.LstdFlags),
 	}
 }
 
 // Open opens and initializes the Log. Will recover from previous unclosed shutdowns
 func (l *Log) Open() error {
-	l.logger = log.New(l.LogOutput, "[wal] ", log.LstdFlags)
 
 	if l.EnableLogging {
 		l.logger.Printf("WAL starting with %d ready series size, %0.2f compaction threshold, and %d partition size threshold\n", l.ReadySeriesSize, l.CompactionThreshold, l.PartitionSizeThreshold)
@@ -375,7 +375,7 @@ func (l *Log) readMetadataFile(fileName string) ([]*seriesAndFields, error) {
 			break
 		} else if err != nil {
 			// print the error and move on since we can't recover the file
-			l.logger.Println("error reading lenght of metadata:", err.Error())
+			l.logger.Println("error reading length of metadata:", err.Error())
 			break
 		}
 

--- a/tsdb/engine/wal/wal.go
+++ b/tsdb/engine/wal/wal.go
@@ -500,6 +500,9 @@ func (l *Log) openPartitionFiles() error {
 	for _, p := range l.partitions {
 
 		go func(p *Partition) {
+			p.mu.Lock()
+			defer p.mu.Unlock()
+
 			// Recover from a partial compaction.
 			if err := p.recoverCompactionFile(); err != nil {
 				results <- fmt.Errorf("recover compaction files: %s", err)


### PR DESCRIPTION
These are panics that occur when the server is starting but hits errors.  You can recreate them by truncating the metadata index file a few bytes.  I managed to get a truncated file locally from a bad shutdown.