### PR TITLE
Prevent write timeouts due to lock contention in WAL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ With this release InfluxDB is moving to Go 1.5.
 - [#3856](https://github.com/influxdb/influxdb/pull/3856): Minor changes to retention enforcement.
 - [#3884](https://github.com/influxdb/influxdb/pull/3884): Fix two panics in WAL that can happen at server startup
 - [#3868](https://github.com/influxdb/influxdb/pull/3868): Add shell option to start the daemon on CentOS. Thanks @SwannCroiset.
+- [#3886](https://github.com/influxdb/influxdb/pull/3886): Prevent write timeouts due to lock contention in WAL
 
 ## v0.9.3 [2015-08-26]
 

--- a/tsdb/engine/wal/wal.go
+++ b/tsdb/engine/wal/wal.go
@@ -238,9 +238,8 @@ func (l *Log) WritePoints(points []tsdb.Point, fields map[string]*tsdb.Measureme
 
 	// persist the raw point data
 	l.mu.RLock()
-	defer l.mu.RUnlock()
-
 	partitionsToWrite := l.pointsToPartitions(points)
+	l.mu.RUnlock()
 
 	for p, points := range partitionsToWrite {
 		if err := p.Write(points); err != nil {

--- a/tsdb/engine/wal/wal.go
+++ b/tsdb/engine/wal/wal.go
@@ -719,7 +719,7 @@ func (l *Log) partition(key []byte) *Partition {
 type Partition struct {
 	id                 uint8
 	path               string
-	mu                 sync.Mutex
+	mu                 sync.RWMutex
 	currentSegmentFile *os.File
 	currentSegmentSize int64
 	currentSegmentID   uint32
@@ -809,8 +809,8 @@ func (p *Partition) Close() error {
 func (p *Partition) Write(points []tsdb.Point) error {
 
 	if func() bool {
-		p.mu.Lock()
-		defer p.mu.Unlock()
+		p.mu.RLock()
+		defer p.mu.RUnlock()
 		// pause writes for a bit if we've hit the size threshold
 		if p.memorySize > p.sizeThreshold {
 			return true


### PR DESCRIPTION
When disk operations slow down or the amount of work required to flush writes to the index takes too long, the lock contention on the WAL can cause timeouts for writes.  The PR reduces some the contention for some of the locks when these timeouts occur and prevents write timeouts in scenarios.