### PR TITLE
Fix index out of bounds panic in int64Decoder

### DIFF
--- a/tsdb/engine/tsm1/int.go
+++ b/tsdb/engine/tsm1/int.go
@@ -173,6 +173,10 @@ func (d *int64Decoder) decodePacked() {
 }
 
 func (d *int64Decoder) decodeUncompressed() {
+	if len(d.bytes) == 0 {
+		return
+	}
+
 	d.values[0] = binary.BigEndian.Uint64(d.bytes[0:8])
 	d.i = 0
 	d.n = 1

--- a/tsdb/engine/tsm1/int_test.go
+++ b/tsdb/engine/tsm1/int_test.go
@@ -181,6 +181,46 @@ func Test_Int64Encoder_Uncompressed(t *testing.T) {
 	}
 }
 
+func Test_Int64Encoder_NegativeUncompressed(t *testing.T) {
+	values := []int64{
+		-2352281900722994752, 1438442655375607923, -4110452567888190110,
+		-1221292455668011702, -1941700286034261841, -2836753127140407751,
+		1432686216250034552, 3663244026151507025, -3068113732684750258,
+		-1949953187327444488, 3713374280993588804, 3226153669854871355,
+		-2093273755080502606, 1006087192578600616, -2272122301622271655,
+		2533238229511593671, -4450454445568858273, 2647789901083530435,
+		2761419461769776844, -1324397441074946198, -680758138988210958,
+		94468846694902125, -2394093124890745254, -2682139311758778198,
+	}
+	enc := tsm1.NewInt64Encoder()
+	for _, v := range values {
+		enc.Write(v)
+	}
+
+	b, err := enc.Bytes()
+	if err != nil {
+		t.Fatalf("expected error: %v", err)
+	}
+
+	dec := tsm1.NewInt64Decoder(b)
+
+	i := 0
+	for dec.Next() {
+		if i > len(values) {
+			t.Fatalf("read too many values: got %v, exp %v", i, len(values))
+		}
+
+		if values[i] != dec.Read() {
+			t.Fatalf("read value %d mismatch: got %v, exp %v", i, dec.Read(), values[i])
+		}
+		i += 1
+	}
+
+	if i != len(values) {
+		t.Fatalf("failed to read enough values: got %v, exp %v", i, len(values))
+	}
+}
+
 func Test_Int64Encoder_AllNegative(t *testing.T) {
 	enc := tsm1.NewInt64Encoder()
 	values := []int64{
@@ -208,6 +248,11 @@ func Test_Int64Encoder_AllNegative(t *testing.T) {
 		}
 		i += 1
 	}
+
+	if i != len(values) {
+		t.Fatalf("failed to read enough values: got %v, exp %v", i, len(values))
+	}
+
 }
 
 func BenchmarkInt64Encoder(b *testing.B) {


### PR DESCRIPTION
Code was missing a check for when we did not have anymore bytes to decode
so it panic when we tried to decode the empty slice.