### PR TITLE
Log a more accurate connection message

### DIFF
--- a/cluster/service.go
+++ b/cluster/service.go
@@ -140,9 +140,9 @@ func (s *Service) handleConn(conn net.Conn) {
 		conn.Close()
 	}()
 
-	s.Logger.Printf("accept remote write connection from %v\n", conn.RemoteAddr())
+	s.Logger.Printf("accept remote connection from %v\n", conn.RemoteAddr())
 	defer func() {
-		s.Logger.Printf("close remote write connection from %v\n", conn.RemoteAddr())
+		s.Logger.Printf("close remote connection from %v\n", conn.RemoteAddr())
 	}()
 	for {
 		// Read type-length-value.


### PR DESCRIPTION
Not all connections are for writes, some are for mapping shards.