### PR TITLE
Rename MonitorService to just Monitor

### DIFF
--- a/cmd/influxd/run/server.go
+++ b/cmd/influxd/run/server.go
@@ -58,7 +58,7 @@ type Server struct {
 	ClusterService     *cluster.Service
 	SnapshotterService *snapshotter.Service
 
-	MonitorService *monitor.Service
+	Monitor *monitor.Monitor
 
 	// Server reporting
 	reportingDisabled bool
@@ -93,8 +93,8 @@ func NewServer(c *Config, version string) (*Server, error) {
 	if err != nil {
 		return nil, err
 	}
-	s.MonitorService = monitor.NewService(c.Monitor)
-	if err := s.MonitorService.Open(clusterID, s.MetaStore.NodeID(), s.Hostname); err != nil {
+	s.Monitor = monitor.New(c.Monitor)
+	if err := s.Monitor.Open(clusterID, s.MetaStore.NodeID(), s.Hostname); err != nil {
 		return nil, err
 	}
 
@@ -113,7 +113,7 @@ func NewServer(c *Config, version string) (*Server, error) {
 	s.QueryExecutor = tsdb.NewQueryExecutor(s.TSDBStore)
 	s.QueryExecutor.MetaStore = s.MetaStore
 	s.QueryExecutor.MetaStatementExecutor = &meta.StatementExecutor{Store: s.MetaStore}
-	s.QueryExecutor.MonitorStatementExecutor = s.MonitorService
+	s.QueryExecutor.MonitorStatementExecutor = s.Monitor
 	s.QueryExecutor.ShardMapper = s.ShardMapper
 
 	// Set the shard writer
@@ -244,7 +244,7 @@ func (s *Server) appendGraphiteService(c graphite.Config) error {
 
 	srv.PointsWriter = s.PointsWriter
 	srv.MetaStore = s.MetaStore
-	srv.MonitorService = s.MonitorService
+	srv.Monitor = s.Monitor
 	s.Services = append(s.Services, srv)
 	return nil
 }

--- a/services/graphite/service.go
+++ b/services/graphite/service.go
@@ -68,7 +68,7 @@ type Service struct {
 	wg   sync.WaitGroup
 	done chan struct{}
 
-	MonitorService interface {
+	Monitor interface {
 		Register(name string, tags map[string]string, client monitor.Client) error
 	}
 	PointsWriter interface {
@@ -120,16 +120,16 @@ func (s *Service) Open() error {
 
 	// One Graphite service hooks up monitoring for all Graphite functionality.
 	monitorOnce.Do(func() {
-		if s.MonitorService == nil {
+		if s.Monitor == nil {
 			s.logger.Println("no monitor service available, no monitoring will be performed")
 			return
 		}
 
 		t := monitor.NewMonitorClient(statMapTCP)
-		s.MonitorService.Register("graphite", map[string]string{"proto": "tcp"}, t)
+		s.Monitor.Register("graphite", map[string]string{"proto": "tcp"}, t)
 
 		u := monitor.NewMonitorClient(statMapUDP)
-		s.MonitorService.Register("graphite", map[string]string{"proto": "udp"}, u)
+		s.Monitor.Register("graphite", map[string]string{"proto": "udp"}, u)
 	})
 
 	if err := s.MetaStore.WaitForLeader(leaderWaitTimeout); err != nil {


### PR DESCRIPTION
monitor is not a service, it has more in common with meta, since it provides functionality to the query layer. This names makes this clearer.