### PR TITLE
Allow retention policy look up trigger cache-invalidate

### DIFF
--- a/meta/data.go
+++ b/meta/data.go
@@ -132,7 +132,7 @@ func (data *Data) RetentionPolicy(database, name string) (*RetentionPolicyInfo, 
 			return &di.RetentionPolicies[i], nil
 		}
 	}
-	return nil, ErrRetentionPolicyNotFound
+	return nil, nil
 }
 
 // CreateRetentionPolicy creates a new retention policy on a database.

--- a/meta/store.go
+++ b/meta/store.go
@@ -861,6 +861,7 @@ func (s *Store) CreateDatabase(name string) (*DatabaseInfo, error) {
 	); err != nil {
 		return nil, err
 	}
+	s.Logger.Printf("database '%s' created", name)
 
 	if s.retentionAutoCreate {
 		// Read node count.
@@ -980,6 +981,7 @@ func (s *Store) CreateRetentionPolicy(database string, rpi *RetentionPolicyInfo)
 		return nil, err
 	}
 
+	s.Logger.Printf("retention policy '%s' for database '%s' created", rpi.Name, database)
 	return s.RetentionPolicy(database, rpi.Name)
 }
 


### PR DESCRIPTION
The call `RetentionPolicy()` in `meta/data.go` returns an error when the given retention policy cannot be found. This prevents the associated call in `meta/store.go` from then hitting Raft to see if the policy exists on the leader. This change fixes this, and makes `RetentionPolicy` operate the same as `Database()`. 

This change also adds some small logging which I believe is needed since some databases and retention policies are auto-created, and this helps see this going on.
