### PR TITLE
Fully disable hinted-handoff service if requested

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - [#4136](https://github.com/influxdb/influxdb/pull/4136): Return an error-on-write if target retention policy does not exist. Thanks for the report @ymettier
 - [#4228](https://github.com/influxdb/influxdb/pull/4228): Add build timestamp to version information.
 - [#4124](https://github.com/influxdb/influxdb/issues/4124): Missing defer/recover/panic idiom in HTTPD service
+- [#4238](https://github.com/influxdb/influxdb/pull/4238): Fully disable hinted-handoff service if so requested.
 - [#4165](https://github.com/influxdb/influxdb/pull/4165): Tag all Go runtime stats when writing to internal database.
 - [#4118](https://github.com/influxdb/influxdb/issues/4118): Return consistent, correct result for SHOW MEASUREMENTS with multiple AND conditions
 - [#4191](https://github.com/influxdb/influxdb/pull/4191): Correctly marshal remote mapper responses. Fixes [#4170](https://github.com/influxdb/influxdb/issues/4170)

--- a/services/hh/service.go
+++ b/services/hh/service.go
@@ -54,6 +54,11 @@ func NewService(c Config, w shardWriter) *Service {
 }
 
 func (s *Service) Open() error {
+	if !s.cfg.Enabled {
+		// Allow Open to proceed, but don't anything.
+		return nil
+	}
+
 	s.Logger.Printf("Starting hinted handoff service")
 
 	s.mu.Lock()


### PR DESCRIPTION
Without this change if hinted-handoff was disabled the service would
correctly reject writes, but it would process any data sitting in
hinted-handoff queues. With this change the service is completely
disabled if so requested.