### PR TITLE
Handle missing values in aggregate derivative queries better

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@
 - [#4264](https://github.com/influxdb/influxdb/issues/4264): Refactor map functions to use list of values
 - [#4278](https://github.com/influxdb/influxdb/pull/4278): Fix error marshalling across the cluster
 - [#4149](https://github.com/influxdb/influxdb/pull/4149): Fix derivative unnecessarily requires aggregate function.  Thanks @peekeri!
+- [#4237](https://github.com/influxdb/influxdb/issues/4237): DERIVATIVE() edge conditions
+- [#4263](https://github.com/influxdb/influxdb/issues/4263): derivative does not work when data is missing
 
 ## v0.9.4 [2015-09-14]
 

--- a/tsdb/executor_test.go
+++ b/tsdb/executor_test.go
@@ -860,7 +860,43 @@ func TestProcessAggregateDerivative(t *testing.T) {
 			},
 			exp: [][]interface{}{
 				[]interface{}{
-					time.Unix(0, 0), 0.0,
+					time.Unix(0, 0).Add(24 * time.Hour), nil,
+				},
+				[]interface{}{
+					time.Unix(0, 0).Add(48 * time.Hour), nil,
+				},
+				[]interface{}{
+					time.Unix(0, 0).Add(72 * time.Hour), nil,
+				},
+			},
+		},
+		{
+			name:     "bool derivatives",
+			fn:       "derivative",
+			interval: 24 * time.Hour,
+			in: [][]interface{}{
+				[]interface{}{
+					time.Unix(0, 0), "1.0",
+				},
+				[]interface{}{
+					time.Unix(0, 0).Add(24 * time.Hour), true,
+				},
+				[]interface{}{
+					time.Unix(0, 0).Add(48 * time.Hour), true,
+				},
+				[]interface{}{
+					time.Unix(0, 0).Add(72 * time.Hour), true,
+				},
+			},
+			exp: [][]interface{}{
+				[]interface{}{
+					time.Unix(0, 0).Add(24 * time.Hour), nil,
+				},
+				[]interface{}{
+					time.Unix(0, 0).Add(48 * time.Hour), nil,
+				},
+				[]interface{}{
+					time.Unix(0, 0).Add(72 * time.Hour), nil,
 				},
 			},
 		},
@@ -1123,8 +1159,53 @@ func TestProcessRawQueryDerivative(t *testing.T) {
 			},
 			exp: []*tsdb.MapperValue{
 				{
+					Time:  time.Unix(0, 0).Add(24 * time.Hour).UnixNano(),
+					Value: nil,
+				},
+				{
+					Time:  time.Unix(0, 0).Add(48 * time.Hour).UnixNano(),
+					Value: nil,
+				},
+				{
+					Time:  time.Unix(0, 0).Add(72 * time.Hour).UnixNano(),
+					Value: nil,
+				},
+			},
+		},
+		{
+			name:     "bool derivatives",
+			fn:       "derivative",
+			interval: 24 * time.Hour,
+			in: []*tsdb.MapperValue{
+				{
 					Time:  time.Unix(0, 0).Unix(),
-					Value: 0.0,
+					Value: true,
+				},
+				{
+					Time:  time.Unix(0, 0).Add(24 * time.Hour).UnixNano(),
+					Value: true,
+				},
+				{
+					Time:  time.Unix(0, 0).Add(48 * time.Hour).UnixNano(),
+					Value: false,
+				},
+				{
+					Time:  time.Unix(0, 0).Add(72 * time.Hour).UnixNano(),
+					Value: false,
+				},
+			},
+			exp: []*tsdb.MapperValue{
+				{
+					Time:  time.Unix(0, 0).Add(24 * time.Hour).UnixNano(),
+					Value: nil,
+				},
+				{
+					Time:  time.Unix(0, 0).Add(48 * time.Hour).UnixNano(),
+					Value: nil,
+				},
+				{
+					Time:  time.Unix(0, 0).Add(72 * time.Hour).UnixNano(),
+					Value: nil,
 				},
 			},
 		},
@@ -1142,8 +1223,14 @@ func TestProcessRawQueryDerivative(t *testing.T) {
 		}
 
 		for i := 0; i < len(test.exp); i++ {
-			if test.exp[i].Time != got[i].Time || math.Abs((test.exp[i].Value.(float64)-got[i].Value.(float64))) > 0.0000001 {
-				t.Fatalf("RawQueryDerivativeProcessor - %s results mismatch:\ngot %v\nexp %v", test.name, got, test.exp)
+			if v, ok := test.exp[i].Value.(float64); ok {
+				if test.exp[i].Time != got[i].Time || math.Abs((v-got[i].Value.(float64))) > 0.0000001 {
+					t.Fatalf("RawQueryDerivativeProcessor - %s results mismatch:\ngot %v\nexp %v", test.name, got, test.exp)
+				}
+			} else {
+				if test.exp[i].Time != got[i].Time || test.exp[i].Value != got[i].Value {
+					t.Fatalf("RawQueryDerivativeProcessor - %s results mismatch:\ngot %v\nexp %v", test.name, got, test.exp)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
If an aggregate derivative query did not have a value in the first
time bucket, it would abort early and return a single row with a value
of 0.  Similarly, if either the current or previous value was nil,
it would skip the row and not append any values causing gaps and
no data to show up.

Instead, this will append a nil value if either the current or previous
value is nil.  This essentially allows nil values to carry through the
results as well as gives a more sensible value for rows where we cannot
compute a difference (instead of dropping the row as before).

Fixes #4237 #4263