### PR TITLE
Add Go memstats to statistics

### DIFF
--- a/monitor/go_runtime.go
+++ b/monitor/go_runtime.go
@@ -4,32 +4,8 @@ import (
 	"runtime"
 )
 
-// goRuntime captures Go runtime statistics and implements the monitor client interface
+// goRuntime captures Go runtime diagnostics
 type goRuntime struct{}
-
-// Statistics returns the statistics for the goRuntime type
-func (g *goRuntime) Statistics() (map[string]interface{}, error) {
-	var m runtime.MemStats
-	runtime.ReadMemStats(&m)
-
-	return map[string]interface{}{
-		"Alloc":        int64(m.Alloc),
-		"TotalAlloc":   int64(m.TotalAlloc),
-		"Sys":          int64(m.Sys),
-		"Lookups":      int64(m.Lookups),
-		"Mallocs":      int64(m.Mallocs),
-		"Frees":        int64(m.Frees),
-		"HeapAlloc":    int64(m.HeapAlloc),
-		"HeapSys":      int64(m.HeapSys),
-		"HeapIdle":     int64(m.HeapIdle),
-		"HeapInUse":    int64(m.HeapInuse),
-		"HeapReleased": int64(m.HeapReleased),
-		"HeapObjects":  int64(m.HeapObjects),
-		"PauseTotalNs": int64(m.PauseTotalNs),
-		"NumGC":        int64(m.NumGC),
-		"NumGoroutine": int64(runtime.NumGoroutine()),
-	}, nil
-}
 
 func (g *goRuntime) Diagnostics() (*Diagnostic, error) {
 	diagnostics := map[string]interface{}{

--- a/monitor/network.go
+++ b/monitor/network.go
@@ -4,13 +4,8 @@ import (
 	"os"
 )
 
-// network captures network statistics and implements the monitor client interface
+// network captures network diagnostics
 type network struct{}
-
-// Statistics returns the statistics for the network type
-func (n *network) Statistics() (map[string]interface{}, error) {
-	return nil, nil
-}
 
 func (n *network) Diagnostics() (*Diagnostic, error) {
 	h, err := os.Hostname()

--- a/monitor/service.go
+++ b/monitor/service.go
@@ -4,6 +4,7 @@ import (
 	"expvar"
 	"log"
 	"os"
+	"runtime"
 	"sort"
 	"strconv"
 	"sync"
@@ -202,8 +203,36 @@ func (m *Monitor) Statistics() ([]*statistic, error) {
 		if len(statistic.Values) == 0 {
 			return
 		}
+
 		statistics = append(statistics, statistic)
 	})
+
+	// Add Go memstats.
+	statistic := &statistic{
+		Name:   "runtime",
+		Tags:   make(map[string]string),
+		Values: make(map[string]interface{}),
+	}
+	var rt runtime.MemStats
+	runtime.ReadMemStats(&rt)
+	statistic.Values = map[string]interface{}{
+		"Alloc":        int64(rt.Alloc),
+		"TotalAlloc":   int64(rt.TotalAlloc),
+		"Sys":          int64(rt.Sys),
+		"Lookups":      int64(rt.Lookups),
+		"Mallocs":      int64(rt.Mallocs),
+		"Frees":        int64(rt.Frees),
+		"HeapAlloc":    int64(rt.HeapAlloc),
+		"HeapSys":      int64(rt.HeapSys),
+		"HeapIdle":     int64(rt.HeapIdle),
+		"HeapInUse":    int64(rt.HeapInuse),
+		"HeapReleased": int64(rt.HeapReleased),
+		"HeapObjects":  int64(rt.HeapObjects),
+		"PauseTotalNs": int64(rt.PauseTotalNs),
+		"NumGC":        int64(rt.NumGC),
+		"NumGoroutine": int64(runtime.NumGoroutine()),
+	}
+	statistics = append(statistics, statistic)
 
 	return statistics, nil
 }

--- a/monitor/system.go
+++ b/monitor/system.go
@@ -11,13 +11,8 @@ func init() {
 	startTime = time.Now().UTC()
 }
 
-// system captures network statistics and implements the monitor client interface
+// system captures system-level diagnostics
 type system struct{}
-
-// Statistics returns the statistics for the system type
-func (s *system) Statistics() (map[string]interface{}, error) {
-	return nil, nil
-}
 
 func (s *system) Diagnostics() (*Diagnostic, error) {
 	diagnostics := map[string]interface{}{


### PR DESCRIPTION
Go runtime stats reworked for the new direct use of `expvar`. Example `SHOW STATS` output:

```
name: runtime
-------------
Alloc   Frees   HeapAlloc       HeapIdle        HeapInUse       HeapObjects     HeapReleased    HeapSys Lookups Mallocs NumGC   NumGoroutine    PauseTotalNs    Sys     TotalAlloc
1577368 0       1577368         696320          2744320         8234            0               3440640 114     8234    0       37              0               7407864 1577368

> 
```

This information is also recorded in the system for longer term analysis.