### PR TITLE
Prevent NaN float values from being stored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,9 @@
 - [#4563](https://github.com/influxdb/influxdb/pull/4536): Fix broken subscriptions updates.
 - [#4538](https://github.com/influxdb/influxdb/issues/4538): Dropping database under a write load causes panics
 - [#4582](https://github.com/influxdb/influxdb/pull/4582): Correct logging tags in cluster and TCP package. Thanks @oiooj
+- [#4513](https://github.com/influxdb/influxdb/issues/4513): TSM1: panic: runtime error: index out of range
+- [#4521](https://github.com/influxdb/influxdb/issues/4521): TSM1: panic: decode of short block: got 1, exp 9
+- [#4587](https://github.com/influxdb/influxdb/pull/4587): Prevent NaN float values from being stored
 
 ## v0.9.4 [2015-09-14]
 

--- a/client/influxdb.go
+++ b/client/influxdb.go
@@ -474,7 +474,10 @@ func (p *Point) MarshalJSON() ([]byte, error) {
 // MarshalString renders string representation of a Point with specified
 // precision. The default precision is nanoseconds.
 func (p *Point) MarshalString() string {
-	pt := models.NewPoint(p.Measurement, p.Tags, p.Fields, p.Time)
+	pt, err := models.NewPoint(p.Measurement, p.Tags, p.Fields, p.Time)
+	if err != nil {
+		return "# ERROR: " + err.Error() + " " + p.Measurement
+	}
 	if p.Precision == "" || p.Precision == "ns" || p.Precision == "n" {
 		return pt.String()
 	}

--- a/client/v2/client.go
+++ b/client/v2/client.go
@@ -198,14 +198,19 @@ func NewPoint(
 	tags map[string]string,
 	fields map[string]interface{},
 	t ...time.Time,
-) *Point {
+) (*Point, error) {
 	var T time.Time
 	if len(t) > 0 {
 		T = t[0]
 	}
-	return &Point{
-		pt: models.NewPoint(name, tags, fields, T),
+
+	pt, err := models.NewPoint(name, tags, fields, T)
+	if err != nil {
+		return nil, err
 	}
+	return &Point{
+		pt: pt,
+	}, nil
 }
 
 // String returns a line-protocol string of the Point

--- a/client/v2/client_test.go
+++ b/client/v2/client_test.go
@@ -157,7 +157,7 @@ func TestClient_PointString(t *testing.T) {
 	time1, _ := time.Parse(shortForm, "2013-Feb-03")
 	tags := map[string]string{"cpu": "cpu-total"}
 	fields := map[string]interface{}{"idle": 10.1, "system": 50.9, "user": 39.0}
-	p := NewPoint("cpu_usage", tags, fields, time1)
+	p, _ := NewPoint("cpu_usage", tags, fields, time1)
 
 	s := "cpu_usage,cpu=cpu-total idle=10.1,system=50.9,user=39 1359849600000000000"
 	if p.String() != s {
@@ -174,7 +174,7 @@ func TestClient_PointString(t *testing.T) {
 func TestClient_PointWithoutTimeString(t *testing.T) {
 	tags := map[string]string{"cpu": "cpu-total"}
 	fields := map[string]interface{}{"idle": 10.1, "system": 50.9, "user": 39.0}
-	p := NewPoint("cpu_usage", tags, fields)
+	p, _ := NewPoint("cpu_usage", tags, fields)
 
 	s := "cpu_usage,cpu=cpu-total idle=10.1,system=50.9,user=39"
 	if p.String() != s {
@@ -190,7 +190,7 @@ func TestClient_PointWithoutTimeString(t *testing.T) {
 func TestClient_PointName(t *testing.T) {
 	tags := map[string]string{"cpu": "cpu-total"}
 	fields := map[string]interface{}{"idle": 10.1, "system": 50.9, "user": 39.0}
-	p := NewPoint("cpu_usage", tags, fields)
+	p, _ := NewPoint("cpu_usage", tags, fields)
 
 	exp := "cpu_usage"
 	if p.Name() != exp {
@@ -202,7 +202,7 @@ func TestClient_PointName(t *testing.T) {
 func TestClient_PointTags(t *testing.T) {
 	tags := map[string]string{"cpu": "cpu-total"}
 	fields := map[string]interface{}{"idle": 10.1, "system": 50.9, "user": 39.0}
-	p := NewPoint("cpu_usage", tags, fields)
+	p, _ := NewPoint("cpu_usage", tags, fields)
 
 	if !reflect.DeepEqual(tags, p.Tags()) {
 		t.Errorf("Error, got %v, expected %v",
@@ -215,7 +215,7 @@ func TestClient_PointUnixNano(t *testing.T) {
 	time1, _ := time.Parse(shortForm, "2013-Feb-03")
 	tags := map[string]string{"cpu": "cpu-total"}
 	fields := map[string]interface{}{"idle": 10.1, "system": 50.9, "user": 39.0}
-	p := NewPoint("cpu_usage", tags, fields, time1)
+	p, _ := NewPoint("cpu_usage", tags, fields, time1)
 
 	exp := int64(1359849600000000000)
 	if p.UnixNano() != exp {
@@ -227,7 +227,7 @@ func TestClient_PointUnixNano(t *testing.T) {
 func TestClient_PointFields(t *testing.T) {
 	tags := map[string]string{"cpu": "cpu-total"}
 	fields := map[string]interface{}{"idle": 10.1, "system": 50.9, "user": 39.0}
-	p := NewPoint("cpu_usage", tags, fields)
+	p, _ := NewPoint("cpu_usage", tags, fields)
 
 	if !reflect.DeepEqual(fields, p.Fields()) {
 		t.Errorf("Error, got %v, expected %v",

--- a/client/v2/example/example.go
+++ b/client/v2/example/example.go
@@ -44,7 +44,10 @@ func ExampleWrite() {
 		"system": 53.3,
 		"user":   46.6,
 	}
-	pt := client.NewPoint("cpu_usage", tags, fields, time.Now())
+	pt, err := client.NewPoint("cpu_usage", tags, fields, time.Now())
+	if err != nil {
+		panic(err.Error())
+	}
 	bp.AddPoint(pt)
 
 	// Write the batch
@@ -82,12 +85,17 @@ func ExampleWrite1000() {
 			"busy": 100.0 - idle,
 		}
 
-		bp.AddPoint(client.NewPoint(
+		pt, err := client.NewPoint(
 			"cpu_usage",
 			tags,
 			fields,
 			time.Now(),
-		))
+		)
+		if err != nil {
+			println("Error:", err.Error())
+			continue
+		}
+		bp.AddPoint(pt)
 	}
 
 	err := clnt.Write(bp)

--- a/cluster/rpc.go
+++ b/cluster/rpc.go
@@ -113,9 +113,13 @@ type WritePointsRequest struct {
 
 // AddPoint adds a point to the WritePointRequest with field key 'value'
 func (w *WritePointsRequest) AddPoint(name string, value interface{}, timestamp time.Time, tags map[string]string) {
-	w.Points = append(w.Points, models.NewPoint(
+	pt, err := models.NewPoint(
 		name, tags, map[string]interface{}{"value": value}, timestamp,
-	))
+	)
+	if err != nil {
+		return
+	}
+	w.Points = append(w.Points, pt)
 }
 
 // WriteShardRequest represents the a request to write a slice of points to a shard
@@ -139,9 +143,13 @@ func (w *WriteShardRequest) Points() []models.Point { return w.unmarshalPoints()
 
 // AddPoint adds a new time series point
 func (w *WriteShardRequest) AddPoint(name string, value interface{}, timestamp time.Time, tags map[string]string) {
-	w.AddPoints([]models.Point{models.NewPoint(
+	pt, err := models.NewPoint(
 		name, tags, map[string]interface{}{"value": value}, timestamp,
-	)})
+	)
+	if err != nil {
+		return
+	}
+	w.AddPoints([]models.Point{pt})
 }
 
 // AddPoints adds a new time series point

--- a/cluster/shard_writer_test.go
+++ b/cluster/shard_writer_test.go
@@ -28,7 +28,7 @@ func TestShardWriter_WriteShard_Success(t *testing.T) {
 	// Build a single point.
 	now := time.Now()
 	var points []models.Point
-	points = append(points, models.NewPoint("cpu", models.Tags{"host": "server01"}, map[string]interface{}{"value": int64(100)}, now))
+	points = append(points, models.MustNewPoint("cpu", models.Tags{"host": "server01"}, map[string]interface{}{"value": int64(100)}, now))
 
 	// Write to shard and close.
 	if err := w.WriteShard(1, 2, points); err != nil {
@@ -75,7 +75,7 @@ func TestShardWriter_WriteShard_Multiple(t *testing.T) {
 	// Build a single point.
 	now := time.Now()
 	var points []models.Point
-	points = append(points, models.NewPoint("cpu", models.Tags{"host": "server01"}, map[string]interface{}{"value": int64(100)}, now))
+	points = append(points, models.MustNewPoint("cpu", models.Tags{"host": "server01"}, map[string]interface{}{"value": int64(100)}, now))
 
 	// Write to shard twice and close.
 	if err := w.WriteShard(1, 2, points); err != nil {
@@ -125,7 +125,7 @@ func TestShardWriter_WriteShard_Error(t *testing.T) {
 	shardID := uint64(1)
 	ownerID := uint64(2)
 	var points []models.Point
-	points = append(points, models.NewPoint(
+	points = append(points, models.MustNewPoint(
 		"cpu", models.Tags{"host": "server01"}, map[string]interface{}{"value": int64(100)}, now,
 	))
 
@@ -153,7 +153,7 @@ func TestShardWriter_Write_ErrDialTimeout(t *testing.T) {
 	shardID := uint64(1)
 	ownerID := uint64(2)
 	var points []models.Point
-	points = append(points, models.NewPoint(
+	points = append(points, models.MustNewPoint(
 		"cpu", models.Tags{"host": "server01"}, map[string]interface{}{"value": int64(100)}, now,
 	))
 
@@ -176,7 +176,7 @@ func TestShardWriter_Write_ErrReadTimeout(t *testing.T) {
 	shardID := uint64(1)
 	ownerID := uint64(2)
 	var points []models.Point
-	points = append(points, models.NewPoint(
+	points = append(points, models.MustNewPoint(
 		"cpu", models.Tags{"host": "server01"}, map[string]interface{}{"value": int64(100)}, now,
 	))
 

--- a/cmd/influxd/run/server_test.go
+++ b/cmd/influxd/run/server_test.go
@@ -769,6 +769,39 @@ func TestServer_Write_LineProtocol_Integer(t *testing.T) {
 	}
 }
 
+// Ensure the server returns a partial write response when some points fail to parse. Also validate that
+// the successfully parsed points can be queried.
+func TestServer_Write_LineProtocol_Partial(t *testing.T) {
+	t.Parallel()
+	s := OpenServer(NewConfig(), "")
+	defer s.Close()
+
+	if err := s.CreateDatabaseAndRetentionPolicy("db0", newRetentionPolicyInfo("rp0", 1, 1*time.Hour)); err != nil {
+		t.Fatal(err)
+	}
+
+	now := now()
+	points := []string{
+		"cpu,host=server01 value=100 " + strconv.FormatInt(now.UnixNano(), 10),
+		"cpu,host=server01 value=NaN " + strconv.FormatInt(now.UnixNano(), 20),
+		"cpu,host=server01 value=NaN " + strconv.FormatInt(now.UnixNano(), 30),
+	}
+	if res, err := s.Write("db0", "rp0", strings.Join(points, "\n"), nil); err == nil {
+		t.Fatal("expected error. got nil", err)
+	} else if exp := ``; exp != res {
+		t.Fatalf("unexpected results\nexp: %s\ngot: %s\n", exp, res)
+	} else if exp := "partial write"; !strings.Contains(err.Error(), exp) {
+		t.Fatalf("unexpected error: exp\nexp: %v\ngot: %v", exp, err)
+	}
+
+	// Verify the data was written.
+	if res, err := s.Query(`SELECT * FROM db0.rp0.cpu GROUP BY *`); err != nil {
+		t.Fatal(err)
+	} else if exp := fmt.Sprintf(`{"results":[{"series":[{"name":"cpu","tags":{"host":"server01"},"columns":["time","value"],"values":[["%s",100]]}]}]}`, now.Format(time.RFC3339Nano)); exp != res {
+		t.Fatalf("unexpected results\nexp: %s\ngot: %s\n", exp, res)
+	}
+}
+
 // Ensure the server can query with default databases (via param) and default retention policy
 func TestServer_Query_DefaultDBAndRP(t *testing.T) {
 	t.Parallel()

--- a/models/points.go
+++ b/models/points.go
@@ -614,14 +614,11 @@ func scanNumber(buf []byte, i int) (int, error) {
 			continue
 		}
 
-		// NaN is a valid float
+		// NaN is an unsupported value
 		if i+2 < len(buf) && (buf[i] == 'N' || buf[i] == 'n') {
-			if (buf[i+1] == 'a' || buf[i+1] == 'A') && (buf[i+2] == 'N' || buf[i+2] == 'n') {
-				i += 3
-				continue
-			}
 			return i, fmt.Errorf("invalid number")
 		}
+
 		if !isNumeric(buf[i]) {
 			return i, fmt.Errorf("invalid number")
 		}

--- a/models/points.go
+++ b/models/points.go
@@ -114,7 +114,8 @@ func ParsePointsString(buf string) ([]Point, error) {
 }
 
 // ParsePoints returns a slice of Points from a text representation of a point
-// with each point separated by newlines.
+// with each point separated by newlines.  If any points fail to parse, a non-nil error
+// will be returned in addition to the points that parsed successfully.
 func ParsePoints(buf []byte) ([]Point, error) {
 	return ParsePointsWithPrecision(buf, time.Now().UTC(), "n")
 }

--- a/models/points_test.go
+++ b/models/points_test.go
@@ -1097,36 +1097,21 @@ func TestNewPointLargeInteger(t *testing.T) {
 	)
 }
 
-func TestNewPointNaN(t *testing.T) {
-	test(t, `cpu value=NaN 1000000000`,
-		models.NewPoint(
-			"cpu",
-			models.Tags{},
-			models.Fields{
-				"value": math.NaN(),
-			},
-			time.Unix(1, 0)),
-	)
+func TestParsePointNaN(t *testing.T) {
+	_, err := models.ParsePointsString("cpu value=NaN 1000000000")
+	if err == nil {
+		t.Fatalf("ParsePoints expected error, got nil")
+	}
 
-	test(t, `cpu value=nAn 1000000000`,
-		models.NewPoint(
-			"cpu",
-			models.Tags{},
-			models.Fields{
-				"value": math.NaN(),
-			},
-			time.Unix(1, 0)),
-	)
+	_, err = models.ParsePointsString("cpu value=nAn 1000000000")
+	if err == nil {
+		t.Fatalf("ParsePoints expected error, got nil")
+	}
 
-	test(t, `nan value=NaN`,
-		models.NewPoint(
-			"nan",
-			models.Tags{},
-			models.Fields{
-				"value": math.NaN(),
-			},
-			time.Unix(0, 0)),
-	)
+	_, err = models.ParsePointsString("cpu value=NaN")
+	if err == nil {
+		t.Fatalf("ParsePoints expected error, got nil")
+	}
 }
 
 func TestNewPointLargeNumberOfTags(t *testing.T) {

--- a/models/points_test.go
+++ b/models/points_test.go
@@ -201,7 +201,7 @@ func TestParsePointNoFields(t *testing.T) {
 }
 
 func TestParsePointNoTimestamp(t *testing.T) {
-	test(t, "cpu value=1", models.NewPoint("cpu", nil, nil, time.Unix(0, 0)))
+	test(t, "cpu value=1", models.MustNewPoint("cpu", nil, nil, time.Unix(0, 0)))
 }
 
 func TestParsePointMissingQuote(t *testing.T) {
@@ -524,7 +524,7 @@ func TestParsePointScientificIntInvalid(t *testing.T) {
 
 func TestParsePointUnescape(t *testing.T) {
 	test(t, `foo\,bar value=1i`,
-		models.NewPoint(
+		models.MustNewPoint(
 			"foo,bar", // comma in the name
 			models.Tags{},
 			models.Fields{
@@ -534,7 +534,7 @@ func TestParsePointUnescape(t *testing.T) {
 
 	// commas in measurement name
 	test(t, `cpu\,main,regions=east\,west value=1.0`,
-		models.NewPoint(
+		models.MustNewPoint(
 			"cpu,main", // comma in the name
 			models.Tags{
 				"regions": "east,west",
@@ -546,7 +546,7 @@ func TestParsePointUnescape(t *testing.T) {
 
 	// spaces in measurement name
 	test(t, `cpu\ load,region=east value=1.0`,
-		models.NewPoint(
+		models.MustNewPoint(
 			"cpu load", // space in the name
 			models.Tags{
 				"region": "east",
@@ -558,7 +558,7 @@ func TestParsePointUnescape(t *testing.T) {
 
 	// commas in tag names
 	test(t, `cpu,region\,zone=east value=1.0`,
-		models.NewPoint("cpu",
+		models.MustNewPoint("cpu",
 			models.Tags{
 				"region,zone": "east", // comma in the tag key
 			},
@@ -569,7 +569,7 @@ func TestParsePointUnescape(t *testing.T) {
 
 	// spaces in tag names
 	test(t, `cpu,region\ zone=east value=1.0`,
-		models.NewPoint("cpu",
+		models.MustNewPoint("cpu",
 			models.Tags{
 				"region zone": "east", // comma in the tag key
 			},
@@ -580,7 +580,7 @@ func TestParsePointUnescape(t *testing.T) {
 
 	// commas in tag values
 	test(t, `cpu,regions=east\,west value=1.0`,
-		models.NewPoint("cpu",
+		models.MustNewPoint("cpu",
 			models.Tags{
 				"regions": "east,west", // comma in the tag value
 			},
@@ -591,7 +591,7 @@ func TestParsePointUnescape(t *testing.T) {
 
 	// spaces in tag values
 	test(t, `cpu,regions=east\ west value=1.0`,
-		models.NewPoint("cpu",
+		models.MustNewPoint("cpu",
 			models.Tags{
 				"regions": "east west", // comma in the tag value
 			},
@@ -602,7 +602,7 @@ func TestParsePointUnescape(t *testing.T) {
 
 	// commas in field keys
 	test(t, `cpu,regions=east value\,ms=1.0`,
-		models.NewPoint("cpu",
+		models.MustNewPoint("cpu",
 			models.Tags{
 				"regions": "east",
 			},
@@ -613,7 +613,7 @@ func TestParsePointUnescape(t *testing.T) {
 
 	// spaces in field keys
 	test(t, `cpu,regions=east value\ ms=1.0`,
-		models.NewPoint("cpu",
+		models.MustNewPoint("cpu",
 			models.Tags{
 				"regions": "east",
 			},
@@ -624,7 +624,7 @@ func TestParsePointUnescape(t *testing.T) {
 
 	// tag with no value
 	test(t, `cpu,regions=east value="1"`,
-		models.NewPoint("cpu",
+		models.MustNewPoint("cpu",
 			models.Tags{
 				"regions": "east",
 				"foobar":  "",
@@ -636,7 +636,7 @@ func TestParsePointUnescape(t *testing.T) {
 
 	// commas in field values
 	test(t, `cpu,regions=east value="1,0"`,
-		models.NewPoint("cpu",
+		models.MustNewPoint("cpu",
 			models.Tags{
 				"regions": "east",
 			},
@@ -647,7 +647,7 @@ func TestParsePointUnescape(t *testing.T) {
 
 	// random character escaped
 	test(t, `cpu,regions=eas\t value=1.0`,
-		models.NewPoint(
+		models.MustNewPoint(
 			"cpu",
 			models.Tags{
 				"regions": "eas\\t",
@@ -659,7 +659,7 @@ func TestParsePointUnescape(t *testing.T) {
 
 	// field keys using escape char.
 	test(t, `cpu \a=1i`,
-		models.NewPoint(
+		models.MustNewPoint(
 			"cpu",
 			models.Tags{},
 			models.Fields{
@@ -669,7 +669,7 @@ func TestParsePointUnescape(t *testing.T) {
 
 	// measurement, tag and tag value with equals
 	test(t, `cpu=load,equals\=foo=tag\=value value=1i`,
-		models.NewPoint(
+		models.MustNewPoint(
 			"cpu=load", // Not escaped
 			models.Tags{
 				"equals=foo": "tag=value", // Tag and value unescaped
@@ -684,7 +684,7 @@ func TestParsePointUnescape(t *testing.T) {
 func TestParsePointWithTags(t *testing.T) {
 	test(t,
 		"cpu,host=serverA,region=us-east value=1.0 1000000000",
-		models.NewPoint("cpu",
+		models.MustNewPoint("cpu",
 			models.Tags{"host": "serverA", "region": "us-east"},
 			models.Fields{"value": 1.0}, time.Unix(1, 0)))
 }
@@ -698,7 +698,7 @@ func TestParsPointWithDuplicateTags(t *testing.T) {
 
 func TestParsePointWithStringField(t *testing.T) {
 	test(t, `cpu,host=serverA,region=us-east value=1.0,str="foo",str2="bar" 1000000000`,
-		models.NewPoint("cpu",
+		models.MustNewPoint("cpu",
 			models.Tags{
 				"host":   "serverA",
 				"region": "us-east",
@@ -712,7 +712,7 @@ func TestParsePointWithStringField(t *testing.T) {
 	)
 
 	test(t, `cpu,host=serverA,region=us-east str="foo \" bar" 1000000000`,
-		models.NewPoint("cpu",
+		models.MustNewPoint("cpu",
 			models.Tags{
 				"host":   "serverA",
 				"region": "us-east",
@@ -727,7 +727,7 @@ func TestParsePointWithStringField(t *testing.T) {
 
 func TestParsePointWithStringWithSpaces(t *testing.T) {
 	test(t, `cpu,host=serverA,region=us-east value=1.0,str="foo bar" 1000000000`,
-		models.NewPoint(
+		models.MustNewPoint(
 			"cpu",
 			models.Tags{
 				"host":   "serverA",
@@ -743,7 +743,7 @@ func TestParsePointWithStringWithSpaces(t *testing.T) {
 
 func TestParsePointWithStringWithNewline(t *testing.T) {
 	test(t, "cpu,host=serverA,region=us-east value=1.0,str=\"foo\nbar\" 1000000000",
-		models.NewPoint(
+		models.MustNewPoint(
 			"cpu",
 			models.Tags{
 				"host":   "serverA",
@@ -760,7 +760,7 @@ func TestParsePointWithStringWithNewline(t *testing.T) {
 func TestParsePointWithStringWithCommas(t *testing.T) {
 	// escaped comma
 	test(t, `cpu,host=serverA,region=us-east value=1.0,str="foo\,bar" 1000000000`,
-		models.NewPoint(
+		models.MustNewPoint(
 			"cpu",
 			models.Tags{
 				"host":   "serverA",
@@ -775,7 +775,7 @@ func TestParsePointWithStringWithCommas(t *testing.T) {
 
 	// non-escaped comma
 	test(t, `cpu,host=serverA,region=us-east value=1.0,str="foo,bar" 1000000000`,
-		models.NewPoint(
+		models.MustNewPoint(
 			"cpu",
 			models.Tags{
 				"host":   "serverA",
@@ -792,7 +792,7 @@ func TestParsePointWithStringWithCommas(t *testing.T) {
 func TestParsePointQuotedMeasurement(t *testing.T) {
 	// non-escaped comma
 	test(t, `"cpu",host=serverA,region=us-east value=1.0 1000000000`,
-		models.NewPoint(
+		models.MustNewPoint(
 			`"cpu"`,
 			models.Tags{
 				"host":   "serverA",
@@ -807,7 +807,7 @@ func TestParsePointQuotedMeasurement(t *testing.T) {
 
 func TestParsePointQuotedTags(t *testing.T) {
 	test(t, `cpu,"host"="serverA",region=us-east value=1.0 1000000000`,
-		models.NewPoint(
+		models.MustNewPoint(
 			"cpu",
 			models.Tags{
 				`"host"`: `"serverA"`,
@@ -831,7 +831,7 @@ func TestParsePointsUnbalancedQuotedTags(t *testing.T) {
 	}
 
 	// Expected " in the tag value
-	exp := models.NewPoint("baz", models.Tags{"mytag": `"a`},
+	exp := models.MustNewPoint("baz", models.Tags{"mytag": `"a`},
 		models.Fields{"x": float64(1)}, time.Unix(0, 1441103862125))
 
 	if pts[0].String() != exp.String() {
@@ -839,7 +839,7 @@ func TestParsePointsUnbalancedQuotedTags(t *testing.T) {
 	}
 
 	// Expected two points to ensure we did not overscan the line
-	exp = models.NewPoint("baz", models.Tags{"mytag": `a`},
+	exp = models.MustNewPoint("baz", models.Tags{"mytag": `a`},
 		models.Fields{"z": float64(1)}, time.Unix(0, 1441103862126))
 
 	if pts[1].String() != exp.String() {
@@ -851,7 +851,7 @@ func TestParsePointsUnbalancedQuotedTags(t *testing.T) {
 func TestParsePointEscapedStringsAndCommas(t *testing.T) {
 	// non-escaped comma and quotes
 	test(t, `cpu,host=serverA,region=us-east value="{Hello\"{,}\" World}" 1000000000`,
-		models.NewPoint(
+		models.MustNewPoint(
 			"cpu",
 			models.Tags{
 				"host":   "serverA",
@@ -865,7 +865,7 @@ func TestParsePointEscapedStringsAndCommas(t *testing.T) {
 
 	// escaped comma and quotes
 	test(t, `cpu,host=serverA,region=us-east value="{Hello\"{\,}\" World}" 1000000000`,
-		models.NewPoint(
+		models.MustNewPoint(
 			"cpu",
 			models.Tags{
 				"host":   "serverA",
@@ -880,7 +880,7 @@ func TestParsePointEscapedStringsAndCommas(t *testing.T) {
 
 func TestParsePointWithStringWithEquals(t *testing.T) {
 	test(t, `cpu,host=serverA,region=us-east str="foo=bar",value=1.0 1000000000`,
-		models.NewPoint(
+		models.MustNewPoint(
 			"cpu",
 			models.Tags{
 				"host":   "serverA",
@@ -896,7 +896,7 @@ func TestParsePointWithStringWithEquals(t *testing.T) {
 
 func TestParsePointWithStringWithBackslash(t *testing.T) {
 	test(t, `cpu value="test\\\"" 1000000000`,
-		models.NewPoint(
+		models.MustNewPoint(
 			"cpu",
 			models.Tags{},
 			models.Fields{
@@ -906,7 +906,7 @@ func TestParsePointWithStringWithBackslash(t *testing.T) {
 	)
 
 	test(t, `cpu value="test\\" 1000000000`,
-		models.NewPoint(
+		models.MustNewPoint(
 			"cpu",
 			models.Tags{},
 			models.Fields{
@@ -916,7 +916,7 @@ func TestParsePointWithStringWithBackslash(t *testing.T) {
 	)
 
 	test(t, `cpu value="test\\\"" 1000000000`,
-		models.NewPoint(
+		models.MustNewPoint(
 			"cpu",
 			models.Tags{},
 			models.Fields{
@@ -926,7 +926,7 @@ func TestParsePointWithStringWithBackslash(t *testing.T) {
 	)
 
 	test(t, `cpu value="test\"" 1000000000`,
-		models.NewPoint(
+		models.MustNewPoint(
 			"cpu",
 			models.Tags{},
 			models.Fields{
@@ -938,7 +938,7 @@ func TestParsePointWithStringWithBackslash(t *testing.T) {
 
 func TestParsePointWithBoolField(t *testing.T) {
 	test(t, `cpu,host=serverA,region=us-east true=true,t=t,T=T,TRUE=TRUE,True=True,false=false,f=f,F=F,FALSE=FALSE,False=False 1000000000`,
-		models.NewPoint(
+		models.MustNewPoint(
 			"cpu",
 			models.Tags{
 				"host":   "serverA",
@@ -962,7 +962,7 @@ func TestParsePointWithBoolField(t *testing.T) {
 
 func TestParsePointUnicodeString(t *testing.T) {
 	test(t, `cpu,host=serverA,region=us-east value="wè" 1000000000`,
-		models.NewPoint(
+		models.MustNewPoint(
 			"cpu",
 			models.Tags{
 				"host":   "serverA",
@@ -977,7 +977,7 @@ func TestParsePointUnicodeString(t *testing.T) {
 
 func TestParsePointNegativeTimestamp(t *testing.T) {
 	test(t, `cpu value=1 -1`,
-		models.NewPoint(
+		models.MustNewPoint(
 			"cpu",
 			models.Tags{},
 			models.Fields{
@@ -989,7 +989,7 @@ func TestParsePointNegativeTimestamp(t *testing.T) {
 
 func TestParsePointMaxTimestamp(t *testing.T) {
 	test(t, `cpu value=1 9223372036854775807`,
-		models.NewPoint(
+		models.MustNewPoint(
 			"cpu",
 			models.Tags{},
 			models.Fields{
@@ -1001,7 +1001,7 @@ func TestParsePointMaxTimestamp(t *testing.T) {
 
 func TestParsePointMinTimestamp(t *testing.T) {
 	test(t, `cpu value=1 -9223372036854775807`,
-		models.NewPoint(
+		models.MustNewPoint(
 			"cpu",
 			models.Tags{},
 			models.Fields{
@@ -1040,7 +1040,7 @@ func TestParsePointInvalidTimestamp(t *testing.T) {
 
 func TestNewPointFloatWithoutDecimal(t *testing.T) {
 	test(t, `cpu value=1 1000000000`,
-		models.NewPoint(
+		models.MustNewPoint(
 			"cpu",
 			models.Tags{},
 			models.Fields{
@@ -1051,7 +1051,7 @@ func TestNewPointFloatWithoutDecimal(t *testing.T) {
 }
 func TestNewPointNegativeFloat(t *testing.T) {
 	test(t, `cpu value=-0.64 1000000000`,
-		models.NewPoint(
+		models.MustNewPoint(
 			"cpu",
 			models.Tags{},
 			models.Fields{
@@ -1063,7 +1063,7 @@ func TestNewPointNegativeFloat(t *testing.T) {
 
 func TestNewPointFloatNoDecimal(t *testing.T) {
 	test(t, `cpu value=1. 1000000000`,
-		models.NewPoint(
+		models.MustNewPoint(
 			"cpu",
 			models.Tags{},
 			models.Fields{
@@ -1075,7 +1075,7 @@ func TestNewPointFloatNoDecimal(t *testing.T) {
 
 func TestNewPointFloatScientific(t *testing.T) {
 	test(t, `cpu value=6.632243e+06 1000000000`,
-		models.NewPoint(
+		models.MustNewPoint(
 			"cpu",
 			models.Tags{},
 			models.Fields{
@@ -1087,7 +1087,7 @@ func TestNewPointFloatScientific(t *testing.T) {
 
 func TestNewPointLargeInteger(t *testing.T) {
 	test(t, `cpu value=6632243i 1000000000`,
-		models.NewPoint(
+		models.MustNewPoint(
 			"cpu",
 			models.Tags{},
 			models.Fields{
@@ -1186,7 +1186,7 @@ func TestParsePointToString(t *testing.T) {
 		t.Errorf("ParsePoint() to string mismatch:\n got %v\n exp %v", got, line)
 	}
 
-	pt = models.NewPoint("cpu", models.Tags{"host": "serverA", "region": "us-east"},
+	pt = models.MustNewPoint("cpu", models.Tags{"host": "serverA", "region": "us-east"},
 		models.Fields{"int": 10, "float": float64(11.0), "float2": float64(12.123), "bool": false, "str": "string val"},
 		time.Unix(1, 0))
 
@@ -1383,19 +1383,19 @@ cpu,host=serverA,region=us-east value=1.0 946730096789012345`,
 
 func TestNewPointEscaped(t *testing.T) {
 	// commas
-	pt := models.NewPoint("cpu,main", models.Tags{"tag,bar": "value"}, models.Fields{"name,bar": 1.0}, time.Unix(0, 0))
+	pt := models.MustNewPoint("cpu,main", models.Tags{"tag,bar": "value"}, models.Fields{"name,bar": 1.0}, time.Unix(0, 0))
 	if exp := `cpu\,main,tag\,bar=value name\,bar=1 0`; pt.String() != exp {
 		t.Errorf("NewPoint().String() mismatch.\ngot %v\nexp %v", pt.String(), exp)
 	}
 
 	// spaces
-	pt = models.NewPoint("cpu main", models.Tags{"tag bar": "value"}, models.Fields{"name bar": 1.0}, time.Unix(0, 0))
+	pt = models.MustNewPoint("cpu main", models.Tags{"tag bar": "value"}, models.Fields{"name bar": 1.0}, time.Unix(0, 0))
 	if exp := `cpu\ main,tag\ bar=value name\ bar=1 0`; pt.String() != exp {
 		t.Errorf("NewPoint().String() mismatch.\ngot %v\nexp %v", pt.String(), exp)
 	}
 
 	// equals
-	pt = models.NewPoint("cpu=main", models.Tags{"tag=bar": "value=foo"}, models.Fields{"name=bar": 1.0}, time.Unix(0, 0))
+	pt = models.MustNewPoint("cpu=main", models.Tags{"tag=bar": "value=foo"}, models.Fields{"name=bar": 1.0}, time.Unix(0, 0))
 	if exp := `cpu=main,tag\=bar=value\=foo name\=bar=1 0`; pt.String() != exp {
 		t.Errorf("NewPoint().String() mismatch.\ngot %v\nexp %v", pt.String(), exp)
 	}
@@ -1403,14 +1403,14 @@ func TestNewPointEscaped(t *testing.T) {
 
 func TestNewPointUnhandledType(t *testing.T) {
 	// nil value
-	pt := models.NewPoint("cpu", nil, models.Fields{"value": nil}, time.Unix(0, 0))
+	pt := models.MustNewPoint("cpu", nil, models.Fields{"value": nil}, time.Unix(0, 0))
 	if exp := `cpu value= 0`; pt.String() != exp {
 		t.Errorf("NewPoint().String() mismatch.\ngot %v\nexp %v", pt.String(), exp)
 	}
 
 	// unsupported type gets stored as string
 	now := time.Unix(0, 0).UTC()
-	pt = models.NewPoint("cpu", nil, models.Fields{"value": now}, time.Unix(0, 0))
+	pt = models.MustNewPoint("cpu", nil, models.Fields{"value": now}, time.Unix(0, 0))
 	if exp := `cpu value="1970-01-01 00:00:00 +0000 UTC" 0`; pt.String() != exp {
 		t.Errorf("NewPoint().String() mismatch.\ngot %v\nexp %v", pt.String(), exp)
 	}
@@ -1485,7 +1485,7 @@ func TestPrecisionString(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		pt := models.NewPoint("cpu", nil, tags, tm)
+		pt := models.MustNewPoint("cpu", nil, tags, tm)
 		act := pt.PrecisionString(test.precision)
 
 		if act != test.exp {

--- a/monitor/service.go
+++ b/monitor/service.go
@@ -368,7 +368,12 @@ func (m *Monitor) storeStatistics() {
 
 			points := make(models.Points, 0, len(stats))
 			for _, s := range stats {
-				points = append(points, models.NewPoint(s.Name, s.Tags, s.Values, time.Now().Truncate(time.Second)))
+				pt, err := models.NewPoint(s.Name, s.Tags, s.Values, time.Now().Truncate(time.Second))
+				if err != nil {
+					m.Logger.Printf("Dropping point %v: %v", s.Name, err)
+					continue
+				}
+				points = append(points, pt)
 			}
 
 			err = m.PointsWriter.WritePoints(&cluster.WritePointsRequest{

--- a/services/collectd/service.go
+++ b/services/collectd/service.go
@@ -293,7 +293,11 @@ func Unmarshal(packet *gollectd.Packet) []models.Point {
 		if packet.TypeInstance != "" {
 			tags["type_instance"] = packet.TypeInstance
 		}
-		p := models.NewPoint(name, tags, fields, timestamp)
+		p, err := models.NewPoint(name, tags, fields, timestamp)
+		// Drop points values of NaN since they are not supported
+		if err != nil {
+			continue
+		}
 
 		points = append(points, p)
 	}

--- a/services/graphite/parser.go
+++ b/services/graphite/parser.go
@@ -116,6 +116,10 @@ func (p *Parser) Parse(line string) (models.Point, error) {
 		return nil, fmt.Errorf(`field "%s" value: %s`, fields[0], err)
 	}
 
+	if math.IsNaN(v) || math.IsInf(v, 0) {
+		return nil, fmt.Errorf(`field "%s" value: '%v" is unsupported`, fields[0], v)
+	}
+
 	fieldValues := map[string]interface{}{}
 	if field != "" {
 		fieldValues[field] = v
@@ -150,9 +154,7 @@ func (p *Parser) Parse(line string) (models.Point, error) {
 			tags[k] = v
 		}
 	}
-	point := models.NewPoint(measurement, tags, fieldValues, timestamp)
-
-	return point, nil
+	return models.NewPoint(measurement, tags, fieldValues, timestamp)
 }
 
 // Apply extracts the template fields form the given line and returns the

--- a/services/graphite/parser_test.go
+++ b/services/graphite/parser_test.go
@@ -1,7 +1,6 @@
 package graphite_test
 
 import (
-	"math"
 	"strconv"
 	"testing"
 	"time"
@@ -224,22 +223,9 @@ func TestParseNaN(t *testing.T) {
 		t.Fatalf("unexpected error creating parser, got %v", err)
 	}
 
-	pt, err := p.Parse("servers.localhost.cpu_load NaN 1435077219")
-	if err != nil {
-		t.Fatalf("parse error: %v", err)
-	}
-
-	exp := models.NewPoint("servers.localhost.cpu_load",
-		models.Tags{},
-		models.Fields{"value": math.NaN()},
-		time.Unix(1435077219, 0))
-
-	if exp.String() != pt.String() {
-		t.Errorf("parse mismatch: got %v, exp %v", pt.String(), exp.String())
-	}
-
-	if !math.IsNaN(pt.Fields()["value"].(float64)) {
-		t.Errorf("parse value mismatch: expected NaN")
+	_, err = p.Parse("servers.localhost.cpu_load NaN 1435077219")
+	if err == nil {
+		t.Fatalf("expected error. got nil")
 	}
 }
 
@@ -249,7 +235,7 @@ func TestFilterMatchDefault(t *testing.T) {
 		t.Fatalf("unexpected error creating parser, got %v", err)
 	}
 
-	exp := models.NewPoint("miss.servers.localhost.cpu_load",
+	exp := models.MustNewPoint("miss.servers.localhost.cpu_load",
 		models.Tags{},
 		models.Fields{"value": float64(11)},
 		time.Unix(1435077219, 0))
@@ -270,7 +256,7 @@ func TestFilterMatchMultipleMeasurement(t *testing.T) {
 		t.Fatalf("unexpected error creating parser, got %v", err)
 	}
 
-	exp := models.NewPoint("cpu.cpu_load.10",
+	exp := models.MustNewPoint("cpu.cpu_load.10",
 		models.Tags{"host": "localhost"},
 		models.Fields{"value": float64(11)},
 		time.Unix(1435077219, 0))
@@ -294,7 +280,7 @@ func TestFilterMatchMultipleMeasurementSeparator(t *testing.T) {
 		t.Fatalf("unexpected error creating parser, got %v", err)
 	}
 
-	exp := models.NewPoint("cpu_cpu_load_10",
+	exp := models.MustNewPoint("cpu_cpu_load_10",
 		models.Tags{"host": "localhost"},
 		models.Fields{"value": float64(11)},
 		time.Unix(1435077219, 0))
@@ -315,7 +301,7 @@ func TestFilterMatchSingle(t *testing.T) {
 		t.Fatalf("unexpected error creating parser, got %v", err)
 	}
 
-	exp := models.NewPoint("cpu_load",
+	exp := models.MustNewPoint("cpu_load",
 		models.Tags{"host": "localhost"},
 		models.Fields{"value": float64(11)},
 		time.Unix(1435077219, 0))
@@ -336,7 +322,7 @@ func TestParseNoMatch(t *testing.T) {
 		t.Fatalf("unexpected error creating parser, got %v", err)
 	}
 
-	exp := models.NewPoint("servers.localhost.memory.VmallocChunk",
+	exp := models.MustNewPoint("servers.localhost.memory.VmallocChunk",
 		models.Tags{},
 		models.Fields{"value": float64(11)},
 		time.Unix(1435077219, 0))
@@ -357,7 +343,7 @@ func TestFilterMatchWildcard(t *testing.T) {
 		t.Fatalf("unexpected error creating parser, got %v", err)
 	}
 
-	exp := models.NewPoint("cpu_load",
+	exp := models.MustNewPoint("cpu_load",
 		models.Tags{"host": "localhost"},
 		models.Fields{"value": float64(11)},
 		time.Unix(1435077219, 0))
@@ -380,7 +366,7 @@ func TestFilterMatchExactBeforeWildcard(t *testing.T) {
 		t.Fatalf("unexpected error creating parser, got %v", err)
 	}
 
-	exp := models.NewPoint("cpu_load",
+	exp := models.MustNewPoint("cpu_load",
 		models.Tags{"host": "localhost"},
 		models.Fields{"value": float64(11)},
 		time.Unix(1435077219, 0))
@@ -408,7 +394,7 @@ func TestFilterMatchMostLongestFilter(t *testing.T) {
 		t.Fatalf("unexpected error creating parser, got %v", err)
 	}
 
-	exp := models.NewPoint("cpu_load",
+	exp := models.MustNewPoint("cpu_load",
 		models.Tags{"host": "localhost", "resource": "cpu"},
 		models.Fields{"value": float64(11)},
 		time.Unix(1435077219, 0))
@@ -435,7 +421,7 @@ func TestFilterMatchMultipleWildcards(t *testing.T) {
 		t.Fatalf("unexpected error creating parser, got %v", err)
 	}
 
-	exp := models.NewPoint("cpu_load",
+	exp := models.MustNewPoint("cpu_load",
 		models.Tags{"host": "server01"},
 		models.Fields{"value": float64(11)},
 		time.Unix(1435077219, 0))
@@ -460,7 +446,7 @@ func TestParseDefaultTags(t *testing.T) {
 		t.Fatalf("unexpected error creating parser, got %v", err)
 	}
 
-	exp := models.NewPoint("cpu_load",
+	exp := models.MustNewPoint("cpu_load",
 		models.Tags{"host": "localhost", "region": "us-east", "zone": "1c"},
 		models.Fields{"value": float64(11)},
 		time.Unix(1435077219, 0))
@@ -484,7 +470,7 @@ func TestParseDefaultTemplateTags(t *testing.T) {
 		t.Fatalf("unexpected error creating parser, got %v", err)
 	}
 
-	exp := models.NewPoint("cpu_load",
+	exp := models.MustNewPoint("cpu_load",
 		models.Tags{"host": "localhost", "region": "us-east", "zone": "1c"},
 		models.Fields{"value": float64(11)},
 		time.Unix(1435077219, 0))
@@ -508,7 +494,7 @@ func TestParseDefaultTemplateTagsOverridGlobal(t *testing.T) {
 		t.Fatalf("unexpected error creating parser, got %v", err)
 	}
 
-	exp := models.NewPoint("cpu_load",
+	exp := models.MustNewPoint("cpu_load",
 		models.Tags{"host": "localhost", "region": "us-east", "zone": "1c"},
 		models.Fields{"value": float64(11)},
 		time.Unix(1435077219, 0))
@@ -532,7 +518,7 @@ func TestParseTemplateWhitespace(t *testing.T) {
 		t.Fatalf("unexpected error creating parser, got %v", err)
 	}
 
-	exp := models.NewPoint("cpu_load",
+	exp := models.MustNewPoint("cpu_load",
 		models.Tags{"host": "localhost", "region": "us-east", "zone": "1c"},
 		models.Fields{"value": float64(11)},
 		time.Unix(1435077219, 0))

--- a/services/graphite/service.go
+++ b/services/graphite/service.go
@@ -5,7 +5,6 @@ import (
 	"expvar"
 	"fmt"
 	"log"
-	"math"
 	"net"
 	"os"
 	"strings"
@@ -325,19 +324,9 @@ func (s *Service) handleLine(line string) {
 	// Parse it.
 	point, err := s.parser.Parse(line)
 	if err != nil {
-		s.logger.Printf("unable to parse line: %s", err)
+		s.logger.Printf("unable to parse line: %s: %s", line, err)
 		s.statMap.Add(statPointsParseFail, 1)
 		return
-	}
-
-	f, ok := point.Fields()["value"].(float64)
-	if ok {
-		// Drop NaN and +/-Inf data points since they are not supported values
-		if math.IsNaN(f) || math.IsInf(f, 0) {
-			s.logger.Printf("dropping unsupported value: '%v'", line)
-			s.statMap.Add(statPointsUnsupported, 1)
-			return
-		}
 	}
 
 	s.batcher.In() <- point

--- a/services/graphite/service_test.go
+++ b/services/graphite/service_test.go
@@ -38,16 +38,17 @@ func Test_ServerGraphiteTCP(t *testing.T) {
 		WritePointsFn: func(req *cluster.WritePointsRequest) error {
 			defer wg.Done()
 
+			pt, _ := models.NewPoint(
+				"cpu",
+				map[string]string{},
+				map[string]interface{}{"value": 23.456},
+				time.Unix(now.Unix(), 0))
+
 			if req.Database != "graphitedb" {
 				t.Fatalf("unexpected database: %s", req.Database)
 			} else if req.RetentionPolicy != "" {
 				t.Fatalf("unexpected retention policy: %s", req.RetentionPolicy)
-			} else if req.Points[0].String() !=
-				models.NewPoint(
-					"cpu",
-					map[string]string{},
-					map[string]interface{}{"value": 23.456},
-					time.Unix(now.Unix(), 0)).String() {
+			} else if req.Points[0].String() != pt.String() {
 			}
 			return nil
 		},
@@ -107,16 +108,16 @@ func Test_ServerGraphiteUDP(t *testing.T) {
 		WritePointsFn: func(req *cluster.WritePointsRequest) error {
 			defer wg.Done()
 
+			pt, _ := models.NewPoint(
+				"cpu",
+				map[string]string{},
+				map[string]interface{}{"value": 23.456},
+				time.Unix(now.Unix(), 0))
 			if req.Database != "graphitedb" {
 				t.Fatalf("unexpected database: %s", req.Database)
 			} else if req.RetentionPolicy != "" {
 				t.Fatalf("unexpected retention policy: %s", req.RetentionPolicy)
-			} else if req.Points[0].String() !=
-				models.NewPoint(
-					"cpu",
-					map[string]string{},
-					map[string]interface{}{"value": 23.456},
-					time.Unix(now.Unix(), 0)).String() {
+			} else if req.Points[0].String() != pt.String() {
 				t.Fatalf("unexpected points: %#v", req.Points[0].String())
 			}
 			return nil

--- a/services/hh/node_processor_test.go
+++ b/services/hh/node_processor_test.go
@@ -35,7 +35,7 @@ func TestNodeProcessorSendBlock(t *testing.T) {
 
 	// expected data to be queue and sent to the shardWriter
 	var expShardID, expNodeID, count = uint64(100), uint64(200), 0
-	pt := models.NewPoint("cpu", models.Tags{"foo": "bar"}, models.Fields{"value": 1.0}, time.Unix(0, 0))
+	pt := models.MustNewPoint("cpu", models.Tags{"foo": "bar"}, models.Fields{"value": 1.0}, time.Unix(0, 0))
 
 	sh := &fakeShardWriter{
 		ShardWriteFn: func(shardID, nodeID uint64, points []models.Point) error {

--- a/services/httpd/handler.go
+++ b/services/httpd/handler.go
@@ -473,13 +473,14 @@ func (h *Handler) serveWriteLine(w http.ResponseWriter, r *http.Request, body []
 		precision = "n"
 	}
 
-	points, err := models.ParsePointsWithPrecision(body, time.Now().UTC(), precision)
-	if err != nil {
-		if err.Error() == "EOF" {
+	points, parseError := models.ParsePointsWithPrecision(body, time.Now().UTC(), precision)
+	// Not points parsed correctly so return the error now
+	if parseError != nil && len(points) == 0 {
+		if parseError.Error() == "EOF" {
 			w.WriteHeader(http.StatusOK)
 			return
 		}
-		h.writeError(w, influxql.Result{Err: err}, http.StatusBadRequest)
+		h.writeError(w, influxql.Result{Err: parseError}, http.StatusBadRequest)
 		return
 	}
 
@@ -533,6 +534,13 @@ func (h *Handler) serveWriteLine(w http.ResponseWriter, r *http.Request, body []
 	} else if err != nil {
 		h.statMap.Add(statPointsWrittenFail, int64(len(points)))
 		h.writeError(w, influxql.Result{Err: err}, http.StatusInternalServerError)
+		return
+	} else if parseError != nil {
+		// We wrote some of the points
+		h.statMap.Add(statPointsWrittenOK, int64(len(points)))
+		// The other points failed to parse which means the client sent invalid line protocol.  We return a 400
+		// response code as well as the lines that failed to parse.
+		h.writeError(w, influxql.Result{Err: fmt.Errorf("partial write:\n%v", parseError)}, http.StatusBadRequest)
 		return
 	}
 

--- a/services/httpd/handler.go
+++ b/services/httpd/handler.go
@@ -905,7 +905,11 @@ func NormalizeBatchPoints(bp client.BatchPoints) ([]models.Point, error) {
 			return points, fmt.Errorf("missing fields")
 		}
 		// Need to convert from a client.Point to a influxdb.Point
-		points = append(points, models.NewPoint(p.Measurement, p.Tags, p.Fields, p.Time))
+		pt, err := models.NewPoint(p.Measurement, p.Tags, p.Fields, p.Time)
+		if err != nil {
+			return points, err
+		}
+		points = append(points, pt)
 	}
 
 	return points, nil

--- a/services/httpd/handler_test.go
+++ b/services/httpd/handler_test.go
@@ -326,7 +326,7 @@ func TestNormalizeBatchPoints(t *testing.T) {
 				},
 			},
 			p: []models.Point{
-				models.NewPoint("cpu", map[string]string{"region": "useast"}, map[string]interface{}{"value": 1.0}, now),
+				models.MustNewPoint("cpu", map[string]string{"region": "useast"}, map[string]interface{}{"value": 1.0}, now),
 			},
 		},
 		{
@@ -338,7 +338,7 @@ func TestNormalizeBatchPoints(t *testing.T) {
 				},
 			},
 			p: []models.Point{
-				models.NewPoint("cpu", map[string]string{"region": "useast"}, map[string]interface{}{"value": 1.0}, now),
+				models.MustNewPoint("cpu", map[string]string{"region": "useast"}, map[string]interface{}{"value": 1.0}, now),
 			},
 		},
 		{
@@ -351,8 +351,8 @@ func TestNormalizeBatchPoints(t *testing.T) {
 				},
 			},
 			p: []models.Point{
-				models.NewPoint("cpu", map[string]string{"day": "monday", "region": "useast"}, map[string]interface{}{"value": 1.0}, now),
-				models.NewPoint("memory", map[string]string{"day": "monday"}, map[string]interface{}{"value": 2.0}, now),
+				models.MustNewPoint("cpu", map[string]string{"day": "monday", "region": "useast"}, map[string]interface{}{"value": 1.0}, now),
+				models.MustNewPoint("memory", map[string]string{"day": "monday"}, map[string]interface{}{"value": 2.0}, now),
 			},
 		},
 	}

--- a/services/opentsdb/handler.go
+++ b/services/opentsdb/handler.go
@@ -109,7 +109,12 @@ func (h *Handler) servePut(w http.ResponseWriter, r *http.Request) {
 			ts = time.Unix(p.Time/1000, (p.Time%1000)*1000)
 		}
 
-		points = append(points, models.NewPoint(p.Metric, p.Tags, map[string]interface{}{"value": p.Value}, ts))
+		pt, err := models.NewPoint(p.Metric, p.Tags, map[string]interface{}{"value": p.Value}, ts)
+		if err != nil {
+			h.Logger.Printf("Dropping point %v: %v", p.Metric, err)
+			continue
+		}
+		points = append(points, pt)
 	}
 
 	// Write points.

--- a/services/opentsdb/service_test.go
+++ b/services/opentsdb/service_test.go
@@ -38,7 +38,7 @@ func TestService_Telnet(t *testing.T) {
 		} else if req.RetentionPolicy != "" {
 			t.Fatalf("unexpected retention policy: %s", req.RetentionPolicy)
 		} else if !reflect.DeepEqual(req.Points, []models.Point{
-			models.NewPoint(
+			models.MustNewPoint(
 				"sys.cpu.user",
 				map[string]string{"host": "webserver01", "cpu": "0"},
 				map[string]interface{}{"value": 42.5},
@@ -92,7 +92,7 @@ func TestService_HTTP(t *testing.T) {
 		} else if req.RetentionPolicy != "" {
 			t.Fatalf("unexpected retention policy: %s", req.RetentionPolicy)
 		} else if !reflect.DeepEqual(req.Points, []models.Point{
-			models.NewPoint(
+			models.MustNewPoint(
 				"sys.cpu.nice",
 				map[string]string{"dc": "lga", "host": "web01"},
 				map[string]interface{}{"value": 18.0},

--- a/tsdb/engine/bz1/bz1_test.go
+++ b/tsdb/engine/bz1/bz1_test.go
@@ -99,11 +99,11 @@ func TestEngine_WritePoints_PointsWriter(t *testing.T) {
 
 	// Points to be inserted.
 	points := []models.Point{
-		models.NewPoint("cpu", models.Tags{}, models.Fields{}, time.Unix(0, 1)),
-		models.NewPoint("cpu", models.Tags{}, models.Fields{}, time.Unix(0, 0)),
-		models.NewPoint("cpu", models.Tags{}, models.Fields{}, time.Unix(1, 0)),
+		models.MustNewPoint("cpu", models.Tags{}, models.Fields{}, time.Unix(0, 1)),
+		models.MustNewPoint("cpu", models.Tags{}, models.Fields{}, time.Unix(0, 0)),
+		models.MustNewPoint("cpu", models.Tags{}, models.Fields{}, time.Unix(1, 0)),
 
-		models.NewPoint("cpu", models.Tags{"host": "serverA"}, models.Fields{}, time.Unix(0, 0)),
+		models.MustNewPoint("cpu", models.Tags{"host": "serverA"}, models.Fields{}, time.Unix(0, 0)),
 	}
 
 	// Mock points writer to ensure points are passed through.

--- a/tsdb/engine/tsm1/encoding.go
+++ b/tsdb/engine/tsm1/encoding.go
@@ -183,7 +183,10 @@ func encodeFloatBlock(buf []byte, values []Value) ([]byte, error) {
 		return nil, err
 	}
 	// Encoded float values
-	vb := venc.Bytes()
+	vb, err := venc.Bytes()
+	if err != nil {
+		return nil, err
+	}
 
 	// Prepend the first timestamp of the block in the first 8 bytes and the block
 	// in the next byte, followed by the block

--- a/tsdb/engine/tsm1/tsm1_test.go
+++ b/tsdb/engine/tsm1/tsm1_test.go
@@ -388,7 +388,7 @@ func TestEngine_WriteCompaction_Concurrent(t *testing.T) {
 				return
 			}
 
-			pt := models.NewPoint("cpu",
+			pt := models.MustNewPoint("cpu",
 				map[string]string{"host": "A"},
 				map[string]interface{}{"value": i},
 				time.Unix(int64(i), 0),

--- a/tsdb/engine/tsm1/wal.go
+++ b/tsdb/engine/tsm1/wal.go
@@ -388,6 +388,7 @@ func (l *Log) readFileToCache(fileName string) error {
 		case pointsEntry:
 			points, err := models.ParsePoints(data)
 			if err != nil {
+				l.logger.Printf("failed to parse points: %v", err)
 				return err
 			}
 			l.addToCache(points, nil, nil, false)

--- a/tsdb/engine/tsm1/wal_test.go
+++ b/tsdb/engine/tsm1/wal_test.go
@@ -195,7 +195,7 @@ func TestLog_WritePoints_FlushConcurrent(t *testing.T) {
 			default:
 			}
 
-			pt := models.NewPoint("cpu",
+			pt := models.MustNewPoint("cpu",
 				map[string]string{"host": "A"},
 				map[string]interface{}{"value": i},
 				time.Unix(int64(i), 0),
@@ -249,7 +249,7 @@ func TestLog_WritePoints_CloseConcurrent(t *testing.T) {
 			default:
 			}
 
-			pt := models.NewPoint("cpu",
+			pt := models.MustNewPoint("cpu",
 				map[string]string{"host": "A"},
 				map[string]interface{}{"value": i},
 				time.Unix(int64(i), 0),
@@ -535,7 +535,7 @@ type Point struct {
 	Time   time.Time
 }
 
-func (p *Point) Encode() models.Point { return models.NewPoint(p.Name, p.Tags, p.Fields, p.Time) }
+func (p *Point) Encode() models.Point { return models.MustNewPoint(p.Name, p.Tags, p.Fields, p.Time) }
 
 type Series struct {
 	Name   string

--- a/tsdb/into.go
+++ b/tsdb/into.go
@@ -2,9 +2,10 @@ package tsdb
 
 import (
 	"errors"
+	"time"
+
 	"github.com/influxdb/influxdb/influxql"
 	"github.com/influxdb/influxdb/models"
-	"time"
 )
 
 // convertRowToPoints will convert a query result Row into Points that can be written back in.
@@ -35,7 +36,11 @@ func convertRowToPoints(measurementName string, row *models.Row) ([]models.Point
 			}
 		}
 
-		p := models.NewPoint(measurementName, row.Tags, vals, v[timeIndex].(time.Time))
+		p, err := models.NewPoint(measurementName, row.Tags, vals, v[timeIndex].(time.Time))
+		if err != nil {
+			// Drop points that can't be stored
+			continue
+		}
 
 		points = append(points, p)
 	}

--- a/tsdb/mapper_test.go
+++ b/tsdb/mapper_test.go
@@ -23,14 +23,14 @@ func TestShardMapper_RawMapperTagSetsFields(t *testing.T) {
 	shard := mustCreateShard(tmpDir)
 
 	pt1time := time.Unix(1, 0).UTC()
-	pt1 := models.NewPoint(
+	pt1 := models.MustNewPoint(
 		"cpu",
 		map[string]string{"host": "serverA", "region": "us-east"},
 		map[string]interface{}{"idle": 60},
 		pt1time,
 	)
 	pt2time := time.Unix(2, 0).UTC()
-	pt2 := models.NewPoint(
+	pt2 := models.MustNewPoint(
 		"cpu",
 		map[string]string{"host": "serverB", "region": "us-east"},
 		map[string]interface{}{"load": 60},
@@ -113,14 +113,14 @@ func TestShardMapper_WriteAndSingleMapperRawQuerySingleValue(t *testing.T) {
 	shard := mustCreateShard(tmpDir)
 
 	pt1time := time.Unix(1, 0).UTC()
-	pt1 := models.NewPoint(
+	pt1 := models.MustNewPoint(
 		"cpu",
 		map[string]string{"host": "serverA", "region": "us-east"},
 		map[string]interface{}{"load": 42},
 		pt1time,
 	)
 	pt2time := time.Unix(2, 0).UTC()
-	pt2 := models.NewPoint(
+	pt2 := models.MustNewPoint(
 		"cpu",
 		map[string]string{"host": "serverB", "region": "us-east"},
 		map[string]interface{}{"load": 60},
@@ -220,14 +220,14 @@ func TestShardMapper_WriteAndSingleMapperRawQueryMultiValue(t *testing.T) {
 	shard := mustCreateShard(tmpDir)
 
 	pt1time := time.Unix(1, 0).UTC()
-	pt1 := models.NewPoint(
+	pt1 := models.MustNewPoint(
 		"cpu",
 		map[string]string{"host": "serverA", "region": "us-east"},
 		map[string]interface{}{"foo": 42, "bar": 43},
 		pt1time,
 	)
 	pt2time := time.Unix(2, 0).UTC()
-	pt2 := models.NewPoint(
+	pt2 := models.MustNewPoint(
 		"cpu",
 		map[string]string{"host": "serverB", "region": "us-east"},
 		map[string]interface{}{"foo": 60, "bar": 61},
@@ -273,14 +273,14 @@ func TestShardMapper_WriteAndSingleMapperRawQueryMultiSource(t *testing.T) {
 	shard := mustCreateShard(tmpDir)
 
 	pt1time := time.Unix(1, 0).UTC()
-	pt1 := models.NewPoint(
+	pt1 := models.MustNewPoint(
 		"cpu0",
 		map[string]string{"host": "serverA", "region": "us-east"},
 		map[string]interface{}{"foo": 42},
 		pt1time,
 	)
 	pt2time := time.Unix(2, 0).UTC()
-	pt2 := models.NewPoint(
+	pt2 := models.MustNewPoint(
 		"cpu1",
 		map[string]string{"host": "serverB", "region": "us-east"},
 		map[string]interface{}{"bar": 60},
@@ -338,14 +338,14 @@ func TestShardMapper_WriteAndSingleMapperAggregateQuery(t *testing.T) {
 	shard := mustCreateShard(tmpDir)
 
 	pt1time := time.Unix(10, 0).UTC()
-	pt1 := models.NewPoint(
+	pt1 := models.MustNewPoint(
 		"cpu",
 		map[string]string{"host": "serverA", "region": "us-east"},
 		map[string]interface{}{"value": 1},
 		pt1time,
 	)
 	pt2time := time.Unix(20, 0).UTC()
-	pt2 := models.NewPoint(
+	pt2 := models.MustNewPoint(
 		"cpu",
 		map[string]string{"host": "serverA", "region": "us-east"},
 		map[string]interface{}{"value": 60},
@@ -432,14 +432,14 @@ func TestShardMapper_SelectMapperTagSetsFields(t *testing.T) {
 	shard := mustCreateShard(tmpDir)
 
 	pt1time := time.Unix(1, 0).UTC()
-	pt1 := models.NewPoint(
+	pt1 := models.MustNewPoint(
 		"cpu",
 		map[string]string{"host": "serverA", "region": "us-east"},
 		map[string]interface{}{"value": 42},
 		pt1time,
 	)
 	pt2time := time.Unix(2, 0).UTC()
-	pt2 := models.NewPoint(
+	pt2 := models.MustNewPoint(
 		"cpu",
 		map[string]string{"host": "serverB", "region": "us-east"},
 		map[string]interface{}{"value": 60},

--- a/tsdb/query_executor_test.go
+++ b/tsdb/query_executor_test.go
@@ -23,7 +23,7 @@ func TestWritePointsAndExecuteQuery(t *testing.T) {
 	defer os.RemoveAll(store.Path())
 
 	// Write first point.
-	if err := store.WriteToShard(shardID, []models.Point{models.NewPoint(
+	if err := store.WriteToShard(shardID, []models.Point{models.MustNewPoint(
 		"cpu",
 		map[string]string{"host": "server"},
 		map[string]interface{}{"value": 1.0},
@@ -33,7 +33,7 @@ func TestWritePointsAndExecuteQuery(t *testing.T) {
 	}
 
 	// Write second point.
-	if err := store.WriteToShard(shardID, []models.Point{models.NewPoint(
+	if err := store.WriteToShard(shardID, []models.Point{models.MustNewPoint(
 		"cpu",
 		map[string]string{"host": "server"},
 		map[string]interface{}{"value": 1.0},
@@ -76,7 +76,7 @@ func TestWritePointsAndExecuteQuery_Update(t *testing.T) {
 	defer os.RemoveAll(store.Path())
 
 	// Write original point.
-	if err := store.WriteToShard(1, []models.Point{models.NewPoint(
+	if err := store.WriteToShard(1, []models.Point{models.MustNewPoint(
 		"temperature",
 		map[string]string{},
 		map[string]interface{}{"value": 100.0},
@@ -97,7 +97,7 @@ func TestWritePointsAndExecuteQuery_Update(t *testing.T) {
 	executor.ShardMapper = &testShardMapper{store: store}
 
 	// Rewrite point with new value.
-	if err := store.WriteToShard(1, []models.Point{models.NewPoint(
+	if err := store.WriteToShard(1, []models.Point{models.MustNewPoint(
 		"temperature",
 		map[string]string{},
 		map[string]interface{}{"value": 200.0},
@@ -117,7 +117,7 @@ func TestDropSeriesStatement(t *testing.T) {
 	store, executor := testStoreAndExecutor("")
 	defer os.RemoveAll(store.Path())
 
-	pt := models.NewPoint(
+	pt := models.MustNewPoint(
 		"cpu",
 		map[string]string{"host": "server"},
 		map[string]interface{}{"value": 1.0},
@@ -173,13 +173,13 @@ func TestDropMeasurementStatement(t *testing.T) {
 	store, executor := testStoreAndExecutor("")
 	defer os.RemoveAll(store.Path())
 
-	pt := models.NewPoint(
+	pt := models.MustNewPoint(
 		"cpu",
 		map[string]string{"host": "server"},
 		map[string]interface{}{"value": 1.0},
 		time.Unix(1, 2),
 	)
-	pt2 := models.NewPoint(
+	pt2 := models.MustNewPoint(
 		"memory",
 		map[string]string{"host": "server"},
 		map[string]interface{}{"value": 1.0},
@@ -239,7 +239,7 @@ func TestDropDatabase(t *testing.T) {
 	store, executor := testStoreAndExecutor("")
 	defer os.RemoveAll(store.Path())
 
-	pt := models.NewPoint(
+	pt := models.MustNewPoint(
 		"cpu",
 		map[string]string{"host": "server"},
 		map[string]interface{}{"value": 1.0},

--- a/tsdb/raw_test.go
+++ b/tsdb/raw_test.go
@@ -58,7 +58,7 @@ func TestWritePointsAndExecuteTwoShards(t *testing.T) {
 
 	// Write two points across shards.
 	pt1time := time.Unix(1, 0).UTC()
-	if err := store.WriteToShard(sID0, []models.Point{models.NewPoint(
+	if err := store.WriteToShard(sID0, []models.Point{models.MustNewPoint(
 		"cpu",
 		map[string]string{"host": "serverA", "region": "us-east"},
 		map[string]interface{}{"value": 100},
@@ -67,7 +67,7 @@ func TestWritePointsAndExecuteTwoShards(t *testing.T) {
 		t.Fatalf(err.Error())
 	}
 	pt2time := time.Unix(2, 0).UTC()
-	if err := store.WriteToShard(sID1, []models.Point{models.NewPoint(
+	if err := store.WriteToShard(sID1, []models.Point{models.MustNewPoint(
 		"cpu",
 		map[string]string{"host": "serverB", "region": "us-east"},
 		map[string]interface{}{"value": 200},
@@ -188,7 +188,7 @@ func TestWritePointsAndExecuteTwoShardsAlign(t *testing.T) {
 	}
 
 	// Write interleaving, by time, chunks to the shards.
-	if err := store.WriteToShard(sID0, []models.Point{models.NewPoint(
+	if err := store.WriteToShard(sID0, []models.Point{models.MustNewPoint(
 		"cpu",
 		map[string]string{"host": "serverA"},
 		map[string]interface{}{"value": 100},
@@ -196,7 +196,7 @@ func TestWritePointsAndExecuteTwoShardsAlign(t *testing.T) {
 	)}); err != nil {
 		t.Fatalf(err.Error())
 	}
-	if err := store.WriteToShard(sID1, []models.Point{models.NewPoint(
+	if err := store.WriteToShard(sID1, []models.Point{models.MustNewPoint(
 		"cpu",
 		map[string]string{"host": "serverB"},
 		map[string]interface{}{"value": 200},
@@ -204,7 +204,7 @@ func TestWritePointsAndExecuteTwoShardsAlign(t *testing.T) {
 	)}); err != nil {
 		t.Fatalf(err.Error())
 	}
-	if err := store.WriteToShard(sID1, []models.Point{models.NewPoint(
+	if err := store.WriteToShard(sID1, []models.Point{models.MustNewPoint(
 		"cpu",
 		map[string]string{"host": "serverA"},
 		map[string]interface{}{"value": 300},
@@ -268,7 +268,7 @@ func TestWritePointsAndExecuteTwoShardsQueryRewrite(t *testing.T) {
 
 	// Write two points across shards.
 	pt1time := time.Unix(1, 0).UTC()
-	if err := store0.WriteToShard(sID0, []models.Point{models.NewPoint(
+	if err := store0.WriteToShard(sID0, []models.Point{models.MustNewPoint(
 		"cpu",
 		map[string]string{"host": "serverA"},
 		map[string]interface{}{"value1": 100},
@@ -277,7 +277,7 @@ func TestWritePointsAndExecuteTwoShardsQueryRewrite(t *testing.T) {
 		t.Fatalf(err.Error())
 	}
 	pt2time := time.Unix(2, 0).UTC()
-	if err := store1.WriteToShard(sID1, []models.Point{models.NewPoint(
+	if err := store1.WriteToShard(sID1, []models.Point{models.MustNewPoint(
 		"cpu",
 		map[string]string{"host": "serverB"},
 		map[string]interface{}{"value2": 200},
@@ -360,7 +360,7 @@ func TestWritePointsAndExecuteTwoShardsTagSetOrdering(t *testing.T) {
 	}
 
 	// Write tagsets "y" and "z" to first shard.
-	if err := store.WriteToShard(sID0, []models.Point{models.NewPoint(
+	if err := store.WriteToShard(sID0, []models.Point{models.MustNewPoint(
 		"cpu",
 		map[string]string{"host": "y"},
 		map[string]interface{}{"value": 100},
@@ -368,7 +368,7 @@ func TestWritePointsAndExecuteTwoShardsTagSetOrdering(t *testing.T) {
 	)}); err != nil {
 		t.Fatalf(err.Error())
 	}
-	if err := store.WriteToShard(sID0, []models.Point{models.NewPoint(
+	if err := store.WriteToShard(sID0, []models.Point{models.MustNewPoint(
 		"cpu",
 		map[string]string{"host": "z"},
 		map[string]interface{}{"value": 200},
@@ -378,7 +378,7 @@ func TestWritePointsAndExecuteTwoShardsTagSetOrdering(t *testing.T) {
 	}
 
 	// Write tagsets "x", y" and "z" to second shard.
-	if err := store.WriteToShard(sID1, []models.Point{models.NewPoint(
+	if err := store.WriteToShard(sID1, []models.Point{models.MustNewPoint(
 		"cpu",
 		map[string]string{"host": "x"},
 		map[string]interface{}{"value": 300},
@@ -386,7 +386,7 @@ func TestWritePointsAndExecuteTwoShardsTagSetOrdering(t *testing.T) {
 	)}); err != nil {
 		t.Fatalf(err.Error())
 	}
-	if err := store.WriteToShard(sID1, []models.Point{models.NewPoint(
+	if err := store.WriteToShard(sID1, []models.Point{models.MustNewPoint(
 		"cpu",
 		map[string]string{"host": "y"},
 		map[string]interface{}{"value": 400},
@@ -394,7 +394,7 @@ func TestWritePointsAndExecuteTwoShardsTagSetOrdering(t *testing.T) {
 	)}); err != nil {
 		t.Fatalf(err.Error())
 	}
-	if err := store.WriteToShard(sID1, []models.Point{models.NewPoint(
+	if err := store.WriteToShard(sID1, []models.Point{models.MustNewPoint(
 		"cpu",
 		map[string]string{"host": "z"},
 		map[string]interface{}{"value": 500},
@@ -452,13 +452,13 @@ func TestShowMeasurementsMultipleShards(t *testing.T) {
 	// Write two points across shards.
 	pt1time := time.Unix(1, 0).UTC()
 	if err := store0.WriteToShard(sID0, []models.Point{
-		models.NewPoint(
+		models.MustNewPoint(
 			"cpu_user",
 			map[string]string{"host": "serverA", "region": "east", "cpuid": "cpu0"},
 			map[string]interface{}{"value1": 100},
 			pt1time,
 		),
-		models.NewPoint(
+		models.MustNewPoint(
 			"mem_free",
 			map[string]string{"host": "serverA", "region": "east"},
 			map[string]interface{}{"value2": 200},
@@ -468,13 +468,13 @@ func TestShowMeasurementsMultipleShards(t *testing.T) {
 		t.Fatalf(err.Error())
 	}
 	pt2time := time.Unix(2, 0).UTC()
-	if err := store1.WriteToShard(sID1, []models.Point{models.NewPoint(
+	if err := store1.WriteToShard(sID1, []models.Point{models.MustNewPoint(
 		"mem_used",
 		map[string]string{"host": "serverB", "region": "west"},
 		map[string]interface{}{"value3": 300},
 		pt2time,
 	),
-		models.NewPoint(
+		models.MustNewPoint(
 			"cpu_sys",
 			map[string]string{"host": "serverB", "region": "west", "cpuid": "cpu0"},
 			map[string]interface{}{"value4": 400},
@@ -551,13 +551,13 @@ func TestShowShowTagKeysMultipleShards(t *testing.T) {
 	// Write two points across shards.
 	pt1time := time.Unix(1, 0).UTC()
 	if err := store0.WriteToShard(sID0, []models.Point{
-		models.NewPoint(
+		models.MustNewPoint(
 			"cpu",
 			map[string]string{"host": "serverA", "region": "uswest"},
 			map[string]interface{}{"value1": 100},
 			pt1time,
 		),
-		models.NewPoint(
+		models.MustNewPoint(
 			"cpu",
 			map[string]string{"host": "serverB", "region": "useast"},
 			map[string]interface{}{"value1": 100},
@@ -568,13 +568,13 @@ func TestShowShowTagKeysMultipleShards(t *testing.T) {
 	}
 	pt2time := time.Unix(2, 0).UTC()
 	if err := store1.WriteToShard(sID1, []models.Point{
-		models.NewPoint(
+		models.MustNewPoint(
 			"cpu",
 			map[string]string{"host": "serverB", "region": "useast", "rack": "12"},
 			map[string]interface{}{"value1": 100},
 			pt1time,
 		),
-		models.NewPoint(
+		models.MustNewPoint(
 			"mem",
 			map[string]string{"host": "serverB"},
 			map[string]interface{}{"value2": 200},

--- a/tsdb/shard_test.go
+++ b/tsdb/shard_test.go
@@ -30,7 +30,7 @@ func TestShardWriteAndIndex(t *testing.T) {
 		t.Fatalf("error openeing shard: %s", err.Error())
 	}
 
-	pt := models.NewPoint(
+	pt := models.MustNewPoint(
 		"cpu",
 		map[string]string{"host": "server"},
 		map[string]interface{}{"value": 1.0},
@@ -99,7 +99,7 @@ func TestShardWriteAddNewField(t *testing.T) {
 	}
 	defer sh.Close()
 
-	pt := models.NewPoint(
+	pt := models.MustNewPoint(
 		"cpu",
 		map[string]string{"host": "server"},
 		map[string]interface{}{"value": 1.0},
@@ -111,7 +111,7 @@ func TestShardWriteAddNewField(t *testing.T) {
 		t.Fatalf(err.Error())
 	}
 
-	pt = models.NewPoint(
+	pt = models.MustNewPoint(
 		"cpu",
 		map[string]string{"host": "server"},
 		map[string]interface{}{"value": 1.0, "value2": 2.0},
@@ -159,7 +159,7 @@ func TestShard_Autoflush(t *testing.T) {
 
 	// Write a bunch of points.
 	for i := 0; i < 100; i++ {
-		if err := sh.WritePoints([]models.Point{models.NewPoint(
+		if err := sh.WritePoints([]models.Point{models.MustNewPoint(
 			fmt.Sprintf("cpu%d", i),
 			map[string]string{"host": "server"},
 			map[string]interface{}{"value": 1.0},
@@ -199,7 +199,7 @@ func TestShard_Autoflush_FlushInterval(t *testing.T) {
 
 	// Write some points.
 	for i := 0; i < 100; i++ {
-		if err := sh.WritePoints([]models.Point{models.NewPoint(
+		if err := sh.WritePoints([]models.Point{models.MustNewPoint(
 			fmt.Sprintf("cpu%d", i),
 			map[string]string{"host": "server"},
 			map[string]interface{}{"value": 1.0},
@@ -256,7 +256,7 @@ func benchmarkWritePoints(b *testing.B, mCnt, tkCnt, tvCnt, pntCnt int) {
 	points := []models.Point{}
 	for _, s := range series {
 		for val := 0.0; val < float64(pntCnt); val++ {
-			p := models.NewPoint(s.Measurement, s.Series.Tags, map[string]interface{}{"value": val}, time.Now())
+			p := models.MustNewPoint(s.Measurement, s.Series.Tags, map[string]interface{}{"value": val}, time.Now())
 			points = append(points, p)
 		}
 	}
@@ -297,7 +297,7 @@ func benchmarkWritePointsExistingSeries(b *testing.B, mCnt, tkCnt, tvCnt, pntCnt
 	points := []models.Point{}
 	for _, s := range series {
 		for val := 0.0; val < float64(pntCnt); val++ {
-			p := models.NewPoint(s.Measurement, s.Series.Tags, map[string]interface{}{"value": val}, time.Now())
+			p := models.MustNewPoint(s.Measurement, s.Series.Tags, map[string]interface{}{"value": val}, time.Now())
 			points = append(points, p)
 		}
 	}

--- a/tsdb/store_test.go
+++ b/tsdb/store_test.go
@@ -286,7 +286,7 @@ func benchmarkStoreOpen(b *testing.B, mCnt, tkCnt, tvCnt, pntCnt, shardCnt int) 
 	points := []models.Point{}
 	for _, s := range series {
 		for val := 0.0; val < float64(pntCnt); val++ {
-			p := models.NewPoint(s.Measurement, s.Series.Tags, map[string]interface{}{"value": val}, time.Now())
+			p := models.MustNewPoint(s.Measurement, s.Series.Tags, map[string]interface{}{"value": val}, time.Now())
 			points = append(points, p)
 		}
 	}


### PR DESCRIPTION
This PR has a few changes to how points are accepted and stored.

* Float `NaN` values were not supported, but were able to be written through the line protocol, collectd, and other inputs.  These values caused problem during query time as well as with the the `tsm1` engine since they were not intended to be stored.  This change returns parse error for `NaN` float values as well as prevents `NewPoint` from returning a valid point if given a `NaN` float value.  The `tsm1` float encoding will now also return an error if a `NaN` value is attempted to be encoded.
* The change to `NewPoint` returning an error propagated up to the client packages which will require upgrades to users that are not controlling the version of the client that they are using.  They will need to handle the error and determine the best thing to do with points that can't be stored.
* Since many clients already assume `NaN` can be stored, the inputs have been updated to drop and log (when appropriate) points with invalid field values.  Graphite, UDP, Collectd, and OpenTSDB inputs already dropped points so this change makes the behavior consistent across all inputs.
* HTTP line protocol handler will now write all successfully parsed points instead of failing the entire batch if one failed.  When some points fail to parse and the remaining are written successfully, the endpoint returns a `partial write` error with the failed lines in the response.  This makes the behavior more consistent with the other inputs.
* Since `NaN` values cannot be parsed correctly now, TSM WAL entries will fail to parse and the WAL will abort startup.  TSM data will need to be removed, but we'll log the point data that failed to parse to help with troubleshooting.

Fixes #4521 #4513