### PR TITLE
Increase performance of the UDP client

### DIFF
--- a/client/v2/example_test.go
+++ b/client/v2/example_test.go
@@ -28,7 +28,12 @@ func ExampleClient_NewClient() client.Client {
 // Write a point using the UDP client
 func ExampleClient_WriteUDP() {
 	// Make client
-	c := client.NewUDPClient("localhost:8089")
+	config := client.UDPConfig{Addr: "localhost:8089"}
+	c, err := client.NewUDPClient(config)
+	if err != nil {
+		panic(err.Error())
+	}
+	defer c.Close()
 
 	// Create a new point batch
 	bp, _ := client.NewBatchPoints(client.BatchPointsConfig{
@@ -59,6 +64,7 @@ func ExampleClient_Write() {
 	c := client.NewClient(client.Config{
 		URL: u,
 	})
+	defer c.Close()
 
 	// Create a new point batch
 	bp, _ := client.NewBatchPoints(client.BatchPointsConfig{
@@ -163,6 +169,7 @@ func ExampleClient_Write1000() {
 	clnt := client.NewClient(client.Config{
 		URL: u,
 	})
+	defer clnt.Close()
 
 	rand.Seed(42)
 
@@ -211,6 +218,7 @@ func ExampleClient_Query() {
 	c := client.NewClient(client.Config{
 		URL: u,
 	})
+	defer c.Close()
 
 	q := client.Query{
 		Command:   "SELECT count(value) FROM shapes",
@@ -229,6 +237,7 @@ func ExampleClient_CreateDatabase() {
 	c := client.NewClient(client.Config{
 		URL: u,
 	})
+	defer c.Close()
 
 	q := client.Query{
 		Command: "CREATE DATABASE telegraf",


### PR DESCRIPTION
I made the UDP client only resolve and dial once, when it's created. This does two things: it makes Write significantly faster, and it pushes name resolution errors to when you first create the client. 

I also added a buffer size knob the new UDP config struct I created. This is very important, as before the client was likely broken unless you were using it on your own machine. MTUs will generally not be ~65000, they will be more like 1500 or 500 and this needs to be tuneable if people plan on using this client over the internet. Unfortunately, UDPConn.SetReadBuffer sets the OS read buffer size and will not change the maximum size datagram you can receive so I removed it.

Lastly, in the UDP service I moved buffer creation outside of the loop to save allocations.

This is just an idea. I don't know if you'd want to commit to an extra function on the Client interface or the UDPConfig struct, but I believe they are necessary.

