### PR TITLE
Refactor map functions to use list of values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - [#4222](https://github.com/influxdb/influxdb/pull/4222): Graphite TCP connections should not block shutdown
 - [#4180](https://github.com/influxdb/influxdb/pull/4180): Cursor & SelectMapper Refactor
 - [#1577](https://github.com/influxdb/influxdb/issues/1577): selectors (e.g. min, max, first, last) should have equivalents to return the actual point
+- [#4264](https://github.com/influxdb/influxdb/issues/4264): Refactor map functions to use list of values
 
 ## v0.9.4 [2015-09-14]
 

--- a/cmd/influxd/run/server_test.go
+++ b/cmd/influxd/run/server_test.go
@@ -2573,6 +2573,7 @@ func TestServer_Query_AggregateSelectors(t *testing.T) {
 			t.Logf("SKIP:: %s", query.name)
 			continue
 		}
+
 		if err := query.Execute(s); err != nil {
 			t.Error(query.Error(err))
 		} else if !query.success() {

--- a/tsdb/functions_test.go
+++ b/tsdb/functions_test.go
@@ -11,63 +11,15 @@ import (
 
 import "sort"
 
-type testPoint struct {
-	seriesKey string
-	time      int64
-	value     interface{}
-	fields    map[string]interface{}
-	tags      map[string]string
-}
-
-type testIterator struct {
-	values     []testPoint
-	lastFields map[string]interface{}
-	lastTags   map[string]string
-	nextFunc   func() (timestamp int64, value interface{})
-	fieldsFunc func() map[string]interface{}
-	tagsFunc   func() map[string]string
-	tMinFunc   func() int64
-}
-
-func (t *testIterator) Next() (timestamp int64, value interface{}) {
-	if t.nextFunc != nil {
-		return t.nextFunc()
-	}
-	if len(t.values) > 0 {
-		v := t.values[0]
-		t.lastFields = t.values[0].fields
-		t.lastTags = t.values[0].tags
-		t.values = t.values[1:]
-		return v.time, v.value
-	}
-
-	return -1, nil
-}
-
-func (t *testIterator) Fields() map[string]interface{} {
-	if t.fieldsFunc != nil {
-		return t.fieldsFunc()
-	}
-	return t.lastFields
-}
-
-func (t *testIterator) Tags() map[string]string {
-	if t.tagsFunc != nil {
-		return t.tagsFunc()
-	}
-	return t.lastTags
-}
-
-func (t *testIterator) TMin() int64 {
-	if t.tMinFunc != nil {
-		return t.tMinFunc()
-	}
-	return -1
-}
+// type testPoint struct {
+// 	time   int64
+// 	value  interface{}
+// 	fields map[string]interface{}
+// 	tags   map[string]string
+// }
 
 func TestMapMeanNoValues(t *testing.T) {
-	iter := &testIterator{}
-	if got := MapMean(iter); got != nil {
+	if got := MapMean(&MapInput{}); got != nil {
 		t.Errorf("output mismatch: exp nil got %v", got)
 	}
 }
@@ -75,28 +27,30 @@ func TestMapMeanNoValues(t *testing.T) {
 func TestMapMean(t *testing.T) {
 
 	tests := []struct {
-		input  []testPoint
+		input  *MapInput
 		output *meanMapOutput
 	}{
 		{ // Single point
-			input:  []testPoint{testPoint{"0", 1, 1.0, nil, nil}},
+			input: &MapInput{
+				Items: []MapItem{
+					{Timestamp: 1, Value: 1.0},
+				},
+			},
 			output: &meanMapOutput{1, 1, Float64Type},
 		},
 		{ // Two points
-			input: []testPoint{
-				testPoint{"0", 1, 2.0, nil, nil},
-				testPoint{"0", 2, 8.0, nil, nil},
+			input: &MapInput{
+				Items: []MapItem{
+					{Timestamp: 1, Value: float64(2.0)},
+					{Timestamp: 2, Value: float64(8.0)},
+				},
 			},
 			output: &meanMapOutput{2, 5.0, Float64Type},
 		},
 	}
 
 	for _, test := range tests {
-		iter := &testIterator{
-			values: test.input,
-		}
-
-		got := MapMean(iter)
+		got := MapMean(test.input)
 		if got == nil {
 			t.Fatalf("MapMean(%v): output mismatch: exp %v got %v", test.input, test.output, got)
 		}
@@ -154,11 +108,6 @@ func TestReducePercentileNil(t *testing.T) {
 }
 
 func TestMapDistinct(t *testing.T) {
-	const ( // prove that we're ignoring seriesKey
-		seriesKey1 = "1"
-		seriesKey2 = "2"
-	)
-
 	const ( // prove that we're ignoring time
 		timeId1 = iota + 1
 		timeId2
@@ -168,18 +117,18 @@ func TestMapDistinct(t *testing.T) {
 		timeId6
 	)
 
-	iter := &testIterator{
-		values: []testPoint{
-			{seriesKey1, timeId1, uint64(1), nil, nil},
-			{seriesKey1, timeId2, uint64(1), nil, nil},
-			{seriesKey1, timeId3, "1", nil, nil},
-			{seriesKey2, timeId4, uint64(1), nil, nil},
-			{seriesKey2, timeId5, float64(1.0), nil, nil},
-			{seriesKey2, timeId6, "1", nil, nil},
+	input := &MapInput{
+		Items: []MapItem{
+			{Timestamp: timeId1, Value: uint64(1)},
+			{Timestamp: timeId2, Value: uint64(1)},
+			{Timestamp: timeId3, Value: "1"},
+			{Timestamp: timeId4, Value: uint64(1)},
+			{Timestamp: timeId5, Value: float64(1.0)},
+			{Timestamp: timeId6, Value: "1"},
 		},
 	}
 
-	values := MapDistinct(iter).(interfaceValues)
+	values := MapDistinct(input).(interfaceValues)
 
 	if exp, got := 3, len(values); exp != got {
 		t.Errorf("Wrong number of values. exp %v got %v", exp, got)
@@ -199,11 +148,7 @@ func TestMapDistinct(t *testing.T) {
 }
 
 func TestMapDistinctNil(t *testing.T) {
-	iter := &testIterator{
-		values: []testPoint{},
-	}
-
-	values := MapDistinct(iter)
+	values := MapDistinct(&MapInput{})
 
 	if values != nil {
 		t.Errorf("Wrong values. exp nil got %v", spew.Sdump(values))
@@ -307,11 +252,6 @@ func Test_distinctValues_Sort(t *testing.T) {
 }
 
 func TestMapCountDistinct(t *testing.T) {
-	const ( // prove that we're ignoring seriesKey
-		seriesKey1 = "1"
-		seriesKey2 = "2"
-	)
-
 	const ( // prove that we're ignoring time
 		timeId1 = iota + 1
 		timeId2
@@ -322,19 +262,19 @@ func TestMapCountDistinct(t *testing.T) {
 		timeId7
 	)
 
-	iter := &testIterator{
-		values: []testPoint{
-			{seriesKey1, timeId1, uint64(1), nil, nil},
-			{seriesKey1, timeId2, uint64(1), nil, nil},
-			{seriesKey1, timeId3, "1", nil, nil},
-			{seriesKey2, timeId4, uint64(1), nil, nil},
-			{seriesKey2, timeId5, float64(1.0), nil, nil},
-			{seriesKey2, timeId6, "1", nil, nil},
-			{seriesKey2, timeId7, true, nil, nil},
+	input := &MapInput{
+		Items: []MapItem{
+			{Timestamp: timeId1, Value: uint64(1)},
+			{Timestamp: timeId2, Value: uint64(1)},
+			{Timestamp: timeId3, Value: "1"},
+			{Timestamp: timeId4, Value: uint64(1)},
+			{Timestamp: timeId5, Value: float64(1.0)},
+			{Timestamp: timeId6, Value: "1"},
+			{Timestamp: timeId7, Value: true},
 		},
 	}
 
-	values := MapCountDistinct(iter).(map[interface{}]struct{})
+	values := MapCountDistinct(input).(map[interface{}]struct{})
 
 	if exp, got := 4, len(values); exp != got {
 		t.Errorf("Wrong number of values. exp %v got %v", exp, got)
@@ -353,13 +293,7 @@ func TestMapCountDistinct(t *testing.T) {
 }
 
 func TestMapCountDistinctNil(t *testing.T) {
-	iter := &testIterator{
-		values: []testPoint{},
-	}
-
-	values := MapCountDistinct(iter)
-
-	if values != nil {
+	if values := MapCountDistinct(&MapInput{}); values != nil {
 		t.Errorf("Wrong values. exp nil got %v", spew.Sdump(values))
 	}
 }
@@ -493,286 +427,225 @@ func BenchmarkGetSortedRangeBySort(b *testing.B) {
 
 func TestMapTopBottom(t *testing.T) {
 	tests := []struct {
-		name string
-		skip bool
-		iter *testIterator
-		exp  positionOut
-		call *influxql.Call
+		name  string
+		skip  bool
+		input *MapInput
+		exp   positionOut
+		call  *influxql.Call
 	}{
 		{
 			name: "top int64 - basic",
-			iter: &testIterator{
-				values: []testPoint{
-					{"", 10, int64(99), nil, map[string]string{"host": "a"}},
-					{"", 10, int64(53), nil, map[string]string{"host": "b"}},
-					{"", 20, int64(88), nil, map[string]string{"host": "a"}},
+			input: &MapInput{
+				TMin: -1,
+				Items: []MapItem{
+					{Timestamp: 10, Value: int64(53), Tags: map[string]string{"host": "a"}},
+					{Timestamp: 20, Value: int64(88), Tags: map[string]string{"host": "a"}},
 				},
 			},
 			exp: positionOut{
 				points: PositionPoints{
-					PositionPoint{10, int64(99), nil, map[string]string{"host": "a"}},
-					PositionPoint{20, int64(88), nil, map[string]string{"host": "a"}},
+					{20, int64(88), nil, map[string]string{"host": "a"}},
+					{10, int64(53), nil, map[string]string{"host": "a"}},
 				},
 			},
 			call: &influxql.Call{Name: "top", Args: []influxql.Expr{&influxql.VarRef{Val: "field1"}, &influxql.NumberLiteral{Val: 2}}},
-		},
-		{
-			name: "top int64 - basic with tag",
-			iter: &testIterator{
-				values: []testPoint{
-					{"", 10, int64(99), nil, map[string]string{"host": "a"}},
-					{"", 20, int64(53), nil, map[string]string{"host": "b"}},
-					{"", 30, int64(88), nil, map[string]string{"host": "a"}},
-				},
-			},
-			exp: positionOut{
-				callArgs: []string{"host"},
-				points: PositionPoints{
-					PositionPoint{10, int64(99), nil, map[string]string{"host": "a"}},
-					PositionPoint{20, int64(53), nil, map[string]string{"host": "b"}},
-				},
-			},
-			call: &influxql.Call{Name: "top", Args: []influxql.Expr{&influxql.VarRef{Val: "field1"}, &influxql.VarRef{Val: "host"}, &influxql.NumberLiteral{Val: 2}}},
 		},
 		{
 			name: "top int64 - tie on value, resolve based on time",
-			iter: &testIterator{
-				values: []testPoint{
-					{"", 20, int64(99), nil, map[string]string{"host": "a"}},
-					{"", 10, int64(53), nil, map[string]string{"host": "a"}},
-					{"", 10, int64(99), nil, map[string]string{"host": "a"}},
+			input: &MapInput{
+				TMin: -1,
+				Items: []MapItem{
+					{Timestamp: 20, Value: int64(99), Tags: map[string]string{"host": "a"}},
+					{Timestamp: 10, Value: int64(53), Tags: map[string]string{"host": "a"}},
+					{Timestamp: 10, Value: int64(99), Tags: map[string]string{"host": "a"}},
 				},
 			},
 			exp: positionOut{
 				callArgs: []string{"host"},
 				points: PositionPoints{
-					PositionPoint{10, int64(99), nil, map[string]string{"host": "a"}},
-					PositionPoint{20, int64(99), nil, map[string]string{"host": "a"}},
+					{10, int64(99), nil, map[string]string{"host": "a"}},
+					{20, int64(99), nil, map[string]string{"host": "a"}},
 				},
 			},
 			call: &influxql.Call{Name: "top", Args: []influxql.Expr{&influxql.VarRef{Val: "field1"}, &influxql.NumberLiteral{Val: 2}}},
 		},
 		{
-			name: "top int64 - tie on value, time, resolve based on tags",
-			iter: &testIterator{
-				values: []testPoint{
-					{"", 10, int64(99), nil, map[string]string{"host": "b"}},
-					{"", 10, int64(99), nil, map[string]string{"host": "a"}},
-					{"", 20, int64(88), nil, map[string]string{"host": "a"}},
-				},
-			},
-			exp: positionOut{
-				callArgs: []string{"host"},
-				points: PositionPoints{
-					PositionPoint{10, int64(99), nil, map[string]string{"host": "a"}},
-					PositionPoint{10, int64(99), nil, map[string]string{"host": "b"}},
-				},
-			},
-			call: &influxql.Call{Name: "top", Args: []influxql.Expr{&influxql.VarRef{Val: "field1"}, &influxql.VarRef{Val: "host"}, &influxql.NumberLiteral{Val: 2}}},
-		},
-		{
 			name: "top mixed numerics - ints",
-			iter: &testIterator{
-				values: []testPoint{
-					{"", 10, int64(99), nil, map[string]string{"host": "a"}},
-					{"", 10, int64(53), nil, map[string]string{"host": "b"}},
-					{"", 20, uint64(88), nil, map[string]string{"host": "a"}},
+			input: &MapInput{
+				TMin: -1,
+				Items: []MapItem{
+					{Timestamp: 10, Value: int64(99), Tags: map[string]string{"host": "a"}},
+					{Timestamp: 10, Value: int64(53), Tags: map[string]string{"host": "a"}},
+					{Timestamp: 20, Value: uint64(88), Tags: map[string]string{"host": "a"}},
 				},
 			},
 			exp: positionOut{
 				points: PositionPoints{
-					PositionPoint{10, int64(99), nil, map[string]string{"host": "a"}},
-					PositionPoint{20, uint64(88), nil, map[string]string{"host": "a"}},
+					{10, int64(99), nil, map[string]string{"host": "a"}},
+					{20, uint64(88), nil, map[string]string{"host": "a"}},
 				},
 			},
 			call: &influxql.Call{Name: "top", Args: []influxql.Expr{&influxql.VarRef{Val: "field1"}, &influxql.NumberLiteral{Val: 2}}},
 		},
 		{
 			name: "top mixed numerics - ints & floats",
-			iter: &testIterator{
-				values: []testPoint{
-					{"", 10, float64(99), nil, map[string]string{"host": "a"}},
-					{"", 10, int64(53), nil, map[string]string{"host": "b"}},
-					{"", 20, uint64(88), nil, map[string]string{"host": "a"}},
+			input: &MapInput{
+				TMin: -1,
+				Items: []MapItem{
+					{Timestamp: 10, Value: float64(99), Tags: map[string]string{"host": "a"}},
+					{Timestamp: 10, Value: int64(53), Tags: map[string]string{"host": "a"}},
+					{Timestamp: 20, Value: uint64(88), Tags: map[string]string{"host": "a"}},
 				},
 			},
 			exp: positionOut{
 				points: PositionPoints{
-					PositionPoint{10, float64(99), nil, map[string]string{"host": "a"}},
-					PositionPoint{20, uint64(88), nil, map[string]string{"host": "a"}},
+					{10, float64(99), nil, map[string]string{"host": "a"}},
+					{20, uint64(88), nil, map[string]string{"host": "a"}},
 				},
 			},
 			call: &influxql.Call{Name: "top", Args: []influxql.Expr{&influxql.VarRef{Val: "field1"}, &influxql.NumberLiteral{Val: 2}}},
 		},
 		{
 			name: "top mixed numerics - ints, floats, & strings",
-			iter: &testIterator{
-				values: []testPoint{
-					{"", 10, float64(99), nil, map[string]string{"host": "a"}},
-					{"", 10, int64(53), nil, map[string]string{"host": "b"}},
-					{"", 20, "88", nil, map[string]string{"host": "a"}},
+			input: &MapInput{
+				TMin: -1,
+				Items: []MapItem{
+					{Timestamp: 10, Value: float64(99), Tags: map[string]string{"host": "a"}},
+					{Timestamp: 10, Value: int64(53), Tags: map[string]string{"host": "a"}},
+					{Timestamp: 20, Value: "88", Tags: map[string]string{"host": "a"}},
 				},
 			},
 			exp: positionOut{
 				points: PositionPoints{
-					PositionPoint{10, float64(99), nil, map[string]string{"host": "a"}},
-					PositionPoint{10, int64(53), nil, map[string]string{"host": "b"}},
+					{10, float64(99), nil, map[string]string{"host": "a"}},
+					{10, int64(53), nil, map[string]string{"host": "a"}},
 				},
 			},
 			call: &influxql.Call{Name: "top", Args: []influxql.Expr{&influxql.VarRef{Val: "field1"}, &influxql.NumberLiteral{Val: 2}}},
 		},
 		{
 			name: "top bools",
-			iter: &testIterator{
-				values: []testPoint{
-					{"", 10, true, nil, map[string]string{"host": "a"}},
-					{"", 10, true, nil, map[string]string{"host": "b"}},
-					{"", 20, false, nil, map[string]string{"host": "a"}},
+			input: &MapInput{
+				TMin: -1,
+				Items: []MapItem{
+					{Timestamp: 10, Value: true, Tags: map[string]string{"host": "a"}},
+					{Timestamp: 10, Value: true, Tags: map[string]string{"host": "a"}},
+					{Timestamp: 20, Value: false, Tags: map[string]string{"host": "a"}},
 				},
 			},
 			exp: positionOut{
 				points: PositionPoints{
-					PositionPoint{10, true, nil, map[string]string{"host": "a"}},
-					PositionPoint{10, true, nil, map[string]string{"host": "b"}},
+					{10, true, nil, map[string]string{"host": "a"}},
+					{10, true, nil, map[string]string{"host": "a"}},
 				},
 			},
 			call: &influxql.Call{Name: "top", Args: []influxql.Expr{&influxql.VarRef{Val: "field1"}, &influxql.NumberLiteral{Val: 2}}},
 		},
 		{
 			name: "bottom int64 - basic",
-			iter: &testIterator{
-				values: []testPoint{
-					{"", 10, int64(99), nil, map[string]string{"host": "a"}},
-					{"", 10, int64(53), nil, map[string]string{"host": "b"}},
-					{"", 20, int64(88), nil, map[string]string{"host": "a"}},
+			input: &MapInput{
+				TMin: -1,
+				Items: []MapItem{
+					{Timestamp: 10, Value: int64(99), Tags: map[string]string{"host": "a"}},
+					{Timestamp: 10, Value: int64(53), Tags: map[string]string{"host": "a"}},
+					{Timestamp: 20, Value: int64(88), Tags: map[string]string{"host": "a"}},
 				},
 			},
 			exp: positionOut{
 				points: PositionPoints{
-					PositionPoint{10, int64(53), nil, map[string]string{"host": "b"}},
-					PositionPoint{20, int64(88), nil, map[string]string{"host": "a"}},
+					{10, int64(53), nil, map[string]string{"host": "a"}},
+					{20, int64(88), nil, map[string]string{"host": "a"}},
 				},
 			},
 			call: &influxql.Call{Name: "bottom", Args: []influxql.Expr{&influxql.VarRef{Val: "field1"}, &influxql.NumberLiteral{Val: 2}}},
-		},
-		{
-			name: "bottom int64 - basic with tag",
-			iter: &testIterator{
-				values: []testPoint{
-					{"", 10, int64(20), nil, map[string]string{"host": "a"}},
-					{"", 20, int64(53), nil, map[string]string{"host": "b"}},
-					{"", 30, int64(30), nil, map[string]string{"host": "a"}},
-				},
-			},
-			exp: positionOut{
-				callArgs: []string{"host"},
-				points: PositionPoints{
-					PositionPoint{10, int64(20), nil, map[string]string{"host": "a"}},
-					PositionPoint{20, int64(53), nil, map[string]string{"host": "b"}},
-				},
-			},
-			call: &influxql.Call{Name: "bottom", Args: []influxql.Expr{&influxql.VarRef{Val: "field1"}, &influxql.VarRef{Val: "host"}, &influxql.NumberLiteral{Val: 2}}},
 		},
 		{
 			name: "bottom int64 - tie on value, resolve based on time",
-			iter: &testIterator{
-				values: []testPoint{
-					{"", 10, int64(53), nil, map[string]string{"host": "a"}},
-					{"", 20, int64(53), nil, map[string]string{"host": "a"}},
-					{"", 20, int64(53), nil, map[string]string{"host": "a"}},
+			input: &MapInput{
+				TMin: -1,
+				Items: []MapItem{
+					{Timestamp: 10, Value: int64(53), Tags: map[string]string{"host": "a"}},
+					{Timestamp: 20, Value: int64(53), Tags: map[string]string{"host": "a"}},
+					{Timestamp: 20, Value: int64(53), Tags: map[string]string{"host": "a"}},
 				},
 			},
 			exp: positionOut{
 				callArgs: []string{"host"},
 				points: PositionPoints{
-					PositionPoint{10, int64(53), nil, map[string]string{"host": "a"}},
-					PositionPoint{20, int64(53), nil, map[string]string{"host": "a"}},
+					{10, int64(53), nil, map[string]string{"host": "a"}},
+					{20, int64(53), nil, map[string]string{"host": "a"}},
 				},
 			},
 			call: &influxql.Call{Name: "bottom", Args: []influxql.Expr{&influxql.VarRef{Val: "field1"}, &influxql.NumberLiteral{Val: 2}}},
 		},
 		{
-			name: "bottom int64 - tie on value, time, resolve based on tags",
-			iter: &testIterator{
-				values: []testPoint{
-					{"", 10, int64(99), nil, map[string]string{"host": "b"}},
-					{"", 10, int64(99), nil, map[string]string{"host": "a"}},
-					{"", 20, int64(100), nil, map[string]string{"host": "a"}},
-				},
-			},
-			exp: positionOut{
-				callArgs: []string{"host"},
-				points: PositionPoints{
-					PositionPoint{10, int64(99), nil, map[string]string{"host": "a"}},
-					PositionPoint{10, int64(99), nil, map[string]string{"host": "b"}},
-				},
-			},
-			call: &influxql.Call{Name: "bottom", Args: []influxql.Expr{&influxql.VarRef{Val: "field1"}, &influxql.VarRef{Val: "host"}, &influxql.NumberLiteral{Val: 2}}},
-		},
-		{
 			name: "bottom mixed numerics - ints",
-			iter: &testIterator{
-				values: []testPoint{
-					{"", 10, int64(99), nil, map[string]string{"host": "a"}},
-					{"", 10, int64(53), nil, map[string]string{"host": "b"}},
-					{"", 20, uint64(88), nil, map[string]string{"host": "a"}},
+			input: &MapInput{
+				TMin: -1,
+				Items: []MapItem{
+					{Timestamp: 10, Value: int64(99), Tags: map[string]string{"host": "a"}},
+					{Timestamp: 10, Value: int64(53), Tags: map[string]string{"host": "a"}},
+					{Timestamp: 20, Value: uint64(88), Tags: map[string]string{"host": "a"}},
 				},
 			},
 			exp: positionOut{
 				points: PositionPoints{
-					PositionPoint{10, int64(53), nil, map[string]string{"host": "b"}},
-					PositionPoint{20, uint64(88), nil, map[string]string{"host": "a"}},
+					{10, int64(53), nil, map[string]string{"host": "a"}},
+					{20, uint64(88), nil, map[string]string{"host": "a"}},
 				},
 			},
 			call: &influxql.Call{Name: "bottom", Args: []influxql.Expr{&influxql.VarRef{Val: "field1"}, &influxql.NumberLiteral{Val: 2}}},
 		},
 		{
 			name: "bottom mixed numerics - ints & floats",
-			iter: &testIterator{
-				values: []testPoint{
-					{"", 10, int64(99), nil, map[string]string{"host": "a"}},
-					{"", 10, float64(53), nil, map[string]string{"host": "b"}},
-					{"", 20, uint64(88), nil, map[string]string{"host": "a"}},
+			input: &MapInput{
+				TMin: -1,
+				Items: []MapItem{
+					{Timestamp: 10, Value: int64(99), Tags: map[string]string{"host": "a"}},
+					{Timestamp: 10, Value: float64(53), Tags: map[string]string{"host": "a"}},
+					{Timestamp: 20, Value: uint64(88), Tags: map[string]string{"host": "a"}},
 				},
 			},
 			exp: positionOut{
 				points: PositionPoints{
-					PositionPoint{10, float64(53), nil, map[string]string{"host": "b"}},
-					PositionPoint{20, uint64(88), nil, map[string]string{"host": "a"}},
+					{10, float64(53), nil, map[string]string{"host": "a"}},
+					{20, uint64(88), nil, map[string]string{"host": "a"}},
 				},
 			},
 			call: &influxql.Call{Name: "bottom", Args: []influxql.Expr{&influxql.VarRef{Val: "field1"}, &influxql.NumberLiteral{Val: 2}}},
 		},
 		{
 			name: "bottom mixed numerics - ints, floats, & strings",
-			iter: &testIterator{
-				values: []testPoint{
-					{"", 10, float64(99), nil, map[string]string{"host": "a"}},
-					{"", 10, int64(53), nil, map[string]string{"host": "b"}},
-					{"", 20, "88", nil, map[string]string{"host": "a"}},
+			input: &MapInput{
+				TMin: -1,
+				Items: []MapItem{
+					{Timestamp: 10, Value: float64(99), Tags: map[string]string{"host": "a"}},
+					{Timestamp: 10, Value: int64(53), Tags: map[string]string{"host": "a"}},
+					{Timestamp: 20, Value: "88", Tags: map[string]string{"host": "a"}},
 				},
 			},
 			exp: positionOut{
 				points: PositionPoints{
-					PositionPoint{10, int64(53), nil, map[string]string{"host": "b"}},
-					PositionPoint{10, float64(99), nil, map[string]string{"host": "a"}},
+					{10, int64(53), nil, map[string]string{"host": "a"}},
+					{10, float64(99), nil, map[string]string{"host": "a"}},
 				},
 			},
 			call: &influxql.Call{Name: "bottom", Args: []influxql.Expr{&influxql.VarRef{Val: "field1"}, &influxql.NumberLiteral{Val: 2}}},
 		},
 		{
 			name: "bottom bools",
-			iter: &testIterator{
-				values: []testPoint{
-					{"", 10, true, nil, map[string]string{"host": "a"}},
-					{"", 10, true, nil, map[string]string{"host": "b"}},
-					{"", 20, false, nil, map[string]string{"host": "a"}},
+			input: &MapInput{
+				TMin: -1,
+				Items: []MapItem{
+					{Timestamp: 10, Value: true, Tags: map[string]string{"host": "a"}},
+					{Timestamp: 10, Value: true, Tags: map[string]string{"host": "a"}},
+					{Timestamp: 20, Value: false, Tags: map[string]string{"host": "a"}},
 				},
 			},
 			exp: positionOut{
 				points: PositionPoints{
-					PositionPoint{20, false, nil, map[string]string{"host": "a"}},
-					PositionPoint{10, true, nil, map[string]string{"host": "a"}},
+					{20, false, nil, map[string]string{"host": "a"}},
+					{10, true, nil, map[string]string{"host": "a"}},
 				},
 			},
 			call: &influxql.Call{Name: "bottom", Args: []influxql.Expr{&influxql.VarRef{Val: "field1"}, &influxql.NumberLiteral{Val: 2}}},
@@ -787,7 +660,7 @@ func TestMapTopBottom(t *testing.T) {
 		limit := int(lit.Val)
 		fields := topCallArgs(test.call)
 
-		values := MapTopBottom(test.iter, limit, fields, len(test.call.Args), test.call.Name).(PositionPoints)
+		values := MapTopBottom(test.input, limit, fields, len(test.call.Args), test.call.Name).(PositionPoints)
 		t.Logf("Test: %s", test.name)
 		if exp, got := len(test.exp.points), len(values); exp != got {
 			t.Errorf("Wrong number of values. exp %v got %v", exp, got)


### PR DESCRIPTION
## Overview

This commit changes `tsdb.mapFunc` to use `tsdb.MapInput` instead of an iterator. This will make it easier and faster to pass blocks of values from the new storage engine into the engine.