### PR TITLE
openTSDB service shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@
 - [#4421](https://github.com/influxdb/influxdb/issues/4421): Fix line protocol accepting tags with no values
 - [#4434](https://github.com/influxdb/influxdb/pull/4434): Allow 'E' for scientific values. Fixes [#4433](https://github.com/influxdb/influxdb/issues/4433)
 - [#4431](https://github.com/influxdb/influxdb/issues/4431): Add tsm1 WAL QuickCheck
+- [#4438](https://github.com/influxdb/influxdb/pull/4438): openTSDB service shutdown fixes
 
 ## v0.9.4 [2015-09-14]
 

--- a/services/opentsdb/service.go
+++ b/services/opentsdb/service.go
@@ -177,7 +177,9 @@ func (s *Service) Close() error {
 		return s.ln.Close()
 	}
 
-	s.batcher.Stop()
+	if s.batcher != nil {
+		s.batcher.Stop()
+	}
 	close(s.done)
 	s.wg.Wait()
 	return nil

--- a/services/opentsdb/service.go
+++ b/services/opentsdb/service.go
@@ -49,6 +49,7 @@ type Service struct {
 	ln     net.Listener  // main listener
 	httpln *chanListener // http channel-based listener
 
+	mu   sync.Mutex
 	wg   sync.WaitGroup
 	done chan struct{}
 	err  chan error
@@ -104,6 +105,9 @@ func NewService(c Config) (*Service, error) {
 
 // Open starts the service
 func (s *Service) Open() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	s.Logger.Println("Starting OpenTSDB service")
 
 	// Configure expvar monitoring. It's OK to do this even if the service fails to open and
@@ -164,8 +168,11 @@ func (s *Service) Open() error {
 	return nil
 }
 
-// Close closes the underlying listener.
+// Close closes the openTSDB service
 func (s *Service) Close() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	if s.ln != nil {
 		return s.ln.Close()
 	}


### PR DESCRIPTION
Fixes issue https://github.com/influxdb/influxdb/issues/4437

This change ensures:

a) Ensure `Open` and `Close` do not run concurrently.
b) Check that the batcher is non-nil before closing it.