### PR TITLE
Don't add a new segment every HH purge check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - [#4291](https://github.com/influxdb/influxdb/pull/4291): Added ALTER DATABASE RENAME. Thanks @linearb
 
 ### Bugfixes
+- [#4389](https://github.com/influxdb/influxdb/pull/4389): Don't add a new segment file on each hinted-handoff purge cycle.
 - [#4166](https://github.com/influxdb/influxdb/pull/4166): Fix parser error on invalid SHOW
 - [#3457](https://github.com/influxdb/influxdb/issues/3457): [0.9.3] cannot select field names with prefix + "." that match the measurement name
 - [#4225](https://github.com/influxdb/influxdb/pull/4225): Always display diags in name-sorted order

--- a/services/hh/queue.go
+++ b/services/hh/queue.go
@@ -173,6 +173,10 @@ func (l *queue) PurgeOlderThan(when time.Time) error {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
+	if len(l.segments) == 0 {
+		return nil
+	}
+
 	cutoff := when.Truncate(time.Second)
 	for {
 		mod, err := l.head.lastModified()


### PR DESCRIPTION
Everytime the purge check was running, a new segment was being added. This meant the list of almost-empty files in the HH directories would grow continually.