### PR TITLE
Retry monitor storage creation and only on Leader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 - [#4263](https://github.com/influxdb/influxdb/issues/4263): derivative does not work when data is missing
 - [#4293](https://github.com/influxdb/influxdb/pull/4293): Ensure shell is invoked when touching PID file. Thanks @christopherjdickson
 - [#4296](https://github.com/influxdb/influxdb/pull/4296): Reject line protocol ending with '-'. Fixes [#4272](https://github.com/influxdb/influxdb/issues/4272)
+- [#4333](https://github.com/influxdb/influxdb/pull/4333): Retry monitor storage creation and only on Leader.
 
 ## v0.9.4 [2015-09-14]
 

--- a/monitor/service.go
+++ b/monitor/service.go
@@ -88,6 +88,7 @@ type Monitor struct {
 		ClusterID() (uint64, error)
 		NodeID() uint64
 		WaitForLeader(d time.Duration) error
+		IsLeader() bool
 		CreateDatabaseIfNotExists(name string) (*meta.DatabaseInfo, error)
 		CreateRetentionPolicyIfNotExists(database string, rpi *meta.RetentionPolicyInfo) (*meta.RetentionPolicyInfo, error)
 		SetDefaultRetentionPolicy(database, name string) error
@@ -297,7 +298,7 @@ func (m *Monitor) Diagnostics() (map[string]*Diagnostic, error) {
 
 // createInternalStorage ensures the internal storage has been created.
 func (m *Monitor) createInternalStorage() {
-	if m.storeCreated {
+	if !m.MetaStore.IsLeader() || m.storeCreated {
 		return
 	}
 

--- a/monitor/service.go
+++ b/monitor/service.go
@@ -357,7 +357,6 @@ func (m *Monitor) storeStatistics() {
 	defer tick.Stop()
 	for {
 		select {
-
 		case <-tick.C:
 			m.createInternalStorage()
 

--- a/monitor/service_test.go
+++ b/monitor/service_test.go
@@ -42,6 +42,7 @@ type mockMetastore struct{}
 func (m *mockMetastore) ClusterID() (uint64, error)                            { return 1, nil }
 func (m *mockMetastore) NodeID() uint64                                        { return 2 }
 func (m *mockMetastore) WaitForLeader(d time.Duration) error                   { return nil }
+func (m *mockMetastore) IsLeader() bool                                        { return true }
 func (m *mockMetastore) SetDefaultRetentionPolicy(database, name string) error { return nil }
 func (m *mockMetastore) DropRetentionPolicy(database, name string) error       { return nil }
 func (m *mockMetastore) CreateDatabaseIfNotExists(name string) (*meta.DatabaseInfo, error) {


### PR DESCRIPTION
With this change the monitor sub-system will retry creation of its internal storage. Previously any failure would cause internal storage to cease, meaning any temporary problems on the cluster would cause storage to cease until a node restart. Instead try every monitor cycle until creation is successful.

Furthermore, this creation only needs to be executed by one node, so only attempt it on the Leader.