### PR TITLE
Add build timestamp to version data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - [#4225](https://github.com/influxdb/influxdb/pull/4225): Always display diags in name-sorted order
 - [#4111](https://github.com/influxdb/influxdb/pull/4111): Update pre-commit hook for go vet composites
 - [#4136](https://github.com/influxdb/influxdb/pull/4136): Return an error-on-write if target retention policy does not exist. Thanks for the report @ymettier
+- [#4228](https://github.com/influxdb/influxdb/pull/4228): Add build timestamp to version information.
 - [#4124](https://github.com/influxdb/influxdb/issues/4124): Missing defer/recover/panic idiom in HTTPD service
 - [#4165](https://github.com/influxdb/influxdb/pull/4165): Tag all Go runtime stats when writing to internal database.
 - [#4118](https://github.com/influxdb/influxdb/issues/4118): Return consistent, correct result for SHOW MEASUREMENTS with multiple AND conditions

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -167,10 +167,10 @@ go install ./...
 To set the version and commit flags during the build pass the following to the build command:
 
 ```bash
--ldflags="-X main.version=$VERSION -X main.branch=$BRANCH -X main.commit=$COMMIT"
+-ldflags="-X main.version=$VERSION -X main.branch=$BRANCH -X main.commit=$COMMIT -X main.buildTime=$TIME"
 ```
 
-where `$VERSION` is the version, `$BRANCH` is the branch, and `$COMMIT` is the git commit hash.
+where `$VERSION` is the version, `$BRANCH` is the branch, `$COMMIT` is the git commit hash, and `$TIME` is the build timestamp.
 
 If you want to build packages, see `package.sh` help:
 ```bash

--- a/cmd/influxd/main.go
+++ b/cmd/influxd/main.go
@@ -20,18 +20,22 @@ import (
 
 // These variables are populated via the Go linker.
 var (
-	version string = "0.9"
-	commit  string
-	branch  string
+	version   string = "0.9"
+	commit    string
+	branch    string
+	buildTime string
 )
 
 func init() {
-	// If commit or branch are not set, make that clear.
+	// If commit, branch, or build time are not set, make that clear.
 	if commit == "" {
 		commit = "unknown"
 	}
 	if branch == "" {
 		branch = "unknown"
+	}
+	if buildTime == "" {
+		buildTime = "unknown"
 	}
 }
 
@@ -77,6 +81,7 @@ func (m *Main) Run(args ...string) error {
 		cmd.Version = version
 		cmd.Commit = commit
 		cmd.Branch = branch
+		cmd.BuildTime = buildTime
 
 		if err := cmd.Run(args...); err != nil {
 			return fmt.Errorf("run: %s", err)
@@ -188,7 +193,7 @@ func (cmd *VersionCommand) Run(args ...string) error {
 	}
 
 	// Print version info.
-	fmt.Fprintf(cmd.Stdout, "InfluxDB v%s (git: %s %s)\n", version, branch, commit)
+	fmt.Fprintf(cmd.Stdout, "InfluxDB v%s (git: %s %s, built %s)\n", version, branch, commit, buildTime)
 
 	return nil
 }

--- a/cmd/influxd/run/command.go
+++ b/cmd/influxd/run/command.go
@@ -30,9 +30,10 @@ const logo = `
 
 // Command represents the command executed by "influxd run".
 type Command struct {
-	Version string
-	Branch  string
-	Commit  string
+	Version   string
+	Branch    string
+	Commit    string
+	BuildTime string
 
 	closing chan struct{}
 	Closed  chan struct{}
@@ -67,7 +68,8 @@ func (cmd *Command) Run(args ...string) error {
 	fmt.Print(logo)
 
 	// Mark start-up in log.
-	log.Printf("InfluxDB starting, version %s, branch %s, commit %s", cmd.Version, cmd.Branch, cmd.Commit)
+	log.Printf("InfluxDB starting, version %s, branch %s, commit %s, built %s",
+		cmd.Version, cmd.Branch, cmd.Commit, cmd.BuildTime)
 	log.Printf("Go version %s, GOMAXPROCS set to %d", runtime.Version(), runtime.GOMAXPROCS(0))
 
 	// Write the PID file.
@@ -104,7 +106,12 @@ func (cmd *Command) Run(args ...string) error {
 	}
 
 	// Create server from config and start it.
-	buildInfo := &BuildInfo{Version: cmd.Version, Commit: cmd.Commit, Branch: cmd.Branch}
+	buildInfo := &BuildInfo{
+		Version: cmd.Version,
+		Commit:  cmd.Commit,
+		Branch:  cmd.Branch,
+		Time:    cmd.BuildTime,
+	}
 	s, err := NewServer(config, buildInfo)
 	if err != nil {
 		return fmt.Errorf("create server: %s", err)

--- a/cmd/influxd/run/server.go
+++ b/cmd/influxd/run/server.go
@@ -37,6 +37,7 @@ type BuildInfo struct {
 	Version string
 	Commit  string
 	Branch  string
+	Time    string
 }
 
 // Server represents a container for the metadata and storage data and services.
@@ -138,6 +139,7 @@ func NewServer(c *Config, buildInfo *BuildInfo) (*Server, error) {
 	s.Monitor.Version = s.buildInfo.Version
 	s.Monitor.Commit = s.buildInfo.Commit
 	s.Monitor.Branch = s.buildInfo.Branch
+	s.Monitor.BuildTime = s.buildInfo.Time
 	s.Monitor.MetaStore = s.MetaStore
 	s.Monitor.PointsWriter = s.PointsWriter
 

--- a/monitor/build_info.go
+++ b/monitor/build_info.go
@@ -5,13 +5,15 @@ type build struct {
 	Version string
 	Commit  string
 	Branch  string
+	Time    string
 }
 
 func (b *build) Diagnostics() (*Diagnostic, error) {
 	diagnostics := map[string]interface{}{
-		"Version": b.Version,
-		"Commit":  b.Commit,
-		"Branch":  b.Branch,
+		"Version":    b.Version,
+		"Commit":     b.Commit,
+		"Branch":     b.Branch,
+		"Build Time": b.Time,
 	}
 
 	return DiagnosticFromMap(diagnostics), nil

--- a/monitor/service.go
+++ b/monitor/service.go
@@ -64,9 +64,10 @@ func (d *Diagnostic) AddRow(r []interface{}) {
 // Monitor represents an instance of the monitor system.
 type Monitor struct {
 	// Build information for diagnostics.
-	Version string
-	Commit  string
-	Branch  string
+	Version   string
+	Commit    string
+	Branch    string
+	BuildTime string
 
 	wg   sync.WaitGroup
 	done chan struct{}
@@ -121,6 +122,7 @@ func (m *Monitor) Open() error {
 		Version: m.Version,
 		Commit:  m.Commit,
 		Branch:  m.Branch,
+		Time:    m.BuildTime,
 	})
 	m.RegisterDiagnosticsClient("runtime", &goRuntime{})
 	m.RegisterDiagnosticsClient("network", &network{})

--- a/package.sh
+++ b/package.sh
@@ -263,7 +263,8 @@ do_build() {
         cleanup_exit 1
     fi
 
-    go install -a -ldflags="-X main.version=$version -X main.branch=$branch -X main.commit=$commit" ./...
+    date=`date -u --iso-8601=seconds`
+    go install -a -ldflags="-X main.version=$version -X main.branch=$branch -X main.commit=$commit -X main.buildTime='$date'" ./...
     if [ $? -ne 0 ]; then
         echo "Build failed, unable to create package -- aborting"
         cleanup_exit 1


### PR DESCRIPTION
This was the final missing part of the version. This makes it trivial to be absolutely sure you're working with, say the latest nightly.

Example output:

```
$ ./influxd version
InfluxDB v0.9.5 (git: master 356871a1b1c2eb2bb682501984b7ef37307c81e7, built 2015-09-25T06:32:21+0000)
```

```
> SHOW DIAGNOSTICS FOR 'build'
name: build
-----------
Branch  Build Time                      Commit                                          Version
master  2015-09-25T06:32:21+0000        356871a1b1c2eb2bb682501984b7ef37307c81e7        0.9.5
```
