### PR TITLE
Reuse tsm1 decode buffer

### DIFF
--- a/cmd/influx_inspect/tsm.go
+++ b/cmd/influx_inspect/tsm.go
@@ -353,7 +353,8 @@ func cmdDumpTsm1(opts *tsdmDumpOpts) {
 
 		encoded := buf[9:]
 
-		v, err := tsm1.DecodeBlock(buf)
+		var v []tsm1.Value
+		err := tsm1.DecodeBlock(buf, &v)
 		if err != nil {
 			fmt.Printf("error: %v\n", err.Error())
 			os.Exit(1)

--- a/tsdb/config.go
+++ b/tsdb/config.go
@@ -8,7 +8,7 @@ import (
 
 const (
 	// DefaultEngine is the default engine for new shards
-	DefaultEngine = "bz1"
+	DefaultEngine = "tsm1"
 
 	// DefaultMaxWALSize is the default size of the WAL before it is flushed.
 	DefaultMaxWALSize = 100 * 1024 * 1024 // 100MB

--- a/tsdb/engine/tsm1/cursor.go
+++ b/tsdb/engine/tsm1/cursor.go
@@ -189,7 +189,7 @@ type cursor struct {
 	pos uint32
 
 	// vals is the current decoded block of Values we're iterating from
-	vals Values
+	vals []Value
 
 	ascending bool
 
@@ -207,6 +207,7 @@ func newCursor(id uint64, files []*dataFile, ascending bool) *cursor {
 		id:        id,
 		ascending: ascending,
 		files:     files,
+		vals:      make([]Value, 0),
 	}
 }
 
@@ -472,7 +473,8 @@ func (c *cursor) blockLength(pos uint32) uint32 {
 func (c *cursor) decodeBlock(position uint32) {
 	length := c.blockLength(position)
 	block := c.f.mmap[position+blockHeaderSize : position+blockHeaderSize+length]
-	c.vals, _ = DecodeBlock(block)
+	c.vals = c.vals[:0]
+	_ = DecodeBlock(block, &c.vals)
 
 	// only adavance the position if we're asceending.
 	// Descending queries use the blockPositions

--- a/tsdb/engine/tsm1/encoding_test.go
+++ b/tsdb/engine/tsm1/encoding_test.go
@@ -1,52 +1,51 @@
 package tsm1_test
 
 import (
-	// "math/rand"
-
 	"fmt"
 	"reflect"
 	"testing"
 	"time"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/influxdb/influxdb/tsdb/engine/tsm1"
 )
 
 func TestEncoding_FloatBlock(t *testing.T) {
 	valueCount := 1000
 	times := getTimes(valueCount, 60, time.Second)
-	values := make(tsm1.Values, len(times))
+	values := make([]tsm1.Value, len(times))
 	for i, t := range times {
 		values[i] = tsm1.NewValue(t, float64(i))
 	}
 
-	b, err := values.Encode(nil)
+	b, err := tsm1.Values(values).Encode(nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	decodedValues, err := tsm1.DecodeBlock(b)
-	if err != nil {
+	var decodedValues []tsm1.Value
+	if err := tsm1.DecodeBlock(b, &decodedValues); err != nil {
 		t.Fatalf("unexpected error decoding block: %v", err)
 	}
 
 	if !reflect.DeepEqual(decodedValues, values) {
-		t.Fatalf("unexpected results:\n\tgot: %v\n\texp: %v\n", decodedValues, values)
+		t.Fatalf("unexpected results:\n\tgot: %s\n\texp: %s\n", spew.Sdump(decodedValues), spew.Sdump(values))
 	}
 }
 
 func TestEncoding_FloatBlock_ZeroTime(t *testing.T) {
-	values := make(tsm1.Values, 3)
+	values := make([]tsm1.Value, 3)
 	for i := 0; i < 3; i++ {
 		values[i] = tsm1.NewValue(time.Unix(0, 0), float64(i))
 	}
 
-	b, err := values.Encode(nil)
+	b, err := tsm1.Values(values).Encode(nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	decodedValues, err := tsm1.DecodeBlock(b)
-	if err != nil {
+	var decodedValues []tsm1.Value
+	if err := tsm1.DecodeBlock(b, &decodedValues); err != nil {
 		t.Fatalf("unexpected error decoding block: %v", err)
 	}
 
@@ -56,20 +55,20 @@ func TestEncoding_FloatBlock_ZeroTime(t *testing.T) {
 }
 
 func TestEncoding_FloatBlock_SimilarFloats(t *testing.T) {
-	values := make(tsm1.Values, 5)
+	values := make([]tsm1.Value, 5)
 	values[0] = tsm1.NewValue(time.Unix(0, 1444238178437870000), 6.00065e+06)
 	values[1] = tsm1.NewValue(time.Unix(0, 1444238185286830000), 6.000656e+06)
 	values[2] = tsm1.NewValue(time.Unix(0, 1444238188441501000), 6.000657e+06)
 	values[3] = tsm1.NewValue(time.Unix(0, 1444238195286811000), 6.000659e+06)
 	values[4] = tsm1.NewValue(time.Unix(0, 1444238198439917000), 6.000661e+06)
 
-	b, err := values.Encode(nil)
+	b, err := tsm1.Values(values).Encode(nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	decodedValues, err := tsm1.DecodeBlock(b)
-	if err != nil {
+	var decodedValues []tsm1.Value
+	if err := tsm1.DecodeBlock(b, &decodedValues); err != nil {
 		t.Fatalf("unexpected error decoding block: %v", err)
 	}
 
@@ -81,18 +80,18 @@ func TestEncoding_FloatBlock_SimilarFloats(t *testing.T) {
 func TestEncoding_IntBlock_Basic(t *testing.T) {
 	valueCount := 1000
 	times := getTimes(valueCount, 60, time.Second)
-	values := make(tsm1.Values, len(times))
+	values := make([]tsm1.Value, len(times))
 	for i, t := range times {
 		values[i] = tsm1.NewValue(t, int64(i))
 	}
 
-	b, err := values.Encode(nil)
+	b, err := tsm1.Values(values).Encode(nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	decodedValues, err := tsm1.DecodeBlock(b)
-	if err != nil {
+	var decodedValues []tsm1.Value
+	if err := tsm1.DecodeBlock(b, &decodedValues); err != nil {
 		t.Fatalf("unexpected error decoding block: %v", err)
 	}
 
@@ -115,7 +114,7 @@ func TestEncoding_IntBlock_Basic(t *testing.T) {
 func TestEncoding_IntBlock_Negatives(t *testing.T) {
 	valueCount := 1000
 	times := getTimes(valueCount, 60, time.Second)
-	values := make(tsm1.Values, len(times))
+	values := make([]tsm1.Value, len(times))
 	for i, t := range times {
 		v := int64(i)
 		if i%2 == 0 {
@@ -124,13 +123,13 @@ func TestEncoding_IntBlock_Negatives(t *testing.T) {
 		values[i] = tsm1.NewValue(t, int64(v))
 	}
 
-	b, err := values.Encode(nil)
+	b, err := tsm1.Values(values).Encode(nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	decodedValues, err := tsm1.DecodeBlock(b)
-	if err != nil {
+	var decodedValues []tsm1.Value
+	if err := tsm1.DecodeBlock(b, &decodedValues); err != nil {
 		t.Fatalf("unexpected error decoding block: %v", err)
 	}
 
@@ -142,7 +141,7 @@ func TestEncoding_IntBlock_Negatives(t *testing.T) {
 func TestEncoding_BoolBlock_Basic(t *testing.T) {
 	valueCount := 1000
 	times := getTimes(valueCount, 60, time.Second)
-	values := make(tsm1.Values, len(times))
+	values := make([]tsm1.Value, len(times))
 	for i, t := range times {
 		v := true
 		if i%2 == 0 {
@@ -151,13 +150,13 @@ func TestEncoding_BoolBlock_Basic(t *testing.T) {
 		values[i] = tsm1.NewValue(t, v)
 	}
 
-	b, err := values.Encode(nil)
+	b, err := tsm1.Values(values).Encode(nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	decodedValues, err := tsm1.DecodeBlock(b)
-	if err != nil {
+	var decodedValues []tsm1.Value
+	if err := tsm1.DecodeBlock(b, &decodedValues); err != nil {
 		t.Fatalf("unexpected error decoding block: %v", err)
 	}
 
@@ -169,18 +168,18 @@ func TestEncoding_BoolBlock_Basic(t *testing.T) {
 func TestEncoding_StringBlock_Basic(t *testing.T) {
 	valueCount := 1000
 	times := getTimes(valueCount, 60, time.Second)
-	values := make(tsm1.Values, len(times))
+	values := make([]tsm1.Value, len(times))
 	for i, t := range times {
 		values[i] = tsm1.NewValue(t, fmt.Sprintf("value %d", i))
 	}
 
-	b, err := values.Encode(nil)
+	b, err := tsm1.Values(values).Encode(nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	decodedValues, err := tsm1.DecodeBlock(b)
-	if err != nil {
+	var decodedValues []tsm1.Value
+	if err := tsm1.DecodeBlock(b, &decodedValues); err != nil {
 		t.Fatalf("unexpected error decoding block: %v", err)
 	}
 


### PR DESCRIPTION
## Overview

This pull request changes `tsm1.DecodeBlock()` to reuse the same slice of `[]tsm1.Value` instead of reallocating a new one each time.

This improves query performance by ~25%. Another large performance win can be made if we can use type specific blocks (instead of `[]tsm1.Value`) but that will take a larger refactor.