### PR TITLE
Add build information to diagnostic output

### DIFF
--- a/cmd/influxd/run/command.go
+++ b/cmd/influxd/run/command.go
@@ -104,7 +104,8 @@ func (cmd *Command) Run(args ...string) error {
 	}
 
 	// Create server from config and start it.
-	s, err := NewServer(config, cmd.Version)
+	buildInfo := &BuildInfo{Version: cmd.Version, Commit: cmd.Commit, Branch: cmd.Branch}
+	s, err := NewServer(config, buildInfo)
 	if err != nil {
 		return fmt.Errorf("create server: %s", err)
 	}

--- a/cmd/influxd/run/server.go
+++ b/cmd/influxd/run/server.go
@@ -133,6 +133,9 @@ func NewServer(c *Config, buildInfo *BuildInfo) (*Server, error) {
 	s.PointsWriter.HintedHandoff = s.HintedHandoff
 
 	// Initialize the monitor
+	s.Monitor.Version = s.buildInfo.Version
+	s.Monitor.Commit = s.buildInfo.Commit
+	s.Monitor.Branch = s.buildInfo.Branch
 	s.Monitor.MetaStore = s.MetaStore
 	s.Monitor.PointsWriter = s.PointsWriter
 

--- a/cmd/influxd/run/server.go
+++ b/cmd/influxd/run/server.go
@@ -32,11 +32,18 @@ import (
 	_ "github.com/influxdb/influxdb/tsdb/engine"
 )
 
+// BuildInfo represents the build details for the server code.
+type BuildInfo struct {
+	Version string
+	Commit  string
+	Branch  string
+}
+
 // Server represents a container for the metadata and storage data and services.
 // It is built using a Config and it manages the startup and shutdown of all
 // services in the proper order.
 type Server struct {
-	version string // Build version
+	buildInfo BuildInfo
 
 	err     chan error
 	closing chan struct{}
@@ -71,15 +78,15 @@ type Server struct {
 }
 
 // NewServer returns a new instance of Server built from a config.
-func NewServer(c *Config, version string) (*Server, error) {
+func NewServer(c *Config, buildInfo *BuildInfo) (*Server, error) {
 	// Construct base meta store and data store.
 	tsdbStore := tsdb.NewStore(c.Data.Dir)
 	tsdbStore.EngineOptions.Config = c.Data
 
 	s := &Server{
-		version: version,
-		err:     make(chan error),
-		closing: make(chan struct{}),
+		buildInfo: *buildInfo,
+		err:       make(chan error),
+		closing:   make(chan struct{}),
 
 		Hostname:    c.Meta.Hostname,
 		BindAddress: c.Meta.BindAddress,
@@ -203,7 +210,7 @@ func (s *Server) appendHTTPDService(c httpd.Config) {
 	srv.Handler.MetaStore = s.MetaStore
 	srv.Handler.QueryExecutor = s.QueryExecutor
 	srv.Handler.PointsWriter = s.PointsWriter
-	srv.Handler.Version = s.version
+	srv.Handler.Version = s.buildInfo.Version
 
 	// If a ContinuousQuerier service has been started, attach it.
 	for _, srvc := range s.Services {
@@ -465,7 +472,7 @@ func (s *Server) reportServer() {
     "name":"reports",
     "columns":["os", "arch", "version", "server_id", "cluster_id", "num_series", "num_measurements", "num_databases"],
     "points":[["%s", "%s", "%s", "%x", "%x", "%d", "%d", "%d"]]
-  }]`, runtime.GOOS, runtime.GOARCH, s.version, s.MetaStore.NodeID(), clusterID, numSeries, numMeasurements, numDatabases)
+  }]`, runtime.GOOS, runtime.GOARCH, s.buildInfo.Version, s.MetaStore.NodeID(), clusterID, numSeries, numMeasurements, numDatabases)
 
 	data := bytes.NewBufferString(json)
 

--- a/cmd/influxd/run/server_helpers_test.go
+++ b/cmd/influxd/run/server_helpers_test.go
@@ -31,7 +31,12 @@ type Server struct {
 
 // NewServer returns a new instance of Server.
 func NewServer(c *run.Config) *Server {
-	srv, _ := run.NewServer(c, "testServer")
+	buildInfo := &run.BuildInfo{
+		Version: "testServer",
+		Commit:  "testCommit",
+		Branch:  "testBranch",
+	}
+	srv, _ := run.NewServer(c, buildInfo)
 	s := Server{
 		Server: srv,
 		Config: c,
@@ -54,7 +59,12 @@ func OpenServer(c *run.Config, joinURLs string) *Server {
 
 // OpenServerWithVersion opens a test server with a specific version.
 func OpenServerWithVersion(c *run.Config, version string) *Server {
-	srv, _ := run.NewServer(c, version)
+	buildInfo := &run.BuildInfo{
+		Version: version,
+		Commit:  "",
+		Branch:  "",
+	}
+	srv, _ := run.NewServer(c, buildInfo)
 	s := Server{
 		Server: srv,
 		Config: c,

--- a/monitor/build_info.go
+++ b/monitor/build_info.go
@@ -1,0 +1,18 @@
+package monitor
+
+// system captures build diagnostics
+type build struct {
+	Version string
+	Commit  string
+	Branch  string
+}
+
+func (b *build) Diagnostics() (*Diagnostic, error) {
+	diagnostics := map[string]interface{}{
+		"Version": b.Version,
+		"Commit":  b.Commit,
+		"Branch":  b.Branch,
+	}
+
+	return DiagnosticFromMap(diagnostics), nil
+}

--- a/monitor/service.go
+++ b/monitor/service.go
@@ -58,6 +58,11 @@ func (d *Diagnostic) AddRow(r []interface{}) {
 
 // Monitor represents an instance of the monitor system.
 type Monitor struct {
+	// Build information for diagnostics.
+	Version string
+	Commit  string
+	Branch  string
+
 	wg   sync.WaitGroup
 	done chan struct{}
 	mu   sync.Mutex
@@ -108,6 +113,11 @@ func (m *Monitor) Open() error {
 	m.Logger.Printf("Starting monitor system")
 
 	// Self-register various stats and diagnostics.
+	m.RegisterDiagnosticsClient("build", &build{
+		Version: m.Version,
+		Commit:  m.Commit,
+		Branch:  m.Branch,
+	})
 	m.RegisterDiagnosticsClient("runtime", &goRuntime{})
 	m.RegisterDiagnosticsClient("network", &network{})
 	m.RegisterDiagnosticsClient("system", &system{})


### PR DESCRIPTION
Adds important build information to `SHOW DIAGNOSTICS` output. To make this work I had to add more information to the `Server` type.

```
> show diagnostics
name: build
-----------
Branch  Commit  Version
master  kahk397 0.9
```
