### PR TITLE
Updated keyword list in INFLUXQL.md

### DIFF
--- a/influxql/INFLUXQL.md
+++ b/influxql/INFLUXQL.md
@@ -84,15 +84,17 @@ _cpu_stats
 ```
 ALL           ALTER         ANY           AS            ASC           BEGIN
 BY            CREATE        CONTINUOUS    DATABASE      DATABASES     DEFAULT
-DELETE        DESC          DESTINATIONS  DROP          DURATION      END
-EXISTS        EXPLAIN       FIELD         FROM          GRANT         GROUP
-IF            IN            INNER         INSERT        INTO          KEY
+DELETE        DESC          DESTINATIONS  DIAGNOSTICS   DISTINCT      DROP
+DURATION      END           EXISTS        EXPLAIN       FIELD         FOR
+FORCE         FROM          GRANT         GRANTS        GROUP         IF
+IN            INF           INNER         INSERT        INTO          KEY
 KEYS          LIMIT         SHOW          MEASUREMENT   MEASUREMENTS  NOT
 OFFSET        ON            ORDER         PASSWORD      POLICY        POLICIES
 PRIVILEGES    QUERIES       QUERY         READ          REPLICATION   RETENTION
-REVOKE        SELECT        SERIES        SLIMIT        SOFFSET       SUBSCRIPTION
-SUBSCRIPTIONS TAG           TO            USER          USERS         VALUES
-WHERE         WITH          WRITE
+REVOKE        SELECT        SERIES        SERVER        SERVERS       SET
+SHARDS        SLIMIT        SOFFSET       STATS         SUBSCRIPTION  SUBSCRIPTIONS
+TAG           TO            USER          USERS         VALUES        WHERE
+WITH          WRITE
 ```
 
 ## Literals


### PR DESCRIPTION
Noticed that https://github.com/influxdb/influxdb/blob/master/influxql/INFLUXQL.md#keywords doesn't seems updated, below 11 keywords are missing from the list:

DIAGNOSTICS
DISTINCT
FOR
FORCE
GRANTS
INF
SERVER
SERVERS
SET
SHARDS
STATS

Thanks for reviewing it =)