### PR TITLE
Fix race in cluster RPC serialization

### DIFF
--- a/cluster/internal/data.pb.go
+++ b/cluster/internal/data.pb.go
@@ -10,9 +10,6 @@ It is generated from these files:
 
 It has these top-level messages:
 	WriteShardRequest
-	Field
-	Tag
-	Point
 	WriteShardResponse
 	MapShardRequest
 	MapShardResponse
@@ -28,7 +25,7 @@ var _ = math.Inf
 
 type WriteShardRequest struct {
 	ShardID          *uint64  `protobuf:"varint,1,req" json:"ShardID,omitempty"`
-	Points           []*Point `protobuf:"bytes,2,rep" json:"Points,omitempty"`
+	Points           [][]byte `protobuf:"bytes,2,rep" json:"Points,omitempty"`
 	XXX_unrecognized []byte   `json:"-"`
 }
 
@@ -43,137 +40,9 @@ func (m *WriteShardRequest) GetShardID() uint64 {
 	return 0
 }
 
-func (m *WriteShardRequest) GetPoints() []*Point {
+func (m *WriteShardRequest) GetPoints() [][]byte {
 	if m != nil {
 		return m.Points
-	}
-	return nil
-}
-
-type Field struct {
-	Name             *string  `protobuf:"bytes,1,req" json:"Name,omitempty"`
-	Int32            *int32   `protobuf:"varint,2,opt" json:"Int32,omitempty"`
-	Int64            *int64   `protobuf:"varint,3,opt" json:"Int64,omitempty"`
-	Float64          *float64 `protobuf:"fixed64,4,opt" json:"Float64,omitempty"`
-	Bool             *bool    `protobuf:"varint,5,opt" json:"Bool,omitempty"`
-	String_          *string  `protobuf:"bytes,6,opt" json:"String,omitempty"`
-	Bytes            []byte   `protobuf:"bytes,7,opt" json:"Bytes,omitempty"`
-	XXX_unrecognized []byte   `json:"-"`
-}
-
-func (m *Field) Reset()         { *m = Field{} }
-func (m *Field) String() string { return proto.CompactTextString(m) }
-func (*Field) ProtoMessage()    {}
-
-func (m *Field) GetName() string {
-	if m != nil && m.Name != nil {
-		return *m.Name
-	}
-	return ""
-}
-
-func (m *Field) GetInt32() int32 {
-	if m != nil && m.Int32 != nil {
-		return *m.Int32
-	}
-	return 0
-}
-
-func (m *Field) GetInt64() int64 {
-	if m != nil && m.Int64 != nil {
-		return *m.Int64
-	}
-	return 0
-}
-
-func (m *Field) GetFloat64() float64 {
-	if m != nil && m.Float64 != nil {
-		return *m.Float64
-	}
-	return 0
-}
-
-func (m *Field) GetBool() bool {
-	if m != nil && m.Bool != nil {
-		return *m.Bool
-	}
-	return false
-}
-
-func (m *Field) GetString_() string {
-	if m != nil && m.String_ != nil {
-		return *m.String_
-	}
-	return ""
-}
-
-func (m *Field) GetBytes() []byte {
-	if m != nil {
-		return m.Bytes
-	}
-	return nil
-}
-
-type Tag struct {
-	Key              *string `protobuf:"bytes,1,req" json:"Key,omitempty"`
-	Value            *string `protobuf:"bytes,2,req" json:"Value,omitempty"`
-	XXX_unrecognized []byte  `json:"-"`
-}
-
-func (m *Tag) Reset()         { *m = Tag{} }
-func (m *Tag) String() string { return proto.CompactTextString(m) }
-func (*Tag) ProtoMessage()    {}
-
-func (m *Tag) GetKey() string {
-	if m != nil && m.Key != nil {
-		return *m.Key
-	}
-	return ""
-}
-
-func (m *Tag) GetValue() string {
-	if m != nil && m.Value != nil {
-		return *m.Value
-	}
-	return ""
-}
-
-type Point struct {
-	Name             *string  `protobuf:"bytes,1,req" json:"Name,omitempty"`
-	Time             *int64   `protobuf:"varint,2,req" json:"Time,omitempty"`
-	Fields           []*Field `protobuf:"bytes,3,rep" json:"Fields,omitempty"`
-	Tags             []*Tag   `protobuf:"bytes,4,rep" json:"Tags,omitempty"`
-	XXX_unrecognized []byte   `json:"-"`
-}
-
-func (m *Point) Reset()         { *m = Point{} }
-func (m *Point) String() string { return proto.CompactTextString(m) }
-func (*Point) ProtoMessage()    {}
-
-func (m *Point) GetName() string {
-	if m != nil && m.Name != nil {
-		return *m.Name
-	}
-	return ""
-}
-
-func (m *Point) GetTime() int64 {
-	if m != nil && m.Time != nil {
-		return *m.Time
-	}
-	return 0
-}
-
-func (m *Point) GetFields() []*Field {
-	if m != nil {
-		return m.Fields
-	}
-	return nil
-}
-
-func (m *Point) GetTags() []*Tag {
-	if m != nil {
-		return m.Tags
 	}
 	return nil
 }

--- a/cluster/internal/data.proto
+++ b/cluster/internal/data.proto
@@ -2,31 +2,7 @@ package internal;
 
 message WriteShardRequest {
     required uint64 ShardID = 1;
-    repeated Point Points = 2;
-}
-
-message Field {
-    required string Name = 1;
-    oneof Value {
-        int32 Int32 = 2;
-        int64 Int64 = 3;
-        double Float64 = 4;
-        bool Bool = 5;
-        string String = 6;
-        bytes Bytes = 7;
-    }
-}
-
-message Tag {
-    required string Key = 1;
-    required string Value = 2;
-}
-
-message Point {
-    required string Name = 1;
-    required int64 Time = 2;
-    repeated Field Fields = 3;
-    repeated Tag Tags = 4;
+    repeated bytes Points = 2;
 }
 
 message WriteShardResponse {


### PR DESCRIPTION
Point was accessed from multiple goroutines and there was a race on the the internal
cachedFields and cachedName fields.  Accessing these fields is unnecessary work as it
requires the point to be unmarshal into Go types and then remarshaled back into protbuf
types.  Instead, just send the line protocol version already available on the point via
the protobuf.  This avoid accesssing these cached fields and eliminates some extra work.

Possible fix for #4069