### PR TITLE
Simplify WAL to not compact

### DIFF
--- a/tsdb/config.go
+++ b/tsdb/config.go
@@ -30,7 +30,7 @@ const (
 
 	// DefaultFlushColdInterval specifies how long after a partition has been cold
 	// for writes that a full flush and compaction are forced
-	DefaultFlushColdInterval = 5 * time.Minute
+	DefaultFlushColdInterval = 5 * time.Second
 
 	// DefaultParititionSizeThreshold specifies when a partition gets to this size in
 	// memory, we should slow down writes until it gets a chance to compact.

--- a/tsdb/engine/wal/wal.go
+++ b/tsdb/engine/wal/wal.go
@@ -211,15 +211,12 @@ func (l *Log) Open() error {
 func (l *Log) DiskSize() (int64, error) {
 	l.mu.RLock()
 	defer l.mu.RUnlock()
-	var size int64
-	for _, partition := range l.partitions {
-		stat, err := os.Stat(partition.path)
-		if err != nil {
-			return 0, err
-		}
-		size += stat.Size()
+
+	stat, err := os.Stat(l.path)
+	if err != nil {
+		return 0, err
 	}
-	return size, nil
+	return stat.Size(), nil
 }
 
 // Cursor will return a cursor object to Seek and iterate with Next for the WAL cache for the given


### PR DESCRIPTION
Updated the WAL to have a single partition, not compact files, and to automatically flush segment files on startup. Greatly simplifies things and should make it easier to see what is happening in the WAL.