### PR TITLE
simplify the sorting for top/distinct.

### DIFF
--- a/tsdb/functions_test.go
+++ b/tsdb/functions_test.go
@@ -177,9 +177,9 @@ func TestMapDistinct(t *testing.T) {
 	sort.Sort(values)
 
 	exp := interfaceValues{
+		"1",
 		uint64(1),
 		float64(1),
-		"1",
 	}
 
 	if !reflect.DeepEqual(values, exp) {
@@ -212,14 +212,14 @@ func TestReduceDistinct(t *testing.T) {
 	}
 
 	expect := interfaceValues{
+		"1",
+		"2",
+		false,
+		true,
 		uint64(1),
 		float64(1),
 		uint64(2),
 		float64(2),
-		false,
-		true,
-		"1",
-		"2",
 	}
 
 	got := ReduceDistinct([]interface{}{v1, v1, expect})
@@ -278,14 +278,14 @@ func Test_distinctValues_Sort(t *testing.T) {
 	}
 
 	expect := interfaceValues{
+		"1",
+		"2",
+		false,
+		true,
 		uint64(1),
 		float64(1),
 		uint64(2),
 		float64(2),
-		false,
-		true,
-		"1",
-		"2",
 	}
 
 	sort.Sort(values)


### PR DESCRIPTION
Instead of using closures and 2 different sort routines, have an
interface compare method that makes it easy to switch directions
for comparisons.

Note that this changes the sort order of distinct to match that of
top. While it is a change, I don't think it will break any code. The
important thing for distinct is just that the ordering is absolute,
not what the order is.