### PR TITLE
Int64 encoding enhancements

### DIFF
--- a/cmd/influx_inspect/tsm.go
+++ b/cmd/influx_inspect/tsm.go
@@ -68,7 +68,7 @@ var (
 		"none", "gor",
 	}
 	intEnc = []string{
-		"none", "s8b",
+		"none", "s8b", "rle",
 	}
 	boolEnc = []string{
 		"none", "bp",

--- a/tsdb/engine/tsm1/int.go
+++ b/tsdb/engine/tsm1/int.go
@@ -112,7 +112,7 @@ func (e *int64Encoder) encodePacked() ([]byte, error) {
 		return nil, nil
 	}
 
-	// Encode all but the first value.  Fist value is written unecoded
+	// Encode all but the first value.  Fist value is written unencoded
 	// using 8 bytes.
 	encoded, err := simple8b.EncodeAll(e.values[1:])
 	if err != nil {
@@ -245,7 +245,7 @@ func (d *int64Decoder) decodeRLE() {
 	count, n := binary.Uvarint(d.bytes[i:])
 
 	// Store the first value and delta value so we do not need to allocate
-	// a large values slice.  We can comput the value at position d.i on
+	// a large values slice.  We can compute the value at position d.i on
 	// demand.
 	d.rleFirst = first
 	d.rleDelta = value

--- a/tsdb/engine/tsm1/int_test.go
+++ b/tsdb/engine/tsm1/int_test.go
@@ -1,29 +1,27 @@
-package tsm1_test
+package tsm1
 
 import (
 	"math"
 	"reflect"
 	"testing"
 	"testing/quick"
-
-	"github.com/influxdb/influxdb/tsdb/engine/tsm1"
 )
 
 func Test_Int64Encoder_NoValues(t *testing.T) {
-	enc := tsm1.NewInt64Encoder()
+	enc := NewInt64Encoder()
 	b, err := enc.Bytes()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	dec := tsm1.NewInt64Decoder(b)
+	dec := NewInt64Decoder(b)
 	if dec.Next() {
 		t.Fatalf("unexpected next value: got true, exp false")
 	}
 }
 
 func Test_Int64Encoder_One(t *testing.T) {
-	enc := tsm1.NewInt64Encoder()
+	enc := NewInt64Encoder()
 	v1 := int64(1)
 
 	enc.Write(1)
@@ -32,7 +30,7 @@ func Test_Int64Encoder_One(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	dec := tsm1.NewInt64Decoder(b)
+	dec := NewInt64Decoder(b)
 	if !dec.Next() {
 		t.Fatalf("unexpected next value: got true, exp false")
 	}
@@ -43,7 +41,7 @@ func Test_Int64Encoder_One(t *testing.T) {
 }
 
 func Test_Int64Encoder_Two(t *testing.T) {
-	enc := tsm1.NewInt64Encoder()
+	enc := NewInt64Encoder()
 	var v1, v2 int64 = 1, 2
 
 	enc.Write(v1)
@@ -54,7 +52,7 @@ func Test_Int64Encoder_Two(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	dec := tsm1.NewInt64Decoder(b)
+	dec := NewInt64Decoder(b)
 	if !dec.Next() {
 		t.Fatalf("unexpected next value: got true, exp false")
 	}
@@ -73,7 +71,7 @@ func Test_Int64Encoder_Two(t *testing.T) {
 }
 
 func Test_Int64Encoder_Negative(t *testing.T) {
-	enc := tsm1.NewInt64Encoder()
+	enc := NewInt64Encoder()
 	var v1, v2, v3 int64 = -2, 0, 1
 
 	enc.Write(v1)
@@ -85,7 +83,7 @@ func Test_Int64Encoder_Negative(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	dec := tsm1.NewInt64Decoder(b)
+	dec := NewInt64Decoder(b)
 	if !dec.Next() {
 		t.Fatalf("unexpected next value: got true, exp false")
 	}
@@ -112,7 +110,7 @@ func Test_Int64Encoder_Negative(t *testing.T) {
 }
 
 func Test_Int64Encoder_Large_Range(t *testing.T) {
-	enc := tsm1.NewInt64Encoder()
+	enc := NewInt64Encoder()
 	var v1, v2 int64 = math.MinInt64, math.MaxInt64
 	enc.Write(v1)
 	enc.Write(v2)
@@ -121,7 +119,7 @@ func Test_Int64Encoder_Large_Range(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	dec := tsm1.NewInt64Decoder(b)
+	dec := NewInt64Decoder(b)
 	if !dec.Next() {
 		t.Fatalf("unexpected next value: got true, exp false")
 	}
@@ -140,7 +138,7 @@ func Test_Int64Encoder_Large_Range(t *testing.T) {
 }
 
 func Test_Int64Encoder_Uncompressed(t *testing.T) {
-	enc := tsm1.NewInt64Encoder()
+	enc := NewInt64Encoder()
 	var v1, v2, v3 int64 = 0, 1, 1 << 60
 
 	enc.Write(v1)
@@ -157,7 +155,7 @@ func Test_Int64Encoder_Uncompressed(t *testing.T) {
 		t.Fatalf("length mismatch: got %v, exp %v", len(b), exp)
 	}
 
-	dec := tsm1.NewInt64Decoder(b)
+	dec := NewInt64Decoder(b)
 	if !dec.Next() {
 		t.Fatalf("unexpected next value: got true, exp false")
 	}
@@ -194,7 +192,7 @@ func Test_Int64Encoder_NegativeUncompressed(t *testing.T) {
 		2761419461769776844, -1324397441074946198, -680758138988210958,
 		94468846694902125, -2394093124890745254, -2682139311758778198,
 	}
-	enc := tsm1.NewInt64Encoder()
+	enc := NewInt64Encoder()
 	for _, v := range values {
 		enc.Write(v)
 	}
@@ -204,7 +202,7 @@ func Test_Int64Encoder_NegativeUncompressed(t *testing.T) {
 		t.Fatalf("expected error: %v", err)
 	}
 
-	dec := tsm1.NewInt64Decoder(b)
+	dec := NewInt64Decoder(b)
 
 	i := 0
 	for dec.Next() {
@@ -224,7 +222,7 @@ func Test_Int64Encoder_NegativeUncompressed(t *testing.T) {
 }
 
 func Test_Int64Encoder_AllNegative(t *testing.T) {
-	enc := tsm1.NewInt64Encoder()
+	enc := NewInt64Encoder()
 	values := []int64{
 		-10, -5, -1,
 	}
@@ -238,7 +236,7 @@ func Test_Int64Encoder_AllNegative(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	dec := tsm1.NewInt64Decoder(b)
+	dec := NewInt64Decoder(b)
 	i := 0
 	for dec.Next() {
 		if i > len(values) {
@@ -254,13 +252,96 @@ func Test_Int64Encoder_AllNegative(t *testing.T) {
 	if i != len(values) {
 		t.Fatalf("failed to read enough values: got %v, exp %v", i, len(values))
 	}
+}
 
+func Test_Int64Encoder_Counter(t *testing.T) {
+	enc := NewInt64Encoder()
+	values := []int64{
+		1e15, 1e15 + 1, 1e15 + 2, 1e15 + 3, 1e15 + 4, 1e15 + 5,
+	}
+
+	for _, v := range values {
+		enc.Write(v)
+	}
+
+	b, err := enc.Bytes()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if b[0]>>4 != intCompressedSimple {
+		t.Fatalf("unexpected encoding format: expected simple, got %v", b[0]>>4)
+	}
+
+	// Should use 1 header byte + 2, 8 byte words if delta-encoding is used based on
+	// values sizes.  Without delta-encoding, we'd get 49 bytes.
+	if exp := 17; len(b) != exp {
+		t.Fatalf("encoded length mismatch: got %v, exp %v", len(b), exp)
+	}
+
+	dec := NewInt64Decoder(b)
+	i := 0
+	for dec.Next() {
+		if i > len(values) {
+			t.Fatalf("read too many values: got %v, exp %v", i, len(values))
+		}
+
+		if values[i] != dec.Read() {
+			t.Fatalf("read value %d mismatch: got %v, exp %v", i, dec.Read(), values[i])
+		}
+		i += 1
+	}
+
+	if i != len(values) {
+		t.Fatalf("failed to read enough values: got %v, exp %v", i, len(values))
+	}
+}
+
+func Test_Int64Encoder_MinMax(t *testing.T) {
+	enc := NewInt64Encoder()
+	values := []int64{
+		math.MinInt64, math.MaxInt64,
+	}
+
+	for _, v := range values {
+		enc.Write(v)
+	}
+
+	b, err := enc.Bytes()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if b[0]>>4 != intUncompressed {
+		t.Fatalf("unexpected encoding format: expected simple, got %v", b[0]>>4)
+	}
+
+	if exp := 17; len(b) != exp {
+		t.Fatalf("encoded length mismatch: got %v, exp %v", len(b), exp)
+	}
+
+	dec := NewInt64Decoder(b)
+	i := 0
+	for dec.Next() {
+		if i > len(values) {
+			t.Fatalf("read too many values: got %v, exp %v", i, len(values))
+		}
+
+		if values[i] != dec.Read() {
+			t.Fatalf("read value %d mismatch: got %v, exp %v", i, dec.Read(), values[i])
+		}
+		i += 1
+	}
+
+	if i != len(values) {
+		t.Fatalf("failed to read enough values: got %v, exp %v", i, len(values))
+	}
 }
 
 func Test_Int64Encoder_Quick(t *testing.T) {
 	quick.Check(func(values []int64) bool {
 		// Write values to encoder.
-		enc := tsm1.NewInt64Encoder()
+		enc := NewInt64Encoder()
 		for _, v := range values {
 			enc.Write(v)
 		}
@@ -273,7 +354,7 @@ func Test_Int64Encoder_Quick(t *testing.T) {
 
 		// Read values out of decoder.
 		got := make([]int64, 0, len(values))
-		dec := tsm1.NewInt64Decoder(buf)
+		dec := NewInt64Decoder(buf)
 		for dec.Next() {
 			if err := dec.Error(); err != nil {
 				t.Fatal(err)
@@ -291,7 +372,7 @@ func Test_Int64Encoder_Quick(t *testing.T) {
 }
 
 func BenchmarkInt64Encoder(b *testing.B) {
-	enc := tsm1.NewInt64Encoder()
+	enc := NewInt64Encoder()
 	x := make([]int64, 1024)
 	for i := 0; i < len(x); i++ {
 		x[i] = int64(i)
@@ -310,7 +391,7 @@ type byteSetter interface {
 
 func BenchmarkInt64Decoder(b *testing.B) {
 	x := make([]int64, 1024)
-	enc := tsm1.NewInt64Encoder()
+	enc := NewInt64Encoder()
 	for i := 0; i < len(x); i++ {
 		x[i] = int64(i)
 		enc.Write(x[i])
@@ -319,7 +400,7 @@ func BenchmarkInt64Decoder(b *testing.B) {
 
 	b.ResetTimer()
 
-	dec := tsm1.NewInt64Decoder(bytes)
+	dec := NewInt64Decoder(bytes)
 
 	for i := 0; i < b.N; i++ {
 		dec.(byteSetter).SetBytes(bytes)


### PR DESCRIPTION
This PR improves the compression for int64 fields in some special cases.  

The first change is to delta-encode the values before packing them.  This is similar to how the timestamp  encoding works.  This mainly improves counter type fields that increment using relatively small values.  Instead of storing the the potentially large count value at each point, we just store the delta from the prior count.  Small counters values still see some improvement, but not as much as counts with very large values.

The second change is to add run-length encoding when the deltas are all the same.  This can really help values that don't change for long periods of time (e.g. a counter that is usually 0).  

These changes are not backwards compatible with the current format.  Using these new encodings with old values will decode them incorrectly.  