### PR TITLE
TSM test and data race fixes

### DIFF
--- a/tsdb/engine/tsm1/tsm1.go
+++ b/tsdb/engine/tsm1/tsm1.go
@@ -472,6 +472,7 @@ func (e *Engine) filesAndLock(min, max int64) (a dataFiles, lockStart, lockEnd i
 		a = make([]*dataFile, 0)
 		files := e.copyFilesCollection()
 
+		e.filesLock.RLock()
 		for _, f := range e.files {
 			fmin, fmax := f.MinTime(), f.MaxTime()
 			if min < fmax && fmin >= fmin {
@@ -480,6 +481,7 @@ func (e *Engine) filesAndLock(min, max int64) (a dataFiles, lockStart, lockEnd i
 				a = append(a, f)
 			}
 		}
+		e.filesLock.RUnlock()
 
 		if len(a) > 0 {
 			lockStart = a[0].MinTime()

--- a/tsdb/engine/tsm1/tsm1_test.go
+++ b/tsdb/engine/tsm1/tsm1_test.go
@@ -301,6 +301,72 @@ func TestEngine_Write_BeforeFirstPoint(t *testing.T) {
 	verify([]models.Point{p4, p1, p2, p3})
 }
 
+// Tests that writing a series with different fields is queryable before and
+// after a full compaction
+func TestEngine_Write_MixedFields(t *testing.T) {
+	e := OpenDefaultEngine()
+	defer e.Close()
+
+	e.RotateFileSize = 1
+
+	fields := []string{"value", "value2"}
+
+	p1 := parsePoint("cpu,host=A value=1.1 1000000000")
+	p2 := parsePoint("cpu,host=A value=1.2,value2=2.1 2000000000")
+	p3 := parsePoint("cpu,host=A value=1.3 3000000000")
+	p4 := parsePoint("cpu,host=A value=1.4 4000000000")
+
+	verify := func(points []models.Point) {
+		tx2, _ := e.Begin(false)
+		defer tx2.Rollback()
+		c := tx2.Cursor("cpu,host=A", fields, nil, true)
+		k, v := c.SeekTo(0)
+
+		for _, p := range points {
+			if k != p.UnixNano() {
+				t.Fatalf("time wrong:\n\texp:%d\n\tgot:%d\n", p.UnixNano(), k)
+			}
+
+			pv := v.(map[string]interface{})
+			for _, key := range fields {
+				if pv[key] != p.Fields()[key] {
+					t.Fatalf("data wrong:\n\texp:%v\n\tgot:%v", p.Fields()[key], pv[key])
+				}
+			}
+			k, v = c.Next()
+		}
+	}
+
+	// Write each point individually to force file rotation
+	for _, p := range []models.Point{p1, p2} {
+		if err := e.WritePoints([]models.Point{p}, nil, nil); err != nil {
+			t.Fatalf("failed to write points: %s", err.Error())
+		}
+	}
+
+	verify([]models.Point{p1, p2})
+
+	// Force a full compaction
+	e.CompactionAge = time.Duration(0)
+	if err := e.Compact(true); err != nil {
+		t.Fatalf("failed to run full compaction: %v", err)
+	}
+
+	// Write a point before the earliest data file
+	if err := e.WritePoints([]models.Point{p3, p4}, nil, nil); err != nil {
+		t.Fatalf("failed to write points: %s", err.Error())
+	}
+
+	// Verify points returned in the correct order before compaction
+	verify([]models.Point{p1, p2, p3, p4})
+
+	if err := e.Compact(true); err != nil {
+		t.Fatalf("failed to run full compaction: %v", err)
+	}
+	// Verify points returned in the correct order after compaction
+	verify([]models.Point{p1, p2, p3, p4})
+}
+
 func TestEngine_CursorCombinesWALAndIndex(t *testing.T) {
 	e := OpenDefaultEngine()
 	defer e.Close()


### PR DESCRIPTION
Adds some additional test coverage and a fix for a data race in `filesAndLock`.  `e.files` is modified in `Compact` and read w/o a lock in `filesAndLock`.
```
WARNING: DATA RACE
Write by goroutine 10:
  github.com/influxdb/influxdb/tsdb/engine/tsm1.(*Engine).Compact()
      /Users/jason/go/src/github.com/influxdb/influxdb/tsdb/engine/tsm1/tsm1.go:716 +0x1a3e
  github.com/influxdb/influxdb/tsdb/engine/tsm1_test.TestEngine_WriteCompaction_Concurrent.func2()
      /Users/jason/go/src/github.com/influxdb/influxdb/tsdb/engine/tsm1/tsm1_test.go:422 +0xc8

Previous read by goroutine 9:
  github.com/influxdb/influxdb/tsdb/engine/tsm1.(*Engine).filesAndLock()
      /Users/jason/go/src/github.com/influxdb/influxdb/tsdb/engine/tsm1/tsm1.go:476 +0xe8
  github.com/influxdb/influxdb/tsdb/engine/tsm1.(*Engine).Write()
      /Users/jason/go/src/github.com/influxdb/influxdb/tsdb/engine/tsm1/tsm1.go:370 +0x216
  github.com/influxdb/influxdb/tsdb/engine/tsm1.(*Log).flush()
      /Users/jason/go/src/github.com/influxdb/influxdb/tsdb/engine/tsm1/wal.go:604 +0xef4
  github.com/influxdb/influxdb/tsdb/engine/tsm1.(*Log).WritePoints()
      /Users/jason/go/src/github.com/influxdb/influxdb/tsdb/engine/tsm1/wal.go:243 +0x794
  github.com/influxdb/influxdb/tsdb/engine/tsm1.(*Engine).WritePoints()
      /Users/jason/go/src/github.com/influxdb/influxdb/tsdb/engine/tsm1/tsm1.go:350 +0xb0
  github.com/influxdb/influxdb/tsdb/engine/tsm1_test.TestEngine_WriteCompaction_Concurrent.func1()
      /Users/jason/go/src/github.com/influxdb/influxdb/tsdb/engine/tsm1/tsm1_test.go:401 +0x432

Goroutine 10 (running) created at:
  github.com/influxdb/influxdb/tsdb/engine/tsm1_test.TestEngine_WriteCompaction_Concurrent()
      /Users/jason/go/src/github.com/influxdb/influxdb/tsdb/engine/tsm1/tsm1_test.go:426 +0x225
  testing.tRunner()
      /private/var/folders/q8/bf_4b1ts2zj0l7b0p1dv36lr0000gp/T/workdir/go/src/testing/testing.go:456 +0xdc

Goroutine 9 (running) created at:
  github.com/influxdb/influxdb/tsdb/engine/tsm1_test.TestEngine_WriteCompaction_Concurrent()
      /Users/jason/go/src/github.com/influxdb/influxdb/tsdb/engine/tsm1/tsm1_test.go:406 +0x182
  testing.tRunner()
      /private/var/folders/q8/bf_4b1ts2zj0l7b0p1dv36lr0000gp/T/workdir/go/src/testing/testing.go:456 +0xdc
```
@pauldix 