### PR TITLE
Fix cluster restarting issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ With this release InfluxDB is moving to Go 1.5.
 - [#3950](https://github.com/influxdb/influxdb/pull/3950): Limit bz1 quickcheck tests to 10 iterations on CI
 - [#3977](https://github.com/influxdb/influxdb/pull/3977): Silence wal logging during testing
 - [#3931](https://github.com/influxdb/influxdb/pull/3931): Don't precreate shard groups entirely in the past
+- [#3960](https://github.com/influxdb/influxdb/issues/3960): possible "catch up" bug with nodes down in a cluster
 
 ## v0.9.3 [2015-08-26]
 

--- a/cluster/service.go
+++ b/cluster/service.go
@@ -185,7 +185,7 @@ func (s *Service) processWriteShardRequest(buf []byte) error {
 			// If we can't find it, then we need to drop this request
 			// as it is no longer valid.  This could happen if writes were queued via
 			// hinted handoff and delivered after a shard group was deleted.
-			s.Logger.Printf("drop write request: shard=%d", req.ShardID())
+			s.Logger.Printf("drop write request: shard=%d. shard group does not exist or was deleted", req.ShardID())
 			return nil
 		}
 

--- a/meta/store.go
+++ b/meta/store.go
@@ -254,7 +254,9 @@ func (s *Store) Open() error {
 		close(s.ready)
 	}
 
-	return nil
+	// Wait for a leader to be elected so we know the raft log is loaded
+	// and up to date
+	return s.WaitForLeader(0)
 }
 
 // syncNodeInfo continuously tries to update the current nodes hostname


### PR DESCRIPTION
This fixes some races when restarting a node in a cluster that may have hinted handoff writes queued on other nodes.  

There were two issues:
-  The first was that the a node would start up and accept writes/queries possibly before the meta-store had finished apply the raft log.  This could cause sporadic errors.  In #3960, it caused writes to be dropped because the receiving node had no way of knowing that the write it received was for a shard that it should own but did not have in it's meta-store yet.  
- The second issue was that the `tcp.Mux` listener was handing demuxing in the same thread that accepted connections.  If a listener was slow or not ready to read off it's connection channel, connections would not be accepted and possibly timeout.  Because of 1, the restarting raft cluster node would sometimes get starved while trying to rejoin the cluster (because they share the same `tcp.Mux` listener).

A side-effect of fixing the first issue also make #3677 repeatedly fail which made it easy to find a subtle restart race in the test.

Fixes #3960 #3677