### PR TITLE
TSM1 fixes

### DIFF
--- a/tsdb/engine/tsm1/tsm1.go
+++ b/tsdb/engine/tsm1/tsm1.go
@@ -1069,7 +1069,7 @@ func (e *Engine) rewriteFile(oldDF *dataFile, valuesByID map[uint64]Values) erro
 				currentPosition += (12 + length)
 
 				// make sure we're not at the end of the file
-				if fpos >= oldDF.size {
+				if fpos >= oldDF.indexPosition() {
 					break
 				}
 			}

--- a/tsdb/engine/tsm1/tsm1_test.go
+++ b/tsdb/engine/tsm1/tsm1_test.go
@@ -1353,61 +1353,6 @@ func TestEngine_RewriteFileAndCompact(t *testing.T) {
 	}()
 }
 
-// Ensure the index won't compact files that would cause the
-// resulting file to be larger than the max file size
-func TestEngine_IndexFileSizeLimitedDuringCompaction(t *testing.T) {
-	e := OpenDefaultEngine()
-	defer e.Cleanup()
-
-	fields := []string{"value"}
-
-	e.RotateFileSize = 10
-	e.MaxFileSize = 100
-
-	p1 := parsePoint("cpu,host=A value=1.1 1000000000")
-	p2 := parsePoint("cpu,host=A value=1.2 2000000000")
-	p3 := parsePoint("cpu,host=A value=1.3 3000000000")
-	p4 := parsePoint("cpu,host=A value=1.5 4000000000")
-	p5 := parsePoint("cpu,host=A value=1.6 5000000000")
-	p6 := parsePoint("cpu,host=B value=2.1 2000000000")
-
-	if err := e.WritePoints([]models.Point{p1, p2}, nil, nil); err != nil {
-		t.Fatalf("failed to write points: %s", err.Error())
-	}
-	if err := e.WritePoints([]models.Point{p3}, nil, nil); err != nil {
-		t.Fatalf("failed to write points: %s", err.Error())
-	}
-
-	if err := e.WritePoints([]models.Point{p4, p5, p6}, nil, nil); err != nil {
-		t.Fatalf("failed to write points: %s", err.Error())
-	}
-
-	if count := e.DataFileCount(); count != 3 {
-		t.Fatalf("execpted 3 data file but got %d", count)
-	}
-
-	if err := e.Compact(true); err != nil {
-		t.Fatalf("error compacting: %s", err.Error())
-	}
-
-	if count := e.DataFileCount(); count != 1 {
-		t.Fatalf("expected 1 data file but got %d", count)
-	}
-
-	func() {
-		tx, _ := e.Begin(false)
-		defer tx.Rollback()
-		c1 := tx.Cursor("cpu,host=A", fields, nil, true)
-		_, _ = c1.Next()
-	}()
-}
-
-// Ensure the index will split a large data file in two if a write
-// will cause the resulting data file to be larger than the max file
-// size limit
-func TestEngine_IndexFilesSplitOnWriteToLargeFile(t *testing.T) {
-}
-
 // Engine represents a test wrapper for tsm1.Engine.
 type Engine struct {
 	*tsm1.Engine


### PR DESCRIPTION
This is still a WIP since there are some other ones I'll be adding in here.

- [x] Ensure rewritten files aren't corrupt if the original had an id not being passed in that was at the end of the file. Fixes #4401
- [ ] Ensure compactions don't create files larger than 4GB. Fixes #4388
- [ ] Ensure that writes to old data files that would cause them to be larger than 4GB cause it to be split into two files