### PR TITLE
CREATE DATABASE [IF NOT EXISTS] ...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ With this release InfluxDB is moving to Go 1.5.
 
 ### Features
 - [#3863](https://github.com/influxdb/influxdb/pull/3863): Move to Go 1.5
+- [#3892](https://github.com/influxdb/influxdb/pull/3892): Support IF NOT EXISTS for CREATE DATABASE
 
 ### Bugfixes
 - [#3804](https://github.com/influxdb/influxdb/pull/3804): init.d script fixes, fixes issue 3803.

--- a/cmd/influxd/run/server_test.go
+++ b/cmd/influxd/run/server_test.go
@@ -52,8 +52,28 @@ func TestServer_DatabaseCommands(t *testing.T) {
 				exp:     `{"results":[{"error":"database already exists"}]}`,
 			},
 			&Query{
-				name:    "drop database should succeed",
+				name:    "create database should not error with existing database with IF NOT EXISTS",
+				command: `CREATE DATABASE IF NOT EXISTS db0`,
+				exp:     `{"results":[{}]}`,
+			},
+			&Query{
+				name:    "create database should create non-existing database with IF NOT EXISTS",
+				command: `CREATE DATABASE IF NOT EXISTS db1`,
+				exp:     `{"results":[{}]}`,
+			},
+			&Query{
+				name:    "show database should succeed",
+				command: `SHOW DATABASES`,
+				exp:     `{"results":[{"series":[{"name":"databases","columns":["name"],"values":[["db0"],["db1"]]}]}]}`,
+			},
+			&Query{
+				name:    "drop database db0 should succeed",
 				command: `DROP DATABASE db0`,
+				exp:     `{"results":[{}]}`,
+			},
+			&Query{
+				name:    "drop database db1 should succeed",
+				command: `DROP DATABASE db1`,
 				exp:     `{"results":[{}]}`,
 			},
 			&Query{

--- a/influxql/INFLUXQL.md
+++ b/influxql/INFLUXQL.md
@@ -87,11 +87,11 @@ CREATE       CONTINUOUS   DATABASE     DATABASES    DEFAULT      DELETE
 DESC         DROP         DURATION     END          EXISTS       EXPLAIN
 FIELD        FROM         GRANT        GROUP        IF           IN
 INNER        INSERT       INTO         KEY          KEYS         LIMIT
-SHOW         MEASUREMENT  MEASUREMENTS OFFSET       ON           ORDER
-PASSWORD     POLICY       POLICIES     PRIVILEGES   QUERIES      QUERY
-READ         REPLICATION  RETENTION    REVOKE       SELECT       SERIES
-SLIMIT       SOFFSET      TAG          TO           USER         USERS
-VALUES       WHERE        WITH         WRITE
+SHOW         MEASUREMENT  MEASUREMENTS NOT          OFFSET       ON
+ORDER        PASSWORD     POLICY       POLICIES     PRIVILEGES   QUERIES
+QUERY        READ         REPLICATION  RETENTION    REVOKE       SELECT
+SERIES       SLIMIT       SOFFSET      TAG          TO           USER
+USERS        VALUES       WHERE        WITH         WRITE
 ```
 
 ## Literals

--- a/influxql/ast.go
+++ b/influxql/ast.go
@@ -302,12 +302,19 @@ func (a SortFields) String() string {
 type CreateDatabaseStatement struct {
 	// Name of the database to be created.
 	Name string
+
+	// IfNotExists indicates whether to return without error if the database
+	// already exists.
+	IfNotExists bool
 }
 
 // String returns a string representation of the create database statement.
 func (s *CreateDatabaseStatement) String() string {
 	var buf bytes.Buffer
 	_, _ = buf.WriteString("CREATE DATABASE ")
+	if s.IfNotExists {
+		_, _ = buf.WriteString("IF NOT EXISTS ")
+	}
 	_, _ = buf.WriteString(s.Name)
 	return buf.String()
 }

--- a/influxql/parser.go
+++ b/influxql/parser.go
@@ -1252,11 +1252,8 @@ func (p *Parser) parseCreateDatabaseStatement() (*CreateDatabaseStatement, error
 
 	// Look for "IF NOT EXISTS"
 	if tok, _, _ := p.scanIgnoreWhitespace(); tok == IF {
-		if tok, pos, lit := p.scanIgnoreWhitespace(); tok != NOT {
-			return nil, newParseError(tokstr(tok, lit), []string{"NOT"}, pos)
-		}
-		if tok, pos, lit := p.scanIgnoreWhitespace(); tok != EXISTS {
-			return nil, newParseError(tokstr(tok, lit), []string{"EXISTS"}, pos)
+		if err := p.parseTokens([]Token{NOT, EXISTS}); err != nil {
+			return nil, err
 		}
 		stmt.IfNotExists = true
 	} else {

--- a/influxql/parser.go
+++ b/influxql/parser.go
@@ -1250,6 +1250,19 @@ func (p *Parser) parseCreateContinuousQueryStatement() (*CreateContinuousQuerySt
 func (p *Parser) parseCreateDatabaseStatement() (*CreateDatabaseStatement, error) {
 	stmt := &CreateDatabaseStatement{}
 
+	// Look for "IF NOT EXISTS"
+	if tok, _, _ := p.scanIgnoreWhitespace(); tok == IF {
+		if tok, pos, lit := p.scanIgnoreWhitespace(); tok != NOT {
+			return nil, newParseError(tokstr(tok, lit), []string{"NOT"}, pos)
+		}
+		if tok, pos, lit := p.scanIgnoreWhitespace(); tok != EXISTS {
+			return nil, newParseError(tokstr(tok, lit), []string{"EXISTS"}, pos)
+		}
+		stmt.IfNotExists = true
+	} else {
+		p.unscan()
+	}
+
 	// Parse the name of the database to be created.
 	lit, err := p.parseIdent()
 	if err != nil {

--- a/influxql/parser_test.go
+++ b/influxql/parser_test.go
@@ -925,7 +925,15 @@ func TestParser_ParseStatement(t *testing.T) {
 		{
 			s: `CREATE DATABASE testdb`,
 			stmt: &influxql.CreateDatabaseStatement{
-				Name: "testdb",
+				Name:        "testdb",
+				IfNotExists: false,
+			},
+		},
+		{
+			s: `CREATE DATABASE IF NOT EXISTS testdb`,
+			stmt: &influxql.CreateDatabaseStatement{
+				Name:        "testdb",
+				IfNotExists: true,
 			},
 		},
 
@@ -1276,6 +1284,10 @@ func TestParser_ParseStatement(t *testing.T) {
 		{s: `CREATE CONTINUOUS`, err: `found EOF, expected QUERY at line 1, char 19`},
 		{s: `CREATE CONTINUOUS QUERY`, err: `found EOF, expected identifier at line 1, char 25`},
 		{s: `DROP FOO`, err: `found FOO, expected SERIES, CONTINUOUS, MEASUREMENT at line 1, char 6`},
+		{s: `CREATE DATABASE`, err: `found EOF, expected identifier at line 1, char 17`},
+		{s: `CREATE DATABASE IF`, err: `found EOF, expected NOT at line 1, char 20`},
+		{s: `CREATE DATABASE IF NOT`, err: `found EOF, expected EXISTS at line 1, char 24`},
+		{s: `CREATE DATABASE IF NOT EXISTS`, err: `found EOF, expected identifier at line 1, char 31`},
 		{s: `DROP DATABASE`, err: `found EOF, expected identifier at line 1, char 15`},
 		{s: `DROP RETENTION`, err: `found EOF, expected POLICY at line 1, char 16`},
 		{s: `DROP RETENTION POLICY`, err: `found EOF, expected identifier at line 1, char 23`},

--- a/influxql/scanner_test.go
+++ b/influxql/scanner_test.go
@@ -138,6 +138,7 @@ func TestScanner_Scan(t *testing.T) {
 		{s: `SHOW`, tok: influxql.SHOW},
 		{s: `MEASUREMENT`, tok: influxql.MEASUREMENT},
 		{s: `MEASUREMENTS`, tok: influxql.MEASUREMENTS},
+		{s: `NOT`, tok: influxql.NOT},
 		{s: `OFFSET`, tok: influxql.OFFSET},
 		{s: `ON`, tok: influxql.ON},
 		{s: `ORDER`, tok: influxql.ORDER},

--- a/influxql/token.go
+++ b/influxql/token.go
@@ -91,6 +91,7 @@ const (
 	LIMIT
 	MEASUREMENT
 	MEASUREMENTS
+	NOT
 	OFFSET
 	ON
 	ORDER
@@ -198,6 +199,7 @@ var tokens = [...]string{
 	LIMIT:        "LIMIT",
 	MEASUREMENT:  "MEASUREMENT",
 	MEASUREMENTS: "MEASUREMENTS",
+	NOT:          "NOT",
 	OFFSET:       "OFFSET",
 	ON:           "ON",
 	ORDER:        "ORDER",

--- a/meta/statement_executor.go
+++ b/meta/statement_executor.go
@@ -89,6 +89,9 @@ func (e *StatementExecutor) ExecuteStatement(stmt influxql.Statement) *influxql.
 
 func (e *StatementExecutor) executeCreateDatabaseStatement(q *influxql.CreateDatabaseStatement) *influxql.Result {
 	_, err := e.Store.CreateDatabase(q.Name)
+	if err == ErrDatabaseExists && q.IfNotExists {
+		err = nil
+	}
 	return &influxql.Result{Err: err}
 }
 


### PR DESCRIPTION
Add support for optional `IF NOT EXISTS` to `CREATE DATABASE` command. This is generally useful to ensure a database exists with a default retention policy, without having to bother with error checking.

It is also specifically useful for the upcoming monitoring functionality.

This was also requested in https://github.com/influxdb/influxdb/issues/2458 and follows the pattern of mysql and sqlite.