### PR TITLE
Drop raft node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - [#4375](https://github.com/influxdb/influxdb/pull/4375): Add Subscriptions so data can be 'forked' out of InfluxDB to another third party.
 - [#4506](https://github.com/influxdb/influxdb/pull/4506): Register with Enterprise service and upload stats, if token is available.
 - [#4501](https://github.com/influxdb/influxdb/pull/4501): Allow filtering SHOW MEASUREMENTS by regex.
+- [#4547](https://github.com/influxdb/influxdb/pull/4547): Drop raft node.
 
 ### Bugfixes
 - [#4389](https://github.com/influxdb/influxdb/pull/4389): Don't add a new segment file on each hinted-handoff purge cycle.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 - [#4375](https://github.com/influxdb/influxdb/pull/4375): Add Subscriptions so data can be 'forked' out of InfluxDB to another third party.
 - [#4506](https://github.com/influxdb/influxdb/pull/4506): Register with Enterprise service and upload stats, if token is available.
 - [#4501](https://github.com/influxdb/influxdb/pull/4501): Allow filtering SHOW MEASUREMENTS by regex.
-- [#4547](https://github.com/influxdb/influxdb/pull/4547): Drop raft node.
+- [#4547](https://github.com/influxdb/influxdb/pull/4547): Allow any node to be dropped, even a raft node (even the leader).
 
 ### Bugfixes
 - [#4389](https://github.com/influxdb/influxdb/pull/4389): Don't add a new segment file on each hinted-handoff purge cycle.

--- a/cmd/influxd/run/server_helpers_test.go
+++ b/cmd/influxd/run/server_helpers_test.go
@@ -367,6 +367,7 @@ func configureLogging(s *Server) {
 		s.HintedHandoff.SetLogger(nullLogger)
 		s.Monitor.SetLogger(nullLogger)
 		s.QueryExecutor.SetLogger(nullLogger)
+		s.Subscriber.SetLogger(nullLogger)
 		for _, service := range s.Services {
 			if service, ok := service.(logSetter); ok {
 				service.SetLogger(nullLogger)

--- a/cmd/influxd/run/server_helpers_test.go
+++ b/cmd/influxd/run/server_helpers_test.go
@@ -90,10 +90,10 @@ func OpenDefaultServer(c *run.Config, joinURLs string) *Server {
 
 // Close shuts down the server and removes all temporary paths.
 func (s *Server) Close() {
+	s.Server.Close()
 	os.RemoveAll(s.Config.Meta.Dir)
 	os.RemoveAll(s.Config.Data.Dir)
 	os.RemoveAll(s.Config.HintedHandoff.Dir)
-	s.Server.Close()
 }
 
 // URL returns the base URL for the httpd endpoint.

--- a/meta/errors.go
+++ b/meta/errors.go
@@ -33,9 +33,6 @@ var (
 	// ErrNodeUnableToDropSingleNode is returned if the node being dropped is the last
 	// node in the cluster
 	ErrNodeUnableToDropFinalNode = newError("unable to drop the final node in a cluster")
-
-	// ErrNodeRaft is returned when attempting an operation prohibted for a Raft-node.
-	ErrNodeRaft = newError("node is a Raft node")
 )
 
 var (

--- a/meta/internal/meta.pb.go
+++ b/meta/internal/meta.pb.go
@@ -42,6 +42,7 @@ It has these top-level messages:
 	UpdateNodeCommand
 	CreateSubscriptionCommand
 	DropSubscriptionCommand
+	RemovePeerCommand
 	Response
 	ResponseHeader
 	ErrorResponse
@@ -119,6 +120,7 @@ const (
 	Command_UpdateNodeCommand                Command_Type = 19
 	Command_CreateSubscriptionCommand        Command_Type = 21
 	Command_DropSubscriptionCommand          Command_Type = 22
+	Command_RemovePeerCommand                Command_Type = 23
 )
 
 var Command_Type_name = map[int32]string{
@@ -143,6 +145,7 @@ var Command_Type_name = map[int32]string{
 	19: "UpdateNodeCommand",
 	21: "CreateSubscriptionCommand",
 	22: "DropSubscriptionCommand",
+	23: "RemovePeerCommand",
 }
 var Command_Type_value = map[string]int32{
 	"CreateNodeCommand":                1,
@@ -166,6 +169,7 @@ var Command_Type_value = map[string]int32{
 	"UpdateNodeCommand":                19,
 	"CreateSubscriptionCommand":        21,
 	"DropSubscriptionCommand":          22,
+	"RemovePeerCommand":                23,
 }
 
 func (x Command_Type) Enum() *Command_Type {
@@ -1368,6 +1372,38 @@ var E_DropSubscriptionCommand_Command = &proto.ExtensionDesc{
 	Tag:           "bytes,122,opt,name=command",
 }
 
+type RemovePeerCommand struct {
+	ID               *uint64 `protobuf:"varint,1,req,name=ID" json:"ID,omitempty"`
+	Addr             *string `protobuf:"bytes,2,req,name=Addr" json:"Addr,omitempty"`
+	XXX_unrecognized []byte  `json:"-"`
+}
+
+func (m *RemovePeerCommand) Reset()         { *m = RemovePeerCommand{} }
+func (m *RemovePeerCommand) String() string { return proto.CompactTextString(m) }
+func (*RemovePeerCommand) ProtoMessage()    {}
+
+func (m *RemovePeerCommand) GetID() uint64 {
+	if m != nil && m.ID != nil {
+		return *m.ID
+	}
+	return 0
+}
+
+func (m *RemovePeerCommand) GetAddr() string {
+	if m != nil && m.Addr != nil {
+		return *m.Addr
+	}
+	return ""
+}
+
+var E_RemovePeerCommand_Command = &proto.ExtensionDesc{
+	ExtendedType:  (*Command)(nil),
+	ExtensionType: (*RemovePeerCommand)(nil),
+	Field:         123,
+	Name:          "internal.RemovePeerCommand.command",
+	Tag:           "bytes,123,opt,name=command",
+}
+
 type Response struct {
 	OK               *bool   `protobuf:"varint,1,req" json:"OK,omitempty"`
 	Error            *string `protobuf:"bytes,2,opt" json:"Error,omitempty"`
@@ -1598,4 +1634,5 @@ func init() {
 	proto.RegisterExtension(E_UpdateNodeCommand_Command)
 	proto.RegisterExtension(E_CreateSubscriptionCommand_Command)
 	proto.RegisterExtension(E_DropSubscriptionCommand_Command)
+	proto.RegisterExtension(E_RemovePeerCommand_Command)
 }

--- a/meta/internal/meta.proto
+++ b/meta/internal/meta.proto
@@ -114,6 +114,7 @@ message Command {
 		UpdateNodeCommand                = 19;
 		CreateSubscriptionCommand        = 21;
 		DropSubscriptionCommand          = 22;
+		RemovePeerCommand                = 23;
     }
 
     required Type type = 1;
@@ -294,6 +295,14 @@ message DropSubscriptionCommand {
     required string Name = 1;
     required string Database = 2;
     required string RetentionPolicy = 3;
+}
+
+message RemovePeerCommand {
+    extend Command {
+        optional RemovePeerCommand command = 123;
+    }
+	required uint64 ID = 1;
+	required string Addr = 2;
 }
 
 message Response {

--- a/meta/rpc.go
+++ b/meta/rpc.go
@@ -51,7 +51,7 @@ type Reply interface {
 // proxyLeader proxies the connection to the current raft leader
 func (r *rpc) proxyLeader(conn *net.TCPConn) {
 	if r.store.Leader() == "" {
-		r.sendError(conn, "no leader")
+		r.sendError(conn, "no leader detected during proxyLeader")
 		return
 	}
 
@@ -289,7 +289,7 @@ func (r *rpc) fetchMetaData(blocking bool) (*Data, error) {
 	// Retrieve the current known leader.
 	leader := r.store.Leader()
 	if leader == "" {
-		return nil, errors.New("no leader")
+		return nil, errors.New("no leader detected during fetchMetaData")
 	}
 
 	var index, term uint64

--- a/meta/state.go
+++ b/meta/state.go
@@ -347,12 +347,7 @@ func (r *localRaft) leader() string {
 		return ""
 	}
 
-	l := r.raft.Leader()
-	if l == "" {
-		log.Println("localRaft was unable to determine a leader???")
-	}
-
-	return l
+	return r.raft.Leader()
 }
 
 func (r *localRaft) isLeader() bool {

--- a/meta/state.go
+++ b/meta/state.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -342,10 +343,16 @@ func (r *localRaft) peers() ([]string, error) {
 
 func (r *localRaft) leader() string {
 	if r.raft == nil {
+		log.Println("localRaft has no underlying raft")
 		return ""
 	}
 
-	return r.raft.Leader()
+	l := r.raft.Leader()
+	if l == "" {
+		log.Println("localRaft was unable to determine a leader???")
+	}
+
+	return l
 }
 
 func (r *localRaft) isLeader() bool {
@@ -463,6 +470,7 @@ func (r *remoteRaft) initialize() error {
 
 func (r *remoteRaft) leader() string {
 	if len(r.store.peers) == 0 {
+		log.Println("remoteRaft store has zero peers")
 		return ""
 	}
 

--- a/meta/state.go
+++ b/meta/state.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -343,7 +342,6 @@ func (r *localRaft) peers() ([]string, error) {
 
 func (r *localRaft) leader() string {
 	if r.raft == nil {
-		log.Println("localRaft has no underlying raft")
 		return ""
 	}
 
@@ -465,7 +463,6 @@ func (r *remoteRaft) initialize() error {
 
 func (r *remoteRaft) leader() string {
 	if len(r.store.peers) == 0 {
-		log.Println("remoteRaft store has zero peers")
 		return ""
 	}
 

--- a/meta/state.go
+++ b/meta/state.go
@@ -92,7 +92,7 @@ func (r *localRaft) invalidate() error {
 
 	ms, err := r.store.rpc.fetchMetaData(false)
 	if err != nil {
-		return err
+		return fmt.Errorf("error fetching meta data: %s", err)
 	}
 
 	r.updateMetaData(ms)
@@ -390,7 +390,7 @@ func (r *remoteRaft) updateMetaData(ms *Data) {
 func (r *remoteRaft) invalidate() error {
 	ms, err := r.store.rpc.fetchMetaData(false)
 	if err != nil {
-		return err
+		return fmt.Errorf("error fetching meta data: %s", err)
 	}
 
 	r.updateMetaData(ms)

--- a/meta/state.go
+++ b/meta/state.go
@@ -28,6 +28,7 @@ type raftState interface {
 	sync(index uint64, timeout time.Duration) error
 	setPeers(addrs []string) error
 	addPeer(addr string) error
+	removePeer(addr string) error
 	peers() ([]string, error)
 	invalidate() error
 	close() error
@@ -318,6 +319,18 @@ func (r *localRaft) addPeer(addr string) error {
 	return nil
 }
 
+// removePeer removes addr from the list of peers in the cluster.
+func (r *localRaft) removePeer(addr string) error {
+	// Only do this on the leader
+	if r.isLeader() {
+		if fut := r.raft.RemovePeer(addr); fut.Error() != nil {
+			return fut.Error()
+		}
+	}
+
+	return nil
+}
+
 // setPeers sets a list of peers in the cluster.
 func (r *localRaft) setPeers(addrs []string) error {
 	return r.raft.SetPeers(addrs).Error()
@@ -399,6 +412,11 @@ func (r *remoteRaft) setPeers(addrs []string) error {
 // addPeer adds addr to the list of peers in the cluster.
 func (r *remoteRaft) addPeer(addr string) error {
 	return fmt.Errorf("cannot add peer using remote raft")
+}
+
+// removePeer does nothing for remoteRaft.
+func (r *remoteRaft) removePeer(addr string) error {
+	return nil
 }
 
 func (r *remoteRaft) peers() ([]string, error) {

--- a/meta/state.go
+++ b/meta/state.go
@@ -322,12 +322,12 @@ func (r *localRaft) addPeer(addr string) error {
 // removePeer removes addr from the list of peers in the cluster.
 func (r *localRaft) removePeer(addr string) error {
 	// Only do this on the leader
-	if r.isLeader() {
-		if fut := r.raft.RemovePeer(addr); fut.Error() != nil {
-			return fut.Error()
-		}
+	if !r.isLeader() {
+		return errors.New("not the leader")
 	}
-
+	if fut := r.raft.RemovePeer(addr); fut.Error() != nil {
+		return fut.Error()
+	}
 	return nil
 }
 

--- a/meta/statement_executor.go
+++ b/meta/statement_executor.go
@@ -174,15 +174,6 @@ func (e *StatementExecutor) executeDropServerStatement(q *influxql.DropServerSta
 		return &influxql.Result{Err: ErrNodeNotFound}
 	}
 
-	// Dropping only non-Raft nodes supported.
-	peers, err := e.Store.Peers()
-	if err != nil {
-		return &influxql.Result{Err: err}
-	}
-	if contains(peers, ni.Host) {
-		return &influxql.Result{Err: ErrNodeRaft}
-	}
-
 	err = e.Store.DeleteNode(q.NodeID, q.Force)
 	return &influxql.Result{Err: err}
 }

--- a/meta/statement_executor_test.go
+++ b/meta/statement_executor_test.go
@@ -166,8 +166,12 @@ func TestStatementExecutor_ExecuteStatement_DropServer(t *testing.T) {
 		}, nil
 	}
 
-	// Ensure Raft nodes cannot be dropped.
-	if res := e.ExecuteStatement(influxql.MustParseStatement(`DROP SERVER 1`)); res.Err != meta.ErrNodeRaft {
+	e.Store.DeleteNodeFn = func(id uint64, force bool) error {
+		return nil
+	}
+
+	// Ensure Raft nodes can be dropped.
+	if res := e.ExecuteStatement(influxql.MustParseStatement(`DROP SERVER 1`)); res.Err != nil {
 		t.Fatalf("unexpected error: %s", res.Err)
 	}
 

--- a/meta/store.go
+++ b/meta/store.go
@@ -580,7 +580,9 @@ func (s *Store) createLocalNode() error {
 	}
 
 	// Set ID locally.
+	s.mu.Lock()
 	s.id = ni.ID
+	s.mu.Unlock()
 
 	s.Logger.Printf("Created local node: id=%d, host=%s", s.id, s.RemoteAddr)
 

--- a/meta/store_test.go
+++ b/meta/store_test.go
@@ -1057,7 +1057,9 @@ func NewStore(c *meta.Config) *Store {
 	s := &Store{
 		Store: meta.NewStore(c),
 	}
-	s.Logger = log.New(&s.Stderr, "", log.LstdFlags)
+	if !testing.Verbose() {
+		s.Logger = log.New(&s.Stderr, "", log.LstdFlags)
+	}
 	s.SetHashPasswordFn(mockHashPassword)
 	return s
 }
@@ -1073,8 +1075,6 @@ func MustOpenStoreWithPath(addr, path string) *Store {
 	s := NewStore(c)
 	if addr != "" {
 		s.BindAddress = addr
-	} else {
-		addr = "127.0.0.1:0"
 	}
 	if err := s.Open(); err != nil {
 		panic(err)

--- a/meta/store_test.go
+++ b/meta/store_test.go
@@ -11,6 +11,7 @@ import (
 	"reflect"
 	"sort"
 	"strconv"
+	"sync"
 	"testing"
 	"time"
 
@@ -1041,6 +1042,17 @@ func TestCluster_Restart(t *testing.T) {
 
 	// ensure all the nodes see the same metastore data
 	assertDatabaseReplicated(t, c)
+	var wg sync.WaitGroup
+	wg.Add(len(c.Stores))
+	for _, s := range c.Stores {
+		go func(s *Store) {
+			defer wg.Done()
+			if err := s.Close(); err != nil {
+				t.Fatalf("error closing store %s", err)
+			}
+		}(s)
+	}
+	wg.Wait()
 }
 
 // Store is a test wrapper for meta.Store.
@@ -1221,9 +1233,16 @@ func (c *Cluster) Open() error {
 
 // Close shuts down all stores.
 func (c *Cluster) Close() error {
+	var wg sync.WaitGroup
+	wg.Add(len(c.Stores))
+
 	for _, s := range c.Stores {
-		s.Close()
+		go func(s *Store) {
+			defer wg.Done()
+			s.Close()
+		}(s)
 	}
+	wg.Wait()
 	return nil
 }
 

--- a/meta/store_test.go
+++ b/meta/store_test.go
@@ -1073,6 +1073,8 @@ func MustOpenStoreWithPath(addr, path string) *Store {
 	s := NewStore(c)
 	if addr != "" {
 		s.BindAddress = addr
+	} else {
+		addr = "127.0.0.1:0"
 	}
 	if err := s.Open(); err != nil {
 		panic(err)

--- a/services/subscriber/service.go
+++ b/services/subscriber/service.go
@@ -92,6 +92,11 @@ func (s *Service) Close() error {
 	return nil
 }
 
+// SetLogger sets the internal logger to the logger passed in.
+func (s *Service) SetLogger(l *log.Logger) {
+	s.Logger = l
+}
+
 func (s *Service) waitForMetaUpdates() {
 	for {
 		err := s.MetaStore.WaitForDataChanged()


### PR DESCRIPTION
Currently, if you drop a raft node (even the leader), to bring another raft node to the cluster, you must launch a NEW node.  Shutting down an existing node and bringing it back up does not make it a raft by default.  This will be fixed in a future PR.