### PR TITLE
Convert expvar values to the correct type int64

### DIFF
--- a/monitor/service.go
+++ b/monitor/service.go
@@ -186,7 +186,7 @@ func (m *Monitor) Statistics() ([]*statistic, error) {
 							return
 						}
 					case *expvar.Int:
-						f, err = strconv.ParseUint(v.String(), 10, 64)
+						f, err = strconv.ParseInt(v.String(), 10, 64)
 						if err != nil {
 							return
 						}


### PR DESCRIPTION
expvar only allows int increments and decrements, so use int64 when converting.

Fix shown in action below:

```
> select * from httpd
name: httpd
-----------
time                            bind    ping_req        req
2015-09-04T21:43:14.676210654Z  :8086   1               1
2015-09-04T21:43:15.676130058Z  :8086   1               1
2015-09-04T21:43:16.676147344Z  :8086   1               1
2015-09-04T21:43:17.67606395Z   :8086   1               1
2015-09-04T21:43:18.67610557Z   :8086   1               1
2015-09-04T21:43:19.676120053Z  :8086   1               1
2015-09-04T21:43:20.676091379Z  :8086   1               1

> select sum(ping_req) from httpd
name: httpd
-----------
time                    sum
1970-01-01T00:00:00Z    16

> 
```