### PR TITLE
Missing defer in httpd recovery.  fixes #4124

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - [#3457](https://github.com/influxdb/influxdb/issues/3457): [0.9.3] cannot select field names with prefix + "." that match the measurement name
 - [#4111](https://github.com/influxdb/influxdb/pull/4111): Update pre-commit hook for go vet composites
 - [#4136](https://github.com/influxdb/influxdb/pull/4136): Return an error-on-write if target retention policy does not exist. Thanks for the report @ymettier
+- [#4124](https://github.com/influxdb/influxdb/issues/4124): Missing defer/recover/panic idiom in HTTPD service
 
 ## v0.9.4 [2015-09-14]
 


### PR DESCRIPTION
fixes #4124 

This will catch any panics that the httpd process spawns.  However, since the majority of the go routines in play that typically panic are not spawned by the http process, those panics will still take the server down.

This only fixes the intended behavior of the httpd recovery middleware.