### PR TITLE
Fix typos.

### DIFF
--- a/cmd/influxd/run/server_test.md
+++ b/cmd/influxd/run/server_test.md
@@ -18,7 +18,7 @@ When each test runs it does the following:
 
 ## Idempotent - Allows for parallel tests
 
-Each test should be `idempotent`, meaining that its data will not be affected by other tests, or use cases within the table tests themselves.
+Each test should be `idempotent`, meaning that its data will not be affected by other tests, or use cases within the table tests themselves.
 This allows for parallel testing, keeping the test suite total execution time very low.
 
 ### Basic sample test

--- a/meta/store.go
+++ b/meta/store.go
@@ -88,7 +88,7 @@ type Store struct {
 	wg      sync.WaitGroup
 	changed chan struct{}
 
-	// clusterTracingEnabled controls whether low-level cluster communcation is logged.
+	// clusterTracingEnabled controls whether low-level cluster communication is logged.
 	// Useful for troubleshooting
 	clusterTracingEnabled bool
 

--- a/models/points.go
+++ b/models/points.go
@@ -341,7 +341,7 @@ func scanKey(buf []byte, i int) (int, []byte, error) {
 	}
 
 	// Now we know where the key region is within buf, and the locations of tags, we
-	// need to deterimine if duplicate tags exist and if the tags are sorted.  This iterates
+	// need to determine if duplicate tags exist and if the tags are sorted.  This iterates
 	// 1/2 of the list comparing each end with each other, walking towards the center from
 	// both sides.
 	for j := 0; j < commas/2; j++ {

--- a/models/points_test.go
+++ b/models/points_test.go
@@ -330,7 +330,7 @@ func TestParsePointMaxInt64(t *testing.T) {
 		t.Fatalf(`ParsePoints("%s") mismatch. got %v, exp nil`, `cpu,host=serverA,region=us-west value=9223372036854775807i`, err)
 	}
 	if exp, got := int64(9223372036854775807), p[0].Fields()["value"].(int64); exp != got {
-		t.Fatalf("ParsePoints Value mistmatch. \nexp: %v\ngot: %v", exp, got)
+		t.Fatalf("ParsePoints Value mismatch. \nexp: %v\ngot: %v", exp, got)
 	}
 
 	// leading zeros
@@ -532,7 +532,7 @@ func TestParsePointUnescape(t *testing.T) {
 			},
 			time.Unix(0, 0)))
 
-	// commas in measuremnt name
+	// commas in measurement name
 	test(t, `cpu\,main,regions=east\,west value=1.0`,
 		models.NewPoint(
 			"cpu,main", // comma in the name

--- a/monitor/service.go
+++ b/monitor/service.go
@@ -115,7 +115,7 @@ func New(c Config) *Monitor {
 }
 
 // Open opens the monitoring system, using the given clusterID, node ID, and hostname
-// for identification purposem.
+// for identification purpose.
 func (m *Monitor) Open() error {
 	m.Logger.Printf("Starting monitor system")
 


### PR DESCRIPTION
* meaining --> meaning
* communcation --> communication
* deterimine --> determine
* mistmatch --> mistmatch