### PR TITLE
Fix write fails for multiple points when tag starts with quote

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ With this release InfluxDB is moving to Go 1.5.
 - [#3574](https://github.com/influxdb/influxdb/issues/3574): Querying data node causes panic
 - [#3913](https://github.com/influxdb/influxdb/issues/3913): Convert meta shard owners to objects
 - [#3927](https://github.com/influxdb/influxdb/issues/3927): Add WAL lock to prevent timing lock contention
+- [#3928](https://github.com/influxdb/influxdb/issues/3928): Write fails for multiple points when tag starts with quote
 
 ## v0.9.3 [2015-08-26]
 

--- a/tsdb/points.go
+++ b/tsdb/points.go
@@ -739,14 +739,19 @@ func skipWhitespace(buf []byte, i int) int {
 func scanLine(buf []byte, i int) (int, []byte) {
 	start := i
 	quoted := false
+	fields := false
 	for {
 		// reached the end of buf?
 		if i >= len(buf) {
 			break
 		}
 
+		if buf[i] == ' ' {
+			fields = true
+		}
+
 		// If we see a double quote, makes sure it is not escaped
-		if buf[i] == '"' && (i-1 > 0 && buf[i-1] != '\\') {
+		if fields && buf[i] == '"' && (i-1 > 0 && buf[i-1] != '\\') {
 			i += 1
 			quoted = !quoted
 			continue


### PR DESCRIPTION
Quotes in tags should are not special.  We were scanning to far if there was an unbalanced quote in the tags section.  This updates `scanLine` to only handle quotes differently if it's scanning in the fields section or later. 

Fixes #3928