### PR TITLE
fix subscriber logic when closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@
 - [#4486](https://github.com/influxdb/influxdb/pull/4486): Fix missing comments for runner package
 - [#4497](https://github.com/influxdb/influxdb/pull/4497): Fix sequence in meta proto
 - [#3367](https://github.com/influxdb/influxdb/issues/3367): Negative timestamps are parsed correctly by the line protocol.
+- [#4563](https://github.com/influxdb/influxdb/pull/4536): Fix broken subscriptions updates.
 
 ## v0.9.4 [2015-09-14]
 


### PR DESCRIPTION
The logic for detecting the closed service was broken. Fixed and added a test.

Also update logging to only log when something changes instead of any time it checks for a change.