### PR TITLE
fix sequence in meta proto

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@
 - [#4472](https://github.com/influxdb/influxdb/issues/4472): Fix 'too many points in GROUP BY interval' error
 - [#4475](https://github.com/influxdb/influxdb/issues/4475): Fix SHOW TAG VALUES error message.
 - [#4486](https://github.com/influxdb/influxdb/pull/4486): Fix missing comments for runner package
+- [#4497](https://github.com/influxdb/influxdb/pull/4497): Fix sequence in meta proto
 
 ## v0.9.4 [2015-09-14]
 

--- a/meta/internal/meta.pb.go
+++ b/meta/internal/meta.pb.go
@@ -121,8 +121,8 @@ const (
 	Command_SetAdminPrivilegeCommand         Command_Type = 18
 	Command_UpdateNodeCommand                Command_Type = 19
 	Command_RenameDatabaseCommand            Command_Type = 20
-	Command_CreateSubscriptionCommand        Command_Type = 22
-	Command_DropSubscriptionCommand          Command_Type = 23
+	Command_CreateSubscriptionCommand        Command_Type = 21
+	Command_DropSubscriptionCommand          Command_Type = 22
 )
 
 var Command_Type_name = map[int32]string{
@@ -146,8 +146,8 @@ var Command_Type_name = map[int32]string{
 	18: "SetAdminPrivilegeCommand",
 	19: "UpdateNodeCommand",
 	20: "RenameDatabaseCommand",
-	22: "CreateSubscriptionCommand",
-	23: "DropSubscriptionCommand",
+	21: "CreateSubscriptionCommand",
+	22: "DropSubscriptionCommand",
 }
 var Command_Type_value = map[string]int32{
 	"CreateNodeCommand":                1,
@@ -170,8 +170,8 @@ var Command_Type_value = map[string]int32{
 	"SetAdminPrivilegeCommand":         18,
 	"UpdateNodeCommand":                19,
 	"RenameDatabaseCommand":            20,
-	"CreateSubscriptionCommand":        22,
-	"DropSubscriptionCommand":          23,
+	"CreateSubscriptionCommand":        21,
+	"DropSubscriptionCommand":          22,
 }
 
 func (x Command_Type) Enum() *Command_Type {
@@ -1569,15 +1569,11 @@ func (m *JoinRequest) GetAddr() string {
 }
 
 type JoinResponse struct {
-	Header *ResponseHeader `protobuf:"bytes,1,req,name=Header" json:"Header,omitempty"`
-	// Indicates that this node should take part in the raft cluster.
-	EnableRaft *bool `protobuf:"varint,2,opt,name=EnableRaft" json:"EnableRaft,omitempty"`
-	// The addresses of raft peers to use if joining as a raft member. If not joining
-	// as a raft member, these are the nodes running raft.
-	RaftNodes []string `protobuf:"bytes,3,rep,name=RaftNodes" json:"RaftNodes,omitempty"`
-	// The node ID assigned to the requesting node.
-	NodeID           *uint64 `protobuf:"varint,4,opt,name=NodeID" json:"NodeID,omitempty"`
-	XXX_unrecognized []byte  `json:"-"`
+	Header           *ResponseHeader `protobuf:"bytes,1,req,name=Header" json:"Header,omitempty"`
+	EnableRaft       *bool           `protobuf:"varint,2,opt,name=EnableRaft" json:"EnableRaft,omitempty"`
+	RaftNodes        []string        `protobuf:"bytes,3,rep,name=RaftNodes" json:"RaftNodes,omitempty"`
+	NodeID           *uint64         `protobuf:"varint,4,opt,name=NodeID" json:"NodeID,omitempty"`
+	XXX_unrecognized []byte          `json:"-"`
 }
 
 func (m *JoinResponse) Reset()         { *m = JoinResponse{} }

--- a/meta/internal/meta.proto
+++ b/meta/internal/meta.proto
@@ -113,8 +113,8 @@ message Command {
 		SetAdminPrivilegeCommand         = 18;
 		UpdateNodeCommand                = 19;
 		RenameDatabaseCommand            = 20;
-		CreateSubscriptionCommand        = 22;
-		DropSubscriptionCommand          = 23;
+		CreateSubscriptionCommand        = 21;
+		DropSubscriptionCommand          = 22;
     }
 
     required Type type = 1;


### PR DESCRIPTION
We skipped a sequence for some reason.  Assuming this was not intentional.

The messages have the right sequence later in the file.  This fix aligns the sequences back up.

@nathanielc can you verify this?