### PR TITLE
Create and configure _internal retention policy

### DIFF
--- a/monitor/service_test.go
+++ b/monitor/service_test.go
@@ -39,9 +39,11 @@ func Test_RegisterStats(t *testing.T) {
 
 type mockMetastore struct{}
 
-func (m *mockMetastore) ClusterID() (uint64, error)          { return 1, nil }
-func (m *mockMetastore) NodeID() uint64                      { return 2 }
-func (m *mockMetastore) WaitForLeader(d time.Duration) error { return nil }
+func (m *mockMetastore) ClusterID() (uint64, error)                            { return 1, nil }
+func (m *mockMetastore) NodeID() uint64                                        { return 2 }
+func (m *mockMetastore) WaitForLeader(d time.Duration) error                   { return nil }
+func (m *mockMetastore) SetDefaultRetentionPolicy(database, name string) error { return nil }
+func (m *mockMetastore) DropRetentionPolicy(database, name string) error       { return nil }
 func (m *mockMetastore) CreateDatabaseIfNotExists(name string) (*meta.DatabaseInfo, error) {
 	return nil, nil
 }


### PR DESCRIPTION
If the retention policy for the `_internal` database does not exist, then create it when monitor starts. The default retention policy duration is 7 days.