### PR TITLE
Fix cluster-level error marshalling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - [#4180](https://github.com/influxdb/influxdb/pull/4180): Cursor & SelectMapper Refactor
 - [#1577](https://github.com/influxdb/influxdb/issues/1577): selectors (e.g. min, max, first, last) should have equivalents to return the actual point
 - [#4264](https://github.com/influxdb/influxdb/issues/4264): Refactor map functions to use list of values
+- [#4278](https://github.com/influxdb/influxdb/pull/4278): Fix error marshalling across the cluster
 
 ## v0.9.4 [2015-09-14]
 

--- a/meta/errors.go
+++ b/meta/errors.go
@@ -7,106 +7,100 @@ import (
 
 var (
 	// ErrStoreOpen is returned when opening an already open store.
-	ErrStoreOpen = errors.New("store already open")
+	ErrStoreOpen = newError("store already open")
 
 	// ErrStoreClosed is returned when closing an already closed store.
-	ErrStoreClosed = errors.New("raft store already closed")
+	ErrStoreClosed = newError("raft store already closed")
 
 	// ErrTooManyPeers is returned when more than 3 peers are used.
-	ErrTooManyPeers = errors.New("too many peers; influxdb v0.9.0 is limited to 3 nodes in a cluster")
+	ErrTooManyPeers = newError("too many peers; influxdb v0.9.0 is limited to 3 nodes in a cluster")
 )
 
 var (
 	// ErrNodeExists is returned when creating an already existing node.
-	ErrNodeExists = errors.New("node already exists")
+	ErrNodeExists = newError("node already exists")
 
 	// ErrNodeNotFound is returned when mutating a node that doesn't exist.
-	ErrNodeNotFound = errors.New("node not found")
+	ErrNodeNotFound = newError("node not found")
 
 	// ErrNodesRequired is returned when at least one node is required for an operation.
 	// This occurs when creating a shard group.
-	ErrNodesRequired = errors.New("at least one node required")
+	ErrNodesRequired = newError("at least one node required")
 )
 
 var (
 	// ErrDatabaseExists is returned when creating an already existing database.
-	ErrDatabaseExists = errors.New("database already exists")
+	ErrDatabaseExists = newError("database already exists")
 
 	// ErrDatabaseNotFound is returned when mutating a database that doesn't exist.
-	ErrDatabaseNotFound = errors.New("database not found")
+	ErrDatabaseNotFound = newError("database not found")
 
 	// ErrDatabaseNameRequired is returned when creating a database without a name.
-	ErrDatabaseNameRequired = errors.New("database name required")
+	ErrDatabaseNameRequired = newError("database name required")
 )
 
 var (
 	// ErrRetentionPolicyExists is returned when creating an already existing policy.
-	ErrRetentionPolicyExists = errors.New("retention policy already exists")
+	ErrRetentionPolicyExists = newError("retention policy already exists")
 
 	// ErrRetentionPolicyDefault is returned when attempting a prohibited operation
 	// on a default retention policy.
-	ErrRetentionPolicyDefault = errors.New("retention policy is default")
+	ErrRetentionPolicyDefault = newError("retention policy is default")
 
 	// ErrRetentionPolicyNotFound is returned when mutating a policy that doesn't exist.
-	ErrRetentionPolicyNotFound = errors.New("retention policy not found")
+	ErrRetentionPolicyNotFound = newError("retention policy not found")
 
 	// ErrRetentionPolicyNameRequired is returned when creating a policy without a name.
-	ErrRetentionPolicyNameRequired = errors.New("retention policy name required")
+	ErrRetentionPolicyNameRequired = newError("retention policy name required")
 
 	// ErrRetentionPolicyNameExists is returned when renaming a policy to
 	// the same name as another existing policy.
-	ErrRetentionPolicyNameExists = errors.New("retention policy name already exists")
+	ErrRetentionPolicyNameExists = newError("retention policy name already exists")
 
 	// ErrRetentionPolicyDurationTooLow is returned when updating a retention
 	// policy that has a duration lower than the allowed minimum.
-	ErrRetentionPolicyDurationTooLow = errors.New(fmt.Sprintf("retention policy duration must be at least %s",
+	ErrRetentionPolicyDurationTooLow = newError(fmt.Sprintf("retention policy duration must be at least %s",
 		RetentionPolicyMinDuration))
 
 	// ErrReplicationFactorTooLow is returned when the replication factor is not in an
 	// acceptable range.
-	ErrReplicationFactorTooLow = errors.New("replication factor must be greater than 0")
+	ErrReplicationFactorTooLow = newError("replication factor must be greater than 0")
 )
 
 var (
 	// ErrShardGroupExists is returned when creating an already existing shard group.
-	ErrShardGroupExists = errors.New("shard group already exists")
+	ErrShardGroupExists = newError("shard group already exists")
 
 	// ErrShardGroupNotFound is returned when mutating a shard group that doesn't exist.
-	ErrShardGroupNotFound = errors.New("shard group not found")
+	ErrShardGroupNotFound = newError("shard group not found")
 )
 
 var (
 	// ErrContinuousQueryExists is returned when creating an already existing continuous query.
-	ErrContinuousQueryExists = errors.New("continuous query already exists")
+	ErrContinuousQueryExists = newError("continuous query already exists")
 
 	// ErrContinuousQueryNotFound is returned when removing a continuous query that doesn't exist.
-	ErrContinuousQueryNotFound = errors.New("continuous query not found")
+	ErrContinuousQueryNotFound = newError("continuous query not found")
 )
 
 var (
 	// ErrUserExists is returned when creating an already existing user.
-	ErrUserExists = errors.New("user already exists")
+	ErrUserExists = newError("user already exists")
 
 	// ErrUserNotFound is returned when mutating a user that doesn't exist.
-	ErrUserNotFound = errors.New("user not found")
+	ErrUserNotFound = newError("user not found")
 
 	// ErrUsernameRequired is returned when creating a user without a username.
-	ErrUsernameRequired = errors.New("username required")
+	ErrUsernameRequired = newError("username required")
 )
-
-var errs = [...]error{
-	ErrStoreOpen, ErrStoreClosed,
-	ErrNodeExists, ErrNodeNotFound,
-	ErrDatabaseExists, ErrDatabaseNotFound, ErrDatabaseNameRequired,
-}
 
 // errLookup stores a mapping of error strings to well defined error types.
 var errLookup = make(map[string]error)
 
-func init() {
-	for _, err := range errs {
-		errLookup[err.Error()] = err
-	}
+func newError(msg string) error {
+	err := errors.New(msg)
+	errLookup[err.Error()] = err
+	return err
 }
 
 // lookupError returns a known error reference, if one exists.

--- a/meta/store.go
+++ b/meta/store.go
@@ -692,7 +692,7 @@ func (s *Store) handleExecConn(conn net.Conn) {
 
 		// Apply against the raft log.
 		if err := s.apply(buf); err != nil {
-			return fmt.Errorf("apply: %s", err)
+			return err
 		}
 		return nil
 	}()
@@ -1553,7 +1553,7 @@ func (s *Store) remoteExec(b []byte) error {
 	if err := proto.Unmarshal(buf, &resp); err != nil {
 		return fmt.Errorf("unmarshal response: %s", err)
 	} else if !resp.GetOK() {
-		return fmt.Errorf("exec failed: %s", resp.GetError())
+		return lookupError(fmt.Errorf(resp.GetError()))
 	}
 
 	// Wait for local FSM to sync to index.


### PR DESCRIPTION
This change corrects use of the error-message lookup table, so that errors that are marshalled just as strings across the cluster are correctly recognised on the receiving nodes. This allows the higher-level code to continue to use error types such as `ErrRetentionPolicyNotFound`

This fix required that certain error prefixes be removed from error handling, and that errors are passed through cleanly.

Fixes https://github.com/influxdb/influxdb/issues/4267