### PR TITLE
Fix panic: runtime error: index out of range - Values.MinTime

### DIFF
--- a/tsdb/engine/tsm1/tsm1.go
+++ b/tsdb/engine/tsm1/tsm1.go
@@ -1649,6 +1649,11 @@ func (e *Engine) readSeries() (map[string]*tsdb.Series, error) {
 // has future encoded blocks so that this method can know how much of its values can be
 // combined and output in the resulting encoded block.
 func (e *Engine) DecodeAndCombine(newValues Values, block, buf []byte, nextTime int64, hasFutureBlock bool) (Values, []byte, error) {
+	// No new values passed in, so nothing to combine.  Just return the existing block.
+	if len(newValues) == 0 {
+		return newValues, block, nil
+	}
+
 	values, err := DecodeBlock(block)
 	if err != nil {
 		panic(fmt.Sprintf("failure decoding block: %v", err))


### PR DESCRIPTION
When rewriting a tsm file, a panic on the Values slice could happen
if there were no values in the slice and the conditions of the rewrite
causes DecodeAndCombine to be called with the empty slice.  This could
happen if the sizes of the values was equal to
the MaxPointsInBlock config options and there were no future blocks after
the current one being written.

When this happens, DecodeAndCombine returns a zero length remaining values
slice which is passed back into DecodeAndCombine one last time.  In this case,
we now just return the original block since there is nothing new to combine.

Fixes #4444 #4365