### PR TITLE
Increase HH retry interval to 10 seconds

### DIFF
--- a/etc/config.sample.toml
+++ b/etc/config.sample.toml
@@ -272,4 +272,4 @@ reporting-disabled = false
   max-size = 1073741824
   max-age = "168h"
   retry-rate-limit = 0
-  retry-interval = "1s"
+  retry-interval = "10s"

--- a/services/hh/config.go
+++ b/services/hh/config.go
@@ -21,7 +21,7 @@ const (
 
 	// DefaultRetryInterval is the default amout of time the system waits before
 	// attempting to flush hinted handoff queues.
-	DefaultRetryInterval = time.Second
+	DefaultRetryInterval = 10 * time.Second
 )
 
 type Config struct {


### PR DESCRIPTION
If a node goes down for any length of time -- failure or upgrade for example, the co-ordinator node continues HH. At an interval of 1 second for every target shard, ephemeral ports are quickly consumed which could result in eventual starvation and a network outage.