### PR TITLE
Limit bz1 quickcheck tests to 10 iterations on CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ With this release InfluxDB is moving to Go 1.5.
 - [#3927](https://github.com/influxdb/influxdb/issues/3927): Add WAL lock to prevent timing lock contention
 - [#3928](https://github.com/influxdb/influxdb/issues/3928): Write fails for multiple points when tag starts with quote
 - [#3901](https://github.com/influxdb/influxdb/pull/3901): Unblock relaxed write consistency level Thanks @takayuki!
+- [#3950](https://github.com/influxdb/influxdb/pull/3950): Limit bz1 quickcheck tests to 10 iterations on CI
 
 ## v0.9.3 [2015-08-26]
 

--- a/tsdb/engine/bz1/bz1_test.go
+++ b/tsdb/engine/bz1/bz1_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"math/rand"
 	"os"
@@ -20,6 +21,16 @@ import (
 	"github.com/influxdb/influxdb/tsdb/engine/bz1"
 	"github.com/influxdb/influxdb/tsdb/engine/wal"
 )
+
+var QuickConfig quick.Config
+
+func init() {
+	// Limit the number of iterations on CI so it doesn't take so long.
+	if os.Getenv("CI") == "true" {
+		QuickConfig.MaxCount = 10
+		fmt.Fprintf(os.Stderr, "Limiting quickchecks to %d iterations (CI)\n", QuickConfig.MaxCount)
+	}
+}
 
 // Ensure the engine can write series metadata and reload it.
 func TestEngine_LoadMetadataIndex_Series(t *testing.T) {
@@ -337,7 +348,7 @@ func TestEngine_WriteIndex_Quick(t *testing.T) {
 		}
 
 		return true
-	}, nil)
+	}, &QuickConfig)
 }
 
 // Ensure the engine can accept randomly generated append-only points.
@@ -384,7 +395,7 @@ func TestEngine_WriteIndex_Quick_Append(t *testing.T) {
 		}
 
 		return true
-	}, nil)
+	}, &QuickConfig)
 }
 
 func BenchmarkEngine_WriteIndex_512b(b *testing.B)  { benchmarkEngine_WriteIndex(b, 512) }


### PR DESCRIPTION
## Overview

This pull request checks the `CI` environment variable in the `bz1` test suite and limits the quickcheck runs if the value is `true`.