### PR TITLE
Don't panic on write if target RP does not exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Bugfixes
 - [#3457](https://github.com/influxdb/influxdb/issues/3457): [0.9.3] cannot select field names with prefix + "." that match the measurement name
 - [#4111](https://github.com/influxdb/influxdb/pull/4111): Update pre-commit hook for go vet composites
+- [#4136](https://github.com/influxdb/influxdb/pull/4136): Return an error-on-write if target retention policy does not exist. Thanks for the report @ymettier
 
 ## v0.9.4 [2015-09-14]
 

--- a/cluster/points_writer.go
+++ b/cluster/points_writer.go
@@ -174,6 +174,9 @@ func (w *PointsWriter) MapShards(wp *WritePointsRequest) (*ShardMapping, error) 
 	if err != nil {
 		return nil, err
 	}
+	if rp == nil {
+		return nil, influxdb.ErrRetentionPolicyNotFound(wp.RetentionPolicy)
+	}
 
 	for _, p := range wp.Points {
 		timeRanges[p.Time().Truncate(rp.ShardGroupDuration)] = nil

--- a/errors.go
+++ b/errors.go
@@ -18,6 +18,10 @@ var (
 
 func ErrDatabaseNotFound(name string) error { return fmt.Errorf("database not found: %s", name) }
 
+func ErrRetentionPolicyNotFound(name string) error {
+	return fmt.Errorf("retention policy not found: %s", name)
+}
+
 func ErrMeasurementNotFound(name string) error { return fmt.Errorf("measurement not found: %s", name) }
 
 func Errorf(format string, a ...interface{}) (err error) {


### PR DESCRIPTION
Cluster write code was not checking that the target retention policy actually existed, like it does for the target database. This change fixes that.

I also added a unit test that shows behaviour of the store on "get retention policy". This seems to be current behaviour so I want to confirm that is correct.

Fixes #4129 