### PR TITLE
PointsWriter will drop writes to subscriber service for any in-flight writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,7 @@
 - [#4625](https://github.com/influxdb/influxdb/pull/4625): Correctly handle bad write requests. Thanks @oiooj.
 - [#4650](https://github.com/influxdb/influxdb/issues/4650): Importer should skip empty lines
 - [#4651](https://github.com/influxdb/influxdb/issues/4651): Importer doesn't flush out last batch
+- [#4602](https://github.com/influxdb/influxdb/issues/4602): Fixes data race between PointsWriter and Subscriber services.
 
 ## v0.9.4 [2015-09-14]
 

--- a/cluster/points_writer_test.go
+++ b/cluster/points_writer_test.go
@@ -322,6 +322,9 @@ func TestPointsWriter_WritePoints(t *testing.T) {
 		c.HintedHandoff = hh
 		c.Subscriber = sub
 
+		c.Open()
+		defer c.Close()
+
 		err := c.WritePoints(pr)
 		if err == nil && test.expErr != nil {
 			t.Errorf("PointsWriter.WritePoints(): '%s' error: got %v, exp %v", test.name, err, test.expErr)

--- a/cmd/influxd/run/server.go
+++ b/cmd/influxd/run/server.go
@@ -385,10 +385,6 @@ func (s *Server) Open() error {
 		// Wait for the store to initialize.
 		<-s.MetaStore.Ready()
 
-		if err := s.Monitor.Open(); err != nil {
-			return fmt.Errorf("open monitor: %v", err)
-		}
-
 		// Open TSDB store.
 		if err := s.TSDBStore.Open(); err != nil {
 			return fmt.Errorf("open tsdb store: %s", err)
@@ -402,6 +398,16 @@ func (s *Server) Open() error {
 		// Open the subcriber service
 		if err := s.Subscriber.Open(); err != nil {
 			return fmt.Errorf("open subscriber: %s", err)
+		}
+
+		// Open the points writer service
+		if err := s.PointsWriter.Open(); err != nil {
+			return fmt.Errorf("open points writer: %s", err)
+		}
+
+		// Open the monitor service
+		if err := s.Monitor.Open(); err != nil {
+			return fmt.Errorf("open monitor: %v", err)
 		}
 
 		for _, service := range s.Services {
@@ -442,6 +448,10 @@ func (s *Server) Close() error {
 
 	if s.Monitor != nil {
 		s.Monitor.Close()
+	}
+
+	if s.PointsWriter != nil {
+		s.PointsWriter.Close()
 	}
 
 	if s.HintedHandoff != nil {


### PR DESCRIPTION
Fixes #4602 

Not sure this is the best solution but it does eliminate the data race.

The race was caused by in-flight writes that were about to write to the points channel as it was being closed. In order to safely close the channel without causing a data race or potential panic on writing to a closed channel, the channel is nil'ed. This causes the select statement to skip the case of writing any points to the subscriber. Essentially any in-flight write requests will not make it to the subscriber on close.

We could make it more robust by processing all writes in a single goroutine or spawn a new goroutine for each write and use a wait group to wait on all of them before closing. But both of those seemed quite heavy and its understood that the subscriber could drop writes.