### PR TITLE
Update pre-commit hook for go vet composites

### DIFF
--- a/.hooks/pre-commit
+++ b/.hooks/pre-commit
@@ -6,7 +6,8 @@ if [ $fmtcount -gt 0 ]; then
     exit 1
 fi
 
-vetcount=`go vet ./... 2>&1 | wc -l`
+# Due to the way composites work, vet will fail for some of our tests so we ignore it
+vetcount=`go tool vet --composites=false ./ 2>&1  | wc -l`
 if [ $vetcount -gt 0 ]; then
     echo "Some files aren't passing vet heuristics, please run 'go vet ./...' to see the errors it flags and correct your source code before committing"
     exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Bugfixes
 - [#3457](https://github.com/influxdb/influxdb/issues/3457): [0.9.3] cannot select field names with prefix + "." that match the measurement name
+- [#4111](https://github.com/influxdb/influxdb/pull/4111): Update pre-commit hook for go vet composites
 
 ## v0.9.4 [2015-09-14]
 


### PR DESCRIPTION
This PR updates the pre-commit hook for git so that vet works regardless of composite errors (which mostly show up in our tests).  This is a known behavior of go vet and it can't be fixed.   While this isn't optimal, we at least benefit from everything else that go-vet does for us (which does catch real bugs).