### PR TITLE
Use HTTPS instead of Https in variable names

### DIFF
--- a/services/admin/config.go
+++ b/services/admin/config.go
@@ -8,14 +8,14 @@ const (
 type Config struct {
 	Enabled          bool   `toml:"enabled"`
 	BindAddress      string `toml:"bind-address"`
-	HttpsEnabled     bool   `toml:"https-enabled"`
-	HttpsCertificate string `toml:"https-certificate"`
+	HTTPSEnabled     bool   `toml:"https-enabled"`
+	HTTPSCertificate string `toml:"https-certificate"`
 }
 
 func NewConfig() Config {
 	return Config{
 		BindAddress:      DefaultBindAddress,
-		HttpsEnabled:     false,
-		HttpsCertificate: "/etc/ssl/influxdb.pem",
+		HTTPSEnabled:     false,
+		HTTPSCertificate: "/etc/ssl/influxdb.pem",
 	}
 }

--- a/services/admin/config_test.go
+++ b/services/admin/config_test.go
@@ -24,9 +24,9 @@ https-certificate = "/dev/null"
 		t.Fatalf("unexpected enabled: %v", c.Enabled)
 	} else if c.BindAddress != ":8083" {
 		t.Fatalf("unexpected bind address: %s", c.BindAddress)
-	} else if c.HttpsEnabled != true {
-		t.Fatalf("unexpected https enabled: %v", c.HttpsEnabled)
-	} else if c.HttpsCertificate != "/dev/null" {
-		t.Fatalf("unexpected https certificate: %v", c.HttpsCertificate)
+	} else if c.HTTPSEnabled != true {
+		t.Fatalf("unexpected https enabled: %v", c.HTTPSEnabled)
+	} else if c.HTTPSCertificate != "/dev/null" {
+		t.Fatalf("unexpected https certificate: %v", c.HTTPSCertificate)
 	}
 }

--- a/services/admin/service.go
+++ b/services/admin/service.go
@@ -29,8 +29,8 @@ type Service struct {
 func NewService(c Config) *Service {
 	return &Service{
 		addr:   c.BindAddress,
-		https:  c.HttpsEnabled,
-		cert:   c.HttpsCertificate,
+		https:  c.HTTPSEnabled,
+		cert:   c.HTTPSCertificate,
 		err:    make(chan error),
 		logger: log.New(os.Stderr, "[admin] ", log.LstdFlags),
 	}

--- a/services/httpd/config.go
+++ b/services/httpd/config.go
@@ -7,8 +7,8 @@ type Config struct {
 	LogEnabled       bool   `toml:"log-enabled"`
 	WriteTracing     bool   `toml:"write-tracing"`
 	PprofEnabled     bool   `toml:"pprof-enabled"`
-	HttpsEnabled     bool   `toml:"https-enabled"`
-	HttpsCertificate string `toml:"https-certificate"`
+	HTTPSEnabled     bool   `toml:"https-enabled"`
+	HTTPSCertificate string `toml:"https-certificate"`
 }
 
 func NewConfig() Config {
@@ -16,7 +16,7 @@ func NewConfig() Config {
 		Enabled:          true,
 		BindAddress:      ":8086",
 		LogEnabled:       true,
-		HttpsEnabled:     false,
-		HttpsCertificate: "/etc/ssl/influxdb.pem",
+		HTTPSEnabled:     false,
+		HTTPSCertificate: "/etc/ssl/influxdb.pem",
 	}
 }

--- a/services/httpd/config_test.go
+++ b/services/httpd/config_test.go
@@ -36,10 +36,10 @@ https-certificate = "/dev/null"
 		t.Fatalf("unexpected write tracing: %v", c.WriteTracing)
 	} else if c.PprofEnabled != true {
 		t.Fatalf("unexpected pprof enabled: %v", c.PprofEnabled)
-	} else if c.HttpsEnabled != true {
-		t.Fatalf("unexpected https enabled: %v", c.HttpsEnabled)
-	} else if c.HttpsCertificate != "/dev/null" {
-		t.Fatalf("unexpected https certificate: %v", c.HttpsCertificate)
+	} else if c.HTTPSEnabled != true {
+		t.Fatalf("unexpected https enabled: %v", c.HTTPSEnabled)
+	} else if c.HTTPSCertificate != "/dev/null" {
+		t.Fatalf("unexpected https certificate: %v", c.HTTPSCertificate)
 	}
 }
 

--- a/services/httpd/service.go
+++ b/services/httpd/service.go
@@ -51,8 +51,8 @@ func NewService(c Config) *Service {
 
 	s := &Service{
 		addr:  c.BindAddress,
-		https: c.HttpsEnabled,
-		cert:  c.HttpsCertificate,
+		https: c.HTTPSEnabled,
+		cert:  c.HTTPSCertificate,
 		err:   make(chan error),
 		Handler: NewHandler(
 			c.AuthEnabled,


### PR DESCRIPTION
Patched some config structs so that attribute names follow Go conventions.

I've already signed the CLA for other contributions.