### PR TITLE
Update systemd unit file

### DIFF
--- a/scripts/influxdb.service
+++ b/scripts/influxdb.service
@@ -9,9 +9,11 @@ After=network.target
 User=influxdb
 Group=influxdb
 LimitNOFILE=65536
+Environment='STDOUT=/dev/null'
+Environment='STDERR=/var/log/influxdb/influxd.log'
 EnvironmentFile=-/etc/default/influxdb
-ExecStart=/opt/influxdb/influxd -config /etc/opt/influxdb/influxdb.conf $INFLUXD_OPTS
-KillMode=process
+ExecStart=/bin/sh -c "/usr/bin/influxd -config /etc/influxdb/influxdb.conf ${INFLUXD_OPTS} > ${STDOUT} 2> ${STDERR}"
+KillMode=control-group
 Restart=on-failure
 
 [Install]


### PR DESCRIPTION
Changes:
* Re-enable logging to file (previously it was handled by `journald`) by wrapping startup in `sh`
* Fix an issue where the `$INFLUXD_OPTS` variable was not being interpreted correctly
* Modify the `KillMode` to ensure `sh` and `influxd` are started/stopped together
* Fixes #4490 