### PR TITLE
Fix restore functionality panics

### DIFF
--- a/cmd/influxd/restore/restore.go
+++ b/cmd/influxd/restore/restore.go
@@ -158,6 +158,7 @@ func (cmd *Command) unpackMeta(mr *snapshot.MultiReader, sf snapshot.File, confi
 	store := meta.NewStore(config.Meta)
 	store.RaftListener = newNopListener()
 	store.ExecListener = newNopListener()
+	store.RPCListener = newNopListener()
 
 	// Determine advertised address.
 	_, port, err := net.SplitHostPort(config.Meta.BindAddress)


### PR DESCRIPTION
fix #4642 

``` 
...
unpacking: _internal/monitor/6 (18436096 bytes)
unpacking: _internal/monitor/7 (20914176 bytes)
unpacking: _internal/monitor/8 (11087872 bytes)
unpacking: meta (407 bytes)
panic: Store.RPCListener not set

goroutine 1 [running]:
github.com/influxdb/influxdb/meta.(*Store).Open(0xc82007c780, 0x0, 0x0)
        /tmp/tmp.CBAd6vC3wi/src/github.com/influxdb/influxdb/meta/store.go:191 +0x1a5
github.com/influxdb/influxdb/cmd/influxd/restore.(*Command).unpackMeta(0xc82000d520, 0xc82000af50, 0xc820112f70, 0x4, 0x197, 0xecdca8d30, 0x2137a205, 0x10a7b20, 0xc8200ee000, 0x0, ...)

....
```