### PR TITLE
Fix WAL Write/Close concurrency issues

### DIFF
--- a/tsdb/engine/tsm1/wal.go
+++ b/tsdb/engine/tsm1/wal.go
@@ -140,7 +140,6 @@ func (l *Log) Path() string { return l.path }
 
 // Open opens and initializes the Log. Will recover from previous unclosed shutdowns
 func (l *Log) Open() error {
-
 	if l.LoggingEnabled {
 		l.logger.Printf("tsm1 WAL starting with %d flush memory size threshold and %d max memory size threshold\n", l.FlushMemorySizeThreshold, l.MaxMemorySizeThreshold)
 		l.logger.Printf("tsm1 WAL writing to %s\n", l.path)
@@ -152,12 +151,13 @@ func (l *Log) Open() error {
 	l.cache = make(map[string]Values)
 	l.cacheDirtySort = make(map[string]bool)
 	l.measurementFieldsCache = make(map[string]*tsdb.MeasurementFields)
+	l.closing = make(chan struct{})
 
 	// flush out any WAL entries that are there from before
 	if err := l.readAndFlushWAL(); err != nil {
 		return err
 	}
-	l.closing = make(chan struct{})
+
 	return nil
 }
 

--- a/tsdb/engine/tsm1/wal.go
+++ b/tsdb/engine/tsm1/wal.go
@@ -517,10 +517,10 @@ func (l *Log) deleteKeysFromCache(keys []string) {
 
 // Close will finish any flush that is currently in process and close file handles
 func (l *Log) Close() error {
-	l.writeLock.Lock()
 	l.cacheLock.Lock()
-	defer l.writeLock.Unlock()
+	l.writeLock.Lock()
 	defer l.cacheLock.Unlock()
+	defer l.writeLock.Unlock()
 
 	// If cache is nil, then we're not open.  This avoids a double-close in tests.
 	if l.cache != nil {


### PR DESCRIPTION
This adds a test for the WAL that closes the WAL while writes are in-flight.  This triggers a number of different issues:

1. Panic in `addToCache` due to `Close` setting the `cache` to nil and `WritePoints` not exiting the call.
2. Panic in `writeToLog` due to `Close` invalidating file segment state.
3. Deadlock in `Close`, `addToCache` and `flush` due to `Close` and `flush` acquiring locks in different order.