### PR TITLE
skip empty string for start position

### DIFF
--- a/models/points.go
+++ b/models/points.go
@@ -726,7 +726,7 @@ func skipWhitespace(buf []byte, i int) int {
 			return i
 		}
 
-		if buf[i] == ' ' || buf[i] == '\t' {
+		if buf[i] == ' ' || buf[i] == '\t' || buf[i] == 0 {
 			i += 1
 			continue
 		}

--- a/models/points_test.go
+++ b/models/points_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"math"
+	"math/rand"
 	"reflect"
 	"strconv"
 	"strings"
@@ -1507,5 +1508,27 @@ func TestPrecisionString(t *testing.T) {
 			t.Errorf("%s: PrecisionString() mismatch:\n actual:	%v\n exp:		%v",
 				test.name, act, test.exp)
 		}
+	}
+}
+
+func TestParsePointsStringWithExtraBuffer(t *testing.T) {
+	b := make([]byte, 70*5000)
+	buf := bytes.NewBuffer(b)
+	key := "cpu,host=A,region=uswest"
+	buf.WriteString(fmt.Sprintf("%s value=%.3f 1\n", key, rand.Float64()))
+
+	points, err := models.ParsePointsString(buf.String())
+	if err != nil {
+		t.Fatalf("failed to write points: %s", err.Error())
+	}
+
+	pointKey := string(points[0].Key())
+
+	if len(key) != len(pointKey) {
+		t.Fatalf("expected length of both keys are same but got %d and %d", len(key), len(pointKey))
+	}
+
+	if key != pointKey {
+		t.Fatalf("expected both keys are same but got %s and %s", key, pointKey)
 	}
 }


### PR DESCRIPTION
Hi,

I found out that **scanLine()** in **models/points.go** doesn't filter empty string (uint8 = 0) for **start** position.
This will introduce some weird issues if the input is made from a large buffer, the Key() from first point gonna be a very large string with all the empty string due to the invalid start position.

One of the obvious example is, if you change the value from **uswest10** to **uswest1** in https://github.com/influxdb/influxdb/blob/master/tsdb/engine/wal/wal_test.go#L327, the test will be failed due to this issue (only uswest1 will fail, uswest2 until uswest100 working fine). The reason is the **first key** is a large string **(350000*uint8 + "cpu,host=A,region=uswest1")**, it return no result when we pass in the valid key **"cpu,host=A,region=uswest1"** to lookup value from map (string comparison failed).
* uswest10 (or uswest2 until uswest99) have no issue is because it is not the first point.

I have also created a test for points_test.go, this test gonna be failed without the new changes.

Sorry if my explanation is not clear enough. 