### PR TITLE
Unblock relaxed write consistency level

### DIFF
--- a/cluster/points_writer.go
+++ b/cluster/points_writer.go
@@ -233,7 +233,11 @@ func (w *PointsWriter) writeToShard(shard *meta.ShardInfo, database, retentionPo
 	}
 
 	// response channel for each shard writer go routine
-	ch := make(chan error, len(shard.Owners))
+	type AsyncWriteResult struct {
+		Owner  meta.ShardOwner
+		Err    error
+	}
+	ch := make(chan *AsyncWriteResult, len(shard.Owners))
 
 	for _, owner := range shard.Owners {
 		go func(shardID uint64, owner meta.ShardOwner, points []tsdb.Point) {
@@ -244,12 +248,12 @@ func (w *PointsWriter) writeToShard(shard *meta.ShardInfo, database, retentionPo
 				if err == tsdb.ErrShardNotFound {
 					err = w.TSDBStore.CreateShard(database, retentionPolicy, shardID)
 					if err != nil {
-						ch <- err
+						ch <- &AsyncWriteResult{owner, err}
 						return
 					}
 					err = w.TSDBStore.WriteToShard(shardID, points)
 				}
-				ch <- err
+				ch <- &AsyncWriteResult{owner, err}
 				return
 			}
 
@@ -262,11 +266,11 @@ func (w *PointsWriter) writeToShard(shard *meta.ShardInfo, database, retentionPo
 				// be considered a successful write so send nil to the response channel
 				// otherwise, let the original error propogate to the response channel
 				if hherr == nil && consistency == ConsistencyLevelAny {
-					ch <- nil
+					ch <- &AsyncWriteResult{owner, nil}
 					return
 				}
 			}
-			ch <- err
+			ch <- &AsyncWriteResult{owner, err}
 
 		}(shard.ID, owner, points)
 	}
@@ -274,32 +278,32 @@ func (w *PointsWriter) writeToShard(shard *meta.ShardInfo, database, retentionPo
 	var wrote int
 	timeout := time.After(w.WriteTimeout)
 	var writeError error
-	for _, owner := range shard.Owners {
+	for range shard.Owners {
 		select {
 		case <-w.closing:
 			return ErrWriteFailed
 		case <-timeout:
 			// return timeout error to caller
 			return ErrTimeout
-		case err := <-ch:
+		case result := <-ch:
 			// If the write returned an error, continue to the next response
-			if err != nil {
-				w.Logger.Printf("write failed for shard %d on node %d: %v", shard.ID, owner.NodeID, err)
+			if result.Err != nil {
+				w.Logger.Printf("write failed for shard %d on node %d: %v", shard.ID, result.Owner.NodeID, result.Err)
 
 				// Keep track of the first error we see to return back to the client
 				if writeError == nil {
-					writeError = err
+					writeError = result.Err
 				}
 				continue
 			}
 
 			wrote += 1
-		}
-	}
 
-	// We wrote the required consistency level
-	if wrote >= required {
-		return nil
+			// We wrote the required consistency level
+			if wrote >= required {
+				return nil
+			}
+		}
 	}
 
 	if wrote > 0 {


### PR DESCRIPTION
This pull request contains two commits; one introducing an option in cmd/influx to select write consistency level, which has been set to 'any' by default, and another fixing writes possibly blocked even with relaxed write consistency level (e.g. any, one, or quorum).

Assume you have a 3-node cluster and one of those nodes went down. Write requests with write consistency level more relaxed than, or equal to quorum, should be completed immediately and successfully. But, the requests are possibly blocked waiting the dead node to respond.
