### PR TITLE
WAL statistics fixes

### DIFF
--- a/tsdb/engine/wal/wal.go
+++ b/tsdb/engine/wal/wal.go
@@ -185,7 +185,7 @@ func NewLog(path string) *Log {
 	// Configure expvar monitoring. It's OK to do this even if the service fails to open and
 	// should be done before any data could arrive for the service.
 	key := strings.Join([]string{"wal", path}, ":")
-	tags := map[string]string{"bind": path}
+	tags := map[string]string{"path": path}
 
 	return &Log{
 		path:  path,


### PR DESCRIPTION
Some changes to how WAL stats are gathered, to increase usability. This does away with partition-level stats since there is only, ever, 1 partition.

```
> SHOW STATS
name: wal
tags: path=/tmp/opt/influxdb/wal/_internal/monitor/1
auto_flush      mem_size        points_write    points_write_req
----------      --------        ------------    ----------------
21              12359           295             21


name: wal
tags: path=/tmp/opt/influxdb/wal/graphite/default/2
auto_flush      flush_duration          idle_flush      mem_size        points_flush    points_write    points_write_req        series_flush
----------      --------------          ----------      --------        ------------    ------------    ----------------        ------------
20              0.7096323800000001      1               0               295270          295270          60                      1
```