### PR TITLE
Package options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 With this release InfluxDB is moving to Go 1.5.
 
 ### Features
+- [#3755](https://github.com/influxdb/influxdb/issues/3755): Add option to build script.
 - [#3863](https://github.com/influxdb/influxdb/pull/3863): Move to Go 1.5
 - [#3892](https://github.com/influxdb/influxdb/pull/3892): Support IF NOT EXISTS for CREATE DATABASE
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 With this release InfluxDB is moving to Go 1.5.
 
 ### Features
-- [#3755](https://github.com/influxdb/influxdb/issues/3755): Add option to build script.
+- [#3755](https://github.com/influxdb/influxdb/issues/3755): Add option to build script. Thanks @fg2it
 - [#3863](https://github.com/influxdb/influxdb/pull/3863): Move to Go 1.5
 - [#3892](https://github.com/influxdb/influxdb/pull/3892): Support IF NOT EXISTS for CREATE DATABASE
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -172,6 +172,11 @@ To set the version and commit flags during the build pass the following to the b
 
 where `$VERSION` is the version, `$BRANCH` is the branch, and `$COMMIT` is the git commit hash.
 
+If you want to build packages, see `package.sh` help:
+```bash
+package.sh -h
+```
+
 To run the tests, execute the following command:
 
 ```bash

--- a/package.sh
+++ b/package.sh
@@ -187,7 +187,7 @@ do_build() {
         rm -f $GOPATH_INSTALL/bin/$b
     done
     
-    if [ ! -z "$WORKING_DIR" ]; then
+    if [ -n "$WORKING_DIR" ]; then
         STASH=`git stash create -a`
         if [ $? -ne 0 ]; then
             echo "WARNING: failed to stash uncommited local changes"
@@ -202,7 +202,7 @@ do_build() {
 
     git checkout $TARGET_BRANCH # go get switches to master, so ensure we're back.
     
-    if [ ! -z "$WORKING_DIR" ]; then
+    if [ -n "$WORKING_DIR" ]; then
         git stash apply $STASH
         if [ $? -ne 0 ]; then #and apply previous uncommited local changes
             echo "WARNING: failed to restore uncommited local changes"
@@ -405,7 +405,7 @@ fi
 
 COMMON_FPM_ARGS="--log error -C $TMP_WORK_DIR --vendor $VENDOR --url $URL --license $LICENSE --maintainer $MAINTAINER --after-install $POST_INSTALL_PATH --name influxdb --version $VERSION --config-files $CONFIG_ROOT_DIR ."
 
-if [ ! -z "$DEB_WANTED" ]; then
+if [ -n "$DEB_WANTED" ]; then
     $FPM -s dir -t deb $deb_args --description "$DESCRIPTION" $COMMON_FPM_ARGS
     if [ $? -ne 0 ]; then
         echo "Failed to create Debian package -- aborting."
@@ -414,7 +414,7 @@ if [ ! -z "$DEB_WANTED" ]; then
     echo "Debian package created successfully."
 fi
 
-if [ ! -z "$TAR_WANTED" ]; then
+if [ -n "$TAR_WANTED" ]; then
     $FPM -s dir -t tar --prefix influxdb_${VERSION}_${ARCH} -p influxdb_${VERSION}_${ARCH}.tar.gz --description "$DESCRIPTION" $COMMON_FPM_ARGS
     if [ $? -ne 0 ]; then
         echo "Failed to create Tar package -- aborting."
@@ -423,7 +423,7 @@ if [ ! -z "$TAR_WANTED" ]; then
     echo "Tar package created successfully."
 fi
 
-if [ ! -z "$RPM_WANTED" ]; then
+if [ -n "$RPM_WANTED" ]; then
     $rpm_args $FPM -s dir -t rpm --description "$DESCRIPTION" $COMMON_FPM_ARGS
     if [ $? -ne 0 ]; then
         echo "Failed to create RPM package -- aborting."
@@ -446,13 +446,13 @@ if [ -z "$NIGHTLY_BUILD" -a -z "$PACKAGES_ONLY" ]; then
             echo "Failed to create tag v$VERSION -- aborting"
             cleanup_exit 1
         fi
-        echo "Tag v$VERSION created ..."
+        echo "Tag v$VERSION created"
         git push origin v$VERSION
         if [ $? -ne 0 ]; then
             echo "Failed to push tag v$VERSION to repo -- aborting"
             cleanup_exit 1
         fi
-        echo "and pushed to repo"
+        echo "Tag v$VERSION pushed to repo"
     else
         echo "Not creating tag v$VERSION."
     fi

--- a/package.sh
+++ b/package.sh
@@ -283,7 +283,7 @@ do
                  ;;
             *)
                  echo "Unknown target distribution $2"
-                 exit 1
+                 usage 1
                  ;;
         esac
         shift 2
@@ -403,7 +403,7 @@ else
     debian_package=influxdb_${VERSION}_amd64.deb
 fi
 
-COMMON_FPM_ARGS="-C $TMP_WORK_DIR --vendor $VENDOR --url $URL --license $LICENSE --maintainer $MAINTAINER --after-install $POST_INSTALL_PATH --name influxdb --version $VERSION --config-files $CONFIG_ROOT_DIR ."
+COMMON_FPM_ARGS="--log error -C $TMP_WORK_DIR --vendor $VENDOR --url $URL --license $LICENSE --maintainer $MAINTAINER --after-install $POST_INSTALL_PATH --name influxdb --version $VERSION --config-files $CONFIG_ROOT_DIR ."
 
 if [ ! -z "$DEB_WANTED" ]; then
     $FPM -s dir -t deb $deb_args --description "$DESCRIPTION" $COMMON_FPM_ARGS


### PR DESCRIPTION
PR to address #3755

# What
Adding options to easy package bulding while preserving current semantics.
```
package.sh [-h] [-p|-w] [-t <dist>] <version>
    -p just build packages
    -w build packages for current working directory
       imply -p
    -t <dist>
       build package for <dist>
       <dist> can be rpm, tar or deb
       can have multiple -t
```

# Tests performed
### Successful
- `./package.sh -p 0.9.4`
- `./package.sh -p -t tar 0.9.4`
- `./package.sh -p -t rpm -t deb 0.9.4`
- `./package.sh -w -t rpm 0.9.4` #with minor change in package.sh
- `./package.sh -w -t deb -t tar 0.9.4` #with minor change in package.sh

### Successfull as far as I can test
- `NIGHTLY_BUILD=true ./package.sh 0.9.4`
fails with
```
./package.sh: line 483: aws: command not found
Upload failed (influxdb-nightly-1.armv7l.rpm) -- aborting.
```
as expected since I don't have `aws` installed (no S3 account)

### Fail as it should
- `./package.sh -xxx` with `Unknown option -xxx`
- `./package.sh - p 0.9.4` with `Unknown option -`
- `./package.sh -t xxx 0.9.4` with `Unknown target distribution xxx`
- `./package.sh -t deb` with `Missing version`

- [x] CHANGELOG.md updated
- [x] Rebased/mergable
- [ ] Tests pass
- [x] Sign [CLA] (http://influxdb.com/community/cla.html) (if not already signed)