### PR TITLE
tsm1 meta lint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,7 +54,6 @@ packages/
 autom4te.cache/
 config.log
 config.status
-Makefile
 
 # log file
 influxdb.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@
 - [#4431](https://github.com/influxdb/influxdb/issues/4431): Add tsm1 WAL QuickCheck
 - [#4438](https://github.com/influxdb/influxdb/pull/4438): openTSDB service shutdown fixes
 - [#3820](https://github.com/influxdb/influxdb/issues/3820): Fix js error in admin UI.
+- [#4460](https://github.com/influxdb/influxdb/issues/4460): tsm1 meta lint
 
 ## v0.9.4 [2015-09-14]
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,38 @@
+PACKAGES=$(shell find . -name '*.go' -print0 | xargs -0 -n1 dirname | sort --unique)
+
+default:
+
+metalint: deadcode cyclo aligncheck defercheck structcheck lint errcheck
+
+deadcode:
+	@deadcode $(PACKAGES) 2>&1
+
+cyclo:
+	@gocyclo -over 10 $(PACKAGES)
+
+aligncheck:
+	@aligncheck $(PACKAGES)
+
+defercheck:
+	@defercheck $(PACKAGES)
+
+
+structcheck:
+	@structcheck $(PACKAGES)
+
+lint:
+	@for pkg in $(PACKAGES); do golint $$pkg; done
+
+errcheck:
+	@for pkg in $(PACKAGES); do \
+	  errcheck -ignorepkg=bytes,fmt -ignore=":(Rollback|Close)" $$pkg \
+	done
+
+tools:
+	go get github.com/remyoudompheng/go-misc/deadcode
+	go get github.com/alecthomas/gocyclo
+	go get github.com/opennota/check/...
+	go get github.com/golang/lint/golint
+	go get github.com/kisielk/errcheck
+
+.PHONY: default,metalint,deadcode,cyclo,aligncheck,defercheck,structcheck,lint,errcheck,tools

--- a/errors.go
+++ b/errors.go
@@ -1,10 +1,8 @@
 package influxdb
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
-	"runtime"
 	"strings"
 )
 
@@ -26,18 +24,6 @@ func ErrRetentionPolicyNotFound(name string) error {
 	return fmt.Errorf("retention policy not found: %s", name)
 }
 
-func errMeasurementNotFound(name string) error { return fmt.Errorf("measurement not found: %s", name) }
-
-func errorf(format string, a ...interface{}) (err error) {
-	if _, file, line, ok := runtime.Caller(2); ok {
-		a = append(a, file, line)
-		err = fmt.Errorf(format+" (%s:%d)", a...)
-	} else {
-		err = fmt.Errorf(format, a...)
-	}
-	return
-}
-
 // IsClientError indicates whether an error is a known client error.
 func IsClientError(err error) bool {
 	if err == nil {
@@ -56,31 +42,4 @@ func IsClientError(err error) bool {
 	}
 
 	return false
-}
-
-// mustMarshal encodes a value to JSON.
-// This will panic if an error occurs. This should only be used internally when
-// an invalid marshal will cause corruption and a panic is appropriate.
-func mustMarshalJSON(v interface{}) []byte {
-	b, err := json.Marshal(v)
-	if err != nil {
-		panic("marshal: " + err.Error())
-	}
-	return b
-}
-
-// mustUnmarshalJSON decodes a value from JSON.
-// This will panic if an error occurs. This should only be used internally when
-// an invalid unmarshal will cause corruption and a panic is appropriate.
-func mustUnmarshalJSON(b []byte, v interface{}) {
-	if err := json.Unmarshal(b, v); err != nil {
-		panic("unmarshal: " + err.Error())
-	}
-}
-
-// assert will panic with a given formatted message if the given condition is false.
-func assert(condition bool, msg string, v ...interface{}) {
-	if !condition {
-		panic(fmt.Sprintf("assert failed: "+msg, v...))
-	}
 }

--- a/tsdb/engine/tsm1/bool.go
+++ b/tsdb/engine/tsm1/bool.go
@@ -8,21 +8,18 @@ package tsm1
 import "encoding/binary"
 
 const (
-	// boolUncompressed is an uncompressed boolean format
+	// boolUncompressed is an uncompressed boolean format.
+	// Not yet implemented.
 	boolUncompressed = 0
+
 	// boolCompressedBitPacked is an bit packed format using 1 bit per boolean
 	boolCompressedBitPacked = 1
 )
 
+// BoolEncoder encodes a series of bools to an in-memory buffer.
 type BoolEncoder interface {
 	Write(b bool)
 	Bytes() ([]byte, error)
-}
-
-type BoolDecoder interface {
-	Next() bool
-	Read() bool
-	Error() error
 }
 
 type boolEncoder struct {
@@ -39,6 +36,7 @@ type boolEncoder struct {
 	n int
 }
 
+// NewBoolEncoder returns a new instance of BoolEncoder.
 func NewBoolEncoder() BoolEncoder {
 	return &boolEncoder{}
 }
@@ -57,16 +55,16 @@ func (e *boolEncoder) Write(b bool) {
 	}
 
 	// Increment the current bool count
-	e.i += 1
+	e.i++
 	// Increment the total bool count
-	e.n += 1
+	e.n++
 }
 
 func (e *boolEncoder) flush() {
 	// Pad remaining byte w/ 0s
 	for e.i < 8 {
 		e.b = e.b << 1
-		e.i += 1
+		e.i++
 	}
 
 	// If we have bits set, append them to the byte slice
@@ -93,6 +91,13 @@ func (e *boolEncoder) Bytes() ([]byte, error) {
 	return append(b[:i], e.bytes...), nil
 }
 
+// BoolDecoder decodes a series of bools from an in-memory buffer.
+type BoolDecoder interface {
+	Next() bool
+	Read() bool
+	Error() error
+}
+
 type boolDecoder struct {
 	b   []byte
 	i   int
@@ -100,6 +105,7 @@ type boolDecoder struct {
 	err error
 }
 
+// NewBoolDecoder returns a new instance of BoolDecoder.
 func NewBoolDecoder(b []byte) BoolDecoder {
 	// First byte stores the encoding type, only have 1 bit-packet format
 	// currently ignore for now.
@@ -109,7 +115,7 @@ func NewBoolDecoder(b []byte) BoolDecoder {
 }
 
 func (e *boolDecoder) Next() bool {
-	e.i += 1
+	e.i++
 	return e.i < e.n
 }
 

--- a/tsdb/engine/tsm1/bool_test.go
+++ b/tsdb/engine/tsm1/bool_test.go
@@ -75,7 +75,7 @@ func Test_BoolEncoder_Multi_Compressed(t *testing.T) {
 }
 
 func Test_BoolEncoder_Quick(t *testing.T) {
-	quick.Check(func(values []bool) bool {
+	if err := quick.Check(func(values []bool) bool {
 		// Write values to encoder.
 		enc := tsm1.NewBoolEncoder()
 		for _, v := range values {
@@ -101,5 +101,7 @@ func Test_BoolEncoder_Quick(t *testing.T) {
 		}
 
 		return true
-	}, nil)
+	}, nil); err != nil {
+		t.Fatal(err)
+	}
 }

--- a/tsdb/engine/tsm1/cursor.go
+++ b/tsdb/engine/tsm1/cursor.go
@@ -20,6 +20,8 @@ type combinedEngineCursor struct {
 	ascending      bool
 }
 
+// NewCombinedEngineCursor returns a Cursor that joins wc and ec.
+// Values from wc take precedence over ec when identical timestamps are returned.
 func NewCombinedEngineCursor(wc, ec tsdb.Cursor, ascending bool) tsdb.Cursor {
 	return &combinedEngineCursor{
 		walCursor:    wc,
@@ -105,6 +107,7 @@ type multiFieldCursor struct {
 	valueBuffer []interface{}
 }
 
+// NewMultiFieldCursor returns an instance of Cursor that joins the results of cursors.
 func NewMultiFieldCursor(fields []string, cursors []tsdb.Cursor, ascending bool) tsdb.Cursor {
 	return &multiFieldCursor{
 		fields:      fields,

--- a/tsdb/engine/tsm1/encoding.go
+++ b/tsdb/engine/tsm1/encoding.go
@@ -61,33 +61,33 @@ func (e *EmptyValue) Size() int          { return 0 }
 // makes the code cleaner.
 type Values []Value
 
-func (v Values) MinTime() int64 {
-	return v[0].Time().UnixNano()
+func (a Values) MinTime() int64 {
+	return a[0].Time().UnixNano()
 }
 
-func (v Values) MaxTime() int64 {
-	return v[len(v)-1].Time().UnixNano()
+func (a Values) MaxTime() int64 {
+	return a[len(a)-1].Time().UnixNano()
 }
 
 // Encode converts the values to a byte slice.  If there are no values,
 // this function panics.
-func (v Values) Encode(buf []byte) ([]byte, error) {
-	if len(v) == 0 {
+func (a Values) Encode(buf []byte) ([]byte, error) {
+	if len(a) == 0 {
 		panic("unable to encode block type")
 	}
 
-	switch v[0].(type) {
+	switch a[0].(type) {
 	case *FloatValue:
-		return encodeFloatBlock(buf, v)
+		return encodeFloatBlock(buf, a)
 	case *Int64Value:
-		return encodeInt64Block(buf, v)
+		return encodeInt64Block(buf, a)
 	case *BoolValue:
-		return encodeBoolBlock(buf, v)
+		return encodeBoolBlock(buf, a)
 	case *StringValue:
-		return encodeStringBlock(buf, v)
+		return encodeStringBlock(buf, a)
 	}
 
-	return nil, fmt.Errorf("unsupported value type %T", v[0])
+	return nil, fmt.Errorf("unsupported value type %T", a[0])
 }
 
 // DecodeBlock takes a byte array and will decode into values of the appropriate type
@@ -115,19 +115,19 @@ func DecodeBlock(block []byte) (Values, error) {
 // Deduplicate returns a new Values slice with any values
 // that have the same  timestamp removed. The Value that appears
 // last in the slice is the one that is kept. The returned slice is in ascending order
-func (v Values) Deduplicate() Values {
+func (a Values) Deduplicate() Values {
 	m := make(map[int64]Value)
-	for _, val := range v {
+	for _, val := range a {
 		m[val.UnixNano()] = val
 	}
 
-	a := make([]Value, 0, len(m))
+	other := make([]Value, 0, len(m))
 	for _, val := range m {
-		a = append(a, val)
+		other = append(other, val)
 	}
-	sort.Sort(Values(a))
+	sort.Sort(Values(other))
 
-	return a
+	return other
 }
 
 // Sort methods
@@ -340,8 +340,8 @@ func (v *Int64Value) Value() interface{} {
 	return v.value
 }
 
-func (f *Int64Value) UnixNano() int64 {
-	return f.time.UnixNano()
+func (v *Int64Value) UnixNano() int64 {
+	return v.time.UnixNano()
 }
 
 func (v *Int64Value) Size() int {

--- a/tsdb/engine/tsm1/float.go
+++ b/tsdb/engine/tsm1/float.go
@@ -18,8 +18,10 @@ import (
 )
 
 const (
-	// floatUncompressed is an uncompressed format using 8 bytes per value
+	// floatUncompressed is an uncompressed format using 8 bytes per value.
+	// Not yet implemented.
 	floatUncompressed = 0
+
 	// floatCompressedGorilla is a compressed format using the gorilla paper encoding
 	floatCompressedGorilla = 1
 )

--- a/tsdb/engine/tsm1/int.go
+++ b/tsdb/engine/tsm1/int.go
@@ -190,7 +190,7 @@ func (d *int64Decoder) Next() bool {
 		return false
 	}
 
-	d.i += 1
+	d.i++
 
 	if d.i >= d.n {
 		switch d.encoding {

--- a/tsdb/engine/tsm1/string.go
+++ b/tsdb/engine/tsm1/string.go
@@ -13,8 +13,10 @@ import (
 )
 
 const (
-	// stringUncompressed is a an uncompressed format encoding strings as raw bytes
+	// stringUncompressed is a an uncompressed format encoding strings as raw bytes.
+	// Not yet implemented.
 	stringUncompressed = 0
+
 	// stringCompressedSnappy is a compressed encoding using Snappy compression
 	stringCompressedSnappy = 1
 )

--- a/tsdb/engine/tsm1/timestamp.go
+++ b/tsdb/engine/tsm1/timestamp.go
@@ -56,7 +56,7 @@ type TimeEncoder interface {
 	Bytes() ([]byte, error)
 }
 
-// TimeEncoder decodes byte slices to time.Time values.
+// TimeDecoder decodes byte slices to time.Time values.
 type TimeDecoder interface {
 	Next() bool
 	Read() time.Time
@@ -264,7 +264,7 @@ func (d *decoder) decodeRLE(b []byte) {
 
 	// Lower 4 bits hold the 10 based exponent so we can scale the values back up
 	mod := int64(math.Pow10(int(b[i] & 0xF)))
-	i += 1
+	i++
 
 	// Next 8 bytes is the starting timestamp
 	first := binary.BigEndian.Uint64(b[i : i+8])
@@ -278,7 +278,7 @@ func (d *decoder) decodeRLE(b []byte) {
 	i += n
 
 	// Last 1-10 bytes is how many times the value repeats
-	count, n := binary.Uvarint(b[i:])
+	count, _ := binary.Uvarint(b[i:])
 
 	// Rebuild construct the original values now
 	deltas := make([]uint64, count)

--- a/tsdb/engine/tsm1/timestamp_test.go
+++ b/tsdb/engine/tsm1/timestamp_test.go
@@ -307,7 +307,7 @@ func Test_TimeEncoder_Reverse(t *testing.T) {
 		if ts[i] != dec.Read() {
 			t.Fatalf("read value %d mismatch: got %v, exp %v", i, dec.Read(), ts[i])
 		}
-		i += 1
+		i++
 	}
 }
 
@@ -343,7 +343,7 @@ func Test_TimeEncoder_220SecondDelta(t *testing.T) {
 		if ts[i] != dec.Read() {
 			t.Fatalf("read value %d mismatch: got %v, exp %v", i, dec.Read(), ts[i])
 		}
-		i += 1
+		i++
 	}
 
 	if i != len(ts) {

--- a/tsdb/engine/tsm1/tsm1_test.go
+++ b/tsdb/engine/tsm1/tsm1_test.go
@@ -18,7 +18,7 @@ import (
 
 func TestEngine_WriteAndReadFloats(t *testing.T) {
 	e := OpenDefaultEngine()
-	defer e.Cleanup()
+	defer e.Close()
 
 	p1 := parsePoint("cpu,host=A value=1.1 1000000000")
 	p2 := parsePoint("cpu,host=B value=1.2 1000000000")
@@ -64,7 +64,7 @@ func TestEngine_WriteAndReadFloats(t *testing.T) {
 		}
 
 		if checkSingleBVal {
-			k, v = c.Next()
+			k, _ = c.Next()
 			if k != tsdb.EOF {
 				t.Fatal("expected EOF")
 			}
@@ -113,7 +113,7 @@ func TestEngine_WriteAndReadFloats(t *testing.T) {
 	}
 	tx.Rollback()
 
-	if err := e.Close(); err != nil {
+	if err := e.Engine.Close(); err != nil {
 		t.Fatalf("error closing: %s", err.Error())
 	}
 
@@ -129,7 +129,7 @@ func TestEngine_WriteIndexWithCollision(t *testing.T) {
 
 func TestEngine_WriteIndexQueryAcrossDataFiles(t *testing.T) {
 	e := OpenDefaultEngine()
-	defer e.Cleanup()
+	defer e.Close()
 
 	e.RotateFileSize = 10
 
@@ -191,7 +191,7 @@ func TestEngine_WriteIndexQueryAcrossDataFiles(t *testing.T) {
 
 func TestEngine_WriteOverwritePreviousPoint(t *testing.T) {
 	e := OpenDefaultEngine()
-	defer e.Cleanup()
+	defer e.Close()
 
 	fields := []string{"value"}
 
@@ -232,7 +232,7 @@ func TestEngine_WriteOverwritePreviousPoint(t *testing.T) {
 	if 1.3 != v {
 		t.Fatalf("data wrong:\n\texp:%f\n\tgot:%f", 1.3, v.(float64))
 	}
-	k, v = c.Next()
+	k, _ = c.Next()
 	if k != tsdb.EOF {
 		t.Fatal("expected EOF")
 	}
@@ -240,7 +240,7 @@ func TestEngine_WriteOverwritePreviousPoint(t *testing.T) {
 
 func TestEngine_CursorCombinesWALAndIndex(t *testing.T) {
 	e := OpenDefaultEngine()
-	defer e.Cleanup()
+	defer e.Close()
 
 	fields := []string{"value"}
 
@@ -272,7 +272,7 @@ func TestEngine_CursorCombinesWALAndIndex(t *testing.T) {
 	if 1.2 != v {
 		t.Fatalf("data wrong:\n\texp:%f\n\tgot:%f", 1.2, v.(float64))
 	}
-	k, v = c.Next()
+	k, _ = c.Next()
 	if k != tsdb.EOF {
 		t.Fatal("expected EOF")
 	}
@@ -280,7 +280,7 @@ func TestEngine_CursorCombinesWALAndIndex(t *testing.T) {
 
 func TestEngine_Compaction(t *testing.T) {
 	e := OpenDefaultEngine()
-	defer e.Cleanup()
+	defer e.Close()
 
 	e.RotateFileSize = 10
 
@@ -348,7 +348,7 @@ func TestEngine_Compaction(t *testing.T) {
 
 	verify("cpu,host=A", []models.Point{p1, p3, p5, p7}, 0)
 	verify("cpu,host=B", []models.Point{p2, p4, p6, p8}, 0)
-	if err := e.Close(); err != nil {
+	if err := e.Engine.Close(); err != nil {
 		t.Fatalf("error closing: %s", err.Error())
 	}
 	if err := e.Open(); err != nil {
@@ -361,7 +361,7 @@ func TestEngine_Compaction(t *testing.T) {
 // Ensure that if two keys have the same fnv64-a id, we handle it
 func TestEngine_KeyCollisionsAreHandled(t *testing.T) {
 	e := OpenDefaultEngine()
-	defer e.Cleanup()
+	defer e.Close()
 
 	fields := []string{"value"}
 
@@ -416,7 +416,7 @@ func TestEngine_KeyCollisionsAreHandled(t *testing.T) {
 	verify("cpu,host=C", []models.Point{p3, p6}, 0)
 
 	// verify collisions are handled after closing and reopening
-	if err := e.Close(); err != nil {
+	if err := e.Engine.Close(); err != nil {
 		t.Fatalf("error closing: %s", err.Error())
 	}
 	if err := e.Open(); err != nil {
@@ -442,7 +442,7 @@ func TestEngine_KeyCollisionsAreHandled(t *testing.T) {
 
 func TestEngine_SupportMultipleFields(t *testing.T) {
 	e := OpenDefaultEngine()
-	defer e.Cleanup()
+	defer e.Close()
 
 	fields := []string{"value", "foo"}
 
@@ -605,7 +605,7 @@ func TestEngine_SupportMultipleFields(t *testing.T) {
 
 func TestEngine_WriteManyPointsToSingleSeries(t *testing.T) {
 	e := OpenDefaultEngine()
-	defer e.Cleanup()
+	defer e.Close()
 
 	fields := []string{"value"}
 
@@ -641,7 +641,7 @@ func TestEngine_WriteManyPointsToSingleSeries(t *testing.T) {
 
 func TestEngine_WritePointsInMultipleRequestsWithSameTime(t *testing.T) {
 	e := OpenDefaultEngine()
-	defer e.Cleanup()
+	defer e.Close()
 
 	fields := []string{"value"}
 
@@ -676,7 +676,7 @@ func TestEngine_WritePointsInMultipleRequestsWithSameTime(t *testing.T) {
 
 	verify()
 
-	if err := e.Close(); err != nil {
+	if err := e.Engine.Close(); err != nil {
 		t.Fatalf("error closing: %s", err.Error())
 	}
 	if err := e.Open(); err != nil {
@@ -688,7 +688,7 @@ func TestEngine_WritePointsInMultipleRequestsWithSameTime(t *testing.T) {
 
 func TestEngine_CursorDescendingOrder(t *testing.T) {
 	e := OpenDefaultEngine()
-	defer e.Cleanup()
+	defer e.Close()
 
 	fields := []string{"value"}
 
@@ -763,7 +763,7 @@ func TestEngine_CursorDescendingOrder(t *testing.T) {
 
 func TestEngine_CompactWithSeriesInOneFile(t *testing.T) {
 	e := OpenDefaultEngine()
-	defer e.Cleanup()
+	defer e.Close()
 
 	fields := []string{"value"}
 
@@ -844,7 +844,7 @@ func TestEngine_CompactWithSeriesInOneFile(t *testing.T) {
 	if k != 3000000000 {
 		t.Fatalf("expected time 3000000000 but got %d", k)
 	}
-	k, v = c.Next()
+	k, _ = c.Next()
 	if k != 4000000000 {
 		t.Fatalf("expected time 3000000000 but got %d", k)
 	}
@@ -854,7 +854,7 @@ func TestEngine_CompactWithSeriesInOneFile(t *testing.T) {
 // skip decoding and just get copied over to the new data file works.
 func TestEngine_CompactionWithCopiedBlocks(t *testing.T) {
 	e := OpenDefaultEngine()
-	defer e.Cleanup()
+	defer e.Close()
 
 	fields := []string{"value"}
 
@@ -932,7 +932,7 @@ func TestEngine_CompactionWithCopiedBlocks(t *testing.T) {
 
 func TestEngine_RewritingOldBlocks(t *testing.T) {
 	e := OpenDefaultEngine()
-	defer e.Cleanup()
+	defer e.Close()
 
 	fields := []string{"value"}
 
@@ -976,7 +976,7 @@ func TestEngine_RewritingOldBlocks(t *testing.T) {
 
 func TestEngine_WriteIntoCompactedFile(t *testing.T) {
 	e := OpenDefaultEngine()
-	defer e.Cleanup()
+	defer e.Close()
 
 	fields := []string{"value"}
 
@@ -1043,7 +1043,7 @@ func TestEngine_WriteIntoCompactedFile(t *testing.T) {
 
 func TestEngine_DuplicatePointsInWalAndIndex(t *testing.T) {
 	e := OpenDefaultEngine()
-	defer e.Cleanup()
+	defer e.Close()
 
 	fields := []string{"value"}
 	p1 := parsePoint("cpu,host=A value=1.1 1000000000")
@@ -1073,7 +1073,7 @@ func TestEngine_DuplicatePointsInWalAndIndex(t *testing.T) {
 
 func TestEngine_Deletes(t *testing.T) {
 	e := OpenDefaultEngine()
-	defer e.Cleanup()
+	defer e.Close()
 
 	fields := []string{"value"}
 	// Create metadata.
@@ -1153,7 +1153,7 @@ func TestEngine_Deletes(t *testing.T) {
 	// the wal flushes to the index. To verify that the delete gets
 	// persisted and will go all the way through the index
 
-	if err := e.Close(); err != nil {
+	if err := e.Engine.Close(); err != nil {
 		t.Fatalf("error closing: %s", err.Error())
 	}
 	if err := e.Open(); err != nil {
@@ -1179,7 +1179,7 @@ func TestEngine_Deletes(t *testing.T) {
 	verify()
 
 	// open and close to verify thd delete was persisted
-	if err := e.Close(); err != nil {
+	if err := e.Engine.Close(); err != nil {
 		t.Fatalf("error closing: %s", err.Error())
 	}
 	if err := e.Open(); err != nil {
@@ -1218,7 +1218,7 @@ func TestEngine_Deletes(t *testing.T) {
 	}()
 
 	// open and close to verify thd delete was persisted
-	if err := e.Close(); err != nil {
+	if err := e.Engine.Close(); err != nil {
 		t.Fatalf("error closing: %s", err.Error())
 	}
 	if err := e.Open(); err != nil {
@@ -1238,7 +1238,7 @@ func TestEngine_Deletes(t *testing.T) {
 
 func TestEngine_IndexGoodAfterFlush(t *testing.T) {
 	e := OpenDefaultEngine()
-	defer e.Cleanup()
+	defer e.Close()
 
 	fields := []string{"value"}
 
@@ -1339,8 +1339,8 @@ func OpenEngine(opt tsdb.EngineOptions) *Engine {
 // OpenDefaultEngine returns an open Engine with default options.
 func OpenDefaultEngine() *Engine { return OpenEngine(tsdb.NewEngineOptions()) }
 
-// Cleanup closes the engine and removes all data.
-func (e *Engine) Cleanup() error {
+// Close closes the engine and removes all data.
+func (e *Engine) Close() error {
 	e.Engine.Close()
 	os.RemoveAll(e.Path())
 	return nil

--- a/tsdb/engine/tsm1/tx.go
+++ b/tsdb/engine/tsm1/tx.go
@@ -33,8 +33,8 @@ func (t *tx) Cursor(series string, fields []string, dec *tsdb.FieldCodec, ascend
 
 	// multiple fields. use just the MultiFieldCursor, which also handles time collisions
 	// so we don't need to use the combined cursor
-	cursors := make([]tsdb.Cursor, 0)
-	cursorFields := make([]string, 0)
+	var cursors []tsdb.Cursor
+	var cursorFields []string
 	for _, field := range fields {
 		id := t.engine.keyAndFieldToID(series, field)
 		_, isDeleted := t.engine.deletes[id]

--- a/tsdb/engine/tsm1/write_lock.go
+++ b/tsdb/engine/tsm1/write_lock.go
@@ -57,7 +57,7 @@ func (w *WriteLock) UnlockRange(min, max int64) {
 	defer w.rangesLock.Unlock()
 
 	// take the range out of the slice and unlock it
-	a := make([]*rangeLock, 0)
+	var a []*rangeLock
 	for _, r := range w.ranges {
 		if r.min == min && r.max == max {
 			r.mu.Unlock()


### PR DESCRIPTION
## Overview

This pull request fixes a bunch of warnings reported by `gometalinter`. The `gometalinter` output was also excessive so I moved a subset of the functionality into a `Makefile` with the following targets:

```
deadcode
cyclo
aligncheck
defercheck
structcheck
lint
errcheck

metalint # runs all the above
```

### Cyclomatic Complexity

Within `tsm1`, there 26 functions which have a cyclomatic complexity score higher than 10:

```
39 tsm1 (*Engine).Compact tsdb/engine/tsm1/tsm1.go:507:1
35 tsm1 (*Engine).rewriteFile tsdb/engine/tsm1/tsm1.go:988:1
23 tsm1 (*Log).flush tsdb/engine/tsm1/wal.go:516:1
21 tsm1 (*Engine).convertKeysAndWriteMetadata tsdb/engine/tsm1/tsm1.go:811:1
21 tsm1 (*cursor).SeekTo tsdb/engine/tsm1/cursor.go:213:1
19 tsm1 (*Log).readFileToCache tsdb/engine/tsm1/wal.go:331:1
15 tsm1 (*Engine).flushDeletes tsdb/engine/tsm1/tsm1.go:1189:1
14 tsm1 (*Engine).Write tsdb/engine/tsm1/tsm1.go:351:1
14 tsm1 (*FloatDecoder).Next tsdb/engine/tsm1/float.go:152:1
12 tsm1 (*multiFieldCursor).read tsdb/engine/tsm1/cursor.go:136:1
12 tsm1 (*Log).WritePoints tsdb/engine/tsm1/wal.go:195:1
12 tsm1 (*Engine).filterDataBetweenTimes tsdb/engine/tsm1/tsm1.go:944:1
11 tsm1 (*Log).addToCache tsdb/engine/tsm1/wal.go:253:1
11 tsm1 (*Engine).Open tsdb/engine/tsm1/tsm1.go:210:1
```

```
36 tsm1_test TestEngine_SupportMultipleFields tsdb/engine/tsm1/tsm1_test.go:443:1
25 tsm1_test TestLog_TestWriteQueryOpen tsdb/engine/tsm1/wal_test.go:21:1
23 tsm1_test TestEngine_Deletes tsdb/engine/tsm1/tsm1_test.go:1074:1
22 tsm1_test TestEngine_WriteAndReadFloats tsdb/engine/tsm1/tsm1_test.go:19:1
17 tsm1_test TestEngine_CompactWithSeriesInOneFile tsdb/engine/tsm1/tsm1_test.go:764:1
15 tsm1_test TestEngine_Compaction tsdb/engine/tsm1/tsm1_test.go:281:1
13 tsm1_test TestEngine_IndexGoodAfterFlush tsdb/engine/tsm1/tsm1_test.go:1239:1
13 tsm1_test TestEngine_WriteIntoCompactedFile tsdb/engine/tsm1/tsm1_test.go:977:1
12 tsm1_test TestEngine_CursorDescendingOrder tsdb/engine/tsm1/tsm1_test.go:689:1
12 tsm1_test TestEngine_CompactionWithCopiedBlocks tsdb/engine/tsm1/tsm1_test.go:855:1
11 tsm1_test TestLog_Quick tsdb/engine/tsm1/wal_test.go:149:1
11 tsm1_test TestEngine_KeyCollisionsAreHandled tsdb/engine/tsm1/tsm1_test.go:362:1
```

Paul is currently in the compaction code but I think it'd be worth it to break that code up once he's done.