### PR TITLE
Support sorting by time desc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ With this release InfluxDB is moving to Go 1.5.
 - [#3901](https://github.com/influxdb/influxdb/pull/3901): Add consistency level option to influx cli Thanks @takayuki
 - [#3876](https://github.com/influxdb/influxdb/pull/3876): Allow the following syntax in CQs: INTO "1hPolicy".:MEASUREMENT
 - [#3975](https://github.com/influxdb/influxdb/pull/3975): Add shard copy service
+- [#3986](https://github.com/influxdb/influxdb/pull/3986): Support sorting by time desc
 
 ### Bugfixes
 - [#3804](https://github.com/influxdb/influxdb/pull/3804): init.d script fixes, fixes issue 3803.

--- a/cmd/influxd/run/server_test.go
+++ b/cmd/influxd/run/server_test.go
@@ -2201,6 +2201,14 @@ func TestServer_Query_Aggregates(t *testing.T) {
 			command: `SELECT sum(value)/2 FROM load`,
 			exp:     `{"results":[{"series":[{"name":"load","columns":["time",""],"values":[["1970-01-01T00:00:00Z",75]]}]}]}`,
 		},
+
+		// order by time desc
+		&Query{
+			name:    "order by time desc",
+			params:  url.Values{"db": []string{"db0"}},
+			command: `SELECT max(value) FROM intmany where time >= '2000-01-01T00:00:00Z' AND time <= '2000-01-01T00:01:00Z' group by time(10s) order by time desc`,
+			exp:     `{"results":[{"series":[{"name":"intmany","columns":["time","max"],"values":[["2000-01-01T00:01:00Z",7],["2000-01-01T00:00:50Z",5],["2000-01-01T00:00:40Z",5],["2000-01-01T00:00:30Z",4],["2000-01-01T00:00:20Z",4],["2000-01-01T00:00:10Z",4],["2000-01-01T00:00:00Z",2]]}]}]}`,
+		},
 	}...)
 
 	for i, query := range test.queries {

--- a/cmd/influxd/run/server_test.go
+++ b/cmd/influxd/run/server_test.go
@@ -2204,7 +2204,7 @@ func TestServer_Query_Aggregates(t *testing.T) {
 
 		// order by time desc
 		&Query{
-			name:    "order by time desc",
+			name:    "aggregate order by time desc",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT max(value) FROM intmany where time >= '2000-01-01T00:00:00Z' AND time <= '2000-01-01T00:01:00Z' group by time(10s) order by time desc`,
 			exp:     `{"results":[{"series":[{"name":"intmany","columns":["time","max"],"values":[["2000-01-01T00:01:00Z",7],["2000-01-01T00:00:50Z",5],["2000-01-01T00:00:40Z",5],["2000-01-01T00:00:30Z",4],["2000-01-01T00:00:20Z",4],["2000-01-01T00:00:10Z",4],["2000-01-01T00:00:00Z",2]]}]}]}`,

--- a/influxql/ast.go
+++ b/influxql/ast.go
@@ -276,7 +276,7 @@ type SortField struct {
 // String returns a string representation of a sort field
 func (field *SortField) String() string {
 	var buf bytes.Buffer
-	if field.Name == "" {
+	if field.Name != "" {
 		_, _ = buf.WriteString(field.Name)
 		_, _ = buf.WriteString(" ")
 	}

--- a/influxql/parser.go
+++ b/influxql/parser.go
@@ -1822,6 +1822,11 @@ func (p *Parser) parseSortFields() (SortFields, error) {
 		if err != nil {
 			return nil, err
 		}
+
+		if lit != "time" {
+			return nil, errors.New("only ORDER BY time supported at this time")
+		}
+
 		fields = append(fields, field)
 	// Parse error...
 	default:
@@ -1843,6 +1848,10 @@ func (p *Parser) parseSortFields() (SortFields, error) {
 		}
 
 		fields = append(fields, field)
+	}
+
+	if len(fields) > 1 {
+		return nil, errors.New("only ORDER BY time supported at this time")
 	}
 
 	return fields, nil

--- a/influxql/parser.go
+++ b/influxql/parser.go
@@ -1809,24 +1809,24 @@ func (p *Parser) parseOrderBy() (SortFields, error) {
 func (p *Parser) parseSortFields() (SortFields, error) {
 	var fields SortFields
 
-	// If first token is ASC or DESC, all fields are sorted.
-	if tok, pos, lit := p.scanIgnoreWhitespace(); tok == ASC || tok == DESC {
-		if tok == DESC {
-			// Token must be ASC, until other sort orders are supported.
-			return nil, errors.New("only ORDER BY time ASC supported at this time")
+	tok, pos, lit := p.scanIgnoreWhitespace()
+
+	switch tok {
+	// The first field after an order by may not have a field name (e.g. ORDER BY ASC)
+	case ASC, DESC:
+		fields = append(fields, &SortField{Ascending: (tok == ASC)})
+	// If it's a token, parse it as a sort field.  At least one is required.
+	case IDENT:
+		p.unscan()
+		field, err := p.parseSortField()
+		if err != nil {
+			return nil, err
 		}
-		return append(fields, &SortField{Ascending: (tok == ASC)}), nil
-	} else if tok != IDENT {
+		fields = append(fields, field)
+	// Parse error...
+	default:
 		return nil, newParseError(tokstr(tok, lit), []string{"identifier", "ASC", "DESC"}, pos)
 	}
-	p.unscan()
-
-	// At least one field is required.
-	field, err := p.parseSortField()
-	if err != nil {
-		return nil, err
-	}
-	fields = append(fields, field)
 
 	// Parse additional fields.
 	for {
@@ -1843,11 +1843,6 @@ func (p *Parser) parseSortFields() (SortFields, error) {
 		}
 
 		fields = append(fields, field)
-	}
-
-	// First SortField must be time ASC, until other sort orders are supported.
-	if len(fields) > 1 || fields[0].Name != "time" || !fields[0].Ascending {
-		return nil, errors.New("only ORDER BY time ASC supported at this time")
 	}
 
 	return fields, nil

--- a/influxql/parser_test.go
+++ b/influxql/parser_test.go
@@ -585,7 +585,8 @@ func TestParser_ParseStatement(t *testing.T) {
 
 		// SHOW SERIES WHERE with ORDER BY and LIMIT
 		{
-			s: `SHOW SERIES WHERE region = 'order by desc' ORDER BY DESC, field1, field2 DESC LIMIT 10`,
+			skip: true,
+			s:    `SHOW SERIES WHERE region = 'order by desc' ORDER BY DESC, field1, field2 DESC LIMIT 10`,
 			stmt: &influxql.ShowSeriesStatement{
 				Condition: &influxql.BinaryExpr{
 					Op:  influxql.EQ,
@@ -1258,6 +1259,7 @@ func TestParser_ParseStatement(t *testing.T) {
 		{s: `SELECT field1 FROM myseries ORDER BY /`, err: `found /, expected identifier, ASC, DESC at line 1, char 38`},
 		{s: `SELECT field1 FROM myseries ORDER BY 1`, err: `found 1, expected identifier, ASC, DESC at line 1, char 38`},
 		{s: `SELECT field1 FROM myseries ORDER BY time ASC,`, err: `found EOF, expected identifier at line 1, char 47`},
+		{s: `SELECT field1 FROM myseries ORDER BY time, field1`, err: `only ORDER BY time supported at this time`},
 		{s: `SELECT field1 AS`, err: `found EOF, expected identifier at line 1, char 18`},
 		{s: `SELECT field1 FROM foo group by time(1s)`, err: `GROUP BY requires at least one aggregate function`},
 		{s: `SELECT count(value), value FROM foo`, err: `mixing aggregate and non-aggregate queries is not supported`},

--- a/tsdb/cursor.go
+++ b/tsdb/cursor.go
@@ -5,21 +5,48 @@ import (
 	"container/heap"
 )
 
+// Direction represents a cursor navigation direction.
+type Direction bool
+
+const (
+	// Forward indicates that a cursor will move forward over its values.
+	Forward Direction = true
+	// Reverse indicates that a cursor will move backwards over its values.
+	Reverse Direction = false
+)
+
+func (d Direction) String() string {
+	if d.Forward() {
+		return "forward"
+	}
+	return "reverse"
+}
+
+// Forward returns true if direction is forward
+func (d Direction) Forward() bool {
+	return d == Forward
+}
+
+// Forward returns true if direction is reverse
+func (d Direction) Reverse() bool {
+	return d == Reverse
+}
+
 // MultiCursor returns a single cursor that combines the results of all cursors in order.
 //
 // If the same key is returned from multiple cursors then the first cursor
 // specified will take precendence. A key will only be returned once from the
 // returned cursor.
-func MultiCursor(forward bool, cursors ...Cursor) Cursor {
-	return &multiCursor{cursors: cursors, forward: forward}
+func MultiCursor(d Direction, cursors ...Cursor) Cursor {
+	return &multiCursor{cursors: cursors, direction: d}
 }
 
 // multiCursor represents a cursor that combines multiple cursors into one.
 type multiCursor struct {
-	cursors []Cursor
-	heap    cursorHeap
-	prev    []byte
-	forward bool
+	cursors   []Cursor
+	heap      cursorHeap
+	prev      []byte
+	direction Direction
 }
 
 // Seek moves the cursor to a given key.
@@ -49,7 +76,7 @@ func (mc *multiCursor) Seek(seek []byte) (key, value []byte) {
 	return mc.pop()
 }
 
-func (mc *multiCursor) Direction() bool { return mc.forward }
+func (mc *multiCursor) Direction() Direction { return mc.direction }
 
 // Next returns the next key/value from the cursor.
 func (mc *multiCursor) Next() (key, value []byte) { return mc.pop() }

--- a/tsdb/cursor_test.go
+++ b/tsdb/cursor_test.go
@@ -14,8 +14,8 @@ import (
 
 // Ensure the multi-cursor can correctly iterate across a single subcursor.
 func TestMultiCursor_Single(t *testing.T) {
-	mc := tsdb.MultiCursor(true,
-		NewCursor(true, []CursorItem{
+	mc := tsdb.MultiCursor(tsdb.Forward,
+		NewCursor(tsdb.Forward, []CursorItem{
 			{Key: []byte{0x00}, Value: []byte{0x00}},
 			{Key: []byte{0x01}, Value: []byte{0x10}},
 			{Key: []byte{0x02}, Value: []byte{0x20}},
@@ -35,8 +35,8 @@ func TestMultiCursor_Single(t *testing.T) {
 
 // Ensure the multi-cursor can correctly iterate across a single subcursor in reverse order.
 func TestMultiCursor_Single_Reverse(t *testing.T) {
-	mc := tsdb.MultiCursor(false,
-		NewCursor(false, []CursorItem{
+	mc := tsdb.MultiCursor(tsdb.Reverse,
+		NewCursor(tsdb.Reverse, []CursorItem{
 			{Key: []byte{0x00}, Value: []byte{0x00}},
 			{Key: []byte{0x01}, Value: []byte{0x10}},
 			{Key: []byte{0x02}, Value: []byte{0x20}},
@@ -56,13 +56,13 @@ func TestMultiCursor_Single_Reverse(t *testing.T) {
 
 // Ensure the multi-cursor can correctly iterate across multiple non-overlapping subcursors.
 func TestMultiCursor_Multiple_NonOverlapping(t *testing.T) {
-	mc := tsdb.MultiCursor(true,
-		NewCursor(true, []CursorItem{
+	mc := tsdb.MultiCursor(tsdb.Forward,
+		NewCursor(tsdb.Forward, []CursorItem{
 			{Key: []byte{0x00}, Value: []byte{0x00}},
 			{Key: []byte{0x03}, Value: []byte{0x30}},
 			{Key: []byte{0x04}, Value: []byte{0x40}},
 		}),
-		NewCursor(true, []CursorItem{
+		NewCursor(tsdb.Forward, []CursorItem{
 			{Key: []byte{0x01}, Value: []byte{0x10}},
 			{Key: []byte{0x02}, Value: []byte{0x20}},
 		}),
@@ -85,13 +85,13 @@ func TestMultiCursor_Multiple_NonOverlapping(t *testing.T) {
 
 // Ensure the multi-cursor can correctly iterate across multiple non-overlapping subcursors.
 func TestMultiCursor_Multiple_NonOverlapping_Reverse(t *testing.T) {
-	mc := tsdb.MultiCursor(false,
-		NewCursor(false, []CursorItem{
+	mc := tsdb.MultiCursor(tsdb.Reverse,
+		NewCursor(tsdb.Reverse, []CursorItem{
 			{Key: []byte{0x00}, Value: []byte{0x00}},
 			{Key: []byte{0x03}, Value: []byte{0x30}},
 			{Key: []byte{0x04}, Value: []byte{0x40}},
 		}),
-		NewCursor(false, []CursorItem{
+		NewCursor(tsdb.Reverse, []CursorItem{
 			{Key: []byte{0x01}, Value: []byte{0x10}},
 			{Key: []byte{0x02}, Value: []byte{0x20}},
 		}),
@@ -114,13 +114,13 @@ func TestMultiCursor_Multiple_NonOverlapping_Reverse(t *testing.T) {
 
 // Ensure the multi-cursor can correctly iterate across multiple overlapping subcursors.
 func TestMultiCursor_Multiple_Overlapping(t *testing.T) {
-	mc := tsdb.MultiCursor(true,
-		NewCursor(true, []CursorItem{
+	mc := tsdb.MultiCursor(tsdb.Forward,
+		NewCursor(tsdb.Forward, []CursorItem{
 			{Key: []byte{0x00}, Value: []byte{0x00}},
 			{Key: []byte{0x03}, Value: []byte{0x03}},
 			{Key: []byte{0x04}, Value: []byte{0x04}},
 		}),
-		NewCursor(true, []CursorItem{
+		NewCursor(tsdb.Forward, []CursorItem{
 			{Key: []byte{0x00}, Value: []byte{0xF0}},
 			{Key: []byte{0x02}, Value: []byte{0xF2}},
 			{Key: []byte{0x04}, Value: []byte{0xF4}},
@@ -142,13 +142,13 @@ func TestMultiCursor_Multiple_Overlapping(t *testing.T) {
 
 // Ensure the multi-cursor can correctly iterate across multiple overlapping subcursors.
 func TestMultiCursor_Multiple_Overlapping_Reverse(t *testing.T) {
-	mc := tsdb.MultiCursor(false,
-		NewCursor(false, []CursorItem{
+	mc := tsdb.MultiCursor(tsdb.Reverse,
+		NewCursor(tsdb.Reverse, []CursorItem{
 			{Key: []byte{0x00}, Value: []byte{0x00}},
 			{Key: []byte{0x03}, Value: []byte{0x03}},
 			{Key: []byte{0x04}, Value: []byte{0x04}},
 		}),
-		NewCursor(false, []CursorItem{
+		NewCursor(tsdb.Reverse, []CursorItem{
 			{Key: []byte{0x00}, Value: []byte{0xF0}},
 			{Key: []byte{0x02}, Value: []byte{0xF2}},
 			{Key: []byte{0x04}, Value: []byte{0xF4}},
@@ -196,7 +196,7 @@ func TestMultiCursor_Quick(t *testing.T) {
 		sort.Sort(byteSlices(exp))
 
 		// Create multi-cursor and iterate over all items.
-		mc := tsdb.MultiCursor(true, tsdbCursorSlice(cursors)...)
+		mc := tsdb.MultiCursor(tsdb.Forward, tsdbCursorSlice(cursors)...)
 		for k, v := mc.Seek(u64tob(seek)); k != nil; k, v = mc.Next() {
 			got = append(got, append(k, v...))
 		}

--- a/tsdb/cursor_test.go
+++ b/tsdb/cursor_test.go
@@ -14,7 +14,7 @@ import (
 
 // Ensure the multi-cursor can correctly iterate across a single subcursor.
 func TestMultiCursor_Single(t *testing.T) {
-	mc := tsdb.MultiCursor(
+	mc := tsdb.MultiCursor(true,
 		NewCursor([]CursorItem{
 			{Key: []byte{0x00}, Value: []byte{0x00}},
 			{Key: []byte{0x01}, Value: []byte{0x10}},
@@ -35,7 +35,7 @@ func TestMultiCursor_Single(t *testing.T) {
 
 // Ensure the multi-cursor can correctly iterate across multiple non-overlapping subcursors.
 func TestMultiCursor_Multiple_NonOverlapping(t *testing.T) {
-	mc := tsdb.MultiCursor(
+	mc := tsdb.MultiCursor(true,
 		NewCursor([]CursorItem{
 			{Key: []byte{0x00}, Value: []byte{0x00}},
 			{Key: []byte{0x03}, Value: []byte{0x30}},
@@ -64,7 +64,7 @@ func TestMultiCursor_Multiple_NonOverlapping(t *testing.T) {
 
 // Ensure the multi-cursor can correctly iterate across multiple overlapping subcursors.
 func TestMultiCursor_Multiple_Overlapping(t *testing.T) {
-	mc := tsdb.MultiCursor(
+	mc := tsdb.MultiCursor(true,
 		NewCursor([]CursorItem{
 			{Key: []byte{0x00}, Value: []byte{0x00}},
 			{Key: []byte{0x03}, Value: []byte{0x03}},
@@ -118,7 +118,7 @@ func TestMultiCursor_Quick(t *testing.T) {
 		sort.Sort(byteSlices(exp))
 
 		// Create multi-cursor and iterate over all items.
-		mc := tsdb.MultiCursor(tsdbCursorSlice(cursors)...)
+		mc := tsdb.MultiCursor(true, tsdbCursorSlice(cursors)...)
 		for k, v := mc.Seek(u64tob(seek)); k != nil; k, v = mc.Next() {
 			got = append(got, append(k, v...))
 		}
@@ -143,6 +143,8 @@ func NewCursor(items []CursorItem) *Cursor {
 	sort.Sort(CursorItems(items))
 	return &Cursor{items: items}
 }
+
+func (c *Cursor) Direction() bool { return true }
 
 // Seek seeks to an item by key.
 func (c *Cursor) Seek(seek []byte) (key, value []byte) {

--- a/tsdb/cursor_test.go
+++ b/tsdb/cursor_test.go
@@ -15,7 +15,7 @@ import (
 // Ensure the multi-cursor can correctly iterate across a single subcursor.
 func TestMultiCursor_Single(t *testing.T) {
 	mc := tsdb.MultiCursor(true,
-		NewCursor([]CursorItem{
+		NewCursor(true, []CursorItem{
 			{Key: []byte{0x00}, Value: []byte{0x00}},
 			{Key: []byte{0x01}, Value: []byte{0x10}},
 			{Key: []byte{0x02}, Value: []byte{0x20}},
@@ -33,15 +33,36 @@ func TestMultiCursor_Single(t *testing.T) {
 	}
 }
 
+// Ensure the multi-cursor can correctly iterate across a single subcursor in reverse order.
+func TestMultiCursor_Single_Reverse(t *testing.T) {
+	mc := tsdb.MultiCursor(false,
+		NewCursor(false, []CursorItem{
+			{Key: []byte{0x00}, Value: []byte{0x00}},
+			{Key: []byte{0x01}, Value: []byte{0x10}},
+			{Key: []byte{0x02}, Value: []byte{0x20}},
+		}),
+	)
+
+	if k, v := mc.Seek([]byte{0x02}); !bytes.Equal(k, []byte{0x02}) || !bytes.Equal(v, []byte{0x20}) {
+		t.Fatalf("unexpected key/value: %x / %x", k, v)
+	} else if k, v = mc.Next(); !bytes.Equal(k, []byte{0x01}) || !bytes.Equal(v, []byte{0x10}) {
+		t.Fatalf("unexpected key/value: %x / %x", k, v)
+	} else if k, v = mc.Next(); !bytes.Equal(k, []byte{0x00}) || !bytes.Equal(v, []byte{0x00}) {
+		t.Fatalf("unexpected key/value: %x / %x", k, v)
+	} else if k, v = mc.Next(); k != nil {
+		t.Fatalf("expected eof, got: %x / %x", k, v)
+	}
+}
+
 // Ensure the multi-cursor can correctly iterate across multiple non-overlapping subcursors.
 func TestMultiCursor_Multiple_NonOverlapping(t *testing.T) {
 	mc := tsdb.MultiCursor(true,
-		NewCursor([]CursorItem{
+		NewCursor(true, []CursorItem{
 			{Key: []byte{0x00}, Value: []byte{0x00}},
 			{Key: []byte{0x03}, Value: []byte{0x30}},
 			{Key: []byte{0x04}, Value: []byte{0x40}},
 		}),
-		NewCursor([]CursorItem{
+		NewCursor(true, []CursorItem{
 			{Key: []byte{0x01}, Value: []byte{0x10}},
 			{Key: []byte{0x02}, Value: []byte{0x20}},
 		}),
@@ -62,15 +83,44 @@ func TestMultiCursor_Multiple_NonOverlapping(t *testing.T) {
 	}
 }
 
+// Ensure the multi-cursor can correctly iterate across multiple non-overlapping subcursors.
+func TestMultiCursor_Multiple_NonOverlapping_Reverse(t *testing.T) {
+	mc := tsdb.MultiCursor(false,
+		NewCursor(false, []CursorItem{
+			{Key: []byte{0x00}, Value: []byte{0x00}},
+			{Key: []byte{0x03}, Value: []byte{0x30}},
+			{Key: []byte{0x04}, Value: []byte{0x40}},
+		}),
+		NewCursor(false, []CursorItem{
+			{Key: []byte{0x01}, Value: []byte{0x10}},
+			{Key: []byte{0x02}, Value: []byte{0x20}},
+		}),
+	)
+
+	if k, v := mc.Seek([]byte{0x04}); !bytes.Equal(k, []byte{0x04}) || !bytes.Equal(v, []byte{0x40}) {
+		t.Fatalf("unexpected key/value: %x / %x", k, v)
+	} else if k, v = mc.Next(); !bytes.Equal(k, []byte{0x03}) || !bytes.Equal(v, []byte{0x30}) {
+		t.Fatalf("unexpected key/value: %x / %x", k, v)
+	} else if k, v = mc.Next(); !bytes.Equal(k, []byte{0x02}) || !bytes.Equal(v, []byte{0x20}) {
+		t.Fatalf("unexpected key/value: %x / %x", k, v)
+	} else if k, v = mc.Next(); !bytes.Equal(k, []byte{0x01}) || !bytes.Equal(v, []byte{0x10}) {
+		t.Fatalf("unexpected key/value: %x / %x", k, v)
+	} else if k, v = mc.Next(); !bytes.Equal(k, []byte{0x00}) || !bytes.Equal(v, []byte{0x00}) {
+		t.Fatalf("unexpected key/value: %x / %x", k, v)
+	} else if k, v = mc.Next(); k != nil {
+		t.Fatalf("expected eof, got: %x / %x", k, v)
+	}
+}
+
 // Ensure the multi-cursor can correctly iterate across multiple overlapping subcursors.
 func TestMultiCursor_Multiple_Overlapping(t *testing.T) {
 	mc := tsdb.MultiCursor(true,
-		NewCursor([]CursorItem{
+		NewCursor(true, []CursorItem{
 			{Key: []byte{0x00}, Value: []byte{0x00}},
 			{Key: []byte{0x03}, Value: []byte{0x03}},
 			{Key: []byte{0x04}, Value: []byte{0x04}},
 		}),
-		NewCursor([]CursorItem{
+		NewCursor(true, []CursorItem{
 			{Key: []byte{0x00}, Value: []byte{0xF0}},
 			{Key: []byte{0x02}, Value: []byte{0xF2}},
 			{Key: []byte{0x04}, Value: []byte{0xF4}},
@@ -84,6 +134,34 @@ func TestMultiCursor_Multiple_Overlapping(t *testing.T) {
 	} else if k, v = mc.Next(); !bytes.Equal(k, []byte{0x03}) || !bytes.Equal(v, []byte{0x03}) {
 		t.Fatalf("unexpected key/value: %x / %x", k, v)
 	} else if k, v = mc.Next(); !bytes.Equal(k, []byte{0x04}) || !bytes.Equal(v, []byte{0x04}) {
+		t.Fatalf("unexpected key/value: %x / %x", k, v)
+	} else if k, v = mc.Next(); k != nil {
+		t.Fatalf("expected eof, got: %x / %x", k, v)
+	}
+}
+
+// Ensure the multi-cursor can correctly iterate across multiple overlapping subcursors.
+func TestMultiCursor_Multiple_Overlapping_Reverse(t *testing.T) {
+	mc := tsdb.MultiCursor(false,
+		NewCursor(false, []CursorItem{
+			{Key: []byte{0x00}, Value: []byte{0x00}},
+			{Key: []byte{0x03}, Value: []byte{0x03}},
+			{Key: []byte{0x04}, Value: []byte{0x04}},
+		}),
+		NewCursor(false, []CursorItem{
+			{Key: []byte{0x00}, Value: []byte{0xF0}},
+			{Key: []byte{0x02}, Value: []byte{0xF2}},
+			{Key: []byte{0x04}, Value: []byte{0xF4}},
+		}),
+	)
+
+	if k, v := mc.Seek([]byte{0x04}); !bytes.Equal(k, []byte{0x04}) || !bytes.Equal(v, []byte{0x04}) {
+		t.Fatalf("unexpected key/value: %x / %x", k, v)
+	} else if k, v = mc.Next(); !bytes.Equal(k, []byte{0x03}) || !bytes.Equal(v, []byte{0x03}) {
+		t.Fatalf("unexpected key/value: %x / %x", k, v)
+	} else if k, v = mc.Next(); !bytes.Equal(k, []byte{0x02}) || !bytes.Equal(v, []byte{0xF2}) {
+		t.Fatalf("unexpected key/value: %x / %x", k, v)
+	} else if k, v = mc.Next(); !bytes.Equal(k, []byte{0x00}) || !bytes.Equal(v, []byte{0x00}) {
 		t.Fatalf("unexpected key/value: %x / %x", k, v)
 	} else if k, v = mc.Next(); k != nil {
 		t.Fatalf("expected eof, got: %x / %x", k, v)
@@ -134,20 +212,33 @@ func TestMultiCursor_Quick(t *testing.T) {
 
 // Cursor represents an in-memory test cursor.
 type Cursor struct {
-	items []CursorItem
-	index int
+	forward bool
+	items   []CursorItem
+	index   int
 }
 
 // NewCursor returns a new instance of Cursor.
-func NewCursor(items []CursorItem) *Cursor {
+func NewCursor(forward bool, items []CursorItem) *Cursor {
+	index := 0
 	sort.Sort(CursorItems(items))
-	return &Cursor{items: items}
+
+	if !forward {
+		index = len(items)
+	}
+	return &Cursor{forward: forward, items: items, index: index}
 }
 
-func (c *Cursor) Direction() bool { return true }
+func (c *Cursor) Direction() bool { return c.forward }
 
 // Seek seeks to an item by key.
 func (c *Cursor) Seek(seek []byte) (key, value []byte) {
+	if c.forward {
+		return c.seekForward(seek)
+	}
+	return c.seekReverse(seek)
+}
+
+func (c *Cursor) seekForward(seek []byte) (key, value []byte) {
 	for c.index = 0; c.index < len(c.items); c.index++ {
 		if bytes.Compare(c.items[c.index].Key, seek) == -1 { // skip keys less than seek
 			continue
@@ -157,19 +248,40 @@ func (c *Cursor) Seek(seek []byte) (key, value []byte) {
 	return nil, nil
 }
 
+func (c *Cursor) seekReverse(seek []byte) (key, value []byte) {
+	for c.index = len(c.items) - 1; c.index >= 0; c.index-- {
+		if bytes.Compare(c.items[c.index].Key, seek) == 1 { // skip keys greater than seek
+			continue
+		}
+		return c.items[c.index].Key, c.items[c.index].Value
+	}
+	return nil, nil
+}
+
 // Next returns the next key/value pair.
 func (c *Cursor) Next() (key, value []byte) {
-	if c.index >= len(c.items)-1 {
+	if !c.forward && c.index < 0 {
 		return nil, nil
 	}
 
-	c.index++
-	return c.items[c.index].Key, c.items[c.index].Value
+	if c.forward && c.index >= len(c.items) {
+		return nil, nil
+	}
+
+	k, v := c.items[c.index].Key, c.items[c.index].Value
+
+	if c.forward {
+		c.index++
+	} else {
+		c.index--
+	}
+	return k, v
 }
 
 // Generate returns a randomly generated cursor. Implements quick.Generator.
 func (c Cursor) Generate(rand *rand.Rand, size int) reflect.Value {
 	c.index = 0
+	c.forward = true
 
 	c.items = make([]CursorItem, rand.Intn(size))
 	for i := range c.items {

--- a/tsdb/engine.go
+++ b/tsdb/engine.go
@@ -123,7 +123,7 @@ func NewEngineOptions() EngineOptions {
 type Tx interface {
 	io.WriterTo
 
-	Cursor(series string) Cursor
+	Cursor(series string, forward bool) Cursor
 	Size() int64
 	Commit() error
 	Rollback() error
@@ -133,6 +133,7 @@ type Tx interface {
 type Cursor interface {
 	Seek(seek []byte) (key, value []byte)
 	Next() (key, value []byte)
+	Direction() bool
 }
 
 // DedupeEntries returns slices with unique keys (the first 8 bytes).

--- a/tsdb/engine.go
+++ b/tsdb/engine.go
@@ -123,7 +123,7 @@ func NewEngineOptions() EngineOptions {
 type Tx interface {
 	io.WriterTo
 
-	Cursor(series string, forward bool) Cursor
+	Cursor(series string, direction Direction) Cursor
 	Size() int64
 	Commit() error
 	Rollback() error
@@ -133,7 +133,7 @@ type Tx interface {
 type Cursor interface {
 	Seek(seek []byte) (key, value []byte)
 	Next() (key, value []byte)
-	Direction() bool
+	Direction() Direction
 }
 
 // DedupeEntries returns slices with unique keys (the first 8 bytes).

--- a/tsdb/engine/b1/b1.go
+++ b/tsdb/engine/b1/b1.go
@@ -568,9 +568,17 @@ func (tx *Tx) Cursor(key string, direction tsdb.Direction) tsdb.Cursor {
 	copy(cache, tx.engine.cache[partitionID][key])
 
 	// Build a cursor that merges the bucket and cache together.
-	cur := &Cursor{cache: cache}
+	cur := &Cursor{cache: cache, direction: direction}
 	if b != nil {
 		cur.cursor = b.Cursor()
+	}
+
+	// If it's a reverse cursor, set the current location to the end.
+	if direction.Reverse() {
+		cur.index = len(cache) - 1
+		if cur.cursor != nil {
+			cur.cursor.Last()
+		}
 	}
 	return cur
 }
@@ -589,9 +597,12 @@ type Cursor struct {
 
 	// Previously read key.
 	prev []byte
+
+	// The direction the cursor pointer moves after each call to Next()
+	direction tsdb.Direction
 }
 
-func (c *Cursor) Direction() tsdb.Direction { return tsdb.Forward }
+func (c *Cursor) Direction() tsdb.Direction { return c.direction }
 
 // Seek moves the cursor to a position and returns the closest key/value pair.
 func (c *Cursor) Seek(seek []byte) (key, value []byte) {
@@ -604,6 +615,12 @@ func (c *Cursor) Seek(seek []byte) (key, value []byte) {
 	c.index = sort.Search(len(c.cache), func(i int) bool {
 		return bytes.Compare(c.cache[i][0:8], seek) != -1
 	})
+
+	// Search will return an index after the length of cache if the seek value is greater
+	// than all the values.  Clamp it to the end of the cache.
+	if c.direction.Reverse() && c.index >= len(c.cache) {
+		c.index = len(c.cache) - 1
+	}
 
 	c.prev = nil
 	return c.read()
@@ -618,20 +635,10 @@ func (c *Cursor) Next() (key, value []byte) {
 func (c *Cursor) read() (key, value []byte) {
 	// Continue skipping ahead through duplicate keys in the cache list.
 	for {
-		// Read next value from the cursor.
-		if c.buf.key == nil && c.cursor != nil {
-			c.buf.key, c.buf.value = c.cursor.Next()
-		}
-
-		// Read from the buffer or cache, which ever is lower.
-		if c.buf.key != nil && (c.index >= len(c.cache) || bytes.Compare(c.buf.key, c.cache[c.index][0:8]) == -1) {
-			key, value = c.buf.key, c.buf.value
-			c.buf.key, c.buf.value = nil, nil
-		} else if c.index < len(c.cache) {
-			key, value = c.cache[c.index][0:8], c.cache[c.index][8:]
-			c.index++
+		if c.direction.Forward() {
+			key, value = c.readForward()
 		} else {
-			key, value = nil, nil
+			key, value = c.readReverse()
 		}
 
 		// Exit loop if we're at the end of the cache or the next key is different.
@@ -641,6 +648,46 @@ func (c *Cursor) read() (key, value []byte) {
 	}
 
 	c.prev = key
+	return
+}
+
+// readForward returns the next key/value from the cursor and moves the current location forward.
+func (c *Cursor) readForward() (key, value []byte) {
+	// Read next value from the cursor.
+	if c.buf.key == nil && c.cursor != nil {
+		c.buf.key, c.buf.value = c.cursor.Next()
+	}
+
+	// Read from the buffer or cache, which ever is lower.
+	if c.buf.key != nil && (c.index >= len(c.cache) || bytes.Compare(c.buf.key, c.cache[c.index][0:8]) == -1) {
+		key, value = c.buf.key, c.buf.value
+		c.buf.key, c.buf.value = nil, nil
+	} else if c.index < len(c.cache) {
+		key, value = c.cache[c.index][0:8], c.cache[c.index][8:]
+		c.index++
+	} else {
+		key, value = nil, nil
+	}
+	return
+}
+
+// readReverse returns the next key/value from the cursor and moves the current location backwards.
+func (c *Cursor) readReverse() (key, value []byte) {
+	// Read prev value from the cursor.
+	if c.buf.key == nil && c.cursor != nil {
+		c.buf.key, c.buf.value = c.cursor.Prev()
+	}
+
+	// Read from the buffer or cache, which ever is lower.
+	if c.buf.key != nil && (c.index < 0 || bytes.Compare(c.buf.key, c.cache[c.index][0:8]) == 1) {
+		key, value = c.buf.key, c.buf.value
+		c.buf.key, c.buf.value = nil, nil
+	} else if c.index >= 0 && c.index < len(c.cache) {
+		key, value = c.cache[c.index][0:8], c.cache[c.index][8:]
+		c.index--
+	} else {
+		key, value = nil, nil
+	}
 	return
 }
 

--- a/tsdb/engine/b1/b1.go
+++ b/tsdb/engine/b1/b1.go
@@ -550,7 +550,7 @@ type Tx struct {
 }
 
 // Cursor returns an iterator for a key.
-func (tx *Tx) Cursor(key string, forward bool) tsdb.Cursor {
+func (tx *Tx) Cursor(key string, direction tsdb.Direction) tsdb.Cursor {
 	// Retrieve key bucket.
 	b := tx.Bucket([]byte(key))
 
@@ -591,7 +591,7 @@ type Cursor struct {
 	prev []byte
 }
 
-func (c *Cursor) Direction() bool { return true }
+func (c *Cursor) Direction() tsdb.Direction { return tsdb.Forward }
 
 // Seek moves the cursor to a position and returns the closest key/value pair.
 func (c *Cursor) Seek(seek []byte) (key, value []byte) {

--- a/tsdb/engine/b1/b1.go
+++ b/tsdb/engine/b1/b1.go
@@ -550,7 +550,7 @@ type Tx struct {
 }
 
 // Cursor returns an iterator for a key.
-func (tx *Tx) Cursor(key string) tsdb.Cursor {
+func (tx *Tx) Cursor(key string, forward bool) tsdb.Cursor {
 	// Retrieve key bucket.
 	b := tx.Bucket([]byte(key))
 
@@ -590,6 +590,8 @@ type Cursor struct {
 	// Previously read key.
 	prev []byte
 }
+
+func (c *Cursor) Direction() bool { return true }
 
 // Seek moves the cursor to a position and returns the closest key/value pair.
 func (c *Cursor) Seek(seek []byte) (key, value []byte) {

--- a/tsdb/engine/b1/b1_test.go
+++ b/tsdb/engine/b1/b1_test.go
@@ -64,7 +64,7 @@ func TestEngine_WritePoints(t *testing.T) {
 	tx := e.MustBegin(false)
 	defer tx.Rollback()
 
-	c := tx.Cursor("temperature")
+	c := tx.Cursor("temperature", true)
 	if k, v := c.Seek([]byte{0}); !bytes.Equal(k, u64tob(uint64(time.Unix(1434059627, 0).UnixNano()))) {
 		t.Fatalf("unexpected key: %#v", k)
 	} else if m, err := mf.Codec.DecodeFieldsWithNames(v); err != nil {

--- a/tsdb/engine/b1/b1_test.go
+++ b/tsdb/engine/b1/b1_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"io/ioutil"
+	"math"
 	"os"
 	"testing"
 	"time"
@@ -64,12 +65,79 @@ func TestEngine_WritePoints(t *testing.T) {
 	tx := e.MustBegin(false)
 	defer tx.Rollback()
 
-	c := tx.Cursor("temperature", true)
+	c := tx.Cursor("temperature", tsdb.Forward)
 	if k, v := c.Seek([]byte{0}); !bytes.Equal(k, u64tob(uint64(time.Unix(1434059627, 0).UnixNano()))) {
 		t.Fatalf("unexpected key: %#v", k)
 	} else if m, err := mf.Codec.DecodeFieldsWithNames(v); err != nil {
 		t.Fatal(err)
 	} else if m["value"] != float64(200) {
+		t.Errorf("unexpected value: %#v", m)
+	}
+
+	if k, v := c.Next(); k != nil {
+		t.Fatalf("unexpected key/value: %#v / %#v", k, v)
+	}
+}
+
+// Ensure points can be written to the engine and queried in reverse order.
+func TestEngine_WritePoints_Reverse(t *testing.T) {
+	e := OpenDefaultEngine()
+	defer e.Close()
+
+	// Create metadata.
+	mf := &tsdb.MeasurementFields{Fields: make(map[string]*tsdb.Field)}
+	mf.CreateFieldIfNotExists("value", influxql.Float)
+	seriesToCreate := []*tsdb.SeriesCreate{
+		{Series: tsdb.NewSeries(string(tsdb.MakeKey([]byte("temperature"), nil)), nil)},
+	}
+
+	// Parse point.
+	points, err := tsdb.ParsePointsWithPrecision([]byte("temperature value=100 0"), time.Now().UTC(), "s")
+	if err != nil {
+		t.Fatal(err)
+	} else if data, err := mf.Codec.EncodeFields(points[0].Fields()); err != nil {
+		t.Fatal(err)
+	} else {
+		points[0].SetData(data)
+	}
+
+	// Write original value.
+	if err := e.WritePoints(points, map[string]*tsdb.MeasurementFields{"temperature": mf}, seriesToCreate); err != nil {
+		t.Fatal(err)
+	}
+
+	// Flush to disk.
+	if err := e.Flush(0); err != nil {
+		t.Fatal(err)
+	}
+
+	// Parse new point.
+	points, err = tsdb.ParsePointsWithPrecision([]byte("temperature value=200 1"), time.Now().UTC(), "s")
+	if err != nil {
+		t.Fatal(err)
+	} else if data, err := mf.Codec.EncodeFields(points[0].Fields()); err != nil {
+		t.Fatal(err)
+	} else {
+		points[0].SetData(data)
+	}
+
+	// Write the new points existing value.
+	if err := e.WritePoints(points, nil, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	// Ensure only the updated value is read.
+	tx := e.MustBegin(false)
+	defer tx.Rollback()
+
+	c := tx.Cursor("temperature", tsdb.Reverse)
+	if k, _ := c.Seek(u64tob(math.MaxInt64)); !bytes.Equal(k, u64tob(uint64(time.Unix(1, 0).UnixNano()))) {
+		t.Fatalf("unexpected key: %v", btou64(k))
+	} else if k, v := c.Next(); !bytes.Equal(k, u64tob(uint64(time.Unix(0, 0).UnixNano()))) {
+		t.Fatalf("unexpected key: %#v", k)
+	} else if m, err := mf.Codec.DecodeFieldsWithNames(v); err != nil {
+		t.Fatal(err)
+	} else if m["value"] != float64(100) {
 		t.Errorf("unexpected value: %#v", m)
 	}
 

--- a/tsdb/engine/bz1/bz1.go
+++ b/tsdb/engine/bz1/bz1.go
@@ -59,7 +59,7 @@ type WAL interface {
 	WritePoints(points []tsdb.Point, measurementFieldsToSave map[string]*tsdb.MeasurementFields, seriesToCreate []*tsdb.SeriesCreate) error
 	LoadMetadataIndex(index *tsdb.DatabaseIndex, measurementFields map[string]*tsdb.MeasurementFields) error
 	DeleteSeries(keys []string) error
-	Cursor(key string) tsdb.Cursor
+	Cursor(key string, forward bool) tsdb.Cursor
 	Open() error
 	Close() error
 	Flush() error
@@ -606,8 +606,8 @@ type Tx struct {
 }
 
 // Cursor returns an iterator for a key.
-func (tx *Tx) Cursor(key string) tsdb.Cursor {
-	walCursor := tx.wal.Cursor(key)
+func (tx *Tx) Cursor(key string, forward bool) tsdb.Cursor {
+	walCursor := tx.wal.Cursor(key, forward)
 
 	// Retrieve points bucket. Ignore if there is no bucket.
 	b := tx.Bucket([]byte("points")).Bucket([]byte(key))
@@ -616,18 +616,24 @@ func (tx *Tx) Cursor(key string) tsdb.Cursor {
 	}
 
 	c := &Cursor{
-		cursor: b.Cursor(),
+		cursor:  b.Cursor(),
+		forward: forward,
 	}
 
-	return tsdb.MultiCursor(walCursor, c)
+	return tsdb.MultiCursor(forward, walCursor, c)
 }
 
 // Cursor provides ordered iteration across a series.
 type Cursor struct {
-	cursor *bolt.Cursor
-	buf    []byte // uncompressed buffer
-	off    int    // buffer offset
+	cursor       *bolt.Cursor
+	buf          []byte // uncompressed buffer
+	off          int    // buffer offset
+	forward      bool
+	fieldIndices []int
+	index        int
 }
+
+func (c *Cursor) Direction() bool { return c.forward }
 
 // Seek moves the cursor to a position and returns the closest key/value pair.
 func (c *Cursor) Seek(seek []byte) (key, value []byte) {
@@ -659,12 +665,26 @@ func (c *Cursor) seekBuf(seek []byte) (key, value []byte) {
 		buf := c.buf[c.off:]
 
 		// Exit if current entry's timestamp is on or after the seek.
-		if len(buf) == 0 || bytes.Compare(buf[0:8], seek) != -1 {
+		if len(buf) == 0 {
 			return
 		}
 
-		// Otherwise skip ahead to the next entry.
-		c.off += entryHeaderSize + entryDataSize(buf)
+		if c.forward && bytes.Compare(buf[0:8], seek) != -1 {
+			return
+		} else if !c.forward && bytes.Compare(buf[0:8], seek) != 1 {
+			return
+		}
+
+		if c.forward {
+			// Otherwise skip ahead to the next entry.
+			c.off += entryHeaderSize + entryDataSize(buf)
+		} else {
+			c.index -= 1
+			if c.index < 0 {
+				return
+			}
+			c.off = c.fieldIndices[c.index]
+		}
 	}
 }
 
@@ -675,8 +695,22 @@ func (c *Cursor) Next() (key, value []byte) {
 		return nil, nil
 	}
 
-	// Move forward to next entry.
-	c.off += entryHeaderSize + entryDataSize(c.buf[c.off:])
+	if c.forward {
+		// Move forward to next entry.
+		c.off += entryHeaderSize + entryDataSize(c.buf[c.off:])
+	} else {
+		c.index -= 1
+
+		// If we've move past the beginning of buf, grab the previous block
+		if c.index < 0 {
+			_, v := c.cursor.Prev()
+			c.setBuf(v)
+		}
+
+		if len(c.fieldIndices) > 0 {
+			c.off = c.fieldIndices[c.index]
+		}
+	}
 
 	// If no items left then read first item from next block.
 	if c.off >= len(c.buf) {
@@ -691,7 +725,7 @@ func (c *Cursor) Next() (key, value []byte) {
 func (c *Cursor) setBuf(block []byte) {
 	// Clear if the block is empty.
 	if len(block) == 0 {
-		c.buf, c.off = c.buf[0:0], 0
+		c.buf, c.off, c.fieldIndices, c.index = c.buf[0:0], 0, c.fieldIndices[0:0], 0
 		return
 	}
 
@@ -702,7 +736,31 @@ func (c *Cursor) setBuf(block []byte) {
 		c.buf = c.buf[0:0]
 		log.Printf("block decode error: %s", err)
 	}
-	c.buf, c.off = buf, 0
+
+	if c.forward {
+		c.buf, c.off = buf, 0
+	} else {
+		c.buf, c.off = buf, 0
+
+		// Buf contains multiple fields packed into a byte slice with timestamp
+		// and data lengths.  We need to build an index into this byte slice that
+		// tells us where each field block is in buf so we can iterate backward without
+		// rescanning the buf each time Next is called.  Forward iteration does not
+		// need this because we know the entries lenghth and the header size so we can
+		// skip forward that many bytes.
+		c.fieldIndices = []int{}
+		for {
+			if c.off >= len(buf) {
+				break
+			}
+
+			c.fieldIndices = append(c.fieldIndices, c.off)
+			c.off += entryHeaderSize + entryDataSize(buf[c.off:])
+		}
+
+		c.off = c.fieldIndices[len(c.fieldIndices)-1]
+		c.index = len(c.fieldIndices) - 1
+	}
 }
 
 // read reads the current key and value from the current block.

--- a/tsdb/engine/bz1/bz1_test.go
+++ b/tsdb/engine/bz1/bz1_test.go
@@ -582,18 +582,18 @@ func (w *EnginePointsWriter) Open() error { return nil }
 
 func (w *EnginePointsWriter) Close() error { return nil }
 
-func (w *EnginePointsWriter) Cursor(key string, forward bool) tsdb.Cursor {
-	return &Cursor{forward: forward}
+func (w *EnginePointsWriter) Cursor(key string, direction tsdb.Direction) tsdb.Cursor {
+	return &Cursor{direction: direction}
 }
 
 func (w *EnginePointsWriter) Flush() error { return nil }
 
 // Cursor represents a mock that implements tsdb.Curosr.
 type Cursor struct {
-	forward bool
+	direction tsdb.Direction
 }
 
-func (c *Cursor) Direction() bool { return c.forward }
+func (c *Cursor) Direction() tsdb.Direction { return c.direction }
 
 func (c *Cursor) Seek(key []byte) ([]byte, []byte) { return nil, nil }
 

--- a/tsdb/engine/bz1/bz1_test.go
+++ b/tsdb/engine/bz1/bz1_test.go
@@ -176,7 +176,7 @@ func TestEngine_WriteIndex_Append(t *testing.T) {
 	defer tx.Rollback()
 
 	// Iterate over "cpu" series.
-	c := tx.Cursor("cpu", true)
+	c := tx.Cursor("cpu", tsdb.Forward)
 	if k, v := c.Seek(u64tob(0)); !reflect.DeepEqual(k, []byte{0, 0, 0, 0, 0, 0, 0, 1}) || !reflect.DeepEqual(v, []byte{0x10}) {
 		t.Fatalf("unexpected key/value: %x / %x", k, v)
 	} else if k, v = c.Next(); !reflect.DeepEqual(k, []byte{0, 0, 0, 0, 0, 0, 0, 2}) || !reflect.DeepEqual(v, []byte{0x20}) {
@@ -186,7 +186,7 @@ func TestEngine_WriteIndex_Append(t *testing.T) {
 	}
 
 	// Iterate over "mem" series.
-	c = tx.Cursor("mem", true)
+	c = tx.Cursor("mem", tsdb.Forward)
 	if k, v := c.Seek(u64tob(0)); !reflect.DeepEqual(k, []byte{0, 0, 0, 0, 0, 0, 0, 0}) || !reflect.DeepEqual(v, []byte{0x30}) {
 		t.Fatalf("unexpected key/value: %x / %x", k, v)
 	} else if k, _ = c.Next(); k != nil {
@@ -236,7 +236,7 @@ func TestEngine_WriteIndex_Insert(t *testing.T) {
 	defer tx.Rollback()
 
 	// Iterate over "cpu" series.
-	c := tx.Cursor("cpu", true)
+	c := tx.Cursor("cpu", tsdb.Forward)
 	if k, v := c.Seek(u64tob(0)); btou64(k) != 9 || !bytes.Equal(v, []byte{0x09}) {
 		t.Fatalf("unexpected key/value: %x / %x", k, v)
 	} else if k, v = c.Next(); btou64(k) != 10 || !bytes.Equal(v, []byte{0xFF}) {
@@ -294,7 +294,7 @@ func TestEngine_Cursor_Reverse(t *testing.T) {
 	defer tx.Rollback()
 
 	// Iterate over "cpu" series.
-	c := tx.Cursor("cpu", false)
+	c := tx.Cursor("cpu", tsdb.Reverse)
 	if k, v := c.Seek(u64tob(math.MaxUint64)); btou64(k) != 31 || !bytes.Equal(v, []byte{0xFF}) {
 		t.Fatalf("unexpected key/value: %x / %x", k, v)
 	} else if k, v = c.Next(); btou64(k) != 30 || !bytes.Equal(v, []byte{0x30}) {
@@ -335,7 +335,7 @@ func TestEngine_WriteIndex_SeekAgainstInBlockValue(t *testing.T) {
 	defer tx.Rollback()
 
 	// Ensure that we can seek to a block in the middle
-	c := tx.Cursor("cpu", true)
+	c := tx.Cursor("cpu", tsdb.Forward)
 	if k, _ := c.Seek(u64tob(15)); btou64(k) != 20 {
 		t.Fatalf("expected to seek to time 20, but got %d", btou64(k))
 	}
@@ -393,7 +393,7 @@ func TestEngine_WriteIndex_Quick(t *testing.T) {
 
 		// Iterate over results to ensure they are correct.
 		for _, key := range keys {
-			c := tx.Cursor(key, true)
+			c := tx.Cursor(key, tsdb.Forward)
 
 			// Read list of key/values.
 			var got [][]byte
@@ -440,7 +440,7 @@ func TestEngine_WriteIndex_Quick_Append(t *testing.T) {
 
 		// Iterate over results to ensure they are correct.
 		for _, key := range keys {
-			c := tx.Cursor(key, true)
+			c := tx.Cursor(key, tsdb.Forward)
 
 			// Read list of key/values.
 			var got [][]byte

--- a/tsdb/engine/bz1/bz1_test.go
+++ b/tsdb/engine/bz1/bz1_test.go
@@ -175,7 +175,7 @@ func TestEngine_WriteIndex_Append(t *testing.T) {
 	defer tx.Rollback()
 
 	// Iterate over "cpu" series.
-	c := tx.Cursor("cpu")
+	c := tx.Cursor("cpu", true)
 	if k, v := c.Seek(u64tob(0)); !reflect.DeepEqual(k, []byte{0, 0, 0, 0, 0, 0, 0, 1}) || !reflect.DeepEqual(v, []byte{0x10}) {
 		t.Fatalf("unexpected key/value: %x / %x", k, v)
 	} else if k, v = c.Next(); !reflect.DeepEqual(k, []byte{0, 0, 0, 0, 0, 0, 0, 2}) || !reflect.DeepEqual(v, []byte{0x20}) {
@@ -185,7 +185,7 @@ func TestEngine_WriteIndex_Append(t *testing.T) {
 	}
 
 	// Iterate over "mem" series.
-	c = tx.Cursor("mem")
+	c = tx.Cursor("mem", true)
 	if k, v := c.Seek(u64tob(0)); !reflect.DeepEqual(k, []byte{0, 0, 0, 0, 0, 0, 0, 0}) || !reflect.DeepEqual(v, []byte{0x30}) {
 		t.Fatalf("unexpected key/value: %x / %x", k, v)
 	} else if k, _ = c.Next(); k != nil {
@@ -235,7 +235,7 @@ func TestEngine_WriteIndex_Insert(t *testing.T) {
 	defer tx.Rollback()
 
 	// Iterate over "cpu" series.
-	c := tx.Cursor("cpu")
+	c := tx.Cursor("cpu", true)
 	if k, v := c.Seek(u64tob(0)); btou64(k) != 9 || !bytes.Equal(v, []byte{0x09}) {
 		t.Fatalf("unexpected key/value: %x / %x", k, v)
 	} else if k, v = c.Next(); btou64(k) != 10 || !bytes.Equal(v, []byte{0xFF}) {
@@ -276,7 +276,7 @@ func TestEngine_WriteIndex_SeekAgainstInBlockValue(t *testing.T) {
 	defer tx.Rollback()
 
 	// Ensure that we can seek to a block in the middle
-	c := tx.Cursor("cpu")
+	c := tx.Cursor("cpu", true)
 	if k, _ := c.Seek(u64tob(15)); btou64(k) != 20 {
 		t.Fatalf("expected to seek to time 20, but got %d", btou64(k))
 	}
@@ -334,7 +334,7 @@ func TestEngine_WriteIndex_Quick(t *testing.T) {
 
 		// Iterate over results to ensure they are correct.
 		for _, key := range keys {
-			c := tx.Cursor(key)
+			c := tx.Cursor(key, true)
 
 			// Read list of key/values.
 			var got [][]byte
@@ -381,7 +381,7 @@ func TestEngine_WriteIndex_Quick_Append(t *testing.T) {
 
 		// Iterate over results to ensure they are correct.
 		for _, key := range keys {
-			c := tx.Cursor(key)
+			c := tx.Cursor(key, true)
 
 			// Read list of key/values.
 			var got [][]byte
@@ -523,13 +523,15 @@ func (w *EnginePointsWriter) Open() error { return nil }
 
 func (w *EnginePointsWriter) Close() error { return nil }
 
-func (w *EnginePointsWriter) Cursor(key string) tsdb.Cursor { return &Cursor{} }
+func (w *EnginePointsWriter) Cursor(key string, forward bool) tsdb.Cursor { return &Cursor{} }
 
 func (w *EnginePointsWriter) Flush() error { return nil }
 
 // Cursor represents a mock that implements tsdb.Curosr.
 type Cursor struct {
 }
+
+func (c *Cursor) Direction() bool { return true }
 
 func (c *Cursor) Seek(key []byte) ([]byte, []byte) { return nil, nil }
 

--- a/tsdb/engine/wal/wal.go
+++ b/tsdb/engine/wal/wal.go
@@ -223,11 +223,11 @@ func (l *Log) Open() error {
 }
 
 // Cursor will return a cursor object to Seek and iterate with Next for the WAL cache for the given
-func (l *Log) Cursor(key string) tsdb.Cursor {
+func (l *Log) Cursor(key string, forward bool) tsdb.Cursor {
 	l.mu.RLock()
 	defer l.mu.RUnlock()
 
-	return l.partition([]byte(key)).cursor(key)
+	return l.partition([]byte(key)).cursor(key, forward)
 }
 
 func (l *Log) WritePoints(points []tsdb.Point, fields map[string]*tsdb.MeasurementFields, series []*tsdb.SeriesCreate) error {
@@ -1380,7 +1380,7 @@ func (p *Partition) addToCache(key, data []byte, timestamp int64) {
 }
 
 // cursor will combine the in memory cache and flush cache (if a flush is currently happening) to give a single ordered cursor for the key
-func (p *Partition) cursor(key string) *cursor {
+func (p *Partition) cursor(key string, forward bool) *cursor {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
@@ -1398,7 +1398,7 @@ func (p *Partition) cursor(key string) *cursor {
 			c = append(c, entry.points...)
 
 			dedupe := tsdb.DedupeEntries(c)
-			return &cursor{cache: dedupe}
+			return &cursor{cache: dedupe, forward: forward}
 		}
 	}
 
@@ -1410,7 +1410,7 @@ func (p *Partition) cursor(key string) *cursor {
 	// build a copy so modifications to the partition don't change the result set
 	a := make([][]byte, len(entry.points))
 	copy(a, entry.points)
-	return &cursor{cache: a}
+	return &cursor{cache: a, forward: forward}
 }
 
 // idFromFileName parses the segment file ID from its name
@@ -1593,7 +1593,10 @@ type entry struct {
 type cursor struct {
 	cache    [][]byte
 	position int
+	forward  bool
 }
+
+func (c *cursor) Direction() bool { return c.forward }
 
 // Seek will point the cursor to the given time (or key)
 func (c *cursor) Seek(seek []byte) (key, value []byte) {
@@ -1607,12 +1610,26 @@ func (c *cursor) Seek(seek []byte) (key, value []byte) {
 
 // Next moves the cursor to the next key/value. will return nil if at the end
 func (c *cursor) Next() (key, value []byte) {
-	if c.position >= len(c.cache) {
+
+	if !c.forward && c.position >= len(c.cache) {
+		c.position--
+	}
+
+	if c.forward && c.position >= len(c.cache) {
+		return nil, nil
+	}
+
+	if !c.forward && c.position < 0 {
 		return nil, nil
 	}
 
 	v := c.cache[c.position]
-	c.position++
+
+	if c.forward {
+		c.position++
+	} else {
+		c.position--
+	}
 
 	return v[0:8], v[8:]
 

--- a/tsdb/engine/wal/wal.go
+++ b/tsdb/engine/wal/wal.go
@@ -1398,7 +1398,7 @@ func (p *Partition) cursor(key string, forward bool) *cursor {
 			c = append(c, entry.points...)
 
 			dedupe := tsdb.DedupeEntries(c)
-			return &cursor{cache: dedupe, forward: forward}
+			return newCursor(dedupe, forward)
 		}
 	}
 
@@ -1410,7 +1410,7 @@ func (p *Partition) cursor(key string, forward bool) *cursor {
 	// build a copy so modifications to the partition don't change the result set
 	a := make([][]byte, len(entry.points))
 	copy(a, entry.points)
-	return &cursor{cache: a, forward: forward}
+	return newCursor(a, forward)
 }
 
 // idFromFileName parses the segment file ID from its name
@@ -1594,6 +1594,14 @@ type cursor struct {
 	cache    [][]byte
 	position int
 	forward  bool
+}
+
+func newCursor(cache [][]byte, forward bool) *cursor {
+	c := &cursor{cache: cache, forward: forward}
+	if !forward {
+		c.position = len(c.cache)
+	}
+	return c
 }
 
 func (c *cursor) Direction() bool { return c.forward }

--- a/tsdb/engine/wal/wal.go
+++ b/tsdb/engine/wal/wal.go
@@ -1617,7 +1617,7 @@ func (c *cursor) Seek(seek []byte) (key, value []byte) {
 
 	// If seek is not in the cache, return the last value in the cache
 	if c.direction.Reverse() && c.position >= len(c.cache) {
-		c.position = len(c.cache) - 1
+		c.position = len(c.cache)
 	}
 
 	// Make sure our position points to something in the cache

--- a/tsdb/engine/wal/wal_test.go
+++ b/tsdb/engine/wal/wal_test.go
@@ -46,7 +46,7 @@ func TestWAL_WritePoints(t *testing.T) {
 	}
 
 	verify := func() {
-		c := log.Cursor("cpu,host=A", true)
+		c := log.Cursor("cpu,host=A", tsdb.Forward)
 		k, v := c.Seek(inttob(1))
 
 		// ensure the series are there and points are in order
@@ -64,7 +64,7 @@ func TestWAL_WritePoints(t *testing.T) {
 			t.Fatalf("expected nil on last seek: %v %v", k, v)
 		}
 
-		c = log.Cursor("cpu,host=B", true)
+		c = log.Cursor("cpu,host=B", tsdb.Forward)
 		k, v = c.Next()
 		if bytes.Compare(v, p3.Data()) != 0 {
 			t.Fatalf("expected to seek to first point but got key and value: %v %v", k, v)
@@ -92,7 +92,7 @@ func TestWAL_WritePoints(t *testing.T) {
 	}
 
 	verify2 := func() {
-		c := log.Cursor("cpu,host=A", true)
+		c := log.Cursor("cpu,host=A", tsdb.Forward)
 		k, v := c.Next()
 		if bytes.Compare(v, p1.Data()) != 0 {
 			t.Fatalf("order wrong, expected p1, %v %v %v", v, k, p1.Data())
@@ -110,7 +110,7 @@ func TestWAL_WritePoints(t *testing.T) {
 			t.Fatal("order wrong, expected p6")
 		}
 
-		c = log.Cursor("cpu,host=C", true)
+		c = log.Cursor("cpu,host=C", tsdb.Forward)
 		_, v = c.Next()
 		if bytes.Compare(v, p5.Data()) != 0 {
 			t.Fatal("order wrong, expected p6")
@@ -150,7 +150,7 @@ func TestWAL_CorruptDataLengthSize(t *testing.T) {
 	}
 
 	verify := func() {
-		c := log.Cursor("cpu,host=A", true)
+		c := log.Cursor("cpu,host=A", tsdb.Forward)
 		_, v := c.Next()
 		if bytes.Compare(v, p1.Data()) != 0 {
 			t.Fatal("p1 value wrong")
@@ -183,7 +183,7 @@ func TestWAL_CorruptDataLengthSize(t *testing.T) {
 	}
 
 	verify = func() {
-		c := log.Cursor("cpu,host=A", true)
+		c := log.Cursor("cpu,host=A", tsdb.Forward)
 		_, v := c.Next()
 		if bytes.Compare(v, p1.Data()) != 0 {
 			t.Fatal("p1 value wrong")
@@ -229,7 +229,7 @@ func TestWAL_CorruptDataBlock(t *testing.T) {
 	}
 
 	verify := func() {
-		c := log.Cursor("cpu,host=A", true)
+		c := log.Cursor("cpu,host=A", tsdb.Forward)
 		_, v := c.Next()
 		if bytes.Compare(v, p1.Data()) != 0 {
 			t.Fatal("p1 value wrong")
@@ -268,7 +268,7 @@ func TestWAL_CorruptDataBlock(t *testing.T) {
 	}
 
 	verify = func() {
-		c := log.Cursor("cpu,host=A", true)
+		c := log.Cursor("cpu,host=A", tsdb.Forward)
 		_, v := c.Next()
 		if bytes.Compare(v, p1.Data()) != 0 {
 			t.Fatal("p1 value wrong")
@@ -349,7 +349,7 @@ func TestWAL_CompactAfterPercentageThreshold(t *testing.T) {
 	}
 
 	// ensure we have some data
-	c := log.Cursor("cpu,host=A,region=uswest23", true)
+	c := log.Cursor("cpu,host=A,region=uswest23", tsdb.Forward)
 	k, v := c.Next()
 	if btou64(k) != 1 {
 		t.Fatalf("expected timestamp of 1, but got %v %v", k, v)
@@ -365,13 +365,13 @@ func TestWAL_CompactAfterPercentageThreshold(t *testing.T) {
 	}
 
 	// should be nil
-	c = log.Cursor("cpu,host=A,region=uswest23", true)
+	c = log.Cursor("cpu,host=A,region=uswest23", tsdb.Forward)
 	k, v = c.Next()
 	if k != nil || v != nil {
 		t.Fatal("expected cache to be nil after flush: ", k, v)
 	}
 
-	c = log.Cursor("cpu,host=A,region=useast1", true)
+	c = log.Cursor("cpu,host=A,region=useast1", tsdb.Forward)
 	k, v = c.Next()
 	if btou64(k) != 1 {
 		t.Fatal("expected cache to be there after flush and compact: ", k, v)
@@ -385,13 +385,13 @@ func TestWAL_CompactAfterPercentageThreshold(t *testing.T) {
 	log.Close()
 	log.Open()
 
-	c = log.Cursor("cpu,host=A,region=uswest23", true)
+	c = log.Cursor("cpu,host=A,region=uswest23", tsdb.Forward)
 	k, v = c.Next()
 	if k != nil || v != nil {
 		t.Fatal("expected cache to be nil after flush and re-open: ", k, v)
 	}
 
-	c = log.Cursor("cpu,host=A,region=useast1", true)
+	c = log.Cursor("cpu,host=A,region=useast1", tsdb.Forward)
 	k, v = c.Next()
 	if btou64(k) != 1 {
 		t.Fatal("expected cache to be there after flush and compact: ", k, v)
@@ -444,7 +444,7 @@ func TestWAL_CompactAfterTimeWithoutWrite(t *testing.T) {
 	}
 
 	// ensure we have some data
-	c := log.Cursor("cpu,host=A,region=uswest10", true)
+	c := log.Cursor("cpu,host=A,region=uswest10", tsdb.Forward)
 	k, _ := c.Next()
 	if btou64(k) != 1 {
 		t.Fatalf("expected first data point but got one with key: %v", k)
@@ -625,12 +625,12 @@ func TestWAL_DeleteSeries(t *testing.T) {
 	}
 
 	// ensure data is there
-	c := log.Cursor("cpu,host=A", true)
+	c := log.Cursor("cpu,host=A", tsdb.Forward)
 	if k, _ := c.Next(); btou64(k) != 1 {
 		t.Fatal("expected data point for cpu,host=A")
 	}
 
-	c = log.Cursor("cpu,host=B", true)
+	c = log.Cursor("cpu,host=B", tsdb.Forward)
 	if k, _ := c.Next(); btou64(k) != 2 {
 		t.Fatal("expected data point for cpu,host=B")
 	}
@@ -641,13 +641,13 @@ func TestWAL_DeleteSeries(t *testing.T) {
 	}
 
 	// ensure data is there
-	c = log.Cursor("cpu,host=A", true)
+	c = log.Cursor("cpu,host=A", tsdb.Forward)
 	if k, _ := c.Next(); btou64(k) != 1 {
 		t.Fatal("expected data point for cpu,host=A")
 	}
 
 	// ensure series is deleted
-	c = log.Cursor("cpu,host=B", true)
+	c = log.Cursor("cpu,host=B", tsdb.Forward)
 	if k, _ := c.Next(); k != nil {
 		t.Fatal("expected no data for cpu,host=B")
 	}
@@ -675,13 +675,13 @@ func TestWAL_DeleteSeries(t *testing.T) {
 	}
 
 	// ensure data is there
-	c = log.Cursor("cpu,host=A", true)
+	c = log.Cursor("cpu,host=A", tsdb.Forward)
 	if k, _ := c.Next(); btou64(k) != 1 {
 		t.Fatal("expected data point for cpu,host=A")
 	}
 
 	// ensure series is deleted
-	c = log.Cursor("cpu,host=B", true)
+	c = log.Cursor("cpu,host=B", tsdb.Forward)
 	if k, _ := c.Next(); k != nil {
 		t.Fatal("expected no data for cpu,host=B")
 	}
@@ -805,7 +805,7 @@ func TestWAL_QueryDuringCompaction(t *testing.T) {
 	}
 
 	verify := func() {
-		c := log.Cursor("cpu,host=A", true)
+		c := log.Cursor("cpu,host=A", tsdb.Forward)
 		k, v := c.Seek(inttob(1))
 		// ensure the series are there and points are in order
 		if bytes.Compare(v, p1.Data()) != 0 {
@@ -851,7 +851,7 @@ func TestWAL_PointsSorted(t *testing.T) {
 		t.Fatalf("failed to write points: %s", err.Error())
 	}
 
-	c := log.Cursor("cpu,host=A", true)
+	c := log.Cursor("cpu,host=A", tsdb.Forward)
 	k, _ := c.Next()
 	if btou64(k) != 1 {
 		t.Fatal("points out of order")
@@ -896,7 +896,7 @@ func TestWAL_Cursor_Reverse(t *testing.T) {
 		t.Fatalf("failed to write points: %s", err.Error())
 	}
 
-	c := log.Cursor("cpu,host=A", false)
+	c := log.Cursor("cpu,host=A", tsdb.Reverse)
 	k, _ := c.Next()
 	if btou64(k) != 6 {
 		t.Fatal("points out of order")

--- a/tsdb/engine/wal/wal_test.go
+++ b/tsdb/engine/wal/wal_test.go
@@ -870,6 +870,51 @@ func TestWAL_PointsSorted(t *testing.T) {
 	}
 }
 
+func TestWAL_Cursor_Reverse(t *testing.T) {
+	log := openTestWAL()
+	defer log.Close()
+	defer os.RemoveAll(log.path)
+
+	if err := log.Open(); err != nil {
+		t.Fatalf("couldn't open wal: %s", err.Error())
+	}
+
+	codec := tsdb.NewFieldCodec(map[string]*tsdb.Field{
+		"value": {
+			ID:   uint8(1),
+			Name: "value",
+			Type: influxql.Float,
+		},
+	})
+
+	// test that we can write to two different series
+	p1 := parsePoint("cpu,host=A value=1.1 1", codec)
+	p2 := parsePoint("cpu,host=A value=4.4 4", codec)
+	p3 := parsePoint("cpu,host=A value=2.2 2", codec)
+	p4 := parsePoint("cpu,host=A value=6.6 6", codec)
+	if err := log.WritePoints([]tsdb.Point{p1, p2, p3, p4}, nil, nil); err != nil {
+		t.Fatalf("failed to write points: %s", err.Error())
+	}
+
+	c := log.Cursor("cpu,host=A", false)
+	k, _ := c.Next()
+	if btou64(k) != 6 {
+		t.Fatal("points out of order")
+	}
+	k, _ = c.Next()
+	if btou64(k) != 4 {
+		t.Fatal("points out of order")
+	}
+	k, _ = c.Next()
+	if btou64(k) != 2 {
+		t.Fatal("points out of order")
+	}
+	k, _ = c.Next()
+	if btou64(k) != 1 {
+		t.Fatal("points out of order")
+	}
+}
+
 // test that partitions get compacted and flushed when number of series hits compaction threshold
 // test that partitions get compacted and flushed when a single series hits the compaction threshold
 // test that writes slow down when the partition size threshold is hit

--- a/tsdb/engine/wal/wal_test.go
+++ b/tsdb/engine/wal/wal_test.go
@@ -46,7 +46,7 @@ func TestWAL_WritePoints(t *testing.T) {
 	}
 
 	verify := func() {
-		c := log.Cursor("cpu,host=A")
+		c := log.Cursor("cpu,host=A", true)
 		k, v := c.Seek(inttob(1))
 
 		// ensure the series are there and points are in order
@@ -64,7 +64,7 @@ func TestWAL_WritePoints(t *testing.T) {
 			t.Fatalf("expected nil on last seek: %v %v", k, v)
 		}
 
-		c = log.Cursor("cpu,host=B")
+		c = log.Cursor("cpu,host=B", true)
 		k, v = c.Next()
 		if bytes.Compare(v, p3.Data()) != 0 {
 			t.Fatalf("expected to seek to first point but got key and value: %v %v", k, v)
@@ -92,7 +92,7 @@ func TestWAL_WritePoints(t *testing.T) {
 	}
 
 	verify2 := func() {
-		c := log.Cursor("cpu,host=A")
+		c := log.Cursor("cpu,host=A", true)
 		k, v := c.Next()
 		if bytes.Compare(v, p1.Data()) != 0 {
 			t.Fatalf("order wrong, expected p1, %v %v %v", v, k, p1.Data())
@@ -110,7 +110,7 @@ func TestWAL_WritePoints(t *testing.T) {
 			t.Fatal("order wrong, expected p6")
 		}
 
-		c = log.Cursor("cpu,host=C")
+		c = log.Cursor("cpu,host=C", true)
 		_, v = c.Next()
 		if bytes.Compare(v, p5.Data()) != 0 {
 			t.Fatal("order wrong, expected p6")
@@ -150,7 +150,7 @@ func TestWAL_CorruptDataLengthSize(t *testing.T) {
 	}
 
 	verify := func() {
-		c := log.Cursor("cpu,host=A")
+		c := log.Cursor("cpu,host=A", true)
 		_, v := c.Next()
 		if bytes.Compare(v, p1.Data()) != 0 {
 			t.Fatal("p1 value wrong")
@@ -183,7 +183,7 @@ func TestWAL_CorruptDataLengthSize(t *testing.T) {
 	}
 
 	verify = func() {
-		c := log.Cursor("cpu,host=A")
+		c := log.Cursor("cpu,host=A", true)
 		_, v := c.Next()
 		if bytes.Compare(v, p1.Data()) != 0 {
 			t.Fatal("p1 value wrong")
@@ -229,7 +229,7 @@ func TestWAL_CorruptDataBlock(t *testing.T) {
 	}
 
 	verify := func() {
-		c := log.Cursor("cpu,host=A")
+		c := log.Cursor("cpu,host=A", true)
 		_, v := c.Next()
 		if bytes.Compare(v, p1.Data()) != 0 {
 			t.Fatal("p1 value wrong")
@@ -268,7 +268,7 @@ func TestWAL_CorruptDataBlock(t *testing.T) {
 	}
 
 	verify = func() {
-		c := log.Cursor("cpu,host=A")
+		c := log.Cursor("cpu,host=A", true)
 		_, v := c.Next()
 		if bytes.Compare(v, p1.Data()) != 0 {
 			t.Fatal("p1 value wrong")
@@ -349,7 +349,7 @@ func TestWAL_CompactAfterPercentageThreshold(t *testing.T) {
 	}
 
 	// ensure we have some data
-	c := log.Cursor("cpu,host=A,region=uswest23")
+	c := log.Cursor("cpu,host=A,region=uswest23", true)
 	k, v := c.Next()
 	if btou64(k) != 1 {
 		t.Fatalf("expected timestamp of 1, but got %v %v", k, v)
@@ -365,13 +365,13 @@ func TestWAL_CompactAfterPercentageThreshold(t *testing.T) {
 	}
 
 	// should be nil
-	c = log.Cursor("cpu,host=A,region=uswest23")
+	c = log.Cursor("cpu,host=A,region=uswest23", true)
 	k, v = c.Next()
 	if k != nil || v != nil {
 		t.Fatal("expected cache to be nil after flush: ", k, v)
 	}
 
-	c = log.Cursor("cpu,host=A,region=useast1")
+	c = log.Cursor("cpu,host=A,region=useast1", true)
 	k, v = c.Next()
 	if btou64(k) != 1 {
 		t.Fatal("expected cache to be there after flush and compact: ", k, v)
@@ -385,13 +385,13 @@ func TestWAL_CompactAfterPercentageThreshold(t *testing.T) {
 	log.Close()
 	log.Open()
 
-	c = log.Cursor("cpu,host=A,region=uswest23")
+	c = log.Cursor("cpu,host=A,region=uswest23", true)
 	k, v = c.Next()
 	if k != nil || v != nil {
 		t.Fatal("expected cache to be nil after flush and re-open: ", k, v)
 	}
 
-	c = log.Cursor("cpu,host=A,region=useast1")
+	c = log.Cursor("cpu,host=A,region=useast1", true)
 	k, v = c.Next()
 	if btou64(k) != 1 {
 		t.Fatal("expected cache to be there after flush and compact: ", k, v)
@@ -444,7 +444,7 @@ func TestWAL_CompactAfterTimeWithoutWrite(t *testing.T) {
 	}
 
 	// ensure we have some data
-	c := log.Cursor("cpu,host=A,region=uswest10")
+	c := log.Cursor("cpu,host=A,region=uswest10", true)
 	k, _ := c.Next()
 	if btou64(k) != 1 {
 		t.Fatalf("expected first data point but got one with key: %v", k)
@@ -625,12 +625,12 @@ func TestWAL_DeleteSeries(t *testing.T) {
 	}
 
 	// ensure data is there
-	c := log.Cursor("cpu,host=A")
+	c := log.Cursor("cpu,host=A", true)
 	if k, _ := c.Next(); btou64(k) != 1 {
 		t.Fatal("expected data point for cpu,host=A")
 	}
 
-	c = log.Cursor("cpu,host=B")
+	c = log.Cursor("cpu,host=B", true)
 	if k, _ := c.Next(); btou64(k) != 2 {
 		t.Fatal("expected data point for cpu,host=B")
 	}
@@ -641,13 +641,13 @@ func TestWAL_DeleteSeries(t *testing.T) {
 	}
 
 	// ensure data is there
-	c = log.Cursor("cpu,host=A")
+	c = log.Cursor("cpu,host=A", true)
 	if k, _ := c.Next(); btou64(k) != 1 {
 		t.Fatal("expected data point for cpu,host=A")
 	}
 
 	// ensure series is deleted
-	c = log.Cursor("cpu,host=B")
+	c = log.Cursor("cpu,host=B", true)
 	if k, _ := c.Next(); k != nil {
 		t.Fatal("expected no data for cpu,host=B")
 	}
@@ -675,13 +675,13 @@ func TestWAL_DeleteSeries(t *testing.T) {
 	}
 
 	// ensure data is there
-	c = log.Cursor("cpu,host=A")
+	c = log.Cursor("cpu,host=A", true)
 	if k, _ := c.Next(); btou64(k) != 1 {
 		t.Fatal("expected data point for cpu,host=A")
 	}
 
 	// ensure series is deleted
-	c = log.Cursor("cpu,host=B")
+	c = log.Cursor("cpu,host=B", true)
 	if k, _ := c.Next(); k != nil {
 		t.Fatal("expected no data for cpu,host=B")
 	}
@@ -805,7 +805,7 @@ func TestWAL_QueryDuringCompaction(t *testing.T) {
 	}
 
 	verify := func() {
-		c := log.Cursor("cpu,host=A")
+		c := log.Cursor("cpu,host=A", true)
 		k, v := c.Seek(inttob(1))
 		// ensure the series are there and points are in order
 		if bytes.Compare(v, p1.Data()) != 0 {
@@ -851,7 +851,7 @@ func TestWAL_PointsSorted(t *testing.T) {
 		t.Fatalf("failed to write points: %s", err.Error())
 	}
 
-	c := log.Cursor("cpu,host=A")
+	c := log.Cursor("cpu,host=A", true)
 	k, _ := c.Next()
 	if btou64(k) != 1 {
 		t.Fatal("points out of order")

--- a/tsdb/executor.go
+++ b/tsdb/executor.go
@@ -140,6 +140,23 @@ func (e *SelectExecutor) nextMapperLowestTime(tagset string) int64 {
 	return minTime
 }
 
+// nextMapperHighestTime returns the highest time across all Mappers, for the given tagset.
+func (e *SelectExecutor) nextMapperHighestTime(tagset string) int64 {
+	maxTime := int64(math.MinInt64)
+	for _, m := range e.mappers {
+		if !m.drained && m.bufferedChunk != nil {
+			if m.bufferedChunk.key() != tagset {
+				continue
+			}
+			t := m.bufferedChunk.Values[0].Time
+			if t > maxTime {
+				maxTime = t
+			}
+		}
+	}
+	return maxTime
+}
+
 // tagSetIsLimited returns whether data for the given tagset has been LIMITed.
 func (e *SelectExecutor) tagSetIsLimited(tagset string) bool {
 	_, ok := e.limitedTagSets[tagset]
@@ -246,9 +263,21 @@ func (e *SelectExecutor) executeRaw(out chan *influxql.Row) {
 			rowWriter = nil
 		}
 
-		// Process the mapper outputs. We can send out everything up to the min of the last time
-		// of the chunks for the next tagset.
-		minTime := e.nextMapperLowestTime(tagset)
+		ascending := true
+		if len(e.stmt.SortFields) > 0 {
+			ascending = e.stmt.SortFields[0].Ascending
+
+		}
+
+		var timeBoundary int64
+
+		if ascending {
+			// Process the mapper outputs. We can send out everything up to the min of the last time
+			// of the chunks for the next tagset.
+			timeBoundary = e.nextMapperLowestTime(tagset)
+		} else {
+			timeBoundary = e.nextMapperHighestTime(tagset)
+		}
 
 		// Now empty out all the chunks up to the min time. Create new output struct for this data.
 		var chunkedOutput *MapperOutput
@@ -257,19 +286,30 @@ func (e *SelectExecutor) executeRaw(out chan *influxql.Row) {
 				continue
 			}
 
+			chunkBoundary := false
+			if ascending {
+				chunkBoundary = m.bufferedChunk.Values[0].Time > timeBoundary
+			} else {
+				chunkBoundary = m.bufferedChunk.Values[0].Time < timeBoundary
+			}
+
 			// This mapper's next chunk is not for the next tagset, or the very first value of
 			// the chunk is at a higher acceptable timestamp. Skip it.
-			if m.bufferedChunk.key() != tagset || m.bufferedChunk.Values[0].Time > minTime {
+			if m.bufferedChunk.key() != tagset || chunkBoundary {
 				continue
 			}
 
 			// Find the index of the point up to the min.
 			ind := len(m.bufferedChunk.Values)
 			for i, mo := range m.bufferedChunk.Values {
-				if mo.Time > minTime {
+				if ascending && mo.Time > timeBoundary {
+					ind = i
+					break
+				} else if !ascending && mo.Time < timeBoundary {
 					ind = i
 					break
 				}
+
 			}
 
 			// Add up to the index to the values
@@ -293,8 +333,12 @@ func (e *SelectExecutor) executeRaw(out chan *influxql.Row) {
 			}
 		}
 
-		// Sort the values by time first so we can then handle offset and limit
-		sort.Sort(MapperValues(chunkedOutput.Values))
+		if ascending {
+			// Sort the values by time first so we can then handle offset and limit
+			sort.Sort(MapperValues(chunkedOutput.Values))
+		} else {
+			sort.Sort(sort.Reverse(MapperValues(chunkedOutput.Values)))
+		}
 
 		// Now that we have full name and tag details, initialize the rowWriter.
 		// The Name and Tags will be the same for all mappers.

--- a/tsdb/executor.go
+++ b/tsdb/executor.go
@@ -266,7 +266,6 @@ func (e *SelectExecutor) executeRaw(out chan *influxql.Row) {
 		ascending := true
 		if len(e.stmt.SortFields) > 0 {
 			ascending = e.stmt.SortFields[0].Ascending
-
 		}
 
 		var timeBoundary int64
@@ -434,6 +433,11 @@ func (e *SelectExecutor) executeAggregate(out chan *influxql.Row) {
 		}
 	}
 
+	ascending := true
+	if len(e.stmt.SortFields) > 0 {
+		ascending = e.stmt.SortFields[0].Ascending
+	}
+
 	// Keep looping until all mappers drained.
 	for !e.mappersDrained() {
 		// Send out data for the next alphabetically-lowest tagset. All Mappers send out in this order
@@ -506,7 +510,12 @@ func (e *SelectExecutor) executeAggregate(out chan *influxql.Row) {
 		for k, _ := range buckets {
 			tMins = append(tMins, k)
 		}
-		sort.Sort(tMins)
+
+		if ascending {
+			sort.Sort(tMins)
+		} else {
+			sort.Sort(sort.Reverse(tMins))
+		}
 
 		values := make([][]interface{}, len(tMins))
 		for i, t := range tMins {


### PR DESCRIPTION
This PR adds support for sorting results by time in descending order.  Two syntaxes are allowed:

```
select value from cpu order by time desc
select value from cpu order by desc
```

This allows queries to find the most recent value instead of having to query the whole data set to see the last value.  Currently only sorting by time is allowed on raw and aggregate queries.  If there are multiple sort fields, a parse error will be returned.  Similarly, if a sort field other than `time` is specified, a parse error is returned.

Fixes #2022 