### PR TITLE
Fix panics when stopping server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ With this release InfluxDB is moving to Go 1.5.
 - [#3980](https://github.com/influxdb/influxdb/pull/3980): 'service stop' waits until service actually stops. Fixes issue #3548.
 - [#4016](https://github.com/influxdb/influxdb/pull/4016): Shutdown Graphite UDP on SIGTERM.
 - [#4034](https://github.com/influxdb/influxdb/pull/4034): Rollback bolt tx on mapper open error
+- [#3848](https://github.com/influxdb/influxdb/issues/3848): restart influxdb causing panic
+- [#3881](https://github.com/influxdb/influxdb/issues/3881): panic: runtime error: invalid memory address or nil pointer dereference
 
 ## v0.9.3 [2015-08-26]
 

--- a/cluster/service.go
+++ b/cluster/service.go
@@ -108,7 +108,7 @@ func (s *Service) Close() error {
 
 	// Shut down all handlers.
 	close(s.closing)
-	// s.wg.Wait() // FIXME(benbjohnson)
+	s.wg.Wait()
 
 	return nil
 }

--- a/cmd/influxd/run/server.go
+++ b/cmd/influxd/run/server.go
@@ -387,7 +387,8 @@ func (s *Server) Close() error {
 		s.Listener.Close()
 	}
 
-	// Close services to any inflight requests can be stopped
+	// Close services to allow any inflight requests to complete
+	// and prevent new requests from being accepted.
 	for _, service := range s.Services {
 		service.Close()
 	}

--- a/cmd/influxd/run/server.go
+++ b/cmd/influxd/run/server.go
@@ -382,23 +382,32 @@ func (s *Server) Open() error {
 func (s *Server) Close() error {
 	stopProfile()
 
+	// Close the listener first to stop any new connections
 	if s.Listener != nil {
 		s.Listener.Close()
 	}
-	if s.MetaStore != nil {
-		s.MetaStore.Close()
+
+	// Close services to any inflight requests can be stopped
+	for _, service := range s.Services {
+		service.Close()
 	}
-	if s.TSDBStore != nil {
-		s.TSDBStore.Close()
-	}
-	if s.HintedHandoff != nil {
-		s.HintedHandoff.Close()
-	}
+
 	if s.Monitor != nil {
 		s.Monitor.Close()
 	}
-	for _, service := range s.Services {
-		service.Close()
+
+	if s.HintedHandoff != nil {
+		s.HintedHandoff.Close()
+	}
+
+	// Close the TSDBStore, no more reads or writes at this point
+	if s.TSDBStore != nil {
+		s.TSDBStore.Close()
+	}
+
+	// Finally close the meta-store since everything else depends on it
+	if s.MetaStore != nil {
+		s.MetaStore.Close()
 	}
 
 	close(s.closing)


### PR DESCRIPTION
Two different panics could occur if in-flight writes or queries were running on the server when the server started to shutdown.  The problem was that lower level services were closed before the higher level ones were.  The cluster service was also not waiting for connections to complete before returning from `Close`.

Fixes #3848 #3881 