### PR TITLE
Removing deprecated JSON Protocol from README.md

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -195,8 +195,8 @@ for i, row := range res[0].Series[0].Values {
 	if err != nil {
 		log.Fatal(err)
 	}
-	val, err := row[1].(json.Number).Int64()
-	log.Printf("[%2d] %s: %03d\n", i, t.Format(time.Stamp), val)
+	val := row[1].(string)
+	log.Printf("[%2d] %s: %s\n", i, t.Format(time.Stamp), val)
 }
 ```
 


### PR DESCRIPTION
The following panic is produced when running the code from the 'Find the last 10 _shapes_ records' section:

panic: interface conversion: interface is string, not json.Number

I have changed the type assertion from type json.Number to type string and amended the log output for the string type.