### PR TITLE
Basic support for multiple shard locations

### DIFF
--- a/cmd/influxd/restore/restore.go
+++ b/cmd/influxd/restore/restore.go
@@ -44,8 +44,12 @@ func (cmd *Command) Restore(config *Config, path string) error {
 	// Remove meta and data directories.
 	if err := os.RemoveAll(config.Meta.Dir); err != nil {
 		return fmt.Errorf("remove meta dir: %s", err)
-	} else if err := os.RemoveAll(config.Data.Dir); err != nil {
-		return fmt.Errorf("remove data dir: %s", err)
+	} else {
+		for _, dir := range config.Data.Dir {
+			if err := os.RemoveAll(dir); err != nil {
+				return fmt.Errorf("remove data dir: %s", err)
+			}
+		}
 	}
 
 	// Open snapshot file and all incremental backups.
@@ -195,7 +199,7 @@ func (cmd *Command) unpackMeta(mr *snapshot.MultiReader, sf snapshot.File, confi
 }
 
 func (cmd *Command) unpackData(mr *snapshot.MultiReader, sf snapshot.File, config *Config) error {
-	path := filepath.Join(config.Data.Dir, sf.Name)
+	path := filepath.Join(config.Data.Dir[0], sf.Name)
 	// Create parent directory for output file.
 	if err := os.MkdirAll(filepath.Dir(path), 0777); err != nil {
 		return fmt.Errorf("mkdir: entry=%s, err=%s", sf.Name, err)

--- a/cmd/influxd/run/config.go
+++ b/cmd/influxd/run/config.go
@@ -89,7 +89,8 @@ func NewDemoConfig() (*Config, error) {
 	}
 
 	c.Meta.Dir = filepath.Join(homeDir, ".influxdb/meta")
-	c.Data.Dir = filepath.Join(homeDir, ".influxdb/data")
+	c.Data.Dir = make([]string, 1)
+	c.Data.Dir = append(c.Data.Dir, filepath.Join(homeDir, ".influxdb/data"))
 	c.HintedHandoff.Dir = filepath.Join(homeDir, ".influxdb/hh")
 	c.Data.WALDir = filepath.Join(homeDir, ".influxdb/wal")
 
@@ -102,7 +103,7 @@ func NewDemoConfig() (*Config, error) {
 func (c *Config) Validate() error {
 	if c.Meta.Dir == "" {
 		return errors.New("Meta.Dir must be specified")
-	} else if c.Data.Dir == "" {
+	} else if len(c.Data.Dir) == 0 {
 		return errors.New("Data.Dir must be specified")
 	} else if c.HintedHandoff.Dir == "" {
 		return errors.New("HintedHandoff.Dir must be specified")

--- a/cmd/inspect/main.go
+++ b/cmd/inspect/main.go
@@ -22,9 +22,11 @@ func main() {
 	flag.StringVar(&path, "p", os.Getenv("HOME")+"/.influxdb", "Root storage path. [$HOME/.influxdb]")
 	flag.Parse()
 
-	tstore := tsdb.NewStore(filepath.Join(path, "data"))
+	var paths []string
+	paths = append(paths, filepath.Join(path, "data"))
+	tstore := tsdb.NewStore(paths)
 	tstore.Logger = log.New(ioutil.Discard, "", log.LstdFlags)
-	tstore.EngineOptions.Config.Dir = filepath.Join(path, "data")
+	tstore.EngineOptions.Config.Dir = paths
 	tstore.EngineOptions.Config.WALLoggingEnabled = false
 	tstore.EngineOptions.Config.WALDir = filepath.Join(path, "wal")
 	if err := tstore.Open(); err != nil {

--- a/tsdb/config.go
+++ b/tsdb/config.go
@@ -43,7 +43,7 @@ const (
 )
 
 type Config struct {
-	Dir string `toml:"dir"`
+	Dir []string `toml:"dir"`
 
 	// WAL config options for b1 (introduced in 0.9.2)
 	MaxWALSize             int           `toml:"max-wal-size"`


### PR DESCRIPTION
User could set multiple data locations like
```
[data]
  dir = ["/var/opt/influxdb/data1", "/var/opt/influxdb/data2"]
```
in config file so as to support multiple hard disks.