### PR TITLE
Add cluster-level tags to all stats when stored

### DIFF
--- a/monitor/service.go
+++ b/monitor/service.go
@@ -2,6 +2,7 @@ package monitor
 
 import (
 	"expvar"
+	"fmt"
 	"log"
 	"os"
 	"runtime"
@@ -137,8 +138,9 @@ func (m *Monitor) RegisterDiagnosticsClient(name string, client DiagsClient) err
 	return nil
 }
 
-// statistics returns the combined statistics for all expvar data.
-func (m *Monitor) Statistics() ([]*statistic, error) {
+// Statistics returns the combined statistics for all expvar data. The given
+// tags are added to each of the returned statistics.
+func (m *Monitor) Statistics(tags map[string]string) ([]*statistic, error) {
 	statistics := make([]*statistic, 0)
 
 	expvar.Do(func(kv expvar.KeyValue) {
@@ -150,6 +152,11 @@ func (m *Monitor) Statistics() ([]*statistic, error) {
 		statistic := &statistic{
 			Tags:   make(map[string]string),
 			Values: make(map[string]interface{}),
+		}
+
+		// Add any supplied tags.
+		for k, v := range tags {
+			statistic.Tags[k] = v
 		}
 
 		// Every other top-level expvar value is a map.
@@ -263,6 +270,16 @@ func (m *Monitor) storeStatistics() {
 		return
 	}
 
+	// Get cluster-level metadata. Nothing different is going to happen if errors occur.
+	clusterID, _ := m.MetaStore.ClusterID()
+	nodeID := m.MetaStore.NodeID()
+	hostname, _ := os.Hostname()
+	clusterTags := map[string]string{
+		"clusterID": fmt.Sprintf("%d", clusterID),
+		"nodeID":    fmt.Sprintf("%d", nodeID),
+		"hostname":  hostname,
+	}
+
 	if _, err := m.MetaStore.CreateDatabaseIfNotExists(m.storeDatabase); err != nil {
 		m.Logger.Printf("failed to create database '%s', terminating storage: %s",
 			m.storeDatabase, err.Error())
@@ -274,7 +291,7 @@ func (m *Monitor) storeStatistics() {
 	for {
 		select {
 		case <-tick.C:
-			stats, err := m.Statistics()
+			stats, err := m.Statistics(clusterTags)
 			if err != nil {
 				m.Logger.Printf("failed to retrieve registered statistics: %s", err)
 				continue

--- a/monitor/statement_executor.go
+++ b/monitor/statement_executor.go
@@ -9,7 +9,7 @@ import (
 // StatementExecutor translates InfluxQL queries to Monitor methods.
 type StatementExecutor struct {
 	Monitor interface {
-		Statistics() ([]*statistic, error)
+		Statistics(map[string]string) ([]*statistic, error)
 		Diagnostics() (map[string]*Diagnostic, error)
 	}
 }
@@ -27,7 +27,7 @@ func (s *StatementExecutor) ExecuteStatement(stmt influxql.Statement) *influxql.
 }
 
 func (s *StatementExecutor) executeShowStatistics() *influxql.Result {
-	stats, err := s.Monitor.Statistics()
+	stats, err := s.Monitor.Statistics(nil)
 	if err != nil {
 		return &influxql.Result{Err: err}
 	}


### PR DESCRIPTION
With this change when stats are written to `_internal`, the stats are tagged with cluster ID, node ID, and hostname. This allows the data to be easily SELECTed on, say, a cluster-wide basis. E.g.

`SELECT * from httpd WHERE clusterID=1234`

Example:

```
> select * from httpd
name: httpd
-----------
time                            bind    clusterID               hostname        nodeID  ping_req        query_req       query_resp_bytes        req
2015-09-05T01:19:48.21240791Z   :8086   7119479025908527661     marx            1       1               1               414                     2

> select * from httpd group by *
name: httpd
tags: bind=:8086, clusterID=7119479025908527661, hostname=marx, nodeID=1
time                            ping_req        query_req       query_resp_bytes        req
----                            --------        ---------       ----------------        ---
2015-09-05T01:19:48.21240791Z   1               1               414                     2
```