### PR TITLE
Shutdown UDP Graphite on SIGTERM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ With this release InfluxDB is moving to Go 1.5.
 - [#3931](https://github.com/influxdb/influxdb/pull/3931): Don't precreate shard groups entirely in the past
 - [#3960](https://github.com/influxdb/influxdb/issues/3960): possible "catch up" bug with nodes down in a cluster
 - [#3980](https://github.com/influxdb/influxdb/pull/3980): 'service stop' waits until service actually stops. Fixes issue #3548.
+- [#4016](https://github.com/influxdb/influxdb/pull/4016): Shutdown Graphite UDP on SIGTERM.
 
 ## v0.9.3 [2015-08-26]
 


### PR DESCRIPTION
Service.Close() had no way of closing the UDP Conn. This change makes the UDP conn an attribute of the server, so Close() can access it. Before this change if Graphite UDP was enabled, the process would hang in response to SIGTERM, and required SIGKILL.