### PR TITLE
Symlink influx and influxd to /usr/bin on install.

### DIFF
--- a/package.sh
+++ b/package.sh
@@ -288,6 +288,9 @@ ln -s $INSTALL_ROOT_DIR/versions/$version/influxd $INSTALL_ROOT_DIR/influxd
 ln -s $INSTALL_ROOT_DIR/versions/$version/influx $INSTALL_ROOT_DIR/influx
 ln -s $INSTALL_ROOT_DIR/versions/$version/scripts/init.sh $INSTALL_ROOT_DIR/init.sh
 
+ln -s $INSTALL_ROOT_DIR/influxd /usr/bin/
+ln -s $INSTALL_ROOT_DIR/influx /usr/bin/
+
 if ! id influxdb >/dev/null 2>&1; then
         useradd --system -U -M influxdb
 fi


### PR DESCRIPTION
While not strictly following the FHS, symlinking the `influx` and `influxd` binaries to `/usr/bin` will help avoid a lot of confusion with users who are used to programs immediately being added to their path. For example, influxdb/issues/2933.