### PR TITLE
export tsdb.Iterator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [#4065](https://github.com/influxdb/influxdb/pull/4065): Added precision support in cmd client. Thanks @sbouchex
 - [#4140](https://github.com/influxdb/influxdb/pull/4140): Make storage engine configurable
 - [#4161](https://github.com/influxdb/influxdb/pull/4161): Implement bottom selector function
+- [#4196](https://github.com/influxdb/influxdb/pull/4196): Export tsdb.Iterator
 
 ### Bugfixes
 - [#3457](https://github.com/influxdb/influxdb/issues/3457): [0.9.3] cannot select field names with prefix + "." that match the measurement name


### PR DESCRIPTION
To be able to consume the exported Map Reduce functions we need to also export the tsdb.Iterator
