### PR TITLE
Fix go vet warnings

### DIFF
--- a/services/continuous_querier/service.go
+++ b/services/continuous_querier/service.go
@@ -323,7 +323,7 @@ func (s *Service) ExecuteContinuousQuery(dbi *meta.DatabaseInfo, cqi *meta.Conti
 func (s *Service) runContinuousQueryAndWriteResult(cq *ContinuousQuery) error {
 	// Wrap the CQ's inner SELECT statement in a Query for the QueryExecutor.
 	q := &influxql.Query{
-		Statements: influxql.Statements{cq.q},
+		Statements: influxql.Statements([]influxql.Statement{cq.q}),
 	}
 
 	// Execute the SELECT.

--- a/services/httpd/handler_test.go
+++ b/services/httpd/handler_test.go
@@ -142,8 +142,8 @@ func TestHandler_Query(t *testing.T) {
 			t.Fatalf("unexpected db: %s", db)
 		}
 		return NewResultChan(
-			&influxql.Result{StatementID: 1, Series: models.Rows{{Name: "series0"}}},
-			&influxql.Result{StatementID: 2, Series: models.Rows{{Name: "series1"}}},
+			&influxql.Result{StatementID: 1, Series: models.Rows([]*models.Row{{Name: "series0"}})},
+			&influxql.Result{StatementID: 2, Series: models.Rows([]*models.Row{{Name: "series1"}})},
 			nil,
 		), nil
 	}
@@ -162,8 +162,8 @@ func TestHandler_Query_MergeResults(t *testing.T) {
 	h := NewHandler(false)
 	h.QueryExecutor.ExecuteQueryFn = func(q *influxql.Query, db string, chunkSize int) (<-chan *influxql.Result, error) {
 		return NewResultChan(
-			&influxql.Result{StatementID: 1, Series: models.Rows{{Name: "series0"}}},
-			&influxql.Result{StatementID: 1, Series: models.Rows{{Name: "series1"}}},
+			&influxql.Result{StatementID: 1, Series: models.Rows([]*models.Row{{Name: "series0"}})},
+			&influxql.Result{StatementID: 1, Series: models.Rows([]*models.Row{{Name: "series1"}})},
 		), nil
 	}
 
@@ -184,8 +184,8 @@ func TestHandler_Query_Chunked(t *testing.T) {
 			t.Fatalf("unexpected chunk size: %d", chunkSize)
 		}
 		return NewResultChan(
-			&influxql.Result{StatementID: 1, Series: models.Rows{{Name: "series0"}}},
-			&influxql.Result{StatementID: 1, Series: models.Rows{{Name: "series1"}}},
+			&influxql.Result{StatementID: 1, Series: models.Rows([]*models.Row{{Name: "series0"}})},
+			&influxql.Result{StatementID: 1, Series: models.Rows([]*models.Row{{Name: "series1"}})},
 		), nil
 	}
 


### PR DESCRIPTION
this patch fixes the following go vet warnings:

```                           
services/continuous_querier/service.go:326: influxql.Statements composite literal uses unkeyed fields
exit status 1
services/httpd/handler_test.go:145: models.Rows composite literal uses unkeyed fields
services/httpd/handler_test.go:146: models.Rows composite literal uses unkeyed fields
services/httpd/handler_test.go:165: models.Rows composite literal uses unkeyed fields
services/httpd/handler_test.go:166: models.Rows composite literal uses unkeyed fields
services/httpd/handler_test.go:187: models.Rows composite literal uses unkeyed fields
services/httpd/handler_test.go:188: models.Rows composite literal uses unkeyed fields
exit status 1
```