### PR TITLE
Auto-create database for UDP input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - [#4178](https://github.com/influxdb/influxdb/pull/4178): Support fields in graphite parser. Thanks @roobert!
 - [#4291](https://github.com/influxdb/influxdb/pull/4291): Added ALTER DATABASE RENAME. Thanks @linearb
 - [#4409](https://github.com/influxdb/influxdb/pull/4291): wire up INTO queries.
+- [#4379](https://github.com/influxdb/influxdb/pull/4379): Auto-create database for UDP input.
 
 ### Bugfixes
 - [#4389](https://github.com/influxdb/influxdb/pull/4389): Don't add a new segment file on each hinted-handoff purge cycle.

--- a/cmd/influxd/run/server.go
+++ b/cmd/influxd/run/server.go
@@ -292,6 +292,7 @@ func (s *Server) appendUDPService(c udp.Config) {
 	}
 	srv := udp.NewService(c)
 	srv.PointsWriter = s.PointsWriter
+	srv.MetaStore = s.MetaStore
 	s.Services = append(s.Services, srv)
 }
 

--- a/etc/config.sample.toml
+++ b/etc/config.sample.toml
@@ -235,7 +235,7 @@ reporting-disabled = false
 [[udp]]
   enabled = false
   # bind-address = ""
-  # database = ""
+  # database = "udp"
   # retention-policy = ""
 
   # These next lines control how batching works. You should have this enabled

--- a/services/udp/README.md
+++ b/services/udp/README.md
@@ -1,0 +1,13 @@
+# Configuration
+
+Each UDP input allows the binding address, target database, and target retention policy to be set. If the database does not exist, it will be created automatically when the input is initialized. If the retention policy is not configured, then the default retention policy for the database is used. However if the retention policy is set, the retention policy must be explicitly created. The input will not automatically create it.
+
+Each UDP input also performs internal batching of the points it receives, as batched writes to the database are more efficient. The default _batch size_ is 1000, _pending batch_ factor is 5, with a _batch timeout_ of 1 second. This means the input will write batches of maximum size 1000, but if a batch has not reached 1000 points within 1 second of the first point being added to a batch, it will emit that batch regardless of size. The pending batch factor controls how many batches can be in memory at once, allowing the input to transmit a batch, while still building other batches.
+
+# Processing
+
+The UDP input can receive up 64KB per read, and splits the received data by newline. Each part is then interpreted as line-protocol, and parsed accordingly.
+
+# UDP is connectionless
+
+Since UDP is a connectionless protocol there is no way to signal to the data source if any error occurs, and if data has even been successfully indexed. This should be kept in mind when deciding if and when to use the UDP input. The built-in UDP statistics are useful for monitoring the UDP inputs.

--- a/services/udp/config.go
+++ b/services/udp/config.go
@@ -7,6 +7,9 @@ import (
 )
 
 const (
+	// DefaultDatabase is the default database for UDP traffic.
+	DefaultDatabase = "udp"
+
 	// DefaultBatchSize is the default UDP batch size.
 	DefaultBatchSize = 1000
 
@@ -32,6 +35,9 @@ type Config struct {
 // default values set.
 func (c *Config) WithDefaults() *Config {
 	d := *c
+	if d.Database == "" {
+		d.Database = DefaultDatabase
+	}
 	if d.BatchSize == 0 {
 		d.BatchSize = DefaultBatchSize
 	}


### PR DESCRIPTION
All other services operate like this, so make UDP service consistent.

This change also adds a README for the UDP service, which fixes issue #4041.
