### PR TITLE
Various init.d script fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - [#4198](https://github.com/influxdb/influxdb/pull/4198): Add basic cluster-service stats
 
 ### Bugfixes
+- [#4227](https://github.com/influxdb/influxdb/pull/4227): Correctly identify running InfluxDB process during shutdown. Thanks @daachi
 - [#4166](https://github.com/influxdb/influxdb/pull/4166): Fix parser error on invalid SHOW
 - [#3457](https://github.com/influxdb/influxdb/issues/3457): [0.9.3] cannot select field names with prefix + "." that match the measurement name
 - [#4225](https://github.com/influxdb/influxdb/pull/4225): Always display diags in name-sorted order

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -83,7 +83,7 @@ if ! typeset -F pidofproc &>/dev/null; then
             echo "Expected three arguments, e.g. $0 -p pidfile daemon-name"
         fi
 
-        pid=`pgrep -f "^$3"`
+        pid=`pgrep -f "^$3$"`
         local pidfile=`cat $2`
 
         if [ "x$pidfile" == "x" ]; then

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -83,7 +83,7 @@ if ! typeset -F pidofproc &>/dev/null; then
             echo "Expected three arguments, e.g. $0 -p pidfile daemon-name"
         fi
 
-        pid=`pgrep -f "^$3$"`
+        pid=`pgrep "^$3$"`
         local pidfile=`cat $2`
 
         if [ "x$pidfile" == "x" ]; then


### PR DESCRIPTION
There are two main fixes here:

-- don't redefine functions if they are already defined by the distro.
-- don't pass `-f` to pgrep, which pattern matches against the entire line. Just match against the process name with a fully anchored pattern.

Tested on Ubuntu 14.04 and service start and stop remain fine, even when the config file is open in an editor.