### PR TITLE
Influx cli consistency level parsing tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ With this release InfluxDB is moving to Go 1.5.
 - [#3863](https://github.com/influxdb/influxdb/pull/3863): Move to Go 1.5
 - [#3892](https://github.com/influxdb/influxdb/pull/3892): Support IF NOT EXISTS for CREATE DATABASE
 - [#3916](https://github.com/influxdb/influxdb/pull/3916): New statistics and diagnostics support. Graphite first to be instrumented.
+- [#3901](https://github.com/influxdb/influxdb/pull/3901): Add consistency level option to influx cli Thanks @takayuki
 
 ### Bugfixes
 - [#3804](https://github.com/influxdb/influxdb/pull/3804): init.d script fixes, fixes issue 3803.
@@ -20,6 +21,7 @@ With this release InfluxDB is moving to Go 1.5.
 - [#3913](https://github.com/influxdb/influxdb/issues/3913): Convert meta shard owners to objects
 - [#3927](https://github.com/influxdb/influxdb/issues/3927): Add WAL lock to prevent timing lock contention
 - [#3928](https://github.com/influxdb/influxdb/issues/3928): Write fails for multiple points when tag starts with quote
+- [#3901](https://github.com/influxdb/influxdb/pull/3901): Unblock relaxed write consistency level Thanks @takayuki!
 
 ## v0.9.3 [2015-08-26]
 

--- a/cluster/points_writer.go
+++ b/cluster/points_writer.go
@@ -234,8 +234,8 @@ func (w *PointsWriter) writeToShard(shard *meta.ShardInfo, database, retentionPo
 
 	// response channel for each shard writer go routine
 	type AsyncWriteResult struct {
-		Owner  meta.ShardOwner
-		Err    error
+		Owner meta.ShardOwner
+		Err   error
 	}
 	ch := make(chan *AsyncWriteResult, len(shard.Owners))
 

--- a/cmd/influx/main.go
+++ b/cmd/influx/main.go
@@ -53,7 +53,7 @@ type CommandLine struct {
 	Execute          string
 	ShowVersion      bool
 	Import           bool
-	PPS              int    // Controls how many points per second the import will allow via throttling
+	PPS              int // Controls how many points per second the import will allow via throttling
 	Path             string
 	Compressed       bool
 }

--- a/cmd/influx/main_test.go
+++ b/cmd/influx/main_test.go
@@ -91,6 +91,31 @@ func TestParseCommand_Use(t *testing.T) {
 	}
 }
 
+func TestParseCommand_Consistency(t *testing.T) {
+	t.Parallel()
+	c := main.CommandLine{}
+	tests := []struct {
+		cmd string
+	}{
+		{cmd: "consistency one"},
+		{cmd: " consistency one"},
+		{cmd: "consistency one "},
+		{cmd: "consistency one;"},
+		{cmd: "consistency one; "},
+		{cmd: "Consistency one"},
+	}
+
+	for _, test := range tests {
+		if !c.ParseCommand(test.cmd) {
+			t.Fatalf(`Command "consistency" failed for %q.`, test.cmd)
+		}
+
+		if c.WriteConsistency != "one" {
+			t.Fatalf(`Command "consistency" changed consistency to %q. Expected one`, c.WriteConsistency)
+		}
+	}
+}
+
 func TestParseCommand_Insert(t *testing.T) {
 	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Adds a test for 557f796 which adds a new consistency level option for influx cli.