### PR TITLE
Update handler.go

### DIFF
--- a/services/httpd/handler.go
+++ b/services/httpd/handler.go
@@ -767,6 +767,11 @@ func cors(inner http.Handler) http.Handler {
 				`X-CSRF-Token`,
 				`X-HTTP-Method-Override`,
 			}, ", "))
+
+			w.Header().Set(`Access-Control-Expose-Headers`, strings.Join([]string{
+				`Date`,
+				`X-Influxdb-Version`,
+			}, ", "))
 		}
 
 		if r.Method == "OPTIONS" {


### PR DESCRIPTION
Add `Access-Control-Expose-Headers` for `ping` endpoint clients be able to retrieve `X-Influxdb-Version` and `Date` from the server.