### PR TITLE
Period in field name that matches measurement fails.  Fixes #3457

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ### Features
 - [#4065](https://github.com/influxdb/influxdb/pull/4065): Added precision support in cmd client. Thanks @sbouchex
 
+### Bugfixes
+- [#3457](https://github.com/influxdb/influxdb/issues/3457): [0.9.3] cannot select field names with prefix + "." that match the measurement name
+
 ## v0.9.4 [2015-09-14]
 
 ### Release Notes

--- a/cmd/influxd/run/server_test.go
+++ b/cmd/influxd/run/server_test.go
@@ -4342,7 +4342,6 @@ func TestServer_Query_FieldWithMultiplePeriodsMeasurementPrefixMatch(t *testing.
 
 	test.addQueries([]*Query{
 		&Query{
-			skip:    true,
 			name:    "baseline",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `select * from foo`,

--- a/cmd/influxd/run/server_test.go
+++ b/cmd/influxd/run/server_test.go
@@ -4268,3 +4268,108 @@ func TestServer_Query_OrderByTime(t *testing.T) {
 		}
 	}
 }
+
+func TestServer_Query_FieldWithMultiplePeriods(t *testing.T) {
+	t.Parallel()
+	s := OpenServer(NewConfig(), "")
+	defer s.Close()
+
+	if err := s.CreateDatabaseAndRetentionPolicy("db0", newRetentionPolicyInfo("rp0", 1, 0)); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.MetaStore.SetDefaultRetentionPolicy("db0", "rp0"); err != nil {
+		t.Fatal(err)
+	}
+
+	writes := []string{
+		fmt.Sprintf(`cpu foo.bar.baz=1 %d`, mustParseTime(time.RFC3339Nano, "2000-01-01T00:00:00Z").UnixNano()),
+	}
+
+	test := NewTest("db0", "rp0")
+	test.write = strings.Join(writes, "\n")
+
+	test.addQueries([]*Query{
+		&Query{
+			name:    "baseline",
+			params:  url.Values{"db": []string{"db0"}},
+			command: `select * from cpu`,
+			exp:     `{"results":[{"series":[{"name":"cpu","columns":["time","foo.bar.baz"],"values":[["2000-01-01T00:00:00Z",1]]}]}]}`,
+		},
+		&Query{
+			name:    "select field with periods",
+			params:  url.Values{"db": []string{"db0"}},
+			command: `select "foo.bar.baz" from cpu`,
+			exp:     `{"results":[{"series":[{"name":"cpu","columns":["time","foo.bar.baz"],"values":[["2000-01-01T00:00:00Z",1]]}]}]}`,
+		},
+	}...)
+
+	for i, query := range test.queries {
+		if i == 0 {
+			if err := test.init(s); err != nil {
+				t.Fatalf("test init failed: %s", err)
+			}
+		}
+		if query.skip {
+			t.Logf("SKIP:: %s", query.name)
+			continue
+		}
+		if err := query.Execute(s); err != nil {
+			t.Error(query.Error(err))
+		} else if !query.success() {
+			t.Error(query.failureMessage())
+		}
+	}
+}
+
+func TestServer_Query_FieldWithMultiplePeriodsMeasurementPrefixMatch(t *testing.T) {
+	t.Parallel()
+	s := OpenServer(NewConfig(), "")
+	defer s.Close()
+
+	if err := s.CreateDatabaseAndRetentionPolicy("db0", newRetentionPolicyInfo("rp0", 1, 0)); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.MetaStore.SetDefaultRetentionPolicy("db0", "rp0"); err != nil {
+		t.Fatal(err)
+	}
+
+	writes := []string{
+		fmt.Sprintf(`foo foo.bar.baz=1 %d`, mustParseTime(time.RFC3339Nano, "2000-01-01T00:00:00Z").UnixNano()),
+	}
+
+	test := NewTest("db0", "rp0")
+	test.write = strings.Join(writes, "\n")
+
+	test.addQueries([]*Query{
+		&Query{
+			skip:    true,
+			name:    "baseline",
+			params:  url.Values{"db": []string{"db0"}},
+			command: `select * from foo`,
+			exp:     `{"results":[{"series":[{"name":"foo","columns":["time","foo.bar.baz"],"values":[["2000-01-01T00:00:00Z",1]]}]}]}`,
+		},
+		&Query{
+			name:    "select field with periods",
+			params:  url.Values{"db": []string{"db0"}},
+			command: `select "foo.bar.baz" from foo`,
+			exp:     `{"results":[{"series":[{"name":"foo","columns":["time","foo.bar.baz"],"values":[["2000-01-01T00:00:00Z",1]]}]}]}`,
+		},
+	}...)
+
+	for i, query := range test.queries {
+		if i == 0 {
+			if err := test.init(s); err != nil {
+				t.Fatalf("test init failed: %s", err)
+			}
+		}
+		if query.skip {
+			t.Logf("SKIP:: %s", query.name)
+			continue
+		}
+		if err := query.Execute(s); err != nil {
+			t.Error(query.Error(err))
+		} else if !query.success() {
+			t.Error(query.failureMessage())
+		}
+	}
+}

--- a/influxql/parser_test.go
+++ b/influxql/parser_test.go
@@ -141,6 +141,26 @@ func TestParser_ParseStatement(t *testing.T) {
 				Offset: 10,
 			},
 		},
+		{
+			s: `SELECT "foo.bar.baz" AS foo FROM myseries`,
+			stmt: &influxql.SelectStatement{
+				IsRawQuery: true,
+				Fields: []*influxql.Field{
+					{Expr: &influxql.VarRef{Val: "foo.bar.baz"}, Alias: "foo"},
+				},
+				Sources: []influxql.Source{&influxql.Measurement{Name: "myseries"}},
+			},
+		},
+		{
+			s: `SELECT "foo.bar.baz" AS foo FROM foo`,
+			stmt: &influxql.SelectStatement{
+				IsRawQuery: true,
+				Fields: []*influxql.Field{
+					{Expr: &influxql.VarRef{Val: "foo.bar.baz"}, Alias: "foo"},
+				},
+				Sources: []influxql.Source{&influxql.Measurement{Name: "foo"}},
+			},
+		},
 
 		// derivative
 		{

--- a/tsdb/query_executor.go
+++ b/tsdb/query_executor.go
@@ -6,7 +6,6 @@ import (
 	"log"
 	"os"
 	"sort"
-	"strings"
 	"time"
 
 	"github.com/influxdb/influxdb/influxql"
@@ -855,22 +854,6 @@ func (q *QueryExecutor) normalizeStatement(stmt influxql.Statement, defaultDatab
 			prefixes[n.Name] = n.Name
 		}
 	})
-	if err != nil {
-		return err
-	}
-
-	// Replace all variable references that used measurement prefixes.
-	influxql.WalkFunc(stmt, func(n influxql.Node) {
-		switch n := n.(type) {
-		case *influxql.VarRef:
-			for k, v := range prefixes {
-				if strings.HasPrefix(n.Val, k+".") {
-					n.Val = v + "." + influxql.QuoteIdent(n.Val[len(k)+1:])
-				}
-			}
-		}
-	})
-
 	return
 }
 


### PR DESCRIPTION
fixes #3457

We had some code that used to check to see if we asked for a `measurement.fieldname` in a select statement.  Even though we were apparently `normalizing` this, we don't actually look this back up on the query engine, so effectively it did nothing.

The scenario it should of accounted for was given:

```
insert cpu value=1
insert memory value=2
```

That the following query would work:

```
select cpu.value, memory.value from cpu, memory
```

However, the current affect if we had this:

```
insert cpu cpu.percent=80
```

and then issued this query:

```
select "cpu.percent" from cpu
```

It would fail, is it interpreted the prefix of `cpu.` as the measurement name.

We will need support for this in the future, but currently the query engine nor the query language support it.

I would suggest that to add it in the future, we parse anything inside quotes as a `VarRef`, so that:

`select "foo.bin.bar" from foo`

Will always see the field name `foo.bin.bar`.  But if we want it prefixed, then

`select foo."bin.bar" from foo`

would parse as the measurement `foo` and the field `bin.bar`.

@pauldix @dgnorton thoughts?