### PR TITLE
Prohibit dropping the default retention policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ With this release InfluxDB is moving to Go 1.5.
 - [#3848](https://github.com/influxdb/influxdb/issues/3848): restart influxdb causing panic
 - [#3881](https://github.com/influxdb/influxdb/issues/3881): panic: runtime error: invalid memory address or nil pointer dereference
 - [#3926](https://github.com/influxdb/influxdb/issues/3926): First or last value of `GROUP BY time(x)` is often null. Fixed by [#4038](https://github.com/influxdb/influxdb/pull/4038)
+- [#4053](https://github.com/influxdb/influxdb/pull/4053): Prohibit dropping default retention policy.
 
 ## v0.9.3 [2015-08-26]
 

--- a/cmd/influxd/run/server_test.go
+++ b/cmd/influxd/run/server_test.go
@@ -370,14 +370,34 @@ func TestServer_RetentionPolicyCommands(t *testing.T) {
 				exp:     `{"results":[{"series":[{"columns":["name","duration","replicaN","default"],"values":[["rp0","2h0m0s",3,true]]}]}]}`,
 			},
 			&Query{
-				name:    "drop retention policy should succeed",
+				name:    "dropping default retention policy should not succeed",
 				command: `DROP RETENTION POLICY rp0 ON db0`,
+				exp:     `{"results":[{"error":"retention policy is default"}]}`,
+			},
+			&Query{
+				name:    "show retention policy should still show policy",
+				command: `SHOW RETENTION POLICIES ON db0`,
+				exp:     `{"results":[{"series":[{"columns":["name","duration","replicaN","default"],"values":[["rp0","2h0m0s",3,true]]}]}]}`,
+			},
+			&Query{
+				name:    "create a second non-default retention policy",
+				command: `CREATE RETENTION POLICY rp2 ON db0 DURATION 1h REPLICATION 1`,
 				exp:     `{"results":[{}]}`,
 			},
 			&Query{
-				name:    "show retention policy should be empty after dropping them",
+				name:    "show retention policy should show both",
 				command: `SHOW RETENTION POLICIES ON db0`,
-				exp:     `{"results":[{"series":[{"columns":["name","duration","replicaN","default"]}]}]}`,
+				exp:     `{"results":[{"series":[{"columns":["name","duration","replicaN","default"],"values":[["rp0","2h0m0s",3,true],["rp2","1h0m0s",1,false]]}]}]}`,
+			},
+			&Query{
+				name:    "dropping non-default retention policy succeed",
+				command: `DROP RETENTION POLICY rp2 ON db0`,
+				exp:     `{"results":[{}]}`,
+			},
+			&Query{
+				name:    "show retention policy should show just default",
+				command: `SHOW RETENTION POLICIES ON db0`,
+				exp:     `{"results":[{"series":[{"columns":["name","duration","replicaN","default"],"values":[["rp0","2h0m0s",3,true]]}]}]}`,
 			},
 			&Query{
 				name:    "Ensure retention policy with unacceptable retention cannot be created",

--- a/meta/data.go
+++ b/meta/data.go
@@ -172,6 +172,11 @@ func (data *Data) DropRetentionPolicy(database, name string) error {
 		return ErrDatabaseNotFound
 	}
 
+	// Prohibit dropping the default retention policy.
+	if di.DefaultRetentionPolicy == name {
+		return ErrRetentionPolicyDefault
+	}
+
 	// Remove from list.
 	for i := range di.RetentionPolicies {
 		if di.RetentionPolicies[i].Name == name {

--- a/meta/errors.go
+++ b/meta/errors.go
@@ -43,6 +43,10 @@ var (
 	// ErrRetentionPolicyExists is returned when creating an already existing policy.
 	ErrRetentionPolicyExists = errors.New("retention policy already exists")
 
+	// ErrRetentionPolicyDefault is returned when attempting a prohibited operation
+	// on a default retention policy.
+	ErrRetentionPolicyDefault = errors.New("retention policy is default")
+
 	// ErrRetentionPolicyNotFound is returned when mutating a policy that doesn't exist.
 	ErrRetentionPolicyNotFound = errors.New("retention policy not found")
 


### PR DESCRIPTION
This is to prevents users from putting their system into an awkward
state. It is a policy that all databases must have at least a default
retention policy.

Fixes issue #3699.