### PR TITLE
raft.raftLayer already closed in raft.NetworkTransport.Close()

### DIFF
--- a/cmd/influxd/restore/restore.go
+++ b/cmd/influxd/restore/restore.go
@@ -248,5 +248,12 @@ func (ln *nopListener) Accept() (net.Conn, error) {
 	return nil, errors.New("listener closing")
 }
 
-func (ln *nopListener) Close() error   { close(ln.closing); return nil }
+func (ln *nopListener) Close() error {
+	if ln.closing != nil {
+		close(ln.closing)
+		ln.closing = nil
+	}
+	return nil
+}
+
 func (ln *nopListener) Addr() net.Addr { return nil }

--- a/meta/state.go
+++ b/meta/state.go
@@ -209,11 +209,6 @@ func (r *localRaft) close() error {
 		r.transport = nil
 	}
 
-	if r.raftLayer != nil {
-		r.raftLayer.Close()
-		r.raftLayer = nil
-	}
-
 	// Shutdown raft.
 	if r.raft != nil {
 		if err := r.raft.Shutdown().Error(); err != nil {


### PR DESCRIPTION
Fix functionality panics: close of closed channel 

fix #4707

https://github.com/hashicorp/raft/blob/master/net_transport.go#L174

- [ ] CHANGELOG.md updated
- [x] Rebased/mergable
- [x] Tests pass
- [x] Sign CLA