### PR TITLE
Add influx_inspect filtering support

### DIFF
--- a/cmd/influx_inspect/info.go
+++ b/cmd/influx_inspect/info.go
@@ -31,9 +31,8 @@ func cmdInfo(path string) {
 	}
 
 	// Summary stats
-	fmt.Printf("Shards: %d, Indexes: %d, Databases: %d, Disk Size: %d, Series: %d\n",
+	fmt.Printf("Shards: %d, Indexes: %d, Databases: %d, Disk Size: %d, Series: %d\n\n",
 		tstore.ShardN(), tstore.DatabaseIndexN(), len(tstore.Databases()), size, countSeries(tstore))
-	fmt.Println()
 
 	tw := tabwriter.NewWriter(os.Stdout, 16, 8, 0, '\t', 0)
 
@@ -63,10 +62,6 @@ func cmdInfo(path string) {
 			// Sample a point from each measurement to determine the field types
 			for _, shardID := range shardIDs {
 				shard := tstore.Shard(shardID)
-				if err != nil {
-					fmt.Printf("Failed to get transaction: %v", err)
-				}
-
 				codec := shard.FieldCodec(m.Name)
 				for _, field := range codec.Fields() {
 					ft := fmt.Sprintf("%s:%s", field.Name, field.Type)

--- a/cmd/influx_inspect/info.go
+++ b/cmd/influx_inspect/info.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/influxdb/influxdb/tsdb"
+)
+
+func cmdInfo(path string) {
+	tstore := tsdb.NewStore(filepath.Join(path, "data"))
+	tstore.Logger = log.New(ioutil.Discard, "", log.LstdFlags)
+	tstore.EngineOptions.Config.Dir = filepath.Join(path, "data")
+	tstore.EngineOptions.Config.WALLoggingEnabled = false
+	tstore.EngineOptions.Config.WALDir = filepath.Join(path, "wal")
+	if err := tstore.Open(); err != nil {
+		fmt.Printf("Failed to open dir: %v\n", err)
+		os.Exit(1)
+	}
+
+	size, err := tstore.DiskSize()
+	if err != nil {
+		fmt.Printf("Failed to determine disk usage: %v\n", err)
+	}
+
+	// Summary stats
+	fmt.Printf("Shards: %d, Indexes: %d, Databases: %d, Disk Size: %d, Series: %d\n",
+		tstore.ShardN(), tstore.DatabaseIndexN(), len(tstore.Databases()), size, countSeries(tstore))
+	fmt.Println()
+
+	tw := tabwriter.NewWriter(os.Stdout, 16, 8, 0, '\t', 0)
+
+	fmt.Fprintln(tw, strings.Join([]string{"Shard", "DB", "Measurement", "Tags [#K/#V]", "Fields [Name:Type]", "Series"}, "\t"))
+
+	shardIDs := tstore.ShardIDs()
+
+	databases := tstore.Databases()
+	sort.Strings(databases)
+
+	for _, db := range databases {
+		index := tstore.DatabaseIndex(db)
+		measurements := index.Measurements()
+		sort.Sort(measurements)
+		for _, m := range measurements {
+			tags := m.TagKeys()
+			tagValues := 0
+			for _, tag := range tags {
+				tagValues += len(m.TagValues(tag))
+			}
+			fields := m.FieldNames()
+			sort.Strings(fields)
+			series := m.SeriesKeys()
+			sort.Strings(series)
+			sort.Sort(ShardIDs(shardIDs))
+
+			// Sample a point from each measurement to determine the field types
+			for _, shardID := range shardIDs {
+				shard := tstore.Shard(shardID)
+				if err != nil {
+					fmt.Printf("Failed to get transaction: %v", err)
+				}
+
+				codec := shard.FieldCodec(m.Name)
+				for _, field := range codec.Fields() {
+					ft := fmt.Sprintf("%s:%s", field.Name, field.Type)
+					fmt.Fprintf(tw, "%d\t%s\t%s\t%d/%d\t%d [%s]\t%d\n", shardID, db, m.Name, len(tags), tagValues,
+						len(fields), ft, len(series))
+
+				}
+
+			}
+		}
+	}
+	tw.Flush()
+}
+
+func countSeries(tstore *tsdb.Store) int {
+	var count int
+	for _, shardID := range tstore.ShardIDs() {
+		shard := tstore.Shard(shardID)
+		cnt, err := shard.SeriesCount()
+		if err != nil {
+			fmt.Printf("series count failed: %v\n", err)
+			continue
+		}
+		count += cnt
+	}
+	return count
+}
+
+func btou64(b []byte) uint64 {
+	return binary.BigEndian.Uint64(b)
+}
+
+// u64tob converts a uint64 into an 8-byte slice.
+func u64tob(v uint64) []byte {
+	b := make([]byte, 8)
+	binary.BigEndian.PutUint64(b, v)
+	return b
+}
+
+type ShardIDs []uint64
+
+func (a ShardIDs) Len() int           { return len(a) }
+func (a ShardIDs) Less(i, j int) bool { return a[i] < a[j] }
+func (a ShardIDs) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }

--- a/cmd/influx_inspect/main.go
+++ b/cmd/influx_inspect/main.go
@@ -64,6 +64,7 @@ func main() {
 		fs.BoolVar(&opts.dumpIndex, "dump-index", false, "Dump raw index data")
 		fs.BoolVar(&opts.dumpBlocks, "dump-blocks", false, "Dump raw block data")
 		fs.BoolVar(&dumpAll, "dump-all", false, "Dump all data. Caution: This may print a lot of information")
+		fs.StringVar(&opts.filterKey, "filter-key", "", "Only display index and block data match this key substring")
 
 		fs.Usage = func() {
 			println("Usage: influx_inspect dumptsm [options] <path>\n\n  Dumps low-level details about tsm1 files.")
@@ -85,8 +86,8 @@ func main() {
 			os.Exit(1)
 		}
 		opts.path = fs.Args()[0]
-		opts.dumpBlocks = opts.dumpBlocks || dumpAll
-		opts.dumpIndex = opts.dumpIndex || dumpAll
+		opts.dumpBlocks = opts.dumpBlocks || dumpAll || opts.filterKey != ""
+		opts.dumpIndex = opts.dumpIndex || dumpAll || opts.filterKey != ""
 		dumpTsm1(opts)
 		return
 

--- a/cmd/influx_inspect/main.go
+++ b/cmd/influx_inspect/main.go
@@ -1,18 +1,10 @@
 package main
 
 import (
-	"encoding/binary"
 	"flag"
 	"fmt"
-	"io/ioutil"
-	"log"
 	"os"
-	"path/filepath"
-	"sort"
-	"strings"
-	"text/tabwriter"
 
-	"github.com/influxdb/influxdb/tsdb"
 	_ "github.com/influxdb/influxdb/tsdb/engine"
 )
 
@@ -57,7 +49,6 @@ func main() {
 		}
 		cmdInfo(path)
 	case "dumptsm":
-
 		var dumpAll bool
 		opts := &tsdmDumpOpts{}
 		fs := flag.NewFlagSet("file", flag.ExitOnError)
@@ -88,109 +79,9 @@ func main() {
 		opts.path = fs.Args()[0]
 		opts.dumpBlocks = opts.dumpBlocks || dumpAll || opts.filterKey != ""
 		opts.dumpIndex = opts.dumpIndex || dumpAll || opts.filterKey != ""
-		dumpTsm1(opts)
-		return
-
+		cmdDumpTsm1(opts)
 	default:
 		flag.Usage()
 		os.Exit(1)
 	}
 }
-
-func cmdInfo(path string) {
-	tstore := tsdb.NewStore(filepath.Join(path, "data"))
-	tstore.Logger = log.New(ioutil.Discard, "", log.LstdFlags)
-	tstore.EngineOptions.Config.Dir = filepath.Join(path, "data")
-	tstore.EngineOptions.Config.WALLoggingEnabled = false
-	tstore.EngineOptions.Config.WALDir = filepath.Join(path, "wal")
-	if err := tstore.Open(); err != nil {
-		fmt.Printf("Failed to open dir: %v\n", err)
-		os.Exit(1)
-	}
-
-	size, err := tstore.DiskSize()
-	if err != nil {
-		fmt.Printf("Failed to determine disk usage: %v\n", err)
-	}
-
-	// Summary stats
-	fmt.Printf("Shards: %d, Indexes: %d, Databases: %d, Disk Size: %d, Series: %d\n",
-		tstore.ShardN(), tstore.DatabaseIndexN(), len(tstore.Databases()), size, countSeries(tstore))
-	fmt.Println()
-
-	tw := tabwriter.NewWriter(os.Stdout, 16, 8, 0, '\t', 0)
-
-	fmt.Fprintln(tw, strings.Join([]string{"Shard", "DB", "Measurement", "Tags [#K/#V]", "Fields [Name:Type]", "Series"}, "\t"))
-
-	shardIDs := tstore.ShardIDs()
-
-	databases := tstore.Databases()
-	sort.Strings(databases)
-
-	for _, db := range databases {
-		index := tstore.DatabaseIndex(db)
-		measurements := index.Measurements()
-		sort.Sort(measurements)
-		for _, m := range measurements {
-			tags := m.TagKeys()
-			tagValues := 0
-			for _, tag := range tags {
-				tagValues += len(m.TagValues(tag))
-			}
-			fields := m.FieldNames()
-			sort.Strings(fields)
-			series := m.SeriesKeys()
-			sort.Strings(series)
-			sort.Sort(ShardIDs(shardIDs))
-
-			// Sample a point from each measurement to determine the field types
-			for _, shardID := range shardIDs {
-				shard := tstore.Shard(shardID)
-				if err != nil {
-					fmt.Printf("Failed to get transaction: %v", err)
-				}
-
-				codec := shard.FieldCodec(m.Name)
-				for _, field := range codec.Fields() {
-					ft := fmt.Sprintf("%s:%s", field.Name, field.Type)
-					fmt.Fprintf(tw, "%d\t%s\t%s\t%d/%d\t%d [%s]\t%d\n", shardID, db, m.Name, len(tags), tagValues,
-						len(fields), ft, len(series))
-
-				}
-
-			}
-		}
-	}
-	tw.Flush()
-}
-
-func countSeries(tstore *tsdb.Store) int {
-	var count int
-	for _, shardID := range tstore.ShardIDs() {
-		shard := tstore.Shard(shardID)
-		cnt, err := shard.SeriesCount()
-		if err != nil {
-			fmt.Printf("series count failed: %v\n", err)
-			continue
-		}
-		count += cnt
-	}
-	return count
-}
-
-func btou64(b []byte) uint64 {
-	return binary.BigEndian.Uint64(b)
-}
-
-// u64tob converts a uint64 into an 8-byte slice.
-func u64tob(v uint64) []byte {
-	b := make([]byte, 8)
-	binary.BigEndian.PutUint64(b, v)
-	return b
-}
-
-type ShardIDs []uint64
-
-func (a ShardIDs) Len() int           { return len(a) }
-func (a ShardIDs) Less(i, j int) bool { return a[i] < a[j] }
-func (a ShardIDs) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }

--- a/cmd/influx_inspect/main.go
+++ b/cmd/influx_inspect/main.go
@@ -61,9 +61,9 @@ func main() {
 		var dumpAll bool
 		opts := &tsdmDumpOpts{}
 		fs := flag.NewFlagSet("file", flag.ExitOnError)
-		fs.BoolVar(&opts.dumpIndex, "dump-index", false, "Dump raw index data")
-		fs.BoolVar(&opts.dumpBlocks, "dump-blocks", false, "Dump raw block data")
-		fs.BoolVar(&dumpAll, "dump-all", false, "Dump all data. Caution: This may print a lot of information")
+		fs.BoolVar(&opts.dumpIndex, "index", false, "Dump raw index data")
+		fs.BoolVar(&opts.dumpBlocks, "blocks", false, "Dump raw block data")
+		fs.BoolVar(&dumpAll, "all", false, "Dump all data. Caution: This may print a lot of information")
 		fs.StringVar(&opts.filterKey, "filter-key", "", "Only display index and block data match this key substring")
 
 		fs.Usage = func() {

--- a/cmd/influx_inspect/main.go
+++ b/cmd/influx_inspect/main.go
@@ -57,11 +57,20 @@ func main() {
 		}
 		cmdInfo(path)
 	case "dumptsm":
-		var file string
+
+		var dumpAll bool
+		opts := &tsdmDumpOpts{}
 		fs := flag.NewFlagSet("file", flag.ExitOnError)
+		fs.BoolVar(&opts.dumpIndex, "dump-index", false, "Dump raw index data")
+		fs.BoolVar(&opts.dumpBlocks, "dump-blocks", false, "Dump raw block data")
+		fs.BoolVar(&dumpAll, "dump-all", false, "Dump all data. Caution: This may print a lot of information")
+
 		fs.Usage = func() {
 			println("Usage: influx_inspect dumptsm [options] <path>\n\n  Dumps low-level details about tsm1 files.")
 			println()
+			println("Options:")
+			fs.PrintDefaults()
+			os.Exit(0)
 		}
 
 		if err := fs.Parse(flag.Args()[1:]); err != nil {
@@ -75,8 +84,10 @@ func main() {
 			fs.PrintDefaults()
 			os.Exit(1)
 		}
-		file = fs.Args()[0]
-		dumpTsm1(file)
+		opts.path = fs.Args()[0]
+		opts.dumpBlocks = opts.dumpBlocks || dumpAll
+		opts.dumpIndex = opts.dumpIndex || dumpAll
+		dumpTsm1(opts)
 		return
 
 	default:

--- a/cmd/influx_inspect/tsm.go
+++ b/cmd/influx_inspect/tsm.go
@@ -218,7 +218,7 @@ func readIndex(f *os.File) *tsmIndex {
 	return index
 }
 
-func dumpTsm1(opts *tsdmDumpOpts) {
+func cmdDumpTsm1(opts *tsdmDumpOpts) {
 	var errors []error
 
 	f, err := os.Open(opts.path)

--- a/cmd/influx_inspect/tsm.go
+++ b/cmd/influx_inspect/tsm.go
@@ -20,6 +20,7 @@ import (
 type tsdmDumpOpts struct {
 	dumpIndex  bool
 	dumpBlocks bool
+	filterKey  string
 	path       string
 }
 
@@ -293,6 +294,9 @@ func dumpTsm1(opts *tsdmDumpOpts) {
 			}
 		}
 
+		if opts.filterKey != "" && !strings.Contains(key, opts.filterKey) {
+			continue
+		}
 		fmt.Fprintln(tw, "  "+strings.Join([]string{
 			strconv.FormatInt(int64(i), 10),
 			strconv.FormatUint(block.id, 10),
@@ -300,7 +304,6 @@ func dumpTsm1(opts *tsdmDumpOpts) {
 			measurement,
 			field,
 		}, "\t"))
-
 	}
 
 	if opts.dumpIndex {
@@ -360,6 +363,12 @@ func dumpTsm1(opts *tsdmDumpOpts) {
 		blockStats.inc(0, ts[0]>>4)
 		blockStats.inc(int(blockType+1), values[0]>>4)
 		blockStats.size(len(buf))
+
+		if opts.filterKey != "" && !strings.Contains(invIds[id], opts.filterKey) {
+			i += (12 + int64(length))
+			blockCount += 1
+			continue
+		}
 
 		fmt.Fprintln(tw, "  "+strings.Join([]string{
 			strconv.FormatInt(blockCount, 10),


### PR DESCRIPTION
A few changes to make `influx_inspect` more usable with larger data files as well as add some structure to the code.

* Adds command-line flags `-index`, `-block`, `-all` that will dump only the index, the blocks or all data.  By default, only statistics and summary info is displayed.
* Adds a command-line flag `-filter-key` which is a string to match on the points key (measurement + tags).  If the filter matches, only index and block data for those matching points will be displayed.
* Handles one error case I ran into where the `ids` file was out of sync with the `tsm1` file.  It will now record those errors and display them.  If an ids file is not present, we just shown `UNKNOWN` for that data since we can't determine if there is an error with it or not.
* Added an errors section that will be used to track errors with parts of the file if we see detect any while reading it.
