### PR TITLE
Fix dropping database under write load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@
 - [#4497](https://github.com/influxdb/influxdb/pull/4497): Fix sequence in meta proto
 - [#3367](https://github.com/influxdb/influxdb/issues/3367): Negative timestamps are parsed correctly by the line protocol.
 - [#4563](https://github.com/influxdb/influxdb/pull/4536): Fix broken subscriptions updates.
+- [#4538](https://github.com/influxdb/influxdb/issues/4538): Dropping database under a write load causes panics
 
 ## v0.9.4 [2015-09-14]
 

--- a/tsdb/engine/tsm1/tsm1.go
+++ b/tsdb/engine/tsm1/tsm1.go
@@ -204,7 +204,11 @@ func (e *Engine) PerformMaintenance() {
 		}
 	}
 
-	go e.Compact(true)
+	go func() {
+		if err := e.Compact(true); err != nil {
+			e.logger.Printf("PerformMaintenance: error during compaction: %v", err)
+		}
+	}()
 }
 
 // Format returns the format type of this engine
@@ -482,7 +486,11 @@ func (e *Engine) Write(pointsByKey map[string]Values, measurementFieldsToSave ma
 	}
 
 	if !e.SkipCompaction && e.shouldCompact() {
-		go e.Compact(false)
+		go func() {
+			if err := e.Compact(false); err != nil {
+				e.logger.Printf("Write: error during compaction: %v", err)
+			}
+		}()
 	}
 
 	return nil

--- a/tsdb/engine/tsm1/tsm1.go
+++ b/tsdb/engine/tsm1/tsm1.go
@@ -325,6 +325,8 @@ func (e *Engine) Close() error {
 	e.filesLock.Lock()
 	defer e.filesLock.Unlock()
 
+	e.WAL.Close()
+
 	// ensure all deletes have been processed
 	e.deletesPending.Wait()
 

--- a/tsdb/engine/tsm1/wal.go
+++ b/tsdb/engine/tsm1/wal.go
@@ -659,9 +659,9 @@ func (l *Log) flush(flush flushType) error {
 			return err
 		}
 		if id <= lastFileID {
-			err := os.Remove(fn)
+			err := os.RemoveAll(fn)
 			if err != nil {
-				return err
+				return fmt.Errorf("failed to remove: %v: %v", fn, err)
 			}
 		}
 	}

--- a/tsdb/engine/tsm1/wal.go
+++ b/tsdb/engine/tsm1/wal.go
@@ -431,8 +431,9 @@ func (l *Log) writeToLog(writeType walEntryType, data []byte) error {
 
 	if l.currentSegmentFile == nil || l.currentSegmentSize > DefaultSegmentSize {
 		if err := l.newSegmentFile(); err != nil {
-			// fail hard since we can't write data
-			panic(fmt.Sprintf("error opening new segment file for wal: %s", err.Error()))
+			// A drop database or RP call could trigger this error if writes were in-flight
+			// when the drop statement executes.
+			return fmt.Errorf("error opening new segment file for wal: %s", err.Error())
 		}
 	}
 

--- a/tsdb/engine/tsm1/wal.go
+++ b/tsdb/engine/tsm1/wal.go
@@ -578,7 +578,7 @@ func (l *Log) flush(flush flushType) error {
 			if err := l.currentSegmentFile.Close(); err != nil {
 				l.cacheLock.Unlock()
 				l.writeLock.Unlock()
-				return err
+				return fmt.Errorf("error closing current segment: %v", err)
 			}
 			l.currentSegmentFile = nil
 			l.currentSegmentSize = 0
@@ -587,7 +587,7 @@ func (l *Log) flush(flush flushType) error {
 		if err := l.newSegmentFile(); err != nil {
 			l.cacheLock.Unlock()
 			l.writeLock.Unlock()
-			return fmt.Errorf("error creating new wal file: %s", err.Error())
+			return fmt.Errorf("error creating new wal file: %v", err)
 		}
 	}
 	l.writeLock.Unlock()

--- a/tsdb/store.go
+++ b/tsdb/store.go
@@ -155,7 +155,9 @@ func (s *Store) DeleteDatabase(name string, shardIDs []uint64) error {
 		if shard != nil {
 			shard.Close()
 		}
+		delete(s.shards, id)
 	}
+
 	if err := os.RemoveAll(filepath.Join(s.path, name)); err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixes a number of issues that occur when dropping a database under write load.  

Initially, the changes were to prevent panics that occurred with trying to create a new WAL segment in a DB dir that had been removed.  When those were fixed, a full DB deadlock occurred due to WAL locks not being released when errors were returned.  When those were fixed, shards were getting re-created on writes because we deleted the DB state before updating the meta-store which cause the `PointsWriter` to fall into the case where it should create a shard that does not exist locally.   This also uncovered that shard references were not fully removed from the `tsdb.Store` when a database was dropped which cause spurious errors in the logs due to the long-running periodic maintenance task goroutines.   Finally, the WAL was not closed when a shard was closed which also led to spurious errors in the logs.

Fixes #4538