### PR TITLE
Support multiple Graphite inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ With this release InfluxDB is moving to Go 1.5.
 - [#3886](https://github.com/influxdb/influxdb/pull/3886): Prevent write timeouts due to lock contention in WAL
 - [#3574](https://github.com/influxdb/influxdb/issues/3574): Querying data node causes panic
 - [#3913](https://github.com/influxdb/influxdb/issues/3913): Convert meta shard owners to objects
+- [#4026](https://github.com/influxdb/influxdb/pull/4026): Support multiple Graphite inputs. Fixes issue [#3636](https://github.com/influxdb/influxdb/issues/3636)
 - [#3927](https://github.com/influxdb/influxdb/issues/3927): Add WAL lock to prevent timing lock contention
 - [#3928](https://github.com/influxdb/influxdb/issues/3928): Write fails for multiple points when tag starts with quote
 - [#3901](https://github.com/influxdb/influxdb/pull/3901): Unblock relaxed write consistency level Thanks @takayuki!

--- a/cmd/influxd/run/config.go
+++ b/cmd/influxd/run/config.go
@@ -65,7 +65,6 @@ func NewConfig() *Config {
 	c.HTTPD = httpd.NewConfig()
 	c.Collectd = collectd.NewConfig()
 	c.OpenTSDB = opentsdb.NewConfig()
-	c.Graphites = append(c.Graphites, graphite.NewConfig())
 
 	c.ContinuousQuery = continuous_querier.NewConfig()
 	c.Retention = retention.NewConfig()

--- a/services/graphite/config.go
+++ b/services/graphite/config.go
@@ -73,6 +73,12 @@ func (c *Config) WithDefaults() *Config {
 	if d.Protocol == "" {
 		d.Protocol = DefaultProtocol
 	}
+	if d.BatchSize == 0 {
+		d.BatchSize = DefaultBatchSize
+	}
+	if d.BatchTimeout == 0 {
+		d.BatchTimeout = toml.Duration(DefaultBatchTimeout)
+	}
 	if d.ConsistencyLevel == "" {
 		d.ConsistencyLevel = DefaultConsistencyLevel
 	}

--- a/services/graphite/config.go
+++ b/services/graphite/config.go
@@ -47,19 +47,6 @@ type Config struct {
 	Separator        string        `toml:"separator"`
 }
 
-// NewConfig returns a new Config with defaults.
-func NewConfig() Config {
-	return Config{
-		BindAddress:      DefaultBindAddress,
-		Database:         DefaultDatabase,
-		Protocol:         DefaultProtocol,
-		BatchSize:        DefaultBatchSize,
-		BatchTimeout:     toml.Duration(DefaultBatchTimeout),
-		ConsistencyLevel: DefaultConsistencyLevel,
-		Separator:        DefaultSeparator,
-	}
-}
-
 // WithDefaults takes the given config and returns a new config with any required
 // default values set.
 func (c *Config) WithDefaults() *Config {

--- a/services/graphite/config_test.go
+++ b/services/graphite/config_test.go
@@ -51,7 +51,7 @@ tags=["region=us-east"]
 }
 
 func TestConfigValidateEmptyTemplate(t *testing.T) {
-	c := graphite.NewConfig()
+	c := &graphite.Config{}
 	c.Templates = []string{""}
 	if err := c.Validate(); err == nil {
 		t.Errorf("config validate expected error. got nil")
@@ -64,7 +64,7 @@ func TestConfigValidateEmptyTemplate(t *testing.T) {
 }
 
 func TestConfigValidateTooManyField(t *testing.T) {
-	c := graphite.NewConfig()
+	c := &graphite.Config{}
 	c.Templates = []string{"a measurement b c"}
 	if err := c.Validate(); err == nil {
 		t.Errorf("config validate expected error. got nil")
@@ -72,7 +72,7 @@ func TestConfigValidateTooManyField(t *testing.T) {
 }
 
 func TestConfigValidateTemplatePatterns(t *testing.T) {
-	c := graphite.NewConfig()
+	c := &graphite.Config{}
 	c.Templates = []string{"*measurement"}
 	if err := c.Validate(); err == nil {
 		t.Errorf("config validate expected error. got nil")
@@ -85,7 +85,7 @@ func TestConfigValidateTemplatePatterns(t *testing.T) {
 }
 
 func TestConfigValidateFilter(t *testing.T) {
-	c := graphite.NewConfig()
+	c := &graphite.Config{}
 	c.Templates = []string{".server measurement*"}
 	if err := c.Validate(); err == nil {
 		t.Errorf("config validate expected error. got nil")
@@ -103,7 +103,7 @@ func TestConfigValidateFilter(t *testing.T) {
 }
 
 func TestConfigValidateTemplateTags(t *testing.T) {
-	c := graphite.NewConfig()
+	c := &graphite.Config{}
 	c.Templates = []string{"*.server measurement* foo"}
 	if err := c.Validate(); err == nil {
 		t.Errorf("config validate expected error. got nil")
@@ -126,7 +126,7 @@ func TestConfigValidateTemplateTags(t *testing.T) {
 }
 
 func TestConfigValidateDefaultTags(t *testing.T) {
-	c := graphite.NewConfig()
+	c := &graphite.Config{}
 	c.Tags = []string{"foo"}
 	if err := c.Validate(); err == nil {
 		t.Errorf("config validate expected error. got nil")
@@ -149,7 +149,7 @@ func TestConfigValidateDefaultTags(t *testing.T) {
 }
 
 func TestConfigValidateFilterDuplicates(t *testing.T) {
-	c := graphite.NewConfig()
+	c := &graphite.Config{}
 	c.Templates = []string{"foo measurement*", "foo .host.measurement"}
 	if err := c.Validate(); err == nil {
 		t.Errorf("config validate expected error. got nil")

--- a/services/graphite/service_test.go
+++ b/services/graphite/service_test.go
@@ -19,7 +19,7 @@ func Test_ServerGraphiteTCP(t *testing.T) {
 
 	now := time.Now().UTC().Round(time.Second)
 
-	config := graphite.NewConfig()
+	config := graphite.Config{}
 	config.Database = "graphitedb"
 	config.BatchSize = 0 // No batching.
 	config.BatchTimeout = toml.Duration(time.Second)
@@ -87,7 +87,7 @@ func Test_ServerGraphiteUDP(t *testing.T) {
 
 	now := time.Now().UTC().Round(time.Second)
 
-	config := graphite.NewConfig()
+	config := graphite.Config{}
 	config.Database = "graphitedb"
 	config.BatchSize = 0 // No batching.
 	config.BatchTimeout = toml.Duration(time.Second)


### PR DESCRIPTION
Fixes issue #3636 

The fix for this issue is simple. Don't add any config objects for Graphite, let the `toml` package take care of it. Sensible Graphite defaults are still set when a Graphite service is itself initialized, though a small fix needed to be made to the Graphite config code.

Tested by enabling two Graphite TCP inputs via a config file, one on port 2003, a second on port 2004. Connectivity confirmed to each using telnet, and the logs showed both starting up.

```
[graphite] 2015/09/06 21:27:08 Starting graphite service, batch size 1000, batch timeout 1s
[graphite] 2015/09/06 21:27:08 Listening on TCP: [::]:2003
[graphite] 2015/09/06 21:27:08 Starting graphite service, batch size 1000, batch timeout 1s
[graphite] 2015/09/06 21:27:08 Listening on TCP: [::]:2004
```