### PR TITLE
Fix race when starting monitor service

### DIFF
--- a/cmd/influxd/run/server.go
+++ b/cmd/influxd/run/server.go
@@ -128,9 +128,6 @@ func NewServer(c *Config, version string) (*Server, error) {
 	// Initialize the monitor
 	s.Monitor.MetaStore = s.MetaStore
 	s.Monitor.PointsWriter = s.PointsWriter
-	if err := s.Monitor.Open(); err != nil {
-		return nil, err
-	}
 
 	// Append services.
 	s.appendClusterService(c.Cluster)
@@ -345,6 +342,10 @@ func (s *Server) Open() error {
 
 		// Wait for the store to initialize.
 		<-s.MetaStore.Ready()
+
+		if err := s.Monitor.Open(); err != nil {
+			return fmt.Errorf("open monitor: %v", err)
+		}
 
 		// Open TSDB store.
 		if err := s.TSDBStore.Open(); err != nil {

--- a/meta/store.go
+++ b/meta/store.go
@@ -256,6 +256,7 @@ func (s *Store) Open() error {
 
 	// Wait for a leader to be elected so we know the raft log is loaded
 	// and up to date
+	<-s.ready
 	return s.WaitForLeader(0)
 }
 


### PR DESCRIPTION
Monitor service was started before the meta store was opened and ready which could cause it to fail to create the `_internal` database.  There was also a race in the meta store open where it could return before it had actually created it's local node entry.

Fixes #4014 