### PR TITLE
Issue #4446: Fixing logrotate config file.

### DIFF
--- a/package.sh
+++ b/package.sh
@@ -471,7 +471,7 @@ if [ $? -ne 0 ]; then
     cleanup_exit 1
 fi
 
-cp $LOGROTATE $TMP_WORK_DIR/$LOGROTATE_DIR/influxd
+install -m 644 $LOGROTATE $TMP_WORK_DIR/$LOGROTATE_DIR/influxdb
 if [ $? -ne 0 ]; then
     echo "Failed to copy logrotate configuration to packaging directory -- aborting."
     cleanup_exit 1


### PR DESCRIPTION
This issue switches from "cp" to "install" for the logrotate file,
with the option to specify the mode.  Also uses the name "influxdb"
instead of "influxd".