### PR TITLE
only look at the first value for first()

### DIFF
--- a/influxql/functions.go
+++ b/influxql/functions.go
@@ -935,28 +935,20 @@ type firstLastMapOutput struct {
 }
 
 // MapFirst collects the values to pass to the reducer
+// This function assumes time ordered input
 func MapFirst(itr Iterator) interface{} {
-	out := &firstLastMapOutput{}
-	pointsYielded := false
-
-	for k, v := itr.Next(); k != -1; k, v = itr.Next() {
-		// Initialize first
-		if !pointsYielded {
-			out.Time = k
-			out.Val = v
-			pointsYielded = true
-		}
-		if k < out.Time {
-			out.Time = k
-			out.Val = v
-		} else if k == out.Time && greaterThan(v, out.Val) {
-			out.Val = v
-		}
+	k, v := itr.Next()
+	if k == -1 {
+		return nil
 	}
-	if pointsYielded {
-		return out
-	}
-	return nil
+	nextk, nextv := itr.Next()
+	for nextk == k {
+		if greaterThan(nextv, v) {
+			v = nextv
+		}
+		nextk, nextv = itr.Next()
+	} 
+	return &firstLastMapOutput{k, v}
 }
 
 // ReduceFirst computes the first of value.


### PR DESCRIPTION
Since we set up the aggregate queries so that iterator is ordered,
we only need to look at the first value. This cuts about 10 seconds
off a large single series query running first.