### PR TITLE
Always return time, never strings. fixes #4415

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@
 - [#4438](https://github.com/influxdb/influxdb/pull/4438): openTSDB service shutdown fixes
 - [#3820](https://github.com/influxdb/influxdb/issues/3820): Fix js error in admin UI.
 - [#4460](https://github.com/influxdb/influxdb/issues/4460): tsm1 meta lint
+- [#4415](https://github.com/influxdb/influxdb/issues/4415): Selector (like max, min, first, etc) return a string instead of timestamp
 
 ## v0.9.4 [2015-09-14]
 

--- a/tsdb/executor.go
+++ b/tsdb/executor.go
@@ -644,10 +644,10 @@ func (e *SelectExecutor) processSelectors(results [][]interface{}, callPosition 
 func (e *SelectExecutor) selectorPointToQueryResult(columns []interface{}, hasTimeField bool, columnIndex int, p PositionPoint, tMin time.Time, columnNames []string) []interface{} {
 	callCount := len(e.stmt.FunctionCalls())
 	if callCount == 1 {
-		tm := time.Unix(0, p.Time).UTC().Format(time.RFC3339Nano)
+		tm := time.Unix(0, p.Time).UTC()
 		// If we didn't explicity ask for time, and we have a group by, then use TMIN for the time returned
 		if len(e.stmt.Dimensions) > 0 && !hasTimeField {
-			tm = tMin.UTC().Format(time.RFC3339Nano)
+			tm = tMin.UTC()
 		}
 		columns[0] = tm
 	}
@@ -704,10 +704,10 @@ func (e *SelectExecutor) processAggregates(results [][]interface{}, columnNames 
 }
 
 func (e *SelectExecutor) aggregatePointToQueryResult(p PositionPoint, tMin time.Time, call *influxql.Call, columnNames []string) []interface{} {
-	tm := time.Unix(0, p.Time).UTC().Format(time.RFC3339Nano)
+	tm := time.Unix(0, p.Time).UTC()
 	// If we didn't explicity ask for time, and we have a group by, then use TMIN for the time returned
 	if len(e.stmt.Dimensions) > 0 && !e.stmt.HasTimeFieldSpecified() {
-		tm = tMin.UTC().Format(time.RFC3339Nano)
+		tm = tMin.UTC()
 	}
 	vals := []interface{}{tm}
 	for _, c := range columnNames {


### PR DESCRIPTION
processAggregates and ProcessSelectors were incorrectly sending back a string timestamp instead of a `time.Time` struct.

This also adds some tests for the `epoch` parameter on our query endpoint to validate it won't regress.