### PR TITLE
optimize top queries

### DIFF
--- a/tsdb/functions.go
+++ b/tsdb/functions.go
@@ -961,8 +961,12 @@ func (p *positionOut) lessKey(a, b *PositionPoint) bool {
 	return false
 }
 
-// compares types and if they differ, attempts to coerce them to
-// floating point. Returns the value unchanged if it cannot be converted.
+// typeCompare compares the types of a and b and returns an arbitrary ordering.
+// It returns -1 if type(a) < type(b) , 0 if type(a) == type(b), or 1 if type(a) > type(b), following the strcmp convention
+// from C.
+//
+// If the types are not equal, then it will attempt to coerce them to floating point and return them in the last 2 arguments.
+// If the type cannot be coerced to floating point, it is returned unaltered.
 func typeCompare(a, b interface{}) (int, interface{}, interface{}) {
 	const (
 		stringWeight = iota

--- a/tsdb/functions_test.go
+++ b/tsdb/functions_test.go
@@ -539,7 +539,7 @@ func TestMapTop(t *testing.T) {
 					PositionPoint{20, int64(99), map[string]string{"host": "a"}},
 				},
 			},
-			call: &influxql.Call{Name: "top", Args: []influxql.Expr{&influxql.VarRef{Val: "field1"}, &influxql.VarRef{Val: "host"}, &influxql.NumberLiteral{Val: 2}}},
+			call: &influxql.Call{Name: "top", Args: []influxql.Expr{&influxql.VarRef{Val: "field1"}, &influxql.NumberLiteral{Val: 2}}},
 		},
 		{
 			name: "int64 - tie on value, time, resolve based on tags",
@@ -657,8 +657,8 @@ func TestReduceTop(t *testing.T) {
 			values: []interface{}{
 				PositionPoints{
 					{10, int64(99), map[string]string{"host": "a"}},
-					{10, int64(53), map[string]string{"host": "b"}},
 					{20, int64(88), map[string]string{"host": "a"}},
+					{10, int64(53), map[string]string{"host": "b"}},
 				},
 			},
 			exp: PositionPoints{
@@ -674,8 +674,8 @@ func TestReduceTop(t *testing.T) {
 					{10, int64(99), map[string]string{"host": "a"}},
 				},
 				PositionPoints{
-					{10, int64(53), map[string]string{"host": "b"}},
 					{20, int64(88), map[string]string{"host": "a"}},
+					{10, int64(53), map[string]string{"host": "b"}},
 				},
 			},
 			exp: PositionPoints{
@@ -689,8 +689,8 @@ func TestReduceTop(t *testing.T) {
 			values: []interface{}{
 				PositionPoints{
 					{10, int64(99), map[string]string{"host": "a"}},
-					{10, int64(53), map[string]string{"host": "b"}},
 					{20, int64(88), map[string]string{"host": "a"}},
+					{10, int64(53), map[string]string{"host": "b"}},
 				},
 				nil,
 			},
@@ -705,8 +705,8 @@ func TestReduceTop(t *testing.T) {
 			values: []interface{}{
 				PositionPoints{
 					{10, int64(99), map[string]string{"host": "a"}},
-					{10, int64(53), map[string]string{"host": "b"}},
 					{20, int64(88), map[string]string{}},
+					{10, int64(53), map[string]string{"host": "b"}},
 				},
 				nil,
 			},
@@ -722,8 +722,8 @@ func TestReduceTop(t *testing.T) {
 			values: []interface{}{
 				PositionPoints{
 					{10, int64(99), map[string]string{"host": "a"}},
-					{10, int64(53), map[string]string{"host": "b"}},
 					{20, int64(88), map[string]string{}},
+					{10, int64(53), map[string]string{"host": "b"}},
 				},
 				nil,
 			},


### PR DESCRIPTION
Instead of rounding up the points, sorting and then slicing, keep a
heap that allows us to quickly see if the point needs to be in the
set. This cuts a top query on a dataset of 8 million points from 35
seconds to 11 seconds.