### PR TITLE
Don't close nil channel in TSDB

### DIFF
--- a/tsdb/store.go
+++ b/tsdb/store.go
@@ -361,7 +361,9 @@ func (s *Store) Close() error {
 			return err
 		}
 	}
-	close(s.closing)
+	if s.closing != nil {
+		close(s.closing)
+	}
 	s.closing = nil
 	s.shards = nil
 	s.databaseIndexes = nil


### PR DESCRIPTION
Obviously a TSDB store may be closed before it's opened.