### PR TITLE
Make the startup log message actually first

### DIFF
--- a/cmd/influxd/run/command.go
+++ b/cmd/influxd/run/command.go
@@ -66,6 +66,10 @@ func (cmd *Command) Run(args ...string) error {
 	// Print sweet InfluxDB logo.
 	fmt.Print(logo)
 
+	// Mark start-up in log.
+	log.Printf("InfluxDB starting, version %s, branch %s, commit %s", cmd.Version, cmd.Branch, cmd.Commit)
+	log.Printf("Go version %s, GOMAXPROCS set to %d", runtime.Version(), runtime.GOMAXPROCS(0))
+
 	// Write the PID file.
 	if err := cmd.writePIDFile(options.PIDFile); err != nil {
 		return fmt.Errorf("write pid file: %s", err)
@@ -110,10 +114,6 @@ func (cmd *Command) Run(args ...string) error {
 		return fmt.Errorf("open server: %s", err)
 	}
 	cmd.Server = s
-
-	// Mark start-up in log.
-	log.Printf("InfluxDB starting, version %s, branch %s, commit %s", cmd.Version, cmd.Branch, cmd.Commit)
-	log.Printf("Go version %s, GOMAXPROCS set to %d", runtime.Version(), runtime.GOMAXPROCS(0))
 
 	// Begin monitoring the server's error channel.
 	go cmd.monitorServerErrors()
@@ -187,11 +187,11 @@ func (cmd *Command) writePIDFile(path string) error {
 func (cmd *Command) ParseConfig(path string) (*Config, error) {
 	// Use demo configuration if no config path is specified.
 	if path == "" {
-		fmt.Fprintln(cmd.Stdout, "no configuration provided, using default settings")
+		log.Println("no configuration provided, using default settings")
 		return NewDemoConfig()
 	}
 
-	fmt.Fprintf(cmd.Stdout, "Using configuration at: %s\n", path)
+	log.Println("Using configuration at: %s\n", path)
 
 	config := NewConfig()
 	if _, err := toml.DecodeFile(path, &config); err != nil {


### PR DESCRIPTION
With this change, the very first message in the logs is:

```
2015/08/28 15:08:47 InfluxDB starting, version 0.9, branch unknown, commit unknown
```