### PR TITLE
Log each query before execution

### DIFF
--- a/cmd/influxd/run/server_helpers_test.go
+++ b/cmd/influxd/run/server_helpers_test.go
@@ -344,6 +344,7 @@ func configureLogging(s *Server) {
 		s.TSDBStore.Logger = nullLogger
 		s.HintedHandoff.SetLogger(nullLogger)
 		s.Monitor.SetLogger(nullLogger)
+		s.QueryExecutor.SetLogger(nullLogger)
 		for _, service := range s.Services {
 			if service, ok := service.(logSetter); ok {
 				service.SetLogger(nullLogger)

--- a/tsdb/query_executor.go
+++ b/tsdb/query_executor.go
@@ -60,6 +60,11 @@ func NewQueryExecutor(store *Store) *QueryExecutor {
 	}
 }
 
+// SetLogger sets the internal logger to the logger passed in.
+func (q *QueryExecutor) SetLogger(l *log.Logger) {
+	q.Logger = l
+}
+
 // Authorize user u to execute query q on database.
 // database can be "" for queries that do not require a database.
 // If no user is provided it will return an error unless the query's first statement is to create
@@ -144,6 +149,9 @@ func (q *QueryExecutor) ExecuteQuery(query *influxql.Query, database string, chu
 				results <- &influxql.Result{Err: err}
 				break
 			}
+
+			// Log each normalized statement.
+			q.Logger.Println(stmt.String())
 
 			var res *influxql.Result
 			switch stmt := stmt.(type) {


### PR DESCRIPTION
If a query causes a server to panic, the query is nowhere in the logs, which makes debug very difficult.