### PR TITLE
Implement CLI history command

### DIFF
--- a/cmd/influx/main.go
+++ b/cmd/influx/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/influxdb/influxdb/cluster"
 	"github.com/influxdb/influxdb/importer/v8"
 	"github.com/peterh/liner"
+	"io/ioutil"
 )
 
 // These variables are populated via the Go linker.
@@ -273,6 +274,8 @@ func (c *CommandLine) ParseCommand(cmd string) bool {
 		c.SetAuth(cmd)
 	case strings.HasPrefix(lcmd, "help"):
 		c.help()
+	case strings.HasPrefix(lcmd, "history"):
+		c.history()
 	case strings.HasPrefix(lcmd, "format"):
 		c.SetFormat(cmd)
 	case strings.HasPrefix(lcmd, "precision"):
@@ -753,6 +756,17 @@ func (c *CommandLine) help() {
         a full list of influxql commands can be found at:
         https://influxdb.com/docs/v0.9/query_language/spec.html
 `)
+}
+
+func (c *CommandLine) history() {
+	usr, err := user.Current()
+	// Only load history if we can get the user
+	if err == nil {
+		historyFile := filepath.Join(usr.HomeDir, ".influx_history")
+		if history, err := ioutil.ReadFile(historyFile); err == nil {
+			fmt.Print(string(history))
+		}
+	}
 }
 
 func (c *CommandLine) gopher() {

--- a/cmd/influx/main_test.go
+++ b/cmd/influx/main_test.go
@@ -20,6 +20,7 @@ func TestParseCommand_CommandsExist(t *testing.T) {
 		{cmd: "gopher"},
 		{cmd: "connect"},
 		{cmd: "help"},
+		{cmd: "history"},
 		{cmd: "pretty"},
 		{cmd: "use"},
 		{cmd: ""}, // test that a blank command just returns
@@ -214,6 +215,25 @@ func TestParseCommand_InsertInto(t *testing.T) {
 		}
 		if m.RetentionPolicy != test.rp {
 			t.Fatalf(`Command "insert into" rp parsing failed, expected: %q, actual: %q`, test.rp, m.RetentionPolicy)
+		}
+	}
+}
+
+func TestParseCommand_History(t *testing.T) {
+	t.Parallel()
+	c := main.CommandLine{}
+	tests := []struct {
+		cmd string
+	}{
+		{cmd: "history"},
+		{cmd: " history"},
+		{cmd: "history "},
+		{cmd: "History "},
+	}
+
+	for _, test := range tests {
+		if !c.ParseCommand(test.cmd) {
+			t.Fatalf(`Command "history" failed for %q.`, test.cmd)
 		}
 	}
 }


### PR DESCRIPTION
- [ ] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] Tests pass
- [x] Sign [CLA](http://influxdb.com/community/cla.html) (if not already signed)

Pay special attention to the a couple facts:
* `exit` command returns `false`, thus **it's not stored** in the history file.
  * https://github.com/influxdb/influxdb/blob/master/cmd/influx/main.go#L265
  * https://github.com/influxdb/influxdb/blob/master/cmd/influx/main.go#L243
* any invalid command, e.g. `x` is always treated as a query statement and thus **is stored** in the history file.
  * https://github.com/influxdb/influxdb/blob/master/cmd/influx/main.go#L297

Now, the output:
```
$ influx -host 192.168.99.100
Visit https://enterprise.influxdata.com to register for updates, InfluxDB server management, and monitoring.
Connected to http://192.168.99.100:8086 version 0.9.3
InfluxDB shell 0.9
> history
help
history
help
history
show databases
show tag values
help
history
x
history
x
history
>
```

Fixes #4628