### PR TITLE
Fix line protocol accepting tags with no values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@
 - [#4280](https://github.com/influxdb/influxdb/issues/4280): Only drop points matching WHERE clause
 - [#4410](https://github.com/influxdb/influxdb/pull/4410): Fix infinite recursion in statement string(). Thanks @kostya-sh
 - [#4360](https://github.com/influxdb/influxdb/issues/4360): Aggregate Selectors overwrite values during post-processing
+- [#4421](https://github.com/influxdb/influxdb/issues/4421): Fix line protocol accepting tags with no values
 
 ## v0.9.4 [2015-09-14]
 

--- a/models/points.go
+++ b/models/points.go
@@ -268,8 +268,8 @@ func scanKey(buf []byte, i int) (int, []byte, error) {
 			i += 1
 			equals += 1
 
-			// Check for "cpu,a=1,b= value=1"
-			if i < len(buf) && buf[i] == ' ' {
+			// Check for "cpu,a=1,b= value=1" or "cpu,a=1,b=,c=foo value=1"
+			if i < len(buf) && (buf[i] == ' ' || buf[i] == ',') {
 				return i, buf[start:i], fmt.Errorf("missing tag value")
 			}
 			continue

--- a/models/points_test.go
+++ b/models/points_test.go
@@ -248,6 +248,11 @@ func TestParsePointMissingTagValue(t *testing.T) {
 	if err == nil {
 		t.Errorf(`ParsePoints("%s") mismatch. got nil, exp error`, `cpu,host=serverA,region= value=1i`)
 	}
+	_, err = models.ParsePointsString(`cpu,host=serverA,region=,zone=us-west value=1i`)
+	if err == nil {
+		t.Errorf(`ParsePoints("%s") mismatch. got nil, exp error`, `cpu,host=serverA,region=,zone=us-west value=1i`)
+	}
+
 }
 
 func TestParsePointMissingFieldName(t *testing.T) {


### PR DESCRIPTION
If a tag with no value was in the middle of all the tags, it would
get accepted as valid incorrectly.

Fixes #4421