### PR TITLE
Basic HTTPD statistics

### DIFF
--- a/cmd/influxd/run/server.go
+++ b/cmd/influxd/run/server.go
@@ -203,6 +203,7 @@ func (s *Server) appendHTTPDService(c httpd.Config) {
 		return
 	}
 	srv := httpd.NewService(c)
+	srv.Monitor = s.Monitor
 	srv.Handler.MetaStore = s.MetaStore
 	srv.Handler.QueryExecutor = s.QueryExecutor
 	srv.Handler.PointsWriter = s.PointsWriter

--- a/services/httpd/service.go
+++ b/services/httpd/service.go
@@ -2,38 +2,64 @@ package httpd
 
 import (
 	"crypto/tls"
+	"expvar"
 	"fmt"
 	"log"
 	"net"
 	"net/http"
 	"os"
 	"strings"
+	"sync"
+
+	"github.com/influxdb/influxdb/monitor"
+)
+
+// statistics gathered by the httpd package.
+const (
+	statRequests           = "requests"
+	statCQServed           = "cq_served"
+	statQueriesServed      = "queries_served"
+	statWriteServed        = "write_served"
+	statPingServed         = "ping_served"
+	statWriteBytesReceived = "write_bytes_rx"
+	statPointsTransmitted  = "points_tx"
+	statPointsTransmitFail = "points_tx_fail"
+	statAuthFail           = "auth_fail"
 )
 
 // Service manages the listener and handler for an HTTP endpoint.
 type Service struct {
-	ln    net.Listener
-	addr  string
-	https bool
-	cert  string
-	err   chan error
+	ln      net.Listener
+	addr    string
+	https   bool
+	cert    string
+	err     chan error
+	statMap *expvar.Map
 
 	Handler *Handler
+
+	Monitor interface {
+		RegisterStatsClient(name string, tags map[string]string, client monitor.StatsClient) error
+	}
 
 	Logger *log.Logger
 }
 
 // NewService returns a new instance of Service.
 func NewService(c Config) *Service {
+	serviceStatMap := expvarStatMap(c.BindAddress)
+
 	s := &Service{
-		addr:  c.BindAddress,
-		https: c.HttpsEnabled,
-		cert:  c.HttpsCertificate,
-		err:   make(chan error),
+		addr:    c.BindAddress,
+		https:   c.HttpsEnabled,
+		cert:    c.HttpsCertificate,
+		err:     make(chan error),
+		statMap: serviceStatMap,
 		Handler: NewHandler(
 			c.AuthEnabled,
 			c.LogEnabled,
 			c.WriteTracing,
+			serviceStatMap,
 		),
 		Logger: log.New(os.Stderr, "[httpd] ", log.LstdFlags),
 	}
@@ -70,6 +96,12 @@ func (s *Service) Open() error {
 
 		s.Logger.Println("Listening on HTTP:", listener.Addr().String())
 		s.ln = listener
+	}
+
+	// Register stats for this service, now that it has started successfully.
+	if s.Monitor != nil {
+		t := monitor.NewStatsMonitorClient(s.statMap)
+		s.Monitor.RegisterStatsClient("httpd", map[string]string{"bind": s.addr}, t)
 	}
 
 	// Begin listening for requests in a separate goroutine.
@@ -110,3 +142,22 @@ func (s *Service) serve() {
 		s.err <- fmt.Errorf("listener failed: addr=%s, err=%s", s.Addr(), err)
 	}
 }
+
+// expvarStatMap returns the expvar based collection for this service. It must be done within a
+// lock so previous registrations for this key can be checked. Re-registering a key will result
+// in a panic.
+func expvarStatMap(addr string) *expvar.Map {
+	expvarMu.Lock()
+	defer expvarMu.Unlock()
+
+	key := strings.Join([]string{"httpd", addr}, ":")
+
+	// Add expvar for this service.
+	var m expvar.Var
+	if m = expvar.Get(key); m == nil {
+		m = expvar.NewMap(key)
+	}
+	return m.(*expvar.Map)
+}
+
+var expvarMu sync.Mutex


### PR DESCRIPTION
Addition of HTTPD stats. This is actually against the diagnostics PR, just waiting for that to go through, but this is the patch that will add HTTPD stats.

```
> show stats
name: httpd
tags: bind=:8086, clusterID=0, hostname=marx, nodeID=1
queries_served  requests        write_bytes_rx  write_served
--------------  --------        --------------  ------------
7               9               2116            2

```