### PR TITLE
By default write stats to default retention policy

### DIFF
--- a/etc/config.sample.toml
+++ b/etc/config.sample.toml
@@ -91,13 +91,14 @@ reporting-disabled = false
 ###
 ### Controls the system self-monitoring, statistics and diagnostics.
 ###
+### The retention policy for this data is the default retention policy within
+### the internal database. The internal database is created automatically if
+### if it does not already exist, as is the default retention policy. If you
+### want to use a non-default retention policy, it must be explicitly created.
 
 [monitor]
   store-enabled = true # Whether to record statistics internally.
   store-database = "_internal" # The destination database for recorded statistics
-  store-retention-policy = "monitor" # The destination retention policy
-  store-retention-duration = "168h" # How long to keep the data
-  store-replication-factor = 1 # How many copies of the data to keep
   store-interval = "10s" # The interval at which to record statistics
 
 ###

--- a/monitor/config.go
+++ b/monitor/config.go
@@ -14,37 +14,22 @@ const (
 	// DefaultStoreDatabase is the name of the database where gathered information is written
 	DefaultStoreDatabase = "_internal"
 
-	// DefaultStoreRetentionPolicy is the name of the retention policy for monitor data.
-	DefaultStoreRetentionPolicy = "monitor"
-
-	// DefaultRetentionPolicyDuration is the duration the data is retained.
-	DefaultStoreRetentionPolicyDuration = 168 * time.Hour
-
-	// DefaultStoreReplicationFactor is the default replication factor for the data.
-	DefaultStoreReplicationFactor = 1
-
 	// DefaultStoreInterval is the period between storing gathered information.
 	DefaultStoreInterval = 10 * time.Second
 )
 
 // Config represents the configuration for the monitor service.
 type Config struct {
-	StoreEnabled           bool          `toml:"store-enabled"`
-	StoreDatabase          string        `toml:"store-database"`
-	StoreRetentionPolicy   string        `toml:"store-retention-policy"`
-	StoreRetentionDuration toml.Duration `toml:"store-retention-duration"`
-	StoreReplicationFactor int           `toml:"store-replication-factor"`
-	StoreInterval          toml.Duration `toml:"store-interval"`
+	StoreEnabled  bool          `toml:"store-enabled"`
+	StoreDatabase string        `toml:"store-database"`
+	StoreInterval toml.Duration `toml:"store-interval"`
 }
 
 // NewConfig returns an instance of Config with defaults.
 func NewConfig() Config {
 	return Config{
-		StoreEnabled:           true,
-		StoreDatabase:          DefaultStoreDatabase,
-		StoreRetentionPolicy:   DefaultStoreRetentionPolicy,
-		StoreRetentionDuration: toml.Duration(DefaultStoreRetentionPolicyDuration),
-		StoreReplicationFactor: DefaultStoreReplicationFactor,
-		StoreInterval:          toml.Duration(DefaultStoreInterval),
+		StoreEnabled:  true,
+		StoreDatabase: DefaultStoreDatabase,
+		StoreInterval: toml.Duration(DefaultStoreInterval),
 	}
 }

--- a/monitor/config_test.go
+++ b/monitor/config_test.go
@@ -14,9 +14,6 @@ func TestConfig_Parse(t *testing.T) {
 	if _, err := toml.Decode(`
 store-enabled=true
 store-database="the_db"
-store-retention-policy="the_rp"
-store-retention-duration="1h"
-store-replication-factor=1234
 store-interval="10m"
 `, &c); err != nil {
 		t.Fatal(err)

--- a/monitor/service.go
+++ b/monitor/service.go
@@ -82,7 +82,6 @@ type Monitor struct {
 		NodeID() uint64
 		WaitForLeader(d time.Duration) error
 		CreateDatabaseIfNotExists(name string) (*meta.DatabaseInfo, error)
-		CreateRetentionPolicyIfNotExists(database string, rpi *meta.RetentionPolicyInfo) (*meta.RetentionPolicyInfo, error)
 	}
 
 	PointsWriter interface {
@@ -95,15 +94,12 @@ type Monitor struct {
 // New returns a new instance of the monitor system.
 func New(c Config) *Monitor {
 	return &Monitor{
-		done:                   make(chan struct{}),
-		diagRegistrations:      make(map[string]DiagsClient),
-		storeEnabled:           c.StoreEnabled,
-		storeDatabase:          c.StoreDatabase,
-		storeRetentionPolicy:   c.StoreRetentionPolicy,
-		storeRetentionDuration: time.Duration(c.StoreRetentionDuration),
-		storeReplicationFactor: c.StoreReplicationFactor,
-		storeInterval:          time.Duration(c.StoreInterval),
-		Logger:                 log.New(os.Stderr, "[monitor] ", log.LstdFlags),
+		done:              make(chan struct{}),
+		diagRegistrations: make(map[string]DiagsClient),
+		storeEnabled:      c.StoreEnabled,
+		storeDatabase:     c.StoreDatabase,
+		storeInterval:     time.Duration(c.StoreInterval),
+		Logger:            log.New(os.Stderr, "[monitor] ", log.LstdFlags),
 	}
 }
 
@@ -300,16 +296,6 @@ func (m *Monitor) storeStatistics() {
 	if _, err := m.MetaStore.CreateDatabaseIfNotExists(m.storeDatabase); err != nil {
 		m.Logger.Printf("failed to create database '%s', terminating storage: %s",
 			m.storeDatabase, err.Error())
-		return
-	}
-
-	rpi := meta.NewRetentionPolicyInfo(m.storeRetentionPolicy)
-	rpi.Duration = m.storeRetentionDuration
-	rpi.ReplicaN = m.storeReplicationFactor
-
-	if _, err := m.MetaStore.CreateRetentionPolicyIfNotExists(m.storeDatabase, rpi); err != nil {
-		m.Logger.Printf("failed to create retention policy '%s', terminating storage: %s",
-			m.storeRetentionPolicy, err.Error())
 		return
 	}
 


### PR DESCRIPTION
This reverts to a previous design for storing stats, whereby if a
non-default retention policy is configured as the destination retention
policy, it is up the user to explicitly create it, with the desired
replication factor and duration.