### PR TITLE
Run 1 container of tests with tsm1

### DIFF
--- a/circle-test.sh
+++ b/circle-test.sh
@@ -75,6 +75,10 @@ case $CIRCLE_NODE_INDEX in
         rc=${PIPESTATUS[0]}
         ;;
     1)
+        INFLUXDB_DATA_ENGINE="tsm1" go test $PARALLELISM $TIMEOUT -v ./... 2>&1 | tee $CIRCLE_ARTIFACTS/test_logs.txt
+        rc=${PIPESTATUS[0]}
+        ;;
+    2)
         # 32bit tests.
         if [[ -e ~/docker/image.tar ]]; then docker load -i ~/docker/image.tar; fi
         docker build -f Dockerfile_test_ubuntu32 -t ubuntu-32-influxdb-test .
@@ -86,7 +90,7 @@ case $CIRCLE_NODE_INDEX in
                         -c "cd /root/go/src/github.com/influxdb/influxdb && go get -t -d -v ./... && go build -v ./... && go test ${PARALLELISM} ${TIMEOUT} -v ./... 2>&1 | tee /tmp/artifacts/test_logs_i386.txt && exit \${PIPESTATUS[0]}"
         rc=$?
         ;;
-    2)
+    3)
        GORACE="halt_on_error=1" go test $PARALLELISM $TIMEOUT -v -race ./... 2>&1 | tee $CIRCLE_ARTIFACTS/test_logs_race.txt
        rc=${PIPESTATUS[0]}
        ;;

--- a/tsdb/config.go
+++ b/tsdb/config.go
@@ -1,6 +1,8 @@
 package tsdb
 
 import (
+	"log"
+	"os"
 	"time"
 
 	"github.com/influxdb/influxdb/toml"
@@ -98,8 +100,14 @@ type Config struct {
 }
 
 func NewConfig() Config {
+	defaultEngine := DefaultEngine
+	if engine := os.Getenv("INFLUXDB_DATA_ENGINE"); engine != "" {
+		log.Println("TSDB engine selected via environment variable:", engine)
+		defaultEngine = engine
+	}
+
 	return Config{
-		Engine:                 DefaultEngine,
+		Engine:                 defaultEngine,
 		MaxWALSize:             DefaultMaxWALSize,
 		WALFlushInterval:       toml.Duration(DefaultWALFlushInterval),
 		WALPartitionFlushDelay: toml.Duration(DefaultWALPartitionFlushDelay),


### PR DESCRIPTION
Allow testing of tsm1 engine to proceed on Circle, with container count increased to 4.

https://github.com/influxdb/influxdb/issues/4558 tracks removing this change once `tsm1` ships.