### PR TITLE
ping endpoint can now wait for leader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - [#4516](https://github.com/influxdb/influxdb/pull/4516): Hinted-handoff refactor, with new statistics and diagnostics
 - [#4501](https://github.com/influxdb/influxdb/pull/4501): Allow filtering SHOW MEASUREMENTS by regex.
 - [#4547](https://github.com/influxdb/influxdb/pull/4547): Allow any node to be dropped, even a raft node (even the leader).
+- [#4600](https://github.com/influxdb/influxdb/pull/4600): ping endpoint can wait for leader
 
 ### Bugfixes
 - [#4389](https://github.com/influxdb/influxdb/pull/4389): Don't add a new segment file on each hinted-handoff purge cycle.

--- a/services/httpd/handler.go
+++ b/services/httpd/handler.go
@@ -55,6 +55,7 @@ type Handler struct {
 	Version               string
 
 	MetaStore interface {
+		WaitForLeader(timeout time.Duration) error
 		Database(name string) (*meta.DatabaseInfo, error)
 		Authenticate(username, password string) (ui *meta.UserInfo, err error)
 		Users() ([]meta.UserInfo, error)
@@ -547,6 +548,21 @@ func (h *Handler) serveOptions(w http.ResponseWriter, r *http.Request) {
 
 // servePing returns a simple response to let the client know the server is running.
 func (h *Handler) servePing(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+	wfl := q.Get("wait_for_leader")
+
+	if wfl != "" {
+		d, err := time.ParseDuration(wfl)
+		if err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		if err := h.MetaStore.WaitForLeader(d); err != nil {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+	}
+
 	h.statMap.Add(statPingRequest, 1)
 	w.WriteHeader(http.StatusNoContent)
 }


### PR DESCRIPTION
With this change the `ping` endpoint now accepts an optional parameter `wait_for_leader`, which should be supplied with a timeout. If set then the endpoint will not return until the system has a Raft leader, or the timeout passes. If the timeout passes 503 is returned.

If the timeout is 0, then the endpoint waits forever.

https://github.com/influxdb/influxdb.com/issues/438