### PR TITLE
Disable bz1 recompression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ With this release InfluxDB is moving to Go 1.5.
 - [#4053](https://github.com/influxdb/influxdb/pull/4053): Prohibit dropping default retention policy.
 - [#4060](https://github.com/influxdb/influxdb/pull/4060): Don't log EOF error in openTSDB input.
 - [#3978](https://github.com/influxdb/influxdb/issues/3978): [0.9.3] (regression) cannot use GROUP BY * with more than a single field in SELECT clause
+- [#4058](https://github.com/influxdb/influxdb/pull/4058): Disable bz1 recompression
 
 ## v0.9.3 [2015-08-26]
 


### PR DESCRIPTION
## Overview

This pull request only appends new blocks of points and disables checks for recompressing small blocks at the end of a series.