### PR TITLE
Make engine configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Features
 - [#4065](https://github.com/influxdb/influxdb/pull/4065): Added precision support in cmd client. Thanks @sbouchex
+- [#4140](https://github.com/influxdb/influxdb/pull/4140): Make storage engine configurable
 
 ### Bugfixes
 - [#3457](https://github.com/influxdb/influxdb/issues/3457): [0.9.3] cannot select field names with prefix + "." that match the measurement name

--- a/cmd/influxd/run/server.go
+++ b/cmd/influxd/run/server.go
@@ -100,6 +100,7 @@ func NewServer(c *Config, buildInfo *BuildInfo) (*Server, error) {
 	}
 
 	// Copy TSDB configuration.
+	s.TSDBStore.EngineOptions.EngineVersion = c.Data.Engine
 	s.TSDBStore.EngineOptions.MaxWALSize = c.Data.MaxWALSize
 	s.TSDBStore.EngineOptions.WALFlushInterval = time.Duration(c.Data.WALFlushInterval)
 	s.TSDBStore.EngineOptions.WALPartitionFlushDelay = time.Duration(c.Data.WALPartitionFlushDelay)

--- a/etc/config.sample.toml
+++ b/etc/config.sample.toml
@@ -37,6 +37,9 @@ reporting-disabled = false
 [data]
   dir = "/var/opt/influxdb/data"
 
+  # Controls the engine type for new shards.
+  # engine ="bz1"
+
   # The following WAL settings are for the b1 storage engine used in 0.9.2. They won't
   # apply to any new shards created after upgrading to a version > 0.9.3.
   max-wal-size = 104857600 # Maximum size the WAL can reach before a flush. Defaults to 100MB.

--- a/tsdb/config.go
+++ b/tsdb/config.go
@@ -7,6 +7,9 @@ import (
 )
 
 const (
+	// DefaultEngine is the default engine for new shards
+	DefaultEngine = "bz1"
+
 	// DefaultMaxWALSize is the default size of the WAL before it is flushed.
 	DefaultMaxWALSize = 100 * 1024 * 1024 // 100MB
 
@@ -43,7 +46,8 @@ const (
 )
 
 type Config struct {
-	Dir string `toml:"dir"`
+	Dir    string `toml:"dir"`
+	Engine string `toml:"engine"`
 
 	// WAL config options for b1 (introduced in 0.9.2)
 	MaxWALSize             int           `toml:"max-wal-size"`
@@ -62,6 +66,7 @@ type Config struct {
 
 func NewConfig() Config {
 	return Config{
+		Engine:                 DefaultEngine,
 		MaxWALSize:             DefaultMaxWALSize,
 		WALFlushInterval:       toml.Duration(DefaultWALFlushInterval),
 		WALPartitionFlushDelay: toml.Duration(DefaultWALPartitionFlushDelay),

--- a/tsdb/engine.go
+++ b/tsdb/engine.go
@@ -17,9 +17,6 @@ var (
 	ErrFormatNotFound = errors.New("format not found")
 )
 
-// DefaultEngine is the default engine used by the shard when initializing.
-const DefaultEngine = "bz1"
-
 // Engine represents a swappable storage engine for the shard.
 type Engine interface {
 	Open() error


### PR DESCRIPTION
Allows the engine to be selected. Default remains "bz1" so nothing actually changes.

Tested by setting `bz1` and then `b1` on the config, and seeing that a different engine type was passed to `NewEngine` on each occasion.