### PR TITLE
Support SHOW STATS for specific module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [#4065](https://github.com/influxdb/influxdb/pull/4065): Added precision support in cmd client. Thanks @sbouchex
 - [#4140](https://github.com/influxdb/influxdb/pull/4140): Make storage engine configurable
 - [#4161](https://github.com/influxdb/influxdb/pull/4161): Implement bottom selector function
+- [#4196](https://github.com/influxdb/influxdb/pull/4204): Allow module-level selection for SHOW STATS
 - [#4196](https://github.com/influxdb/influxdb/pull/4196): Export tsdb.Iterator
 - [#4198](https://github.com/influxdb/influxdb/pull/4198): Add basic cluster-service stats
 

--- a/influxql/ast.go
+++ b/influxql/ast.go
@@ -1988,18 +1988,18 @@ func (s *ShowRetentionPoliciesStatement) RequiredPrivileges() ExecutionPrivilege
 	return ExecutionPrivileges{{Admin: false, Name: "", Privilege: ReadPrivilege}}
 }
 
-// ShowRetentionPoliciesStatement represents a command for displaying stats for a given server.
+// ShowStats statement displays statistics for a given module.
 type ShowStatsStatement struct {
-	// Hostname or IP of the server for stats.
-	Host string
+	// Module
+	Module string
 }
 
 // String returns a string representation of a ShowStatsStatement.
 func (s *ShowStatsStatement) String() string {
 	var buf bytes.Buffer
 	_, _ = buf.WriteString("SHOW STATS ")
-	if s.Host != "" {
-		_, _ = buf.WriteString(s.Host)
+	if s.Module != "" {
+		_, _ = buf.WriteString(s.Module)
 	}
 	return buf.String()
 }

--- a/influxql/parser.go
+++ b/influxql/parser.go
@@ -1433,8 +1433,8 @@ func (p *Parser) parseShowStatsStatement() (*ShowStatsStatement, error) {
 	stmt := &ShowStatsStatement{}
 	var err error
 
-	if tok, _, _ := p.scanIgnoreWhitespace(); tok == ON {
-		stmt.Host, err = p.parseString()
+	if tok, _, _ := p.scanIgnoreWhitespace(); tok == FOR {
+		stmt.Module, err = p.parseString()
 	} else {
 		p.unscan()
 	}

--- a/influxql/parser_test.go
+++ b/influxql/parser_test.go
@@ -1396,19 +1396,13 @@ func TestParser_ParseStatement(t *testing.T) {
 		{
 			s: `SHOW STATS`,
 			stmt: &influxql.ShowStatsStatement{
-				Host: "",
+				Module: "",
 			},
 		},
 		{
-			s: `SHOW STATS ON 'servera'`,
+			s: `SHOW STATS FOR 'cluster'`,
 			stmt: &influxql.ShowStatsStatement{
-				Host: "servera",
-			},
-		},
-		{
-			s: `SHOW STATS ON '192.167.1.44'`,
-			stmt: &influxql.ShowStatsStatement{
-				Host: "192.167.1.44",
+				Module: "cluster",
 			},
 		},
 
@@ -1506,7 +1500,7 @@ func TestParser_ParseStatement(t *testing.T) {
 		{s: `SHOW RETENTION POLICIES mydb`, err: `found mydb, expected ON at line 1, char 25`},
 		{s: `SHOW RETENTION POLICIES ON`, err: `found EOF, expected identifier at line 1, char 28`},
 		{s: `SHOW FOO`, err: `found FOO, expected CONTINUOUS, DATABASES, FIELD, GRANTS, MEASUREMENTS, RETENTION, SERIES, SERVERS, TAG, USERS at line 1, char 6`},
-		{s: `SHOW STATS ON`, err: `found EOF, expected string at line 1, char 15`},
+		{s: `SHOW STATS FOR`, err: `found EOF, expected string at line 1, char 16`},
 		{s: `SHOW GRANTS`, err: `found EOF, expected FOR at line 1, char 13`},
 		{s: `SHOW GRANTS FOR`, err: `found EOF, expected identifier at line 1, char 17`},
 		{s: `DROP CONTINUOUS`, err: `found EOF, expected QUERY at line 1, char 17`},

--- a/monitor/README.md
+++ b/monitor/README.md
@@ -9,7 +9,7 @@ A distinction is made between _statistics_ and _diagnostics_ for the purposes of
 An example of statistical information would be the number of points received over UDP, or the number of queries executed. Examples of diagnostic information would be a list of current Graphite TCP connections, the version of InfluxDB, or the uptime of the process.
 
 ## System Statistics
-`SHOW STATS` displays statisics about subsystems within the running `influxd` process. Statistics include points received, points indexed, bytes written to disk, TCP connections handled etc. These statistics are all zero when the InfluxDB process starts.
+`SHOW STATS [FOR <module>]` displays statisics about subsystems within the running `influxd` process. Statistics include points received, points indexed, bytes written to disk, TCP connections handled etc. These statistics are all zero when the InfluxDB process starts. If _module_ is specified, it must be single-quoted. For example `SHOW STATS FOR 'httpd'`.
 
 All statistics are written, by default, by each node to a "monitor" database within the InfluxDB system, allowing analysis of aggregated statistical data using the standard InfluxQL language. This allows users to track the performance of their system. Importantly, this allows cluster-level statistics to be viewed, since by querying the monitor database, statistics from all nodes may be queried. This can be a very powerful approach for troubleshooting your InfluxDB system and understanding its behaviour.
 
@@ -23,7 +23,7 @@ All statistical information is available at HTTP API endpoint `/debug/vars`, in 
 The `monitor` module allows the following configuration:
 
  * Whether to write statistical and diagnostic information to an InfluxDB system. This is enabled by default.
- * The name of the database to where this information should be written. Defaults to `_internal`. The information is written to the default retention policy for the given database. 
+ * The name of the database to where this information should be written. Defaults to `_internal`. The information is written to the default retention policy for the given database.
  * The name of the retention policy, along with full configuration control of the retention policy, if the default retention policy is not suitable.
  * The rate at which this information should be written. The default rate is once every 10 seconds.
 

--- a/monitor/statement_executor.go
+++ b/monitor/statement_executor.go
@@ -19,7 +19,7 @@ type StatementExecutor struct {
 func (s *StatementExecutor) ExecuteStatement(stmt influxql.Statement) *influxql.Result {
 	switch stmt := stmt.(type) {
 	case *influxql.ShowStatsStatement:
-		return s.executeShowStatistics()
+		return s.executeShowStatistics(stmt.Module)
 	case *influxql.ShowDiagnosticsStatement:
 		return s.executeShowDiagnostics()
 	default:
@@ -27,14 +27,17 @@ func (s *StatementExecutor) ExecuteStatement(stmt influxql.Statement) *influxql.
 	}
 }
 
-func (s *StatementExecutor) executeShowStatistics() *influxql.Result {
+func (s *StatementExecutor) executeShowStatistics(module string) *influxql.Result {
 	stats, err := s.Monitor.Statistics(nil)
 	if err != nil {
 		return &influxql.Result{Err: err}
 	}
-	rows := make([]*models.Row, len(stats))
+	rows := make([]*models.Row, 0)
 
-	for n, stat := range stats {
+	for _, stat := range stats {
+		if module != "" && stat.Name != module {
+			continue
+		}
 		row := &models.Row{Name: stat.Name, Tags: stat.Tags}
 
 		values := make([]interface{}, 0, len(stat.Values))
@@ -43,7 +46,7 @@ func (s *StatementExecutor) executeShowStatistics() *influxql.Result {
 			values = append(values, stat.Values[k])
 		}
 		row.Values = [][]interface{}{values}
-		rows[n] = row
+		rows = append(rows, row)
 	}
 	return &influxql.Result{Series: rows}
 }


### PR DESCRIPTION
The reference to `host` is obsolete. We may add it back in at some point, but it was not currently being used.

Example output:

```
> SHOW STATS
name: engine
tags: path=/home/philip/.influxdb/data/_internal/monitor/1, version=bz1
blks_write      blks_write_bytes        blks_write_bytes_c      points_write    points_write_dedupe
----------      ----------------        ------------------      ------------    -------------------
70              4917                    4279                    70              70


name: httpd
tags: bind=:8086
query_req       query_resp_bytes        req
---------       ----------------        ---
6               2268                    6

name: shard
tags: engine=bz1, id=1, path=/home/philip/.influxdb/data/_internal/monitor/1
fields_create   series_create   write_points_ok write_req
-------------   -------------   --------------- ---------
0               6               64              11

name: runtime
-------------
Alloc   Frees   HeapAlloc       HeapIdle        HeapInUse       HeapObjects     HeapReleased    HeapSys Lookups Mallocs NumGC   NumGoroutine    PauseTotalNs    Sys             TotalAlloc
3737136 12003   3737136         2932736         4407296         13398           0               7340032 135     25401   2       43              1295888         11737336        11167896

> SHOW STATS FOR 'httpd'
name: httpd
tags: bind=:8086
query_req       query_resp_bytes        req
---------       ----------------        ---
7               3515                    7

> SHOW STATS FOR 'cluster'
> 
```