### PR TITLE
Fix data races in TSM dataFile

### DIFF
--- a/tsdb/engine/tsm1/tsm1.go
+++ b/tsdb/engine/tsm1/tsm1.go
@@ -11,7 +11,6 @@ import (
 	"math"
 	"os"
 	"path/filepath"
-	"reflect"
 	"sort"
 	"strings"
 	"sync"
@@ -584,7 +583,7 @@ func (e *Engine) getCompactionFiles(fullCompaction bool) (minTime, maxTime int64
 		} else {
 			filesAfterLock = e.filesToCompact()
 		}
-		if !reflect.DeepEqual(files, filesAfterLock) {
+		if !dataFilesEquals(files, filesAfterLock) {
 			e.writeLock.UnlockRange(minTime, maxTime)
 			continue
 		}

--- a/tsdb/engine/tsm1/tsm1.go
+++ b/tsdb/engine/tsm1/tsm1.go
@@ -2017,6 +2017,11 @@ func (d *dataFile) Delete() error {
 	if err := d.close(); err != nil {
 		return err
 	}
+
+	if d.f == nil {
+		return nil
+	}
+
 	err := os.RemoveAll(d.f.Name())
 	if err != nil {
 		return err

--- a/tsdb/engine/tsm1/tsm1_test.go
+++ b/tsdb/engine/tsm1/tsm1_test.go
@@ -1673,7 +1673,6 @@ func TestEngine_DecodeAndCombine_NoNewValues(t *testing.T) {
 }
 
 func TestEngine_Write_Concurrent(t *testing.T) {
-	//t.Skip("re-enable once tsm1 Write refactor is merged")
 	e := OpenDefaultEngine()
 	defer e.Engine.Close()
 

--- a/tsdb/engine/tsm1/tsm1_test.go
+++ b/tsdb/engine/tsm1/tsm1_test.go
@@ -367,7 +367,7 @@ func TestEngine_Write_MixedFields(t *testing.T) {
 	verify([]models.Point{p1, p2, p3, p4})
 }
 
-// Tests that writing and compactions runnign concurrently does not
+// Tests that writing and compactions running concurrently does not
 // fail.
 func TestEngine_WriteCompaction_Concurrent(t *testing.T) {
 	e := OpenDefaultEngine()
@@ -1673,7 +1673,7 @@ func TestEngine_DecodeAndCombine_NoNewValues(t *testing.T) {
 }
 
 func TestEngine_Write_Concurrent(t *testing.T) {
-	t.Skip("re-enable once tsm1 Write refactor is merged")
+	//t.Skip("re-enable once tsm1 Write refactor is merged")
 	e := OpenDefaultEngine()
 	defer e.Engine.Close()
 


### PR DESCRIPTION
`dataFile` was not protected by a mutex in all cases so deleting a file during a rewrite caused data races and possibly corruption.  

Fixes #4534 #4604 #4601 