### PR TITLE
Correctly set Name and Tags for SHOW STATS output

### DIFF
--- a/monitor/service.go
+++ b/monitor/service.go
@@ -125,13 +125,9 @@ func (s *Service) executeShowStatistics(q *influxql.ShowStatsStatement) *influxq
 	rows := make([]*influxql.Row, len(stats))
 
 	for n, stat := range stats {
-		row := &influxql.Row{Name: stat.Name}
-		values := make([]interface{}, 0, len(stat.Tags)+len(stat.Values))
+		row := &influxql.Row{Name: stat.Name, Tags: stat.Tags}
 
-		for _, k := range stat.tagNames() {
-			row.Columns = append(row.Columns, k)
-			values = append(values, stat.Tags[k])
-		}
+		values := make([]interface{}, 0, len(stat.Values))
 		for _, k := range stat.valueNames() {
 			row.Columns = append(row.Columns, k)
 			values = append(values, stat.Values[k])

--- a/monitor/service.go
+++ b/monitor/service.go
@@ -125,11 +125,8 @@ func (s *Service) executeShowStatistics(q *influxql.ShowStatsStatement) *influxq
 	rows := make([]*influxql.Row, len(stats))
 
 	for n, stat := range stats {
-		row := &influxql.Row{}
+		row := &influxql.Row{Name: stat.Name}
 		values := make([]interface{}, 0, len(stat.Tags)+len(stat.Values))
-
-		row.Columns = append(row.Columns, "name")
-		values = append(values, stat.Name)
 
 		for _, k := range stat.tagNames() {
 			row.Columns = append(row.Columns, k)

--- a/monitor/service_test.go
+++ b/monitor/service_test.go
@@ -1,0 +1,70 @@
+package monitor
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/influxdb/influxdb/influxql"
+)
+
+// Test that a registered stats client results in the correct SHOW STATS output.
+func Test_ServiceRegisterStats(t *testing.T) {
+	service := openService(t)
+
+	client := mockStatsClient{
+		StatisticsFn: func() (map[string]interface{}, error) {
+			return map[string]interface{}{
+				"bar": 1,
+				"qux": 2.4,
+			}, nil
+		},
+	}
+
+	// Register a client without tags.
+	if err := service.Register("foo", nil, client); err != nil {
+		t.Fatalf("failed to register client: %s", err.Error())
+	}
+	json := executeShowStatsJSON(t, service)
+	if !strings.Contains(json, `{"name":"foo","columns":["bar","qux"],"values":[[1,2.4]]}]}`) {
+		t.Fatalf("SHOW STATS response incorrect, got: %s\n", json)
+	}
+
+	// Register a client with tags.
+	if err := service.Register("baz", map[string]string{"proto": "tcp"}, client); err != nil {
+		t.Fatalf("failed to register client: %s", err.Error())
+	}
+	json = executeShowStatsJSON(t, service)
+	if !strings.Contains(json, `{"name":"baz","tags":{"proto":"tcp"},"columns":["bar","qux"],"values":[[1,2.4]]}]}`) {
+		t.Fatalf("SHOW STATS response incorrect, got: %s\n", json)
+	}
+}
+
+type mockStatsClient struct {
+	StatisticsFn func() (map[string]interface{}, error)
+}
+
+func (m mockStatsClient) Statistics() (map[string]interface{}, error) {
+	return m.StatisticsFn()
+}
+
+func (m mockStatsClient) Diagnostics() (map[string]interface{}, error) {
+	return nil, nil
+}
+
+func openService(t *testing.T) *Service {
+	service := NewService(NewConfig())
+	err := service.Open(1, 2, "serverA")
+	if err != nil {
+		t.Fatalf("failed to open service: %s", err.Error())
+	}
+	return service
+}
+
+func executeShowStatsJSON(t *testing.T, s *Service) string {
+	r := s.ExecuteStatement(&influxql.ShowStatsStatement{})
+	b, err := r.MarshalJSON()
+	if err != nil {
+		t.Fatalf("failed to decode SHOW STATS response: %s", err.Error())
+	}
+	return string(b)
+}


### PR DESCRIPTION
The output for `SHOW STATS` was not quite right, it wasn't correctly setting the measurement name and tags -- previously both appeared as columns in the output. This change fixes that and also adds unit tests. New example output from `SHOW STATS` is below.

```
> show stats
name: runtime
-------------
Alloc   Frees   HeapAlloc       HeapIdle        HeapInUse       HeapObjects     HeapReleased    HeapSys         Lookups Mallocs NumGC   NumGoroutine    PauseTotalNs    Sys             TotalAlloc
4136056 6684537 4136056         34586624        5816320         49412           0               40402944        110     6733949 83      44              36083006        46692600        439945704


name: graphite
tags: proto=tcp
batches_tx      bytes_rx        connections_active      connections_handled     points_rx       points_tx
----------      --------        ------------------      -------------------     ---------       ---------
159             3999750         0                       1                       158110          158110
```