### PR TITLE
Fix restore panic issue #4671

### DIFF
--- a/cmd/influxd/restore/restore.go
+++ b/cmd/influxd/restore/restore.go
@@ -173,6 +173,7 @@ func (cmd *Command) unpackMeta(mr *snapshot.MultiReader, sf snapshot.File, confi
 		return fmt.Errorf("resolve tcp: addr=%s, err=%s", hostport, err)
 	}
 	store.Addr = addr
+	store.RemoteAddr = addr
 
 	// Open the meta store.
 	if err := store.Open(); err != nil {


### PR DESCRIPTION
When unpacking the meta, the Store `Addr` is built against the hostname and the `bind-address` port.
We can use this resolved address for the `RemoteAddr` as well since according to the clustering docs the `hostname must be resolved by all members in the cluster`