### PR TITLE
Correct CreateRetentionPolicyIfNotExists

### DIFF
--- a/meta/store.go
+++ b/meta/store.go
@@ -984,13 +984,6 @@ func (s *Store) CreateRetentionPolicy(database string, rpi *RetentionPolicyInfo)
 
 // CreateRetentionPolicyIfNotExists creates a new policy in the store if it doesn't already exist.
 func (s *Store) CreateRetentionPolicyIfNotExists(database string, rpi *RetentionPolicyInfo) (*RetentionPolicyInfo, error) {
-	// Try to find policy locally first.
-	if rpi, err := s.RetentionPolicy(database, rpi.Name); err != nil {
-		return nil, err
-	} else if rpi != nil {
-		return rpi, nil
-	}
-
 	// Attempt to create policy.
 	other, err := s.CreateRetentionPolicy(database, rpi)
 	if err == ErrRetentionPolicyExists {

--- a/meta/store_test.go
+++ b/meta/store_test.go
@@ -272,6 +272,22 @@ func TestStore_CreateRetentionPolicy(t *testing.T) {
 	}) {
 		t.Fatalf("unexpected policy: %#v", rpi)
 	}
+
+	// CreateRetentionPolicyIfNotExists should succeed, since it should do nothing.
+	if rpi, err := s.CreateRetentionPolicyIfNotExists("db0", &meta.RetentionPolicyInfo{
+		Name:     "rp0",
+		ReplicaN: 2,
+		Duration: 48 * time.Hour,
+	}); err != nil {
+		t.Fatal(err)
+	} else if !reflect.DeepEqual(rpi, &meta.RetentionPolicyInfo{
+		Name:               "rp0",
+		ReplicaN:           2,
+		Duration:           48 * time.Hour,
+		ShardGroupDuration: 24 * time.Hour,
+	}) {
+		t.Fatalf("unexpected policy: %#v", rpi)
+	}
 }
 
 // Ensure the store can delete a retention policy.


### PR DESCRIPTION
This function was incorrectly returning an error if the retention policy already existed.