### PR TITLE
Fix meta.WaitForDataChanged not signaling for remote nodes

### DIFF
--- a/meta/state.go
+++ b/meta/state.go
@@ -78,6 +78,8 @@ func (r *localRaft) updateMetaData(ms *Data) {
 		r.store.Logger.Printf("Updating metastore to term=%v index=%v", ms.Term, ms.Index)
 		r.store.mu.Lock()
 		r.store.data = ms
+		// Signal any blocked goroutines that the meta store has been updated
+		r.store.notifyChanged()
 		r.store.mu.Unlock()
 	}
 }
@@ -366,6 +368,8 @@ func (r *remoteRaft) updateMetaData(ms *Data) {
 		r.store.Logger.Printf("Updating metastore to term=%v index=%v", ms.Term, ms.Index)
 		r.store.mu.Lock()
 		r.store.data = ms
+		// Signal any blocked goroutines that the meta store has been updated
+		r.store.notifyChanged()
 		r.store.mu.Unlock()
 	}
 }


### PR DESCRIPTION
WaitForDataChanged is used to block a goroutine so it can be woken
up when the metastore has been updated.  This makes it so clients
to the metastore do not need to poll the metastore repeatedly to
watch for changes.  This was only working for local raft nodes, but
was supposed to work for remote nodes as well.