### PR TITLE
support events with missing tag data

### DIFF
--- a/models/points.go
+++ b/models/points.go
@@ -1017,6 +1017,10 @@ func (p *point) Tags() Tags {
 			i, key = scanTo(p.key, i, '=')
 			i, value = scanTagValue(p.key, i+1)
 
+			if len(value) == 0 {
+				continue
+			}
+
 			tags[string(unescapeTag(key))] = string(unescapeTag(value))
 
 			i += 1
@@ -1137,7 +1141,10 @@ func (t Tags) HashKey() []byte {
 	for k, v := range t {
 		ek := escapeTag([]byte(k))
 		ev := escapeTag([]byte(v))
-		escaped[string(ek)] = string(ev)
+
+		if len(string(ev)) > 0 {
+			escaped[string(ek)] = string(ev)
+		}
 	}
 
 	// Extract keys and determine final size.

--- a/models/points_test.go
+++ b/models/points_test.go
@@ -599,6 +599,18 @@ func TestParsePointUnescape(t *testing.T) {
 			},
 			time.Unix(0, 0)))
 
+	// tag with no value
+	test(t, `cpu,regions=east value="1"`,
+		models.NewPoint("cpu",
+			models.Tags{
+				"regions": "east",
+				"foobar":  "",
+			},
+			models.Fields{
+				"value": "1",
+			},
+			time.Unix(0, 0)))
+
 	// commas in field values
 	test(t, `cpu,regions=east value="1,0"`,
 		models.NewPoint("cpu",


### PR DESCRIPTION
I believe with the new storage system setup, it isn't using model.points when writing (only reading) so some of the safe guard checks don't happen. in particular, i have continuous queries that is writing data which can possibly put in empty tags when grouping. either way, this code should probably never write an empty tag if the system is not setup to handle it.