### PR TITLE
Allow filtering SHOW MEASUREMENTS by regex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - [#4379](https://github.com/influxdb/influxdb/pull/4379): Auto-create database for UDP input.
 - [#4375](https://github.com/influxdb/influxdb/pull/4375): Add Subscriptions so data can be 'forked' out of InfluxDB to another third party.
 - [#4459](https://github.com/influxdb/influxdb/pull/4459): Register with Enterprise service if token available.
+- [#4501](https://github.com/influxdb/influxdb/pull/4501): Allow filtering SHOW MEASUREMENTS by regex.
 
 ### Bugfixes
 - [#4389](https://github.com/influxdb/influxdb/pull/4389): Don't add a new segment file on each hinted-handoff purge cycle.

--- a/cmd/influxd/run/server_test.go
+++ b/cmd/influxd/run/server_test.go
@@ -4372,6 +4372,18 @@ func TestServer_Query_ShowMeasurements(t *testing.T) {
 			params:  url.Values{"db": []string{"db0"}},
 		},
 		&Query{
+			name:    `show measurements using WITH`,
+			command: "SHOW MEASUREMENTS WITH MEASUREMENT = cpu",
+			exp:     `{"results":[{"series":[{"name":"measurements","columns":["name"],"values":[["cpu"]]}]}]}`,
+			params:  url.Values{"db": []string{"db0"}},
+		},
+		&Query{
+			name:    `show measurements using WITH and regex`,
+			command: "SHOW MEASUREMENTS WITH MEASUREMENT =~ /[cg]pu/",
+			exp:     `{"results":[{"series":[{"name":"measurements","columns":["name"],"values":[["cpu"],["gpu"]]}]}]}`,
+			params:  url.Values{"db": []string{"db0"}},
+		},
+		&Query{
 			name:    `show measurements where tag matches regular expression`,
 			command: "SHOW MEASUREMENTS WHERE region =~ /ca.*/",
 			exp:     `{"results":[{"series":[{"name":"measurements","columns":["name"],"values":[["gpu"],["other"]]}]}]}`,

--- a/cmd/influxd/run/server_test.go
+++ b/cmd/influxd/run/server_test.go
@@ -4384,6 +4384,12 @@ func TestServer_Query_ShowMeasurements(t *testing.T) {
 			params:  url.Values{"db": []string{"db0"}},
 		},
 		&Query{
+			name:    `show measurements using WITH and regex - no matches`,
+			command: "SHOW MEASUREMENTS WITH MEASUREMENT =~ /.*zzzzz.*/",
+			exp:     `{"results":[{}]}`,
+			params:  url.Values{"db": []string{"db0"}},
+		},
+		&Query{
 			name:    `show measurements where tag matches regular expression`,
 			command: "SHOW MEASUREMENTS WHERE region =~ /ca.*/",
 			exp:     `{"results":[{"series":[{"name":"measurements","columns":["name"],"values":[["gpu"],["other"]]}]}]}`,

--- a/influxql/ast.go
+++ b/influxql/ast.go
@@ -1953,6 +1953,9 @@ func (s *DropContinuousQueryStatement) RequiredPrivileges() ExecutionPrivileges 
 
 // ShowMeasurementsStatement represents a command for listing measurements.
 type ShowMeasurementsStatement struct {
+	// Measurement name or regex.
+	Source Source
+
 	// An expression evaluated on data point.
 	Condition Expr
 

--- a/influxql/parser_test.go
+++ b/influxql/parser_test.go
@@ -751,6 +751,24 @@ func TestParser_ParseStatement(t *testing.T) {
 			},
 		},
 
+		// SHOW MEASUREMENTS WITH MEASUREMENT = cpu
+		{
+			s: `SHOW MEASUREMENTS WITH MEASUREMENT = cpu`,
+			stmt: &influxql.ShowMeasurementsStatement{
+				Source: &influxql.Measurement{Name: "cpu"},
+			},
+		},
+
+		// SHOW MEASUREMENTS WITH MEASUREMENT =~ /regex/
+		{
+			s: `SHOW MEASUREMENTS WITH MEASUREMENT =~ /[cg]pu/`,
+			stmt: &influxql.ShowMeasurementsStatement{
+				Source: &influxql.Measurement{
+					Regex: &influxql.RegexLiteral{Val: regexp.MustCompile(`[cg]pu`)},
+				},
+			},
+		},
+
 		// SHOW RETENTION POLICIES
 		{
 			s: `SHOW RETENTION POLICIES ON mydb`,

--- a/tsdb/show_measurements.go
+++ b/tsdb/show_measurements.go
@@ -164,6 +164,16 @@ func (m *ShowMeasurementsMapper) Open() error {
 	// Start a goroutine to send the names over the channel as needed.
 	go func() {
 		for _, mm := range measurements {
+			// Filter measurements by WITH clause, if one was given.
+			if m.stmt.Source != nil {
+				s, ok := m.stmt.Source.(*influxql.Measurement)
+				if !ok ||
+					s.Regex != nil && !s.Regex.Val.MatchString(mm.Name) ||
+					s.Name != "" && s.Name != mm.Name {
+					continue
+				}
+			}
+
 			ch <- mm.Name
 		}
 		close(ch)


### PR DESCRIPTION
This change allows the results of `SHOW MEASUREMENTS` to be filtered by regular expression.  For example, the following query would return all measurements that begin with `cpu`:

```
SHOW MEASUREMENTS WITH MEASUREMENT =~ /cpu.*/
```