### PR TITLE
Make the startup log message actually first

### DIFF
--- a/cmd/influxd/run/command.go
+++ b/cmd/influxd/run/command.go
@@ -66,6 +66,10 @@ func (cmd *Command) Run(args ...string) error {
 	// Print sweet InfluxDB logo.
 	fmt.Print(logo)
 
+	// Mark start-up in log.
+	log.Printf("InfluxDB starting, version %s, branch %s, commit %s", cmd.Version, cmd.Branch, cmd.Commit)
+	log.Printf("Go version %s, GOMAXPROCS set to %d", runtime.Version(), runtime.GOMAXPROCS(0))
+
 	// Write the PID file.
 	if err := cmd.writePIDFile(options.PIDFile); err != nil {
 		return fmt.Errorf("write pid file: %s", err)
@@ -110,10 +114,6 @@ func (cmd *Command) Run(args ...string) error {
 		return fmt.Errorf("open server: %s", err)
 	}
 	cmd.Server = s
-
-	// Mark start-up in log.
-	log.Printf("InfluxDB starting, version %s, branch %s, commit %s", cmd.Version, cmd.Branch, cmd.Commit)
-	log.Printf("Go version %s, GOMAXPROCS set to %d", runtime.Version(), runtime.GOMAXPROCS(0))
 
 	// Begin monitoring the server's error channel.
 	go cmd.monitorServerErrors()
@@ -187,11 +187,11 @@ func (cmd *Command) writePIDFile(path string) error {
 func (cmd *Command) ParseConfig(path string) (*Config, error) {
 	// Use demo configuration if no config path is specified.
 	if path == "" {
-		fmt.Fprintln(cmd.Stdout, "no configuration provided, using default settings")
+		log.Println("no configuration provided, using default settings")
 		return NewDemoConfig()
 	}
 
-	fmt.Fprintf(cmd.Stdout, "Using configuration at: %s\n", path)
+	log.Printf("Using configuration at: %s\n", path)
 
 	config := NewConfig()
 	if _, err := toml.DecodeFile(path, &config); err != nil {


### PR DESCRIPTION
With this change, the messages below are actually first in the log:

```
 8888888           .d888 888                   8888888b.  888888b.
   888            d88P"  888                   888  "Y88b 888  "88b
   888            888    888                   888    888 888  .88P
   888   88888b.  888888 888 888  888 888  888 888    888 8888888K.
   888   888 "88b 888    888 888  888  Y8bd8P' 888    888 888  "Y88b
   888   888  888 888    888 888  888   X88K   888    888 888    888
   888   888  888 888    888 Y88b 888 .d8""8b. 888  .d88P 888   d88P
 8888888 888  888 888    888  "Y88888 888  888 8888888P"  8888888P"

2015/08/28 15:10:43 InfluxDB starting, version 0.9, branch unknown, commit unknown
2015/08/28 15:11:12 Go version go1.5, GOMAXPROCS set to 8
2015/08/28 15:11:12 no configuration provided, using default settings
```
