### PR TITLE
InfluxDB client v2

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -4,6 +4,10 @@
 
 ## Description
 
+**NOTE:** The Go client library now has a "v2" version, with the old version
+being deprecated. The new version can be imported at
+`import "github.com/influxdb/influxdb/client/v2"`. It is not backwards-compatible.
+
 A Go client library written and maintained by the **InfluxDB** team.
 This package provides convenience functions to read and write time series data.
 It uses the HTTP protocol to communicate with your **InfluxDB** cluster.
@@ -14,8 +18,8 @@ It uses the HTTP protocol to communicate with your **InfluxDB** cluster.
 ### Connecting To Your Database
 
 Connecting to an **InfluxDB** database is straightforward. You will need a host
-name, a port and the cluster user credentials if applicable. The default port is 8086.
-You can customize these settings to your specific installation via the
+name, a port and the cluster user credentials if applicable. The default port is
+8086. You can customize these settings to your specific installation via the
 **InfluxDB** configuration file.
 
 Thought not necessary for experimentation, you may want to create a new user
@@ -44,43 +48,49 @@ the configuration below.
 ```go
 package main
 
-import "github.com/influxdb/influxdb/client"
+import
 import (
-	  "net/url"
-	  "fmt"
-	  "log"
-	  "os"
+	"net/url"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/influxdb/influxdb/client/v2"
 )
 
 const (
-	MyHost        = "localhost"
-	MyPort        = 8086
-	MyDB          = "square_holes"
-	MyMeasurement = "shapes"
+	MyDB = "square_holes"
+	username = "bubba"
+	password = "bumblebeetuna"
 )
 
 func main() {
-	u, err := url.Parse(fmt.Sprintf("http://%s:%d", MyHost, MyPort))
-	if err != nil {
-		log.Fatal(err)
-	}
+	// Make client
+	u, _ := url.Parse("http://localhost:8086")
+	c := client.NewClient(client.Config{
+		URL: u,
+		Username: username,
+		Password: password,
+	})
 
-	conf := client.Config{
-		URL:      *u,
-		Username: os.Getenv("INFLUX_USER"),
-		Password: os.Getenv("INFLUX_PWD"),
-	}
+	// Create a new point batch
+	bp := client.NewBatchPoints(client.BatchPointsConfig{
+		Database:  MyDB,
+		Precision: "s",
+	})
 
-	con, err := client.NewClient(conf)
-	if err != nil {
-		log.Fatal(err)
+	// Create a point and add to batch
+	tags := map[string]string{"cpu": "cpu-total"}
+	fields := map[string]interface{}{
+		"idle":   10.1,
+		"system": 53.3,
+		"user":   46.6,
 	}
+	pt := client.NewPoint("cpu_usage", tags, fields, time.Now())
+	bp.AddPoint(pt)
 
-	dur, ver, err := con.Ping()
-	if err != nil {
-		log.Fatal(err)
-	}
-	log.Printf("Happy as a Hippo! %v, %s", dur, ver)
+	// Write the batch
+	c.Write(bp)
 }
 
 ```
@@ -88,49 +98,50 @@ func main() {
 ### Inserting Data
 
 Time series data aka *points* are written to the database using batch inserts.
-The mechanism is to create one or more points and then create a batch aka *batch points*
-and write these to a given database and series. A series is a combination of a
-measurement (time/values) and a set of tags.
+The mechanism is to create one or more points and then create a batch aka
+*batch points* and write these to a given database and series. A series is a
+combination of a measurement (time/values) and a set of tags.
 
 In this sample we will create a batch of a 1,000 points. Each point has a time and
 a single value as well as 2 tags indicating a shape and color. We write these points
 to a database called _square_holes_ using a measurement named _shapes_.
 
 NOTE: You can specify a RetentionPolicy as part of the batch points. If not
-provided InfluxDB will use the database _default_ retention policy. By default, the _default_
-retention policy never deletes any data it contains.
+provided InfluxDB will use the database _default_ retention policy.
 
 ```go
-func writePoints(con *client.Client) {
-	var (
-		shapes     = []string{"circle", "rectangle", "square", "triangle"}
-		colors     = []string{"red", "blue", "green"}
-		sampleSize = 1000
-		pts        = make([]client.Point, sampleSize)
-	)
-
+func writePoints(clnt client.Client) {
+	sampleSize := 1000
 	rand.Seed(42)
+
+	bp, _ := client.NewBatchPoints(client.BatchPointsConfig{
+		Database:  "systemstats",
+		Precision: "us",
+	})
+
 	for i := 0; i < sampleSize; i++ {
-		pts[i] = client.Point{
-			Measurement: "shapes",
-			Tags: map[string]string{
-				"color": strconv.Itoa(rand.Intn(len(colors))),
-				"shape": strconv.Itoa(rand.Intn(len(shapes))),
-			},
-			Fields: map[string]interface{}{
-				"value": rand.Intn(sampleSize),
-			},
-			Time: time.Now(),
-			Precision: "s",
+		regions := []string{"us-west1", "us-west2", "us-west3", "us-east1"}
+		tags := map[string]string{
+			"cpu":    "cpu-total",
+			"host":   fmt.Sprintf("host%d", rand.Intn(1000)),
+			"region": regions[rand.Intn(len(regions))],
 		}
+
+		idle := rand.Float64() * 100.0
+		fields := map[string]interface{}{
+			"idle": idle,
+			"busy": 100.0 - idle,
+		}
+
+		bp.AddPoint(client.NewPoint(
+			"cpu_usage",
+			tags,
+			fields,
+			time.Now(),
+		))
 	}
 
-	bps := client.BatchPoints{
-		Points:          pts,
-		Database:        MyDB,
-		RetentionPolicy: "default",
-	}
-	_, err := con.Write(bps)
+	err := clnt.Write(bp)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -146,46 +157,47 @@ as follows:
 
 ```go
 // queryDB convenience function to query the database
-func queryDB(con *client.Client, cmd string) (res []client.Result, err error) {
+func queryDB(clnt client.Client, cmd string) (res []client.Result, err error) {
 	q := client.Query{
 		Command:  cmd,
 		Database: MyDB,
 	}
-	if response, err := con.Query(q); err == nil {
+	if response, err := clnt.Query(q); err == nil {
 		if response.Error() != nil {
 			return res, response.Error()
 		}
 		res = response.Results
 	}
-	return
+	return response, nil
 }
 ```
 
 #### Creating a Database
+
 ```go
-_, err := queryDB(con, fmt.Sprintf("create database %s", MyDB))
+_, err := queryDB(clnt, fmt.Sprintf("CREATE DATABASE %s", MyDB))
 if err != nil {
 	log.Fatal(err)
 }
 ```
 
 #### Count Records
+
 ```go
-q := fmt.Sprintf("select count(%s) from %s", "value", MyMeasurement)
-res, err := queryDB(con, q)
+q := fmt.Sprintf("SELECT count(%s) FROM %s", "value", MyMeasurement)
+res, err := queryDB(clnt, q)
 if err != nil {
 	log.Fatal(err)
 }
 count := res[0].Series[0].Values[0][1]
-log.Printf("Found a total of `%v records", count)
-
+log.Printf("Found a total of %v records\n", count)
 ```
 
 #### Find the last 10 _shapes_ records
 
 ```go
-q := fmt.Sprintf("select * from %s limit %d", MyMeasurement, 20)
-res, err = queryDB(con, q)
+q := fmt.Sprintf("SELECT * FROM %s LIMIT %d", MyMeasurement, 20)
+res, err = queryDB(clnt, q)
 if err != nil {
 	log.Fatal(err)
 }

--- a/client/v2/client.go
+++ b/client/v2/client.go
@@ -1,0 +1,353 @@
+package client
+
+import (
+	"bytes"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/influxdb/influxdb/models"
+)
+
+type Config struct {
+	// URL of the InfluxDB database
+	URL *url.URL
+
+	// Username is the influxdb username, optional
+	Username string
+
+	// Password is the influxdb password, optional
+	Password string
+
+	// UserAgent is the http User Agent, defaults to "InfluxDBClient"
+	UserAgent string
+
+	// Timeout for influxdb writes, defaults to no timeout
+	Timeout time.Duration
+
+	// InsecureSkipVerify gets passed to the http client, if true, it will
+	// skip https certificate verification. Defaults to false
+	InsecureSkipVerify bool
+}
+
+type BatchPointsConfig struct {
+	// Precision is the write precision of the points, defaults to "ns"
+	Precision string
+
+	// Database is the database to write points to
+	Database string
+
+	// RetentionPolicy is the retention policy of the points
+	RetentionPolicy string
+
+	// Write consistency is the number of servers required to confirm write
+	WriteConsistency string
+}
+
+type Client interface {
+	// Write takes a BatchPoints object and writes all Points to InfluxDB.
+	Write(bp BatchPoints) error
+
+	// Query makes an InfluxDB Query on the database
+	Query(q Query) (*Response, error)
+}
+
+// NewClient creates a client interface from the given config.
+func NewClient(conf Config) Client {
+	if conf.UserAgent == "" {
+		conf.UserAgent = "InfluxDBClient"
+	}
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: conf.InsecureSkipVerify,
+		},
+	}
+	return &client{
+		url:       conf.URL,
+		username:  conf.Username,
+		password:  conf.Password,
+		useragent: conf.UserAgent,
+		httpClient: &http.Client{
+			Timeout:   conf.Timeout,
+			Transport: tr,
+		},
+	}
+}
+
+type client struct {
+	url        *url.URL
+	username   string
+	password   string
+	useragent  string
+	httpClient *http.Client
+}
+
+// BatchPoints is an interface into a batched grouping of points to write into
+// InfluxDB together. BatchPoints is NOT thread-safe, you must create a separate
+// batch for each goroutine.
+type BatchPoints interface {
+	// AddPoint adds the given point to the Batch of points
+	AddPoint(p *Point)
+	// Points lists the points in the Batch
+	Points() []*Point
+
+	// Precision returns the currently set precision of this Batch
+	Precision() string
+	// SetPrecision sets the precision of this batch.
+	SetPrecision(s string) error
+
+	// Database returns the currently set database of this Batch
+	Database() string
+	// SetDatabase sets the database of this Batch
+	SetDatabase(s string)
+
+	// WriteConsistency returns the currently set write consistency of this Batch
+	WriteConsistency() string
+	// SetWriteConsistency sets the write consistency of this Batch
+	SetWriteConsistency(s string)
+
+	// RetentionPolicy returns the currently set retention policy of this Batch
+	RetentionPolicy() string
+	// SetRetentionPolicy sets the retention policy of this Batch
+	SetRetentionPolicy(s string)
+}
+
+// NewBatchPoints returns a BatchPoints interface based on the given config.
+func NewBatchPoints(c BatchPointsConfig) (BatchPoints, error) {
+	if c.Precision == "" {
+		c.Precision = "ns"
+	}
+	if _, err := time.ParseDuration("1" + c.Precision); err != nil {
+		return nil, err
+	}
+	bp := &batchpoints{
+		database:         c.Database,
+		precision:        c.Precision,
+		retentionPolicy:  c.RetentionPolicy,
+		writeConsistency: c.WriteConsistency,
+	}
+	return bp, nil
+}
+
+type batchpoints struct {
+	points           []*Point
+	database         string
+	precision        string
+	retentionPolicy  string
+	writeConsistency string
+}
+
+func (bp *batchpoints) AddPoint(p *Point) {
+	bp.points = append(bp.points, p)
+}
+
+func (bp *batchpoints) Points() []*Point {
+	return bp.points
+}
+
+func (bp *batchpoints) Precision() string {
+	return bp.precision
+}
+
+func (bp *batchpoints) Database() string {
+	return bp.database
+}
+
+func (bp *batchpoints) WriteConsistency() string {
+	return bp.writeConsistency
+}
+
+func (bp *batchpoints) RetentionPolicy() string {
+	return bp.retentionPolicy
+}
+
+func (bp *batchpoints) SetPrecision(p string) error {
+	if _, err := time.ParseDuration("1" + p); err != nil {
+		return err
+	}
+	bp.precision = p
+	return nil
+}
+
+func (bp *batchpoints) SetDatabase(db string) {
+	bp.database = db
+}
+
+func (bp *batchpoints) SetWriteConsistency(wc string) {
+	bp.writeConsistency = wc
+}
+
+func (bp *batchpoints) SetRetentionPolicy(rp string) {
+	bp.retentionPolicy = rp
+}
+
+type Point struct {
+	pt models.Point
+}
+
+// NewPoint returns a point with the given timestamp. If a timestamp is not
+// given, then data is sent to the database without a timestamp, in which case
+// the server will assign local time upon reception. NOTE: it is recommended
+// to send data with a timestamp.
+func NewPoint(
+	name string,
+	tags map[string]string,
+	fields map[string]interface{},
+	t ...time.Time,
+) *Point {
+	var T time.Time
+	if len(t) > 0 {
+		T = t[0]
+	}
+	return &Point{
+		pt: models.NewPoint(name, tags, fields, T),
+	}
+}
+
+// String returns a line-protocol string of the Point
+func (p *Point) String() string {
+	return p.pt.String()
+}
+
+// PrecisionString returns a line-protocol string of the Point, at precision
+func (p *Point) PrecisionString(precison string) string {
+	return p.pt.PrecisionString(precison)
+}
+
+func (c *client) Write(bp BatchPoints) error {
+	u := c.url
+	u.Path = "write"
+
+	var b bytes.Buffer
+	for _, p := range bp.Points() {
+		if _, err := b.WriteString(p.pt.PrecisionString(bp.Precision())); err != nil {
+			return err
+		}
+
+		if err := b.WriteByte('\n'); err != nil {
+			return err
+		}
+	}
+
+	req, err := http.NewRequest("POST", u.String(), &b)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "")
+	req.Header.Set("User-Agent", c.useragent)
+	if c.username != "" {
+		req.SetBasicAuth(c.username, c.password)
+	}
+
+	params := req.URL.Query()
+	params.Set("db", bp.Database())
+	params.Set("rp", bp.RetentionPolicy())
+	params.Set("precision", bp.Precision())
+	params.Set("consistency", bp.WriteConsistency())
+	req.URL.RawQuery = params.Encode()
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusOK {
+		var err = fmt.Errorf(string(body))
+		return err
+	}
+
+	return nil
+}
+
+// Query defines a query to send to the server
+type Query struct {
+	Command   string
+	Database  string
+	Precision string
+}
+
+// Response represents a list of statement results.
+type Response struct {
+	Results []Result
+	Err     error
+}
+
+// Error returns the first error from any statement.
+// Returns nil if no errors occurred on any statements.
+func (r *Response) Error() error {
+	if r.Err != nil {
+		return r.Err
+	}
+	for _, result := range r.Results {
+		if result.Err != nil {
+			return result.Err
+		}
+	}
+	return nil
+}
+
+// Result represents a resultset returned from a single statement.
+type Result struct {
+	Series []models.Row
+	Err    error
+}
+
+// Query sends a command to the server and returns the Response
+func (c *client) Query(q Query) (*Response, error) {
+	u := c.url
+
+	u.Path = "query"
+	values := u.Query()
+	values.Set("q", q.Command)
+	values.Set("db", q.Database)
+	if q.Precision != "" {
+		values.Set("epoch", q.Precision)
+	}
+	u.RawQuery = values.Encode()
+
+	req, err := http.NewRequest("GET", u.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("User-Agent", c.useragent)
+	if c.username != "" {
+		req.SetBasicAuth(c.username, c.password)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var response Response
+	dec := json.NewDecoder(resp.Body)
+	dec.UseNumber()
+	decErr := dec.Decode(&response)
+
+	// ignore this error if we got an invalid status code
+	if decErr != nil && decErr.Error() == "EOF" && resp.StatusCode != http.StatusOK {
+		decErr = nil
+	}
+	// If we got a valid decode error, send that back
+	if decErr != nil {
+		return nil, decErr
+	}
+	// If we don't have an error in our json response, and didn't get statusOK
+	// then send back an error
+	if resp.StatusCode != http.StatusOK && response.Error() == nil {
+		return &response, fmt.Errorf("received status code %d from server",
+			resp.StatusCode)
+	}
+	return &response, nil
+}

--- a/client/v2/client_test.go
+++ b/client/v2/client_test.go
@@ -1,0 +1,242 @@
+package client
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestClient_Query(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var data Response
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(data)
+	}))
+	defer ts.Close()
+
+	u, _ := url.Parse(ts.URL)
+	config := Config{URL: u}
+	c := NewClient(config)
+
+	query := Query{}
+	_, err := c.Query(query)
+	if err != nil {
+		t.Fatalf("unexpected error.  expected %v, actual %v", nil, err)
+	}
+}
+
+func TestClient_BasicAuth(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		u, p, ok := r.BasicAuth()
+
+		if !ok {
+			t.Errorf("basic auth error")
+		}
+		if u != "username" {
+			t.Errorf("unexpected username, expected %q, actual %q", "username", u)
+		}
+		if p != "password" {
+			t.Errorf("unexpected password, expected %q, actual %q", "password", p)
+		}
+		var data Response
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(data)
+	}))
+	defer ts.Close()
+
+	u, _ := url.Parse(ts.URL)
+	u.User = url.UserPassword("username", "password")
+	config := Config{URL: u, Username: "username", Password: "password"}
+	c := NewClient(config)
+
+	query := Query{}
+	_, err := c.Query(query)
+	if err != nil {
+		t.Fatalf("unexpected error.  expected %v, actual %v", nil, err)
+	}
+}
+
+func TestClient_Write(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var data Response
+		w.WriteHeader(http.StatusNoContent)
+		_ = json.NewEncoder(w).Encode(data)
+	}))
+	defer ts.Close()
+
+	u, _ := url.Parse(ts.URL)
+	config := Config{URL: u}
+	c := NewClient(config)
+
+	bp, err := NewBatchPoints(BatchPointsConfig{})
+	if err != nil {
+		t.Fatalf("unexpected error.  expected %v, actual %v", nil, err)
+	}
+	err = c.Write(bp)
+	if err != nil {
+		t.Fatalf("unexpected error.  expected %v, actual %v", nil, err)
+	}
+}
+
+func TestClient_UserAgent(t *testing.T) {
+	receivedUserAgent := ""
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedUserAgent = r.UserAgent()
+
+		var data Response
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(data)
+	}))
+	defer ts.Close()
+
+	_, err := http.Get(ts.URL)
+	if err != nil {
+		t.Fatalf("unexpected error.  expected %v, actual %v", nil, err)
+	}
+
+	tests := []struct {
+		name      string
+		userAgent string
+		expected  string
+	}{
+		{
+			name:      "Empty user agent",
+			userAgent: "",
+			expected:  "InfluxDBClient",
+		},
+		{
+			name:      "Custom user agent",
+			userAgent: "Test Influx Client",
+			expected:  "Test Influx Client",
+		},
+	}
+
+	for _, test := range tests {
+		u, _ := url.Parse(ts.URL)
+		config := Config{URL: u, UserAgent: test.userAgent}
+		c := NewClient(config)
+
+		receivedUserAgent = ""
+		query := Query{}
+		_, err = c.Query(query)
+		if err != nil {
+			t.Fatalf("unexpected error.  expected %v, actual %v", nil, err)
+		}
+		if !strings.HasPrefix(receivedUserAgent, test.expected) {
+			t.Fatalf("Unexpected user agent. expected %v, actual %v", test.expected, receivedUserAgent)
+		}
+
+		receivedUserAgent = ""
+		bp, _ := NewBatchPoints(BatchPointsConfig{})
+		err = c.Write(bp)
+		if err != nil {
+			t.Fatalf("unexpected error.  expected %v, actual %v", nil, err)
+		}
+		if !strings.HasPrefix(receivedUserAgent, test.expected) {
+			t.Fatalf("Unexpected user agent. expected %v, actual %v", test.expected, receivedUserAgent)
+		}
+
+		receivedUserAgent = ""
+		_, err := c.Query(query)
+		if err != nil {
+			t.Fatalf("unexpected error.  expected %v, actual %v", nil, err)
+		}
+		if receivedUserAgent != test.expected {
+			t.Fatalf("Unexpected user agent. expected %v, actual %v", test.expected, receivedUserAgent)
+		}
+	}
+}
+
+func TestClient_PointString(t *testing.T) {
+	const shortForm = "2006-Jan-02"
+	time1, _ := time.Parse(shortForm, "2013-Feb-03")
+	tags := map[string]string{"cpu": "cpu-total"}
+	fields := map[string]interface{}{"idle": 10.1, "system": 50.9, "user": 39.0}
+	p := NewPoint("cpu_usage", tags, fields, time1)
+
+	s := "cpu_usage,cpu=cpu-total idle=10.1,system=50.9,user=39 1359849600000000000"
+	if p.String() != s {
+		t.Errorf("Point String Error, got %s, expected %s", p.String(), s)
+	}
+
+	s = "cpu_usage,cpu=cpu-total idle=10.1,system=50.9,user=39 1359849600000"
+	if p.PrecisionString("ms") != s {
+		t.Errorf("Point String Error, got %s, expected %s",
+			p.PrecisionString("ms"), s)
+	}
+}
+
+func TestClient_PointWithoutTimeString(t *testing.T) {
+	tags := map[string]string{"cpu": "cpu-total"}
+	fields := map[string]interface{}{"idle": 10.1, "system": 50.9, "user": 39.0}
+	p := NewPoint("cpu_usage", tags, fields)
+
+	s := "cpu_usage,cpu=cpu-total idle=10.1,system=50.9,user=39"
+	if p.String() != s {
+		t.Errorf("Point String Error, got %s, expected %s", p.String(), s)
+	}
+
+	if p.PrecisionString("ms") != s {
+		t.Errorf("Point String Error, got %s, expected %s",
+			p.PrecisionString("ms"), s)
+	}
+}
+
+func TestBatchPoints_PrecisionError(t *testing.T) {
+	_, err := NewBatchPoints(BatchPointsConfig{Precision: "foobar"})
+	if err == nil {
+		t.Errorf("Precision: foobar should have errored")
+	}
+
+	bp, _ := NewBatchPoints(BatchPointsConfig{Precision: "ns"})
+	err = bp.SetPrecision("foobar")
+	if err == nil {
+		t.Errorf("Precision: foobar should have errored")
+	}
+}
+
+func TestBatchPoints_SettersGetters(t *testing.T) {
+	bp, _ := NewBatchPoints(BatchPointsConfig{
+		Precision:        "ns",
+		Database:         "db",
+		RetentionPolicy:  "rp",
+		WriteConsistency: "wc",
+	})
+	if bp.Precision() != "ns" {
+		t.Errorf("Expected: %s, got %s", bp.Precision(), "ns")
+	}
+	if bp.Database() != "db" {
+		t.Errorf("Expected: %s, got %s", bp.Database(), "db")
+	}
+	if bp.RetentionPolicy() != "rp" {
+		t.Errorf("Expected: %s, got %s", bp.RetentionPolicy(), "rp")
+	}
+	if bp.WriteConsistency() != "wc" {
+		t.Errorf("Expected: %s, got %s", bp.WriteConsistency(), "wc")
+	}
+
+	bp.SetDatabase("db2")
+	bp.SetRetentionPolicy("rp2")
+	bp.SetWriteConsistency("wc2")
+	err := bp.SetPrecision("s")
+	if err != nil {
+		t.Errorf("Did not expect error: %s", err.Error())
+	}
+
+	if bp.Precision() != "s" {
+		t.Errorf("Expected: %s, got %s", bp.Precision(), "s")
+	}
+	if bp.Database() != "db2" {
+		t.Errorf("Expected: %s, got %s", bp.Database(), "db2")
+	}
+	if bp.RetentionPolicy() != "rp2" {
+		t.Errorf("Expected: %s, got %s", bp.RetentionPolicy(), "rp2")
+	}
+	if bp.WriteConsistency() != "wc2" {
+		t.Errorf("Expected: %s, got %s", bp.WriteConsistency(), "wc2")
+	}
+}

--- a/client/v2/example/example.go
+++ b/client/v2/example/example.go
@@ -1,0 +1,129 @@
+package client_example
+
+import (
+	"fmt"
+	"log"
+	"math/rand"
+	"net/url"
+	"os"
+	"time"
+
+	"github.com/influxdb/influxdb/client/v2"
+)
+
+func ExampleNewClient() client.Client {
+	u, _ := url.Parse("http://localhost:8086")
+
+	// NOTE: this assumes you've setup a user and have setup shell env variables,
+	// namely INFLUX_USER/INFLUX_PWD. If not just ommit Username/Password below.
+	client := client.NewClient(client.Config{
+		URL:      u,
+		Username: os.Getenv("INFLUX_USER"),
+		Password: os.Getenv("INFLUX_PWD"),
+	})
+	return client
+}
+
+func ExampleWrite() {
+	// Make client
+	u, _ := url.Parse("http://localhost:8086")
+	c := client.NewClient(client.Config{
+		URL: u,
+	})
+
+	// Create a new point batch
+	bp, _ := client.NewBatchPoints(client.BatchPointsConfig{
+		Database:  "BumbleBeeTuna",
+		Precision: "s",
+	})
+
+	// Create a point and add to batch
+	tags := map[string]string{"cpu": "cpu-total"}
+	fields := map[string]interface{}{
+		"idle":   10.1,
+		"system": 53.3,
+		"user":   46.6,
+	}
+	pt := client.NewPoint("cpu_usage", tags, fields, time.Now())
+	bp.AddPoint(pt)
+
+	// Write the batch
+	c.Write(bp)
+}
+
+// Write 1000 points
+func ExampleWrite1000() {
+	sampleSize := 1000
+
+	// Make client
+	u, _ := url.Parse("http://localhost:8086")
+	clnt := client.NewClient(client.Config{
+		URL: u,
+	})
+
+	rand.Seed(42)
+
+	bp, _ := client.NewBatchPoints(client.BatchPointsConfig{
+		Database:  "systemstats",
+		Precision: "us",
+	})
+
+	for i := 0; i < sampleSize; i++ {
+		regions := []string{"us-west1", "us-west2", "us-west3", "us-east1"}
+		tags := map[string]string{
+			"cpu":    "cpu-total",
+			"host":   fmt.Sprintf("host%d", rand.Intn(1000)),
+			"region": regions[rand.Intn(len(regions))],
+		}
+
+		idle := rand.Float64() * 100.0
+		fields := map[string]interface{}{
+			"idle": idle,
+			"busy": 100.0 - idle,
+		}
+
+		bp.AddPoint(client.NewPoint(
+			"cpu_usage",
+			tags,
+			fields,
+			time.Now(),
+		))
+	}
+
+	err := clnt.Write(bp)
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+func ExampleQuery() {
+	// Make client
+	u, _ := url.Parse("http://localhost:8086")
+	c := client.NewClient(client.Config{
+		URL: u,
+	})
+
+	q := client.Query{
+		Command:   "SELECT count(value) FROM shapes",
+		Database:  "square_holes",
+		Precision: "ns",
+	}
+	if response, err := c.Query(q); err == nil && response.Error() == nil {
+		log.Println(response.Results)
+	}
+}
+
+func ExampleCreateDatabase() {
+	// Make client
+	u, _ := url.Parse("http://localhost:8086")
+	c := client.NewClient(client.Config{
+		URL: u,
+	})
+
+	q := client.Query{
+		Command: "CREATE DATABASE telegraf",
+	}
+	if response, err := c.Query(q); err == nil && response.Error() == nil {
+		log.Println(response.Results)
+	}
+}


### PR DESCRIPTION
This is not ready to merge, but I wanted to get feedback on what people think of the design. Main goals here are: 

* Make an interface, simplify
* Points should be immutable once in (thanks @jwilder for that idea)
* Separation of "batchpoints" config from "client" config, no complicated overlap/inheritance between them.
* Use `models.Point`

The code below works for writing the the db, here is an example script using it:

```go
package main

import (
    "net/url"
    "time"

    "github.com/influxdb/influxdb/client/v2"
)

func main() {
    // Make client
    u, _ := url.Parse("http://localhost:8086")
    c := client.NewClient(client.Config{
        URL: u,
    })

    // Create a new point batch
    pb := client.NewBatchPoints(client.BatchPointsConfig{
        Database:  "telegraf",
        Precision: "s",
    })

    // Create a point
    tags := map[string]string{"cpu": "cpu-total"}
    fields := map[string]interface{}{"value": 10.1}
    pt := client.NewPoint("cpu_usage_idle", tags, fields, time.Now())

    // Add point to batch
    pb.AddPoint(pt)

    // Write the batch
    c.Write(pb)
}
```