### PR TITLE
Support forced local mapping

### DIFF
--- a/cluster/config.go
+++ b/cluster/config.go
@@ -20,6 +20,7 @@ const (
 // Config represents the configuration for the clustering service.
 type Config struct {
 	ForceRemoteShardMapping bool          `toml:"force-remote-mapping"`
+	ForceLocalShardMapping  bool          `toml:"force-local-mapping"`
 	WriteTimeout            toml.Duration `toml:"write-timeout"`
 	ShardWriterTimeout      toml.Duration `toml:"shard-writer-timeout"`
 	ShardMapperTimeout      toml.Duration `toml:"shard-mapper-timeout"`

--- a/cluster/service.go
+++ b/cluster/service.go
@@ -127,9 +127,9 @@ func (s *Service) handleConn(conn net.Conn) {
 		conn.Close()
 	}()
 
-	s.Logger.Printf("accept remote write connection from %v\n", conn.RemoteAddr())
+	s.Logger.Printf("accept remote connection from %v\n", conn.RemoteAddr())
 	defer func() {
-		s.Logger.Printf("close remote write connection from %v\n", conn.RemoteAddr())
+		s.Logger.Printf("close remote connection from %v\n", conn.RemoteAddr())
 	}()
 	for {
 		// Read type-length-value.

--- a/cluster/shard_mapper.go
+++ b/cluster/shard_mapper.go
@@ -15,6 +15,9 @@ import (
 // responsible for creating those mappers from the local store, or reaching
 // out to another node on the cluster.
 type ShardMapper struct {
+
+	// Force certain mapping modes. ForceLocal takes precedence if both set.
+	ForceLocalMapping  bool // All shards treated as local. Useful for testing.
 	ForceRemoteMapping bool // All shards treated as remote. Useful for testing.
 
 	MetaStore interface {
@@ -45,7 +48,7 @@ func (s *ShardMapper) CreateMapper(sh meta.ShardInfo, stmt influxql.Statement, c
 		return nil, err
 	}
 
-	if !sh.OwnedBy(s.MetaStore.NodeID()) || s.ForceRemoteMapping {
+	if !s.ForceLocalMapping && (!sh.OwnedBy(s.MetaStore.NodeID()) || s.ForceRemoteMapping) {
 		// Pick a node in a pseudo-random manner.
 		conn, err := s.dial(sh.Owners[rand.Intn(len(sh.Owners))].NodeID)
 		if err != nil {

--- a/cmd/influxd/run/server.go
+++ b/cmd/influxd/run/server.go
@@ -108,6 +108,7 @@ func NewServer(c *Config, buildInfo *BuildInfo) (*Server, error) {
 	// Set the shard mapper
 	s.ShardMapper = cluster.NewShardMapper(time.Duration(c.Cluster.ShardMapperTimeout))
 	s.ShardMapper.ForceRemoteMapping = c.Cluster.ForceRemoteShardMapping
+	s.ShardMapper.ForceLocalMapping = c.Cluster.ForceLocalShardMapping
 	s.ShardMapper.MetaStore = s.MetaStore
 	s.ShardMapper.TSDBStore = s.TSDBStore
 


### PR DESCRIPTION
This allows, for the purposes of testing and certain cluster configurations, to force all shard mapping to be local. In the case that the data is not local, then queries will return no results.