### PR TITLE
Only display Enterprise hint on CLI mode

### DIFF
--- a/cmd/influx/main.go
+++ b/cmd/influx/main.go
@@ -168,16 +168,15 @@ Examples:
 		return
 	}
 
-	token, err := c.DatabaseToken()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to check token: %s\n", err.Error())
-		return
-	}
-	if token == "" {
-		fmt.Printf(noTokenMsg)
-	}
-
 	if c.Execute == "" && !c.Import {
+		token, err := c.DatabaseToken()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to check token: %s\n", err.Error())
+			return
+		}
+		if token == "" {
+			fmt.Printf(noTokenMsg)
+		}
 		fmt.Printf("Connected to %s version %s\n", c.Client.Addr(), c.Version)
 	}
 


### PR DESCRIPTION
This change moves the logic to detect and display the Enterprise
registration hint into the same logic check as that which decides if the
successful-connection message should be displayed.

Addresses comment https://github.com/influxdb/influxdb/pull/4514#issuecomment-151665728