### PR TITLE
Added precision support in cmd client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 With this release InfluxDB is moving to Go 1.5.
 
 ### Features
+- [#4065](https://github.com/influxdb/influxdb/pull/4065): Added precision support in cmd client 
 - [#4050](https://github.com/influxdb/influxdb/pull/4050): Add stats to collectd
 - [#3771](https://github.com/influxdb/influxdb/pull/3771): Close idle Graphite TCP connections
 - [#3755](https://github.com/influxdb/influxdb/issues/3755): Add option to build script. Thanks @fg2it

--- a/client/influxdb.go
+++ b/client/influxdb.go
@@ -136,6 +136,9 @@ func (c *Client) Query(q Query) (*Response, error) {
 	values := u.Query()
 	values.Set("q", q.Command)
 	values.Set("db", q.Database)
+	if c.precision != "" {
+		values.Set("epoch", c.precision)
+	}
 	u.RawQuery = values.Encode()
 
 	req, err := http.NewRequest("GET", u.String(), nil)
@@ -145,10 +148,6 @@ func (c *Client) Query(q Query) (*Response, error) {
 	req.Header.Set("User-Agent", c.userAgent)
 	if c.username != "" {
 		req.SetBasicAuth(c.username, c.password)
-	}
-	
-	if c.precision != "" {
-		req.Header.Set("epoch", c.precision)
 	}
 
 	resp, err := c.httpClient.Do(req)

--- a/client/influxdb.go
+++ b/client/influxdb.go
@@ -79,6 +79,7 @@ type Config struct {
 	Password  string
 	UserAgent string
 	Timeout   time.Duration
+	Precision string
 }
 
 // NewConfig will create a config to be used in connecting to the client
@@ -95,6 +96,7 @@ type Client struct {
 	password   string
 	httpClient *http.Client
 	userAgent  string
+	precision  string
 }
 
 const (
@@ -112,6 +114,7 @@ func NewClient(c Config) (*Client, error) {
 		password:   c.Password,
 		httpClient: &http.Client{Timeout: c.Timeout},
 		userAgent:  c.UserAgent,
+		precision:  c.Precision,
 	}
 	if client.userAgent == "" {
 		client.userAgent = "InfluxDBClient"
@@ -142,6 +145,10 @@ func (c *Client) Query(q Query) (*Response, error) {
 	req.Header.Set("User-Agent", c.userAgent)
 	if c.username != "" {
 		req.SetBasicAuth(c.username, c.password)
+	}
+	
+	if c.precision != "" {
+		req.Header.Set("epoch", c.precision)
 	}
 
 	resp, err := c.httpClient.Do(req)

--- a/client/influxdb.go
+++ b/client/influxdb.go
@@ -128,6 +128,11 @@ func (c *Client) SetAuth(u, p string) {
 	c.password = p
 }
 
+// SetPrecision will update the precision
+func (c *Client) SetPrecision(precision string) {
+        c.precision = precision
+}
+
 // Query sends a command to the server and returns the Response
 func (c *Client) Query(q Query) (*Response, error) {
 	u := c.url

--- a/cmd/influx/main.go
+++ b/cmd/influx/main.go
@@ -72,7 +72,7 @@ func main() {
 	fs.StringVar(&c.Database, "database", c.Database, "Database to connect to the server.")
 	fs.BoolVar(&c.Ssl, "ssl", false, "Use https for connecting to cluster.")
 	fs.StringVar(&c.Format, "format", defaultFormat, "Format specifies the format of the server responses:  json, csv, or column.")
-	fs.StringVar(&c.Precision, "precision", defaultPrecision, "Format specifies the format of the server responses:  json, csv, or column.")
+	fs.StringVar(&c.Precision, "precision", defaultPrecision, "Precision specifies the format of the timestamp:  h,m,s,ms,u or ns.")
 	fs.StringVar(&c.WriteConsistency, "consistency", "any", "Set write consistency level: any, one, quorum, or all.")
 	fs.BoolVar(&c.Pretty, "pretty", false, "Turns on pretty print for the json format.")
 	fs.StringVar(&c.Execute, "execute", c.Execute, "Execute command and quit.")
@@ -104,7 +104,7 @@ func main() {
   -format 'json|csv|column'
        Format specifies the format of the server responses:  json, csv, or column.
   -precision 'h|m|s|ms|u|ns'
-       Format specifies the format of the timestamp:  h|m|s|ms|u|ns.
+       Precision specifies the format of the timestamp:  h, m, s, ms, u or ns.
   -consistency 'any|one|quorum|all'
        Set write consistency level: any, one, quorum, or all
   -pretty
@@ -304,6 +304,7 @@ func (c *CommandLine) connect(cmd string) error {
 	config.Username = c.Username
 	config.Password = c.Password
 	config.UserAgent = "InfluxDBShell/" + version
+	config.Precision = c.Precision
 	cl, err := client.NewClient(config)
 	if err != nil {
 		return fmt.Errorf("Could not create client %s", err)
@@ -361,7 +362,17 @@ func (c *CommandLine) use(cmd string) {
 }
 
 func (c *CommandLine) SetPrecision(cmd string) {
-	c.Precision = cmd
+	// Remove the "precision" keyword if it exists
+	cmd = strings.TrimSpace(strings.Replace(cmd, "precision", "", -1))
+	// normalize cmd
+	cmd = strings.ToLower(cmd)
+
+	switch cmd {
+	case "h","m","s","ms","u","ns":
+		c.Precision = cmd
+	default:
+		fmt.Printf("Unknown precision %q. Please use h, m , s, ms, u or ns.\n", cmd)
+	}
 }
 
 func (c *CommandLine) SetFormat(cmd string) {

--- a/cmd/influx/main.go
+++ b/cmd/influx/main.go
@@ -30,6 +30,8 @@ var (
 const (
 	// defaultFormat is the default format of the results when issuing queries
 	defaultFormat = "column"
+	
+	defaultPrecision = ""
 
 	// defaultPPS is the default points per second that the import will throttle at
 	// by default it's 0, which means it will not throttle
@@ -49,6 +51,7 @@ type CommandLine struct {
 	Version          string
 	Pretty           bool   // controls pretty print for json
 	Format           string // controls the output format.  Valid values are json, csv, or column
+	Precision        string
 	WriteConsistency string
 	Execute          string
 	ShowVersion      bool
@@ -69,6 +72,7 @@ func main() {
 	fs.StringVar(&c.Database, "database", c.Database, "Database to connect to the server.")
 	fs.BoolVar(&c.Ssl, "ssl", false, "Use https for connecting to cluster.")
 	fs.StringVar(&c.Format, "format", defaultFormat, "Format specifies the format of the server responses:  json, csv, or column.")
+	fs.StringVar(&c.Precision, "precision", defaultPrecision, "Format specifies the format of the server responses:  json, csv, or column.")
 	fs.StringVar(&c.WriteConsistency, "consistency", "any", "Set write consistency level: any, one, quorum, or all.")
 	fs.BoolVar(&c.Pretty, "pretty", false, "Turns on pretty print for the json format.")
 	fs.StringVar(&c.Execute, "execute", c.Execute, "Execute command and quit.")
@@ -99,6 +103,8 @@ func main() {
        Execute command and quit.
   -format 'json|csv|column'
        Format specifies the format of the server responses:  json, csv, or column.
+  -precision 'h|m|s|ms|u|ns'
+       Format specifies the format of the timestamp:  h|m|s|ms|u|ns.
   -consistency 'any|one|quorum|all'
        Set write consistency level: any, one, quorum, or all
   -pretty
@@ -184,6 +190,7 @@ Examples:
 		config.URL = u
 		config.Compressed = c.Compressed
 		config.PPS = c.PPS
+		config.Precision = c.Precision
 
 		i := v8.NewImporter(config)
 		if err := i.Import(); err != nil {
@@ -249,6 +256,8 @@ func (c *CommandLine) ParseCommand(cmd string) bool {
 		c.help()
 	case strings.HasPrefix(lcmd, "format"):
 		c.SetFormat(cmd)
+	case strings.HasPrefix(lcmd, "precision"):
+		c.SetPrecision(cmd)
 	case strings.HasPrefix(lcmd, "consistency"):
 		c.SetWriteConsistency(cmd)
 	case strings.HasPrefix(lcmd, "settings"):
@@ -349,6 +358,10 @@ func (c *CommandLine) use(cmd string) {
 	d := args[1]
 	c.Database = d
 	fmt.Printf("Using database %s\n", d)
+}
+
+func (c *CommandLine) SetPrecision(cmd string) {
+	c.Precision = cmd
 }
 
 func (c *CommandLine) SetFormat(cmd string) {
@@ -674,6 +687,7 @@ func (c *CommandLine) help() {
         pretty                toggle pretty print
         use <db_name>         set current databases
         format <format>       set the output format: json, csv, or column
+        precision <format>    set the timestamp format: h,m,s,ms,u,ns
         consistency <level>   set write consistency level: any, one, quorum, or all
         settings              output the current settings for the shell
         exit                  quit the influx shell

--- a/cmd/influx/main.go
+++ b/cmd/influx/main.go
@@ -31,7 +31,8 @@ const (
 	// defaultFormat is the default format of the results when issuing queries
 	defaultFormat = "column"
 	
-	defaultPrecision = ""
+	// defaultPrecision is the default timestamp format of the results when issuing queries 
+	defaultPrecision = "ns"
 
 	// defaultPPS is the default points per second that the import will throttle at
 	// by default it's 0, which means it will not throttle
@@ -72,7 +73,7 @@ func main() {
 	fs.StringVar(&c.Database, "database", c.Database, "Database to connect to the server.")
 	fs.BoolVar(&c.Ssl, "ssl", false, "Use https for connecting to cluster.")
 	fs.StringVar(&c.Format, "format", defaultFormat, "Format specifies the format of the server responses:  json, csv, or column.")
-	fs.StringVar(&c.Precision, "precision", defaultPrecision, "Precision specifies the format of the timestamp:  h,m,s,ms,u or ns.")
+	fs.StringVar(&c.Precision, "precision", defaultPrecision, "Precision specifies the format of the timestamp:  rfc3339,h,m,s,ms,u or ns.")
 	fs.StringVar(&c.WriteConsistency, "consistency", "any", "Set write consistency level: any, one, quorum, or all.")
 	fs.BoolVar(&c.Pretty, "pretty", false, "Turns on pretty print for the json format.")
 	fs.StringVar(&c.Execute, "execute", c.Execute, "Execute command and quit.")
@@ -103,8 +104,8 @@ func main() {
        Execute command and quit.
   -format 'json|csv|column'
        Format specifies the format of the server responses:  json, csv, or column.
-  -precision 'h|m|s|ms|u|ns'
-       Precision specifies the format of the timestamp:  h, m, s, ms, u or ns.
+  -precision 'rfc3339|h|m|s|ms|u|ns'
+       Precision specifies the format of the timestamp:  rfc3339, h, m, s, ms, u or ns.
   -consistency 'any|one|quorum|all'
        Set write consistency level: any, one, quorum, or all
   -pretty
@@ -370,8 +371,10 @@ func (c *CommandLine) SetPrecision(cmd string) {
 	switch cmd {
 	case "h","m","s","ms","u","ns":
 		c.Precision = cmd
+	case "rfc3339":
+		c.Precision = ""; 
 	default:
-		fmt.Printf("Unknown precision %q. Please use h, m , s, ms, u or ns.\n", cmd)
+		fmt.Printf("Unknown precision %q. Please use rfc3339, h, m, s, ms, u or ns.\n", cmd)
 	}
 }
 

--- a/cmd/influx/main.go
+++ b/cmd/influx/main.go
@@ -165,6 +165,8 @@ Examples:
 	}
 
 	if c.Execute != "" {
+		// Modify precision before executing query
+		c.SetPrecision(c.Precision)
 		if err := c.ExecuteQuery(c.Execute); err != nil {
 			c.Line.Close()
 			os.Exit(1)
@@ -371,8 +373,10 @@ func (c *CommandLine) SetPrecision(cmd string) {
 	switch cmd {
 	case "h","m","s","ms","u","ns":
 		c.Precision = cmd
+		c.Client.SetPrecision(c.Precision)
 	case "rfc3339":
-		c.Precision = ""; 
+		c.Precision = ""
+		c.Client.SetPrecision(c.Precision)
 	default:
 		fmt.Printf("Unknown precision %q. Please use rfc3339, h, m, s, ms, u or ns.\n", cmd)
 	}


### PR DESCRIPTION
Added precision support in cmd client in order to have the ability to export timestamp in any support format (secondes, hour...)