### PR TITLE
Fix panic when querying against not-fully replicated shards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ With this release InfluxDB is moving to Go 1.5.
 - [#3884](https://github.com/influxdb/influxdb/pull/3884): Fix two panics in WAL that can happen at server startup
 - [#3868](https://github.com/influxdb/influxdb/pull/3868): Add shell option to start the daemon on CentOS. Thanks @SwannCroiset.
 - [#3886](https://github.com/influxdb/influxdb/pull/3886): Prevent write timeouts due to lock contention in WAL
+- [#3574](https://github.com/influxdb/influxdb/issues/3574): Querying data node causes panic
 
 ## v0.9.3 [2015-08-26]
 

--- a/cluster/shard_mapper_test.go
+++ b/cluster/shard_mapper_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"testing"
 
 	"github.com/influxdb/influxdb/influxql"
@@ -13,6 +14,7 @@ import (
 
 // remoteShardResponder implements the remoteShardConn interface.
 type remoteShardResponder struct {
+	net.Conn
 	t       *testing.T
 	rxBytes []byte
 
@@ -41,8 +43,7 @@ func newRemoteShardResponder(outputs []*tsdb.MapperOutput, tagsets []string) *re
 	return r
 }
 
-func (r remoteShardResponder) MarkUnusable() { return }
-func (r remoteShardResponder) Close() error  { return nil }
+func (r remoteShardResponder) Close() error { return nil }
 func (r remoteShardResponder) Read(p []byte) (n int, err error) {
 	return io.ReadFull(r.buffer, p)
 }

--- a/tsdb/mapper.go
+++ b/tsdb/mapper.go
@@ -88,6 +88,12 @@ func (lm *SelectMapper) Open() error {
 		return lm.remote.Open()
 	}
 
+	// This can happen when a shard has been assigned to this node but we have not
+	// written to it so it may not exist yet.
+	if lm.shard == nil {
+		return nil
+	}
+
 	var err error
 
 	// Get a read-only transaction.

--- a/tsdb/show_measurements.go
+++ b/tsdb/show_measurements.go
@@ -29,9 +29,6 @@ func (e *ShowMeasurementsExecutor) Execute() <-chan *influxql.Row {
 	// Create output channel and stream data in a separate goroutine.
 	out := make(chan *influxql.Row, 0)
 
-	// It's important that all resources are released when execution completes.
-	defer e.close()
-
 	go func() {
 		// Open the mappers.
 		for _, m := range e.mappers {
@@ -104,6 +101,8 @@ func (e *ShowMeasurementsExecutor) Execute() <-chan *influxql.Row {
 		}
 
 		close(out)
+		// It's important that all resources are released when execution completes.
+		e.close()
 	}()
 	return out
 }

--- a/tsdb/show_measurements.go
+++ b/tsdb/show_measurements.go
@@ -144,18 +144,20 @@ func (m *ShowMeasurementsMapper) Open() error {
 
 	var measurements Measurements
 
-	// If a WHERE clause was specified, filter the measurements.
-	if m.stmt.Condition != nil {
-		var err error
-		measurements, err = m.shard.index.measurementsByExpr(m.stmt.Condition)
-		if err != nil {
-			return err
+	if m.shard != nil {
+		// If a WHERE clause was specified, filter the measurements.
+		if m.stmt.Condition != nil {
+			var err error
+			measurements, err = m.shard.index.measurementsByExpr(m.stmt.Condition)
+			if err != nil {
+				return err
+			}
+		} else {
+			// Otherwise, get all measurements from the database.
+			measurements = m.shard.index.Measurements()
 		}
-	} else {
-		// Otherwise, get all measurements from the database.
-		measurements = m.shard.index.Measurements()
+		sort.Sort(measurements)
 	}
-	sort.Sort(measurements)
 
 	// Create a channel to send measurement names on.
 	ch := make(chan string)

--- a/tsdb/store.go
+++ b/tsdb/store.go
@@ -305,10 +305,6 @@ func (s *Store) WriteToShard(shardID uint64, points []Point) error {
 
 func (s *Store) CreateMapper(shardID uint64, stmt influxql.Statement, chunkSize int) (Mapper, error) {
 	shard := s.Shard(shardID)
-	if shard == nil {
-		// This can happen if the shard has been assigned, but hasn't actually been created yet.
-		return nil, nil
-	}
 
 	switch st := stmt.(type) {
 	case *influxql.SelectStatement:


### PR DESCRIPTION
The TSDBStore was returning a nil mapper if the shard did not exist.  The caller always
assumed the mapper would not be nil causing a panic.  Instead, have the mapper skip the mapping
phase if it's shard reference is nil.  This fixes queries against data-only nodes and against
shards that are not fully replicated in the cluster.

Fixes #3574