### PR TITLE
Sort DatabaseIndex.measurementsByTagFilters result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - [#4136](https://github.com/influxdb/influxdb/pull/4136): Return an error-on-write if target retention policy does not exist. Thanks for the report @ymettier
 - [#4124](https://github.com/influxdb/influxdb/issues/4124): Missing defer/recover/panic idiom in HTTPD service
 - [#4165](https://github.com/influxdb/influxdb/pull/4165): Tag all Go runtime stats when writing to _internal
+- [#4118](https://github.com/influxdb/influxdb/issues/4118): Return consistent, correct result for SHOW MEASUREMENTS with multiple AND conditions
 
 ## v0.9.4 [2015-09-14]
 

--- a/tsdb/meta.go
+++ b/tsdb/meta.go
@@ -170,7 +170,7 @@ func (db *DatabaseIndex) measurementsByExpr(expr influxql.Expr) (Measurements, e
 	return nil, fmt.Errorf("%#v", expr)
 }
 
-// measurementsByTagFilters returns the measurements matching the filters on tag values.
+// measurementsByTagFilters returns the sorted measurements matching the filters on tag values.
 func (db *DatabaseIndex) measurementsByTagFilters(filters []*TagFilter) Measurements {
 	// If no filters, then return all measurements.
 	if len(filters) == 0 {
@@ -228,6 +228,7 @@ func (db *DatabaseIndex) measurementsByTagFilters(filters []*TagFilter) Measurem
 		}
 	}
 
+	sort.Sort(measurements)
 	return measurements
 }
 


### PR DESCRIPTION
Fixes #4118 

`measurements.intersect` assumes the receiver and argument are both sorted; prior to this commit, `DatabaseIndex.measurementsByTagFilters` returned Measurements in whatever order the underlying map was iterated.