### PR TITLE
Tag Go memstats during writes to _internal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - [#4111](https://github.com/influxdb/influxdb/pull/4111): Update pre-commit hook for go vet composites
 - [#4136](https://github.com/influxdb/influxdb/pull/4136): Return an error-on-write if target retention policy does not exist. Thanks for the report @ymettier
 - [#4124](https://github.com/influxdb/influxdb/issues/4124): Missing defer/recover/panic idiom in HTTPD service
+- [#4165](https://github.com/influxdb/influxdb/pull/4165): Tag all Go runtime stats when writing to _internal
 
 ## v0.9.4 [2015-09-14]
 

--- a/monitor/service.go
+++ b/monitor/service.go
@@ -241,6 +241,12 @@ func (m *Monitor) Statistics(tags map[string]string) ([]*statistic, error) {
 		Tags:   make(map[string]string),
 		Values: make(map[string]interface{}),
 	}
+
+	// Add any supplied tags to Go memstats
+	for k, v := range tags {
+		statistic.Tags[k] = v
+	}
+
 	var rt runtime.MemStats
 	runtime.ReadMemStats(&rt)
 	statistic.Values = map[string]interface{}{


### PR DESCRIPTION
The Go runtime stats were not being tagged when written to the `_internal` database, where meant there was no way to get stats for just a single node -- data for all nodes was returned in aggregate, if the system was being run as a cluster. This change fixes that.

Before the change:
```
> show tag keys
name: runtime
-------------
tagKey
```

After the change:
```
> show tag keys
name: runtime
-------------
tagKey
clusterID
hostname
nodeID
```