### PR TITLE
Remove support for storing in external InfluxDB

### DIFF
--- a/monitor/config.go
+++ b/monitor/config.go
@@ -16,9 +16,6 @@ const (
 
 	// DefaultStoreInterval is the period between storing gathered information.
 	DefaultStoreInterval = time.Minute
-
-	// DefaultStoreAddress is the destination system for gathered information.
-	DefaultStoreAddress = "127.0.0.1:8086"
 )
 
 // Config represents the configuration for the monitor service.
@@ -26,7 +23,6 @@ type Config struct {
 	StoreEnabled  bool          `toml:"store-enabled"`
 	StoreDatabase string        `toml:"store-database"`
 	StoreInterval toml.Duration `toml:"store-interval"`
-	StoreAddress  string        `toml:"store-address"`
 }
 
 // NewConfig returns an instance of Config with defaults.
@@ -35,6 +31,5 @@ func NewConfig() Config {
 		StoreEnabled:  false,
 		StoreDatabase: DefaultStoreDatabase,
 		StoreInterval: toml.Duration(DefaultStoreInterval),
-		StoreAddress:  DefaultStoreAddress,
 	}
 }

--- a/monitor/config_test.go
+++ b/monitor/config_test.go
@@ -15,7 +15,6 @@ func TestConfig_Parse(t *testing.T) {
 store-enabled=true
 store-database="the_db"
 store-interval="10m"
-store-address="server1"
 `, &c); err != nil {
 		t.Fatal(err)
 	}
@@ -27,7 +26,5 @@ store-address="server1"
 		t.Fatalf("unexpected store-database: %s", c.StoreDatabase)
 	} else if time.Duration(c.StoreInterval) != 10*time.Minute {
 		t.Fatalf("unexpected store-interval:  %s", c.StoreInterval)
-	} else if c.StoreAddress != "server1" {
-		t.Fatalf("unexpected store-address: %s", c.StoreAddress)
 	}
 }

--- a/monitor/service_test.go
+++ b/monitor/service_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/influxdb/influxdb/influxql"
+	"github.com/influxdb/influxdb/meta"
 )
 
 // Test that a registered stats client results in the correct SHOW STATS output.
@@ -51,9 +52,18 @@ func (m mockStatsClient) Diagnostics() (map[string]interface{}, error) {
 	return nil, nil
 }
 
+type mockMetastore struct{}
+
+func (m *mockMetastore) ClusterID() uint64 { return 1 }
+func (m *mockMetastore) NodeID() uint64    { return 2 }
+func (m *mockMetastore) CreateDatabaseIfNotExists(name string) (*meta.DatabaseInfo, error) {
+	return nil, nil
+}
+
 func openService(t *testing.T) *Service {
 	service := NewService(NewConfig())
-	err := service.Open(1, 2, "serverA")
+	service.MetaStore = &mockMetastore{}
+	err := service.Open()
 	if err != nil {
 		t.Fatalf("failed to open service: %s", err.Error())
 	}


### PR DESCRIPTION
This change also starts to move Monitor away from a "service" type system, as that model does not fit well.