### PR TITLE
Refactor monitor system

### DIFF
--- a/cmd/influxd/run/server.go
+++ b/cmd/influxd/run/server.go
@@ -113,7 +113,7 @@ func NewServer(c *Config, version string) (*Server, error) {
 	s.QueryExecutor = tsdb.NewQueryExecutor(s.TSDBStore)
 	s.QueryExecutor.MetaStore = s.MetaStore
 	s.QueryExecutor.MetaStatementExecutor = &meta.StatementExecutor{Store: s.MetaStore}
-	s.QueryExecutor.MonitorStatementExecutor = s.Monitor
+	s.QueryExecutor.MonitorStatementExecutor = &monitor.StatementExecutor{Monitor: s.Monitor}
 	s.QueryExecutor.ShardMapper = s.ShardMapper
 
 	// Set the shard writer

--- a/cmd/influxd/run/server_helpers_test.go
+++ b/cmd/influxd/run/server_helpers_test.go
@@ -164,6 +164,8 @@ func NewConfig() *run.Config {
 	c.HTTPD.BindAddress = "127.0.0.1:0"
 	c.HTTPD.LogEnabled = testing.Verbose()
 
+	c.Monitor.StoreEnabled = false
+
 	return c
 }
 

--- a/etc/config.sample.toml
+++ b/etc/config.sample.toml
@@ -89,14 +89,13 @@ reporting-disabled = false
   check-interval = "10m"
 
 ###
-### Controls the system self-monitoring, statistics, diagnostics, and expvar data.
+### Controls the system self-monitoring, statistics and diagnostics.
 ###
 
 [monitor]
-  store-enabled = false # Whether to record statistics in an InfluxDB system
+  store-enabled = true # Whether to record statistics internally.
   store-database = "_internal" # The destination database for recorded statistics
   store-interval = "1m" # The interval at which to record statistics
-  store-address = "http://127.0.0.1:8086" # The protocol and host for the recorded data
 
 ###
 ### [admin]

--- a/monitor/config.go
+++ b/monitor/config.go
@@ -16,9 +16,6 @@ const (
 
 	// DefaultStoreInterval is the period between storing gathered information.
 	DefaultStoreInterval = time.Minute
-
-	// DefaultStoreAddress is the destination system for gathered information.
-	DefaultStoreAddress = "127.0.0.1:8086"
 )
 
 // Config represents the configuration for the monitor service.
@@ -26,7 +23,6 @@ type Config struct {
 	StoreEnabled  bool          `toml:"store-enabled"`
 	StoreDatabase string        `toml:"store-database"`
 	StoreInterval toml.Duration `toml:"store-interval"`
-	StoreAddress  string        `toml:"store-address"`
 }
 
 // NewConfig returns an instance of Config with defaults.
@@ -35,6 +31,5 @@ func NewConfig() Config {
 		StoreEnabled:  false,
 		StoreDatabase: DefaultStoreDatabase,
 		StoreInterval: toml.Duration(DefaultStoreInterval),
-		StoreAddress:  DefaultStoreAddress,
 	}
 }

--- a/monitor/config.go
+++ b/monitor/config.go
@@ -28,7 +28,7 @@ type Config struct {
 // NewConfig returns an instance of Config with defaults.
 func NewConfig() Config {
 	return Config{
-		StoreEnabled:  false,
+		StoreEnabled:  true,
 		StoreDatabase: DefaultStoreDatabase,
 		StoreInterval: toml.Duration(DefaultStoreInterval),
 	}

--- a/monitor/config_test.go
+++ b/monitor/config_test.go
@@ -15,7 +15,6 @@ func TestConfig_Parse(t *testing.T) {
 store-enabled=true
 store-database="the_db"
 store-interval="10m"
-store-address="server1"
 `, &c); err != nil {
 		t.Fatal(err)
 	}
@@ -27,7 +26,5 @@ store-address="server1"
 		t.Fatalf("unexpected store-database: %s", c.StoreDatabase)
 	} else if time.Duration(c.StoreInterval) != 10*time.Minute {
 		t.Fatalf("unexpected store-interval:  %s", c.StoreInterval)
-	} else if c.StoreAddress != "server1" {
-		t.Fatalf("unexpected store-address: %s", c.StoreAddress)
 	}
 }

--- a/monitor/service.go
+++ b/monitor/service.go
@@ -50,6 +50,7 @@ type Monitor struct {
 // New returns a new instance of the monitor system.
 func New(c Config) *Monitor {
 	return &Monitor{
+		done:          make(chan struct{}),
 		registrations: make([]*clientWithMeta, 0),
 		storeEnabled:  c.StoreEnabled,
 		storeDatabase: c.StoreDatabase,

--- a/monitor/service.go
+++ b/monitor/service.go
@@ -53,7 +53,6 @@ func New(c Config) *Monitor {
 		registrations: make([]*clientWithMeta, 0),
 		storeEnabled:  c.StoreEnabled,
 		storeDatabase: c.StoreDatabase,
-		storeAddress:  c.StoreAddress,
 		storeInterval: time.Duration(c.StoreInterval),
 		Logger:        log.New(os.Stderr, "[monitor] ", log.LstdFlags),
 	}
@@ -69,11 +68,9 @@ func (m *Monitor) Open() error {
 
 	// If enabled, record stats in a InfluxDB system.
 	if m.storeEnabled {
-		m.Logger.Printf("storing in %s, database '%s', interval %s",
-			m.storeAddress, m.storeDatabase, m.storeInterval)
-
-		m.Logger.Printf("ensuring database %s exists on %s", m.storeDatabase, m.storeAddress)
-		if err := ensureDatabaseExists(m.storeAddress, m.storeDatabase); err != nil {
+		m.Logger.Printf("storing statistics in database '%s', interval %s",
+			m.storeDatabase, m.storeInterval)
+		if _, err := m.MetaStore.CreateDatabaseIfNotExists(m.storeDatabase); err != nil {
 			return err
 		}
 
@@ -149,7 +146,7 @@ func (m *Monitor) storeStatistics() {
 		case <-tick.C:
 			// Write stats here.
 		case <-m.done:
-			m.Logger.Printf("terminating storage of statistics to %s", m.storeAddress)
+			m.Logger.Printf("terminating storage of statistics")
 			return
 		}
 

--- a/monitor/service_test.go
+++ b/monitor/service_test.go
@@ -3,6 +3,7 @@ package monitor
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/influxdb/influxdb/influxql"
 	"github.com/influxdb/influxdb/meta"
@@ -55,8 +56,9 @@ func (m mockStatsClient) Diagnostics() (map[string]interface{}, error) {
 
 type mockMetastore struct{}
 
-func (m *mockMetastore) ClusterID() (uint64, error) { return 1, nil }
-func (m *mockMetastore) NodeID() uint64             { return 2 }
+func (m *mockMetastore) ClusterID() (uint64, error)          { return 1, nil }
+func (m *mockMetastore) NodeID() uint64                      { return 2 }
+func (m *mockMetastore) WaitForLeader(d time.Duration) error { return nil }
 func (m *mockMetastore) CreateDatabaseIfNotExists(name string) (*meta.DatabaseInfo, error) {
 	return nil, nil
 }

--- a/monitor/service_test.go
+++ b/monitor/service_test.go
@@ -5,11 +5,13 @@ import (
 	"testing"
 
 	"github.com/influxdb/influxdb/influxql"
+	"github.com/influxdb/influxdb/meta"
 )
 
 // Test that a registered stats client results in the correct SHOW STATS output.
 func Test_RegisterStats(t *testing.T) {
 	monitor := openMonitor(t)
+	executor := &StatementExecutor{Monitor: monitor}
 
 	client := mockStatsClient{
 		StatisticsFn: func() (map[string]interface{}, error) {
@@ -24,7 +26,7 @@ func Test_RegisterStats(t *testing.T) {
 	if err := monitor.Register("foo", nil, client); err != nil {
 		t.Fatalf("failed to register client: %s", err.Error())
 	}
-	json := executeShowStatsJSON(t, monitor)
+	json := executeShowStatsJSON(t, executor)
 	if !strings.Contains(json, `{"name":"foo","columns":["bar","qux"],"values":[[1,2.4]]}]}`) {
 		t.Fatalf("SHOW STATS response incorrect, got: %s\n", json)
 	}
@@ -33,7 +35,7 @@ func Test_RegisterStats(t *testing.T) {
 	if err := monitor.Register("baz", map[string]string{"proto": "tcp"}, client); err != nil {
 		t.Fatalf("failed to register client: %s", err.Error())
 	}
-	json = executeShowStatsJSON(t, monitor)
+	json = executeShowStatsJSON(t, executor)
 	if !strings.Contains(json, `{"name":"baz","tags":{"proto":"tcp"},"columns":["bar","qux"],"values":[[1,2.4]]}]}`) {
 		t.Fatalf("SHOW STATS response incorrect, got: %s\n", json)
 	}
@@ -51,16 +53,25 @@ func (m mockStatsClient) Diagnostics() (map[string]interface{}, error) {
 	return nil, nil
 }
 
+type mockMetastore struct{}
+
+func (m *mockMetastore) ClusterID() (uint64, error) { return 1, nil }
+func (m *mockMetastore) NodeID() uint64             { return 2 }
+func (m *mockMetastore) CreateDatabaseIfNotExists(name string) (*meta.DatabaseInfo, error) {
+	return nil, nil
+}
+
 func openMonitor(t *testing.T) *Monitor {
 	monitor := New(NewConfig())
-	err := monitor.Open(1, 2, "serverA")
+	monitor.MetaStore = &mockMetastore{}
+	err := monitor.Open()
 	if err != nil {
 		t.Fatalf("failed to open monitor: %s", err.Error())
 	}
 	return monitor
 }
 
-func executeShowStatsJSON(t *testing.T, s *Monitor) string {
+func executeShowStatsJSON(t *testing.T, s *StatementExecutor) string {
 	r := s.ExecuteStatement(&influxql.ShowStatsStatement{})
 	b, err := r.MarshalJSON()
 	if err != nil {

--- a/monitor/statement_executor.go
+++ b/monitor/statement_executor.go
@@ -1,0 +1,48 @@
+package monitor
+
+import (
+	"fmt"
+
+	"github.com/influxdb/influxdb/influxql"
+)
+
+// StatementExecutor translates InfluxQL queries to Monitor methods.
+type StatementExecutor struct {
+	Monitor interface {
+		Statistics() ([]*statistic, error)
+	}
+}
+
+// ExecuteStatement executes monitor-related query statements.
+func (s *StatementExecutor) ExecuteStatement(stmt influxql.Statement) *influxql.Result {
+	switch stmt := stmt.(type) {
+	case *influxql.ShowStatsStatement:
+		return s.executeShowStatistics()
+	case *influxql.ShowDiagnosticsStatement:
+		return s.executeShowDiagnostics()
+	default:
+		panic(fmt.Sprintf("unsupported statement type: %T", stmt))
+	}
+}
+
+func (s *StatementExecutor) executeShowStatistics() *influxql.Result {
+	stats, _ := s.Monitor.Statistics()
+	rows := make([]*influxql.Row, len(stats))
+
+	for n, stat := range stats {
+		row := &influxql.Row{Name: stat.Name, Tags: stat.Tags}
+
+		values := make([]interface{}, 0, len(stat.Values))
+		for _, k := range stat.valueNames() {
+			row.Columns = append(row.Columns, k)
+			values = append(values, stat.Values[k])
+		}
+		row.Values = [][]interface{}{values}
+		rows[n] = row
+	}
+	return &influxql.Result{Series: rows}
+}
+
+func (s *StatementExecutor) executeShowDiagnostics() *influxql.Result {
+	return nil
+}


### PR DESCRIPTION
This change adds significant new functionality to the monitor system.

- monitor statements such as `SHOW STATS` are now served by a dedicated query executor layer within the `monitor` module. Modeled on the `meta` package.
- A `PointsWriter` has been added to monitor so it can store statistical data. Very similar to how `http` service gets its `PointsWriter`.
- Since we decided that the `monitor` system will not be responsible for writing data to external InfluxDB systems, all support for that has been removed.
- The `monitor` system now ensures that the target database exists before writing statistics to it.

More to do, including fleshing out the actual diagnostics support, and testing.
