### PR TITLE
Convert meta shard owners to objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ With this release InfluxDB is moving to Go 1.5.
 - [#3868](https://github.com/influxdb/influxdb/pull/3868): Add shell option to start the daemon on CentOS. Thanks @SwannCroiset.
 - [#3886](https://github.com/influxdb/influxdb/pull/3886): Prevent write timeouts due to lock contention in WAL
 - [#3574](https://github.com/influxdb/influxdb/issues/3574): Querying data node causes panic
+- [#3913](https://github.com/influxdb/influxdb/issues/3913): Convert meta shard owners to objects
 
 ## v0.9.3 [2015-08-26]
 

--- a/cluster/points_writer_test.go
+++ b/cluster/points_writer_test.go
@@ -51,8 +51,16 @@ func TestPointsWriter_MapShards_One(t *testing.T) {
 func TestPointsWriter_MapShards_Multiple(t *testing.T) {
 	ms := MetaStore{}
 	rp := NewRetentionPolicy("myp", time.Hour, 3)
-	AttachShardGroupInfo(rp, []uint64{1, 2, 3})
-	AttachShardGroupInfo(rp, []uint64{1, 2, 3})
+	AttachShardGroupInfo(rp, []meta.ShardOwner{
+		{NodeID: 1},
+		{NodeID: 2},
+		{NodeID: 3},
+	})
+	AttachShardGroupInfo(rp, []meta.ShardOwner{
+		{NodeID: 1},
+		{NodeID: 2},
+		{NodeID: 3},
+	})
 
 	ms.NodeIDFn = func() uint64 { return 1 }
 	ms.RetentionPolicyFn = func(db, retentionPolicy string) (*meta.RetentionPolicyInfo, error) {
@@ -249,13 +257,25 @@ func TestPointsWriter_WritePoints(t *testing.T) {
 		theTest := test
 		sm := cluster.NewShardMapping()
 		sm.MapPoint(
-			&meta.ShardInfo{ID: uint64(1), OwnerIDs: []uint64{uint64(1), uint64(2), uint64(3)}},
+			&meta.ShardInfo{ID: uint64(1), Owners: []meta.ShardOwner{
+				{NodeID: 1},
+				{NodeID: 2},
+				{NodeID: 3},
+			}},
 			pr.Points[0])
 		sm.MapPoint(
-			&meta.ShardInfo{ID: uint64(2), OwnerIDs: []uint64{uint64(1), uint64(2), uint64(3)}},
+			&meta.ShardInfo{ID: uint64(2), Owners: []meta.ShardOwner{
+				{NodeID: 1},
+				{NodeID: 2},
+				{NodeID: 3},
+			}},
 			pr.Points[1])
 		sm.MapPoint(
-			&meta.ShardInfo{ID: uint64(2), OwnerIDs: []uint64{uint64(1), uint64(2), uint64(3)}},
+			&meta.ShardInfo{ID: uint64(2), Owners: []meta.ShardOwner{
+				{NodeID: 1},
+				{NodeID: 2},
+				{NodeID: 3},
+			}},
 			pr.Points[2])
 
 		// Local cluster.Node ShardWriter
@@ -334,8 +354,16 @@ func (f *fakeStore) CreateShard(database, retentionPolicy string, shardID uint64
 func NewMetaStore() *MetaStore {
 	ms := &MetaStore{}
 	rp := NewRetentionPolicy("myp", time.Hour, 3)
-	AttachShardGroupInfo(rp, []uint64{1, 2, 3})
-	AttachShardGroupInfo(rp, []uint64{1, 2, 3})
+	AttachShardGroupInfo(rp, []meta.ShardOwner{
+		{NodeID: 1},
+		{NodeID: 2},
+		{NodeID: 3},
+	})
+	AttachShardGroupInfo(rp, []meta.ShardOwner{
+		{NodeID: 1},
+		{NodeID: 2},
+		{NodeID: 3},
+	})
 
 	ms.RetentionPolicyFn = func(db, retentionPolicy string) (*meta.RetentionPolicyInfo, error) {
 		return rp, nil
@@ -380,15 +408,15 @@ func (m MetaStore) ShardOwner(shardID uint64) (string, string, *meta.ShardGroupI
 
 func NewRetentionPolicy(name string, duration time.Duration, nodeCount int) *meta.RetentionPolicyInfo {
 	shards := []meta.ShardInfo{}
-	ownerIDs := []uint64{}
+	owners := []meta.ShardOwner{}
 	for i := 1; i <= nodeCount; i++ {
-		ownerIDs = append(ownerIDs, uint64(i))
+		owners = append(owners, meta.ShardOwner{NodeID: uint64(i)})
 	}
 
 	// each node is fully replicated with each other
 	shards = append(shards, meta.ShardInfo{
-		ID:       nextShardID(),
-		OwnerIDs: ownerIDs,
+		ID:     nextShardID(),
+		Owners: owners,
 	})
 
 	rp := &meta.RetentionPolicyInfo{
@@ -408,7 +436,7 @@ func NewRetentionPolicy(name string, duration time.Duration, nodeCount int) *met
 	return rp
 }
 
-func AttachShardGroupInfo(rp *meta.RetentionPolicyInfo, ownerIDs []uint64) {
+func AttachShardGroupInfo(rp *meta.RetentionPolicyInfo, owners []meta.ShardOwner) {
 	var startTime, endTime time.Time
 	if len(rp.ShardGroups) == 0 {
 		startTime = time.Unix(0, 0)
@@ -423,8 +451,8 @@ func AttachShardGroupInfo(rp *meta.RetentionPolicyInfo, ownerIDs []uint64) {
 		EndTime:   endTime,
 		Shards: []meta.ShardInfo{
 			meta.ShardInfo{
-				ID:       nextShardID(),
-				OwnerIDs: ownerIDs,
+				ID:     nextShardID(),
+				Owners: owners,
 			},
 		},
 	}

--- a/cluster/shard_mapper.go
+++ b/cluster/shard_mapper.go
@@ -47,7 +47,7 @@ func (s *ShardMapper) CreateMapper(sh meta.ShardInfo, stmt influxql.Statement, c
 
 	if !sh.OwnedBy(s.MetaStore.NodeID()) || s.ForceRemoteMapping {
 		// Pick a node in a pseudo-random manner.
-		conn, err := s.dial(sh.OwnerIDs[rand.Intn(len(sh.OwnerIDs))])
+		conn, err := s.dial(sh.Owners[rand.Intn(len(sh.Owners))].NodeID)
 		if err != nil {
 			return nil, err
 		}

--- a/influxql/functions.go
+++ b/influxql/functions.go
@@ -947,7 +947,7 @@ func MapFirst(itr Iterator) interface{} {
 			v = nextv
 		}
 		nextk, nextv = itr.Next()
-	} 
+	}
 	return &firstLastMapOutput{k, v}
 }
 

--- a/meta/internal/meta.pb.go
+++ b/meta/internal/meta.pb.go
@@ -15,6 +15,7 @@ It has these top-level messages:
 	RetentionPolicyInfo
 	ShardGroupInfo
 	ShardInfo
+	ShardOwner
 	ContinuousQueryInfo
 	UserInfo
 	UserPrivilege
@@ -416,9 +417,10 @@ func (m *ShardGroupInfo) GetShards() []*ShardInfo {
 }
 
 type ShardInfo struct {
-	ID               *uint64  `protobuf:"varint,1,req" json:"ID,omitempty"`
-	OwnerIDs         []uint64 `protobuf:"varint,2,rep" json:"OwnerIDs,omitempty"`
-	XXX_unrecognized []byte   `json:"-"`
+	ID               *uint64       `protobuf:"varint,1,req" json:"ID,omitempty"`
+	OwnerIDs         []uint64      `protobuf:"varint,2,rep" json:"OwnerIDs,omitempty"`
+	Owners           []*ShardOwner `protobuf:"bytes,3,rep" json:"Owners,omitempty"`
+	XXX_unrecognized []byte        `json:"-"`
 }
 
 func (m *ShardInfo) Reset()         { *m = ShardInfo{} }
@@ -437,6 +439,29 @@ func (m *ShardInfo) GetOwnerIDs() []uint64 {
 		return m.OwnerIDs
 	}
 	return nil
+}
+
+func (m *ShardInfo) GetOwners() []*ShardOwner {
+	if m != nil {
+		return m.Owners
+	}
+	return nil
+}
+
+type ShardOwner struct {
+	NodeID           *uint64 `protobuf:"varint,1,req" json:"NodeID,omitempty"`
+	XXX_unrecognized []byte  `json:"-"`
+}
+
+func (m *ShardOwner) Reset()         { *m = ShardOwner{} }
+func (m *ShardOwner) String() string { return proto.CompactTextString(m) }
+func (*ShardOwner) ProtoMessage()    {}
+
+func (m *ShardOwner) GetNodeID() uint64 {
+	if m != nil && m.NodeID != nil {
+		return *m.NodeID
+	}
+	return 0
 }
 
 type ContinuousQueryInfo struct {

--- a/meta/internal/meta.proto
+++ b/meta/internal/meta.proto
@@ -49,8 +49,13 @@ message ShardGroupInfo {
 }
 
 message ShardInfo {
-	required uint64 ID = 1;
-	repeated uint64 OwnerIDs = 2;
+    required uint64 ID = 1;
+    repeated uint64 OwnerIDs = 2 [deprecated=true];
+    repeated ShardOwner Owners = 3;
+}
+
+message ShardOwner {
+    required uint64 NodeID = 1;
 }
 
 message ContinuousQueryInfo {

--- a/tsdb/executor_test.go
+++ b/tsdb/executor_test.go
@@ -34,8 +34,8 @@ func TestWritePointsAndExecuteTwoShards(t *testing.T) {
 					EndTime:   time.Now().Add(time.Hour),
 					Shards: []meta.ShardInfo{
 						{
-							ID:       uint64(sID0),
-							OwnerIDs: []uint64{nID},
+							ID:     uint64(sID0),
+							Owners: []meta.ShardOwner{{NodeID: nID}},
 						},
 					},
 				},
@@ -45,8 +45,8 @@ func TestWritePointsAndExecuteTwoShards(t *testing.T) {
 					EndTime:   time.Now().Add(-time.Hour),
 					Shards: []meta.ShardInfo{
 						{
-							ID:       uint64(sID1),
-							OwnerIDs: []uint64{nID},
+							ID:     uint64(sID1),
+							Owners: []meta.ShardOwner{{NodeID: nID}},
 						},
 					},
 				},
@@ -164,8 +164,8 @@ func TestWritePointsAndExecuteTwoShardsAlign(t *testing.T) {
 					EndTime:   time.Now().Add(-time.Hour),
 					Shards: []meta.ShardInfo{
 						{
-							ID:       uint64(sID1),
-							OwnerIDs: []uint64{nID},
+							ID:     uint64(sID1),
+							Owners: []meta.ShardOwner{{NodeID: nID}},
 						},
 					},
 				},
@@ -175,8 +175,8 @@ func TestWritePointsAndExecuteTwoShardsAlign(t *testing.T) {
 					EndTime:   time.Now().Add(time.Hour),
 					Shards: []meta.ShardInfo{
 						{
-							ID:       uint64(sID0),
-							OwnerIDs: []uint64{nID},
+							ID:     uint64(sID0),
+							Owners: []meta.ShardOwner{{NodeID: nID}},
 						},
 					},
 				},
@@ -338,8 +338,8 @@ func TestWritePointsAndExecuteTwoShardsTagSetOrdering(t *testing.T) {
 					ID: sgID,
 					Shards: []meta.ShardInfo{
 						{
-							ID:       uint64(sID0),
-							OwnerIDs: []uint64{nID},
+							ID:     uint64(sID0),
+							Owners: []meta.ShardOwner{{NodeID: nID}},
 						},
 					},
 				},
@@ -347,8 +347,8 @@ func TestWritePointsAndExecuteTwoShardsTagSetOrdering(t *testing.T) {
 					ID: sgID,
 					Shards: []meta.ShardInfo{
 						{
-							ID:       uint64(sID1),
-							OwnerIDs: []uint64{nID},
+							ID:     uint64(sID1),
+							Owners: []meta.ShardOwner{{NodeID: nID}},
 						},
 					},
 				},

--- a/tsdb/query_executor_test.go
+++ b/tsdb/query_executor_test.go
@@ -406,8 +406,8 @@ func (t *testMetastore) Database(name string) (*meta.DatabaseInfo, error) {
 						EndTime:   time.Now().Add(time.Hour),
 						Shards: []meta.ShardInfo{
 							{
-								ID:       uint64(1),
-								OwnerIDs: []uint64{1},
+								ID:     uint64(1),
+								Owners: []meta.ShardOwner{{NodeID: 1}},
 							},
 						},
 					},
@@ -440,8 +440,8 @@ func (t *testMetastore) RetentionPolicy(database, name string) (rpi *meta.Retent
 				EndTime:   time.Now().Add(time.Hour),
 				Shards: []meta.ShardInfo{
 					{
-						ID:       uint64(1),
-						OwnerIDs: []uint64{1},
+						ID:     uint64(1),
+						Owners: []meta.ShardOwner{{NodeID: 1}},
 					},
 				},
 			},
@@ -461,8 +461,8 @@ func (t *testMetastore) ShardGroupsByTimeRange(database, policy string, min, max
 			EndTime:   time.Now().Add(time.Hour),
 			Shards: []meta.ShardInfo{
 				{
-					ID:       uint64(1),
-					OwnerIDs: []uint64{1},
+					ID:     uint64(1),
+					Owners: []meta.ShardOwner{{NodeID: 1}},
 				},
 			},
 		},


### PR DESCRIPTION
## Overview

This commit converts meta.ShardInfo.OwnerIDs from a slice of ids to a slice of objects. This is to support adding statuses for a shard for a given node. For example, a node may have a shard assigned to it but it is currently copying the shard and is not ready to serve data for it.

The old `OwnerIDs` is marked as deprecated, however, the code still supports loading from older protobuf encoded data.