### PR TITLE
Fix default configuration

### DIFF
--- a/cmd/influxd/run/config_test.go
+++ b/cmd/influxd/run/config_test.go
@@ -1,12 +1,29 @@
 package run_test
 
 import (
+	"bytes"
 	"os"
 	"testing"
 
 	"github.com/BurntSushi/toml"
 	"github.com/influxdb/influxdb/cmd/influxd/run"
 )
+
+// Ensure the demo configuration can be parsed.
+func TestConfig_Parse_Demo(t *testing.T) {
+	config, err := run.NewDemoConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	buf := new(bytes.Buffer)
+	if err := toml.NewEncoder(buf).Encode(config); err != nil {
+		t.Fatal(err)
+	}
+	_, err = toml.Decode(buf.String(), &config)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
 
 // Ensure the configuration can be parsed.
 func TestConfig_Parse(t *testing.T) {

--- a/toml/toml.go
+++ b/toml/toml.go
@@ -36,7 +36,7 @@ func (d *Duration) UnmarshalText(text []byte) error {
 
 // MarshalText converts a duration to a string for decoding toml
 func (d Duration) MarshalText() (text []byte, err error) {
-	return []byte(d.String()), nil
+	return []byte(fmt.Sprintf(`"%s"`, d.String())), nil
 }
 
 // Size represents a TOML parseable file size.


### PR DESCRIPTION
On my machine, influxd fails at parsing the default config generated by `influxd config`

```
# ./influxd -config =(./influxd config)

 8888888           .d888 888                   8888888b.  888888b.
   888            d88P"  888                   888  "Y88b 888  "88b
   888            888    888                   888    888 888  .88P
   888   88888b.  888888 888 888  888 888  888 888    888 8888888K.
   888   888 "88b 888    888 888  888  Y8bd8P' 888    888 888  "Y88b
   888   888  888 888    888 888  888   X88K   888    888 888    888
   888   888  888 888    888 Y88b 888 .d8""8b. 888  .d88P 888   d88P
 8888888 888  888 888    888  "Y88888 888  888 8888888P"  8888888P"

2015/11/04 23:06:44 InfluxDB starting, version 0.9, branch unknown, commit unknown, built unknown
2015/11/04 23:06:44 Go version go1.5, GOMAXPROCS set to 4
2015/11/04 23:06:44 Using configuration at: /var/folders/1r/bmj_jrc92_gf99zmlqqln8v40000gn/T/zshYImWZC
run: parse config: Near line 8, key 'meta': Near line 8: Expected a top-level item to end with a new line, comment or EOF, but got 's' instead.
```

I fixed it and added a test.