### PR TITLE
fix init script

### DIFF
--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -77,6 +77,27 @@ if [ -r $DEFAULT ]; then
     source $DEFAULT
 fi
 
+if ! typeset -F pidofproc &>/dev/null; then
+  function pidofproc() {
+      if [ $# -ne 3 ]; then
+          echo "Expected three arguments, e.g. $0 -p pidfile daemon-name"
+      fi
+
+      pid=`pgrep -f '\'$3'\>'`
+      local pidfile=`cat $2`
+
+      if [ "x$pidfile" == "x" ]; then
+          return 1
+      fi
+
+      if [ "x$pid" != "x" -a "$pidfile" == "$pid" ]; then
+          return 0
+      fi
+
+      return 1
+  }
+fi
+
 function killproc() {
     if [ $# -ne 3 ]; then
         echo "Expected three arguments, e.g. $0 -p pidfile signal"

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -83,7 +83,7 @@ if ! typeset -F pidofproc &>/dev/null; then
           echo "Expected three arguments, e.g. $0 -p pidfile daemon-name"
       fi
 
-      pid=`pgrep -f '\'$3'\>'`
+      pid=`pgrep -f "^$3"`
       local pidfile=`cat $2`
 
       if [ "x$pidfile" == "x" ]; then

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -77,25 +77,6 @@ if [ -r $DEFAULT ]; then
     source $DEFAULT
 fi
 
-function pidofproc() {
-    if [ $# -ne 3 ]; then
-        echo "Expected three arguments, e.g. $0 -p pidfile daemon-name"
-    fi
-
-    PID=`pgrep -f $3`
-    local PIDFILE=`cat $2`
-
-    if [ "x$PIDFILE" == "x" ]; then
-        return 1
-    fi
-
-    if [ "x$PID" != "x" -a "$PIDFILE" == "$PID" ]; then
-        return 0
-    fi
-
-    return 1
-}
-
 function killproc() {
     if [ $# -ne 3 ]; then
         echo "Expected three arguments, e.g. $0 -p pidfile signal"

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -78,56 +78,62 @@ if [ -r $DEFAULT ]; then
 fi
 
 if ! typeset -F pidofproc &>/dev/null; then
-  function pidofproc() {
-      if [ $# -ne 3 ]; then
-          echo "Expected three arguments, e.g. $0 -p pidfile daemon-name"
-      fi
+    function pidofproc() {
+        if [ $# -ne 3 ]; then
+            echo "Expected three arguments, e.g. $0 -p pidfile daemon-name"
+        fi
 
-      pid=`pgrep -f "^$3"`
-      local pidfile=`cat $2`
+        pid=`pgrep -f "^$3"`
+        local pidfile=`cat $2`
 
-      if [ "x$pidfile" == "x" ]; then
-          return 1
-      fi
+        if [ "x$pidfile" == "x" ]; then
+            return 1
+        fi
 
-      if [ "x$pid" != "x" -a "$pidfile" == "$pid" ]; then
-          return 0
-      fi
+        if [ "x$pid" != "x" -a "$pidfile" == "$pid" ]; then
+            return 0
+        fi
 
-      return 1
-  }
+        return 1
+    }
 fi
 
-function killproc() {
-    if [ $# -ne 3 ]; then
-        echo "Expected three arguments, e.g. $0 -p pidfile signal"
-    fi
-
-    PID=`cat $2`
-
-    /bin/kill -s $3 $PID
-    while true; do
-        pidof `basename $DAEMON` >/dev/null
-        if [ $? -ne 0 ]; then
-            return 0
+if ! typeset -F killproc &>/dev/null; then
+    function killproc() {
+        if [ $# -ne 3 ]; then
+            echo "Expected three arguments, e.g. $0 -p pidfile signal"
         fi
 
-        sleep 1
-        n=$(expr $n + 1)
-        if [ $n -eq 30 ]; then
-            /bin/kill -s SIGKILL $PID
-            return 0
-        fi
-    done
-}
+        PID=`cat $2`
 
-function log_failure_msg() {
-    echo "$@" "[ FAILED ]"
-}
+        /bin/kill -s $3 $PID
+        while true; do
+            pidof `basename $DAEMON` >/dev/null
+            if [ $? -ne 0 ]; then
+                return 0
+            fi
 
-function log_success_msg() {
-    echo "$@" "[ OK ]"
-}
+            sleep 1
+            n=$(expr $n + 1)
+            if [ $n -eq 30 ]; then
+                /bin/kill -s SIGKILL $PID
+                return 0
+            fi
+        done
+    }
+fi
+
+if ! typeset -F log_failure_msg &>/dev/null; then
+    function log_failure_msg() {
+        echo "$@" "[ FAILED ]"
+    }
+fi
+
+if ! typeset -F log_success_msg &>/dev/null; then
+    function log_success_msg() {
+        echo "$@" "[ OK ]"
+    }
+fi
 
 case $1 in
     start)


### PR DESCRIPTION
The pidofproc function should not be redefined here because the same function from the LSB works correctly. Using pgrep will not work correctly if you have a file named similarly to the "daemon-name" open (i.e. "/etc/opt/influxdb/influxdb.conf").

This is with 0.9.2 installed on a base 64-Bit Debian Wheezy system, using the `.deb` from InfluxDB.com.

It's easy to recreate this situation by simply opening the configuration file (i.e. `sudo vi /etc/opt/influxdb/influxdb.conf`), and running `/etc/init.d/influxdb status`. With the configuration file open, `pgrep -f /opt/influxdb/influxd` picks up multiple pids, which causes the init script to report incorrectly that the influxd process is not running (e.g. `influxd Process is not running [ FAILED ]`).