### PR TITLE
Graphite TCP should not block system shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - [#4165](https://github.com/influxdb/influxdb/pull/4165): Tag all Go runtime stats when writing to internal database.
 - [#4118](https://github.com/influxdb/influxdb/issues/4118): Return consistent, correct result for SHOW MEASUREMENTS with multiple AND conditions
 - [#4191](https://github.com/influxdb/influxdb/pull/4191): Correctly marshal remote mapper responses. Fixes [#4170](https://github.com/influxdb/influxdb/issues/4170)
+- [#4222](https://github.com/influxdb/influxdb/pull/4222): Graphite TCP connections should not block shutdown
 - [#4180](https://github.com/influxdb/influxdb/pull/4180): Cursor & SelectMapper Refactor
 - [#1577](https://github.com/influxdb/influxdb/issues/1577): selectors (e.g. min, max, first, last) should have equivalents to return the actual point
 

--- a/monitor/service.go
+++ b/monitor/service.go
@@ -151,12 +151,18 @@ func (m *Monitor) SetLogger(l *log.Logger) {
 }
 
 // RegisterDiagnosticsClient registers a diagnostics client with the given name and tags.
-func (m *Monitor) RegisterDiagnosticsClient(name string, client DiagsClient) error {
+func (m *Monitor) RegisterDiagnosticsClient(name string, client DiagsClient) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.diagRegistrations[name] = client
 	m.Logger.Printf(`'%s' registered for diagnostics monitoring`, name)
-	return nil
+}
+
+// DeregisterDiagnosticsClient deregisters a diagnostics client by name.
+func (m *Monitor) DeregisterDiagnosticsClient(name string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.diagRegistrations, name)
 }
 
 // Statistics returns the combined statistics for all expvar data. The given


### PR DESCRIPTION
With this change Graphite TCP connections are tracked on a per-service
basis. This allows a closing Graphite service to first shutdown any
active connections, thereby unblocking the rest of shutdowm.

This work exposed small shortcomings with the existing Diagnostics
system and that code has alse been tweaked.

Fixes issue #4017