### PR TITLE
Check for errors in response during token check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@
 - [#4344](https://github.com/influxdb/influxdb/issues/4344): Make client.Write default to client.precision if none is given.
 - [#3429](https://github.com/influxdb/influxdb/issues/3429): Incorrect parsing of regex containing '/'
 - [#4374](https://github.com/influxdb/influxdb/issues/4374): Add tsm1 quickcheck tests
+- [#4644](https://github.com/influxdb/influxdb/pull/4644): Check for response errors during token check, fixes issue [#4641](https://github.com/influxdb/influxdb/issues/4641)
 - [#4377](https://github.com/influxdb/influxdb/pull/4377): Hinted handoff should not process dropped nodes
 - [#4365](https://github.com/influxdb/influxdb/issues/4365): Prevent panic in DecodeSameTypeBlock
 - [#4280](https://github.com/influxdb/influxdb/issues/4280): Only drop points matching WHERE clause

--- a/cmd/influx/main.go
+++ b/cmd/influx/main.go
@@ -549,9 +549,10 @@ func (c *CommandLine) DatabaseToken() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if len((*response).Results[0].Series) == 0 {
+	if response.Error() != nil || len((*response).Results[0].Series) == 0 {
 		return "", nil
 	}
+
 	// Look for position of "token" column.
 	for i, s := range (*response).Results[0].Series[0].Columns {
 		if s == "token" {


### PR DESCRIPTION
Fixes issue #4641.

If there is any error embedded in the response, simply assume no token and print the token hint.