### PR TITLE
Add graphite and udp services to the default config generator

### DIFF
--- a/cmd/influxd/run/config.go
+++ b/cmd/influxd/run/config.go
@@ -69,8 +69,10 @@ func NewConfig() *Config {
 	c.Monitor = monitor.NewConfig()
 	c.Subscriber = subscriber.NewConfig()
 	c.HTTPD = httpd.NewConfig()
+	c.Graphites = []graphite.Config{graphite.NewConfig()}
 	c.Collectd = collectd.NewConfig()
 	c.OpenTSDB = opentsdb.NewConfig()
+	c.UDPs = []udp.Config{udp.NewConfig()}
 
 	c.ContinuousQuery = continuous_querier.NewConfig()
 	c.Retention = retention.NewConfig()

--- a/services/graphite/config.go
+++ b/services/graphite/config.go
@@ -38,9 +38,9 @@ const (
 
 // Config represents the configuration for Graphite endpoints.
 type Config struct {
+	Enabled          bool          `toml:"enabled"`
 	BindAddress      string        `toml:"bind-address"`
 	Database         string        `toml:"database"`
-	Enabled          bool          `toml:"enabled"`
 	Protocol         string        `toml:"protocol"`
 	BatchSize        int           `toml:"batch-size"`
 	BatchPending     int           `toml:"batch-pending"`
@@ -49,6 +49,19 @@ type Config struct {
 	Templates        []string      `toml:"templates"`
 	Tags             []string      `toml:"tags"`
 	Separator        string        `toml:"separator"`
+}
+
+func NewConfig() Config {
+	return Config{
+		BindAddress:      DefaultBindAddress,
+		Database:         DefaultDatabase,
+		Protocol:         DefaultProtocol,
+		BatchSize:        DefaultBatchSize,
+		BatchPending:     DefaultBatchPending,
+		BatchTimeout:     toml.Duration(DefaultBatchTimeout),
+		ConsistencyLevel: DefaultConsistencyLevel,
+		Separator:        DefaultSeparator,
+	}
 }
 
 // WithDefaults takes the given config and returns a new config with any required

--- a/services/udp/config.go
+++ b/services/udp/config.go
@@ -7,8 +7,14 @@ import (
 )
 
 const (
+	// DefaultBindAddress is the default binding interface if none is specified.
+	DefaultBindAddress = ":8089"
+
 	// DefaultDatabase is the default database for UDP traffic.
 	DefaultDatabase = "udp"
+
+	// DefaultRetentionPolicy is the default retention policy used for writes.
+	DefaultRetentionPolicy = ""
 
 	// DefaultBatchSize is the default UDP batch size.
 	DefaultBatchSize = 1000
@@ -29,6 +35,17 @@ type Config struct {
 	BatchSize       int           `toml:"batch-size"`
 	BatchPending    int           `toml:"batch-pending"`
 	BatchTimeout    toml.Duration `toml:"batch-timeout"`
+}
+
+func NewConfig() Config {
+	return Config{
+		BindAddress:     DefaultBindAddress,
+		Database:        DefaultDatabase,
+		RetentionPolicy: DefaultRetentionPolicy,
+		BatchSize:       DefaultBatchSize,
+		BatchPending:    DefaultBatchPending,
+		BatchTimeout:    toml.Duration(DefaultBatchTimeout),
+	}
 }
 
 // WithDefaults takes the given config and returns a new config with any required


### PR DESCRIPTION
Being too lazy to read the docs, I got slightly frustrated that `influxd config` didn't spit out default configurations for graphite and UDP.

This PR adds `NewConfig()` functions to those services and generates a config for each of them in the `run.NewConfig()`. The graphite service had this previously but it was removed in 332ce64.