### PR TITLE
fix #4472: too many points in the GROUP BY interval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@
 - [#3820](https://github.com/influxdb/influxdb/issues/3820): Fix js error in admin UI.
 - [#4460](https://github.com/influxdb/influxdb/issues/4460): tsm1 meta lint
 - [#4415](https://github.com/influxdb/influxdb/issues/4415): Selector (like max, min, first, etc) return a string instead of timestamp
+- [#4472](https://github.com/influxdb/influxdb/issues/4472): Fix 'too many points in GROUP BY interval' error
 
 ## v0.9.4 [2015-09-14]
 

--- a/services/httpd/handler.go
+++ b/services/httpd/handler.go
@@ -189,7 +189,7 @@ func (h *Handler) serveProcessContinuousQueries(w http.ResponseWriter, r *http.R
 	// Get the name of the CQ to run (blank means run all).
 	name := q.Get("name")
 	// Get the time for which the CQ should be evaluated.
-	var t time.Time
+	t := time.Now()
 	var err error
 	s := q.Get("time")
 	if s != "" {


### PR DESCRIPTION
Fixes the `too many points in the GROUP BY interval` error when using the `/data/process_continuous_queries` endpoint with no `time` parameter.