### PR TITLE
Hinted handoff should not process inactive nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 - [#4296](https://github.com/influxdb/influxdb/pull/4296): Reject line protocol ending with '-'. Fixes [#4272](https://github.com/influxdb/influxdb/issues/4272)
 - [#4333](https://github.com/influxdb/influxdb/pull/4333): Retry monitor storage creation and only on Leader.
 - [#4276](https://github.com/influxdb/influxdb/issues/4276): Walk DropSeriesStatement & check for empty sources
+- [#4339](https://github.com/influxdb/influxdb/pull/4339): HH should only process active nodes.
 
 ## v0.9.4 [2015-09-14]
 

--- a/cmd/influxd/run/server.go
+++ b/cmd/influxd/run/server.go
@@ -126,6 +126,7 @@ func NewServer(c *Config, buildInfo *BuildInfo) (*Server, error) {
 
 	// Create the hinted handoff service
 	s.HintedHandoff = hh.NewService(c.HintedHandoff, s.ShardWriter)
+	s.HintedHandoff.MetaStore = s.MetaStore
 
 	// Initialize points writer.
 	s.PointsWriter = cluster.NewPointsWriter()

--- a/services/hh/processor_test.go
+++ b/services/hh/processor_test.go
@@ -16,6 +16,14 @@ func (f *fakeShardWriter) WriteShard(shardID, nodeID uint64, points []models.Poi
 	return f.ShardWriteFn(shardID, nodeID, points)
 }
 
+type fakeMetaProvider struct {
+	NodesFn func() []uint64
+}
+
+func (f fakeMetaProvider) Nodes() []uint64 {
+	return f.NodesFn()
+}
+
 func TestProcessorProcess(t *testing.T) {
 	dir, err := ioutil.TempDir("", "processor_test")
 	if err != nil {
@@ -76,5 +84,53 @@ func TestProcessorProcess(t *testing.T) {
 	if exp := 1; count != exp {
 		t.Fatalf("Process() write count mismatch: got %v, exp %v", count, exp)
 	}
+}
 
+func TestProcessorProcessWithProvider(t *testing.T) {
+	dir, err := ioutil.TempDir("", "processor_test")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+
+	// Active nodes and a point.
+	activeNodes := []uint64{1}
+	pt := models.NewPoint("cpu", models.Tags{"foo": "bar"}, models.Fields{"value": 1.0}, time.Unix(0, 0))
+
+	// This shard writer should only be called for active nodes.
+	count := 0
+	sh := &fakeShardWriter{
+		ShardWriteFn: func(shardID, nodeID uint64, points []models.Point) error {
+			if !contains(activeNodes, nodeID) {
+				t.Fatalf("proccess incorrectly processed inactive node ID %d", nodeID)
+			}
+			count++
+			return nil
+		},
+	}
+
+	// Create the processor for test.
+	p, err := NewProcessor(dir, sh, ProcessorOptions{MaxSize: 1024})
+	if err != nil {
+		t.Fatalf("Process() failed to create processor: %v", err)
+	}
+	p.MetaProvider = fakeMetaProvider{
+		NodesFn: func() []uint64 { return activeNodes },
+	}
+
+	// This should queue the writes, only the first should actually be processed.
+	if err := p.WriteShard(999, activeNodes[0], []models.Point{pt}); err != nil {
+		t.Fatalf("Process() failed to write points: %v", err)
+	}
+	if err := p.WriteShard(999, 999, []models.Point{pt}); err != nil {
+		t.Fatalf("Process() failed to write points: %v", err)
+	}
+
+	if err := p.Process(); err != nil {
+		t.Fatalf("Process() failed to process points: %v", err)
+	}
+
+	// Shard write should only have been called once.
+	if count != 1 {
+		t.Fatalf("Process() write count mismatch: got %v, exp 1", count)
+	}
 }


### PR DESCRIPTION
It is possible that a node is dropped, while data is still pending in the HH queues for that node. If this happens, the HH processor should skip those nodes, or the system continually complains about unreachable nodes.

Data deletion is still explicitly left to the purge system, though an end-user can always remove HH data by hand if necessary.

This issue is not very serious, but can cause confusion and results in connection errors in the logs.