### PR TITLE
export interfaceValues since it is returned from DisticntReduce 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - [#4690](https://github.com/influxdb/influxdb/pull/4690): SHOW SHARDS now includes database and policy. Thanks @pires
 - [#4676](https://github.com/influxdb/influxdb/pull/4676): UDP service listener performance enhancements
 - [#4659](https://github.com/influxdb/influxdb/pull/4659): Support IF EXISTS for DROP DATABASE. Thanks @ch33hau
+- [#4721](https://github.com/influxdb/influxdb/pull/4721): Export tsdb.InterfaceValues
 
 ### Bugfixes
 - [#4643](https://github.com/influxdb/influxdb/pull/4643): Fix panic during backup restoration. Thanks @oiooj

--- a/tsdb/functions.go
+++ b/tsdb/functions.go
@@ -208,7 +208,7 @@ func InitializeUnmarshaller(c *influxql.Call) (UnmarshalFunc, error) {
 		}, nil
 	case "distinct":
 		return func(b []byte) (interface{}, error) {
-			var val interfaceValues
+			var val InterfaceValues
 			err := json.Unmarshal(b, &val)
 			return val, err
 		}, nil
@@ -257,11 +257,11 @@ func MapCount(input *MapInput) interface{} {
 	return nil
 }
 
-type interfaceValues []interface{}
+type InterfaceValues []interface{}
 
-func (d interfaceValues) Len() int      { return len(d) }
-func (d interfaceValues) Swap(i, j int) { d[i], d[j] = d[j], d[i] }
-func (d interfaceValues) Less(i, j int) bool {
+func (d InterfaceValues) Len() int      { return len(d) }
+func (d InterfaceValues) Swap(i, j int) { d[i], d[j] = d[j], d[i] }
+func (d InterfaceValues) Less(i, j int) bool {
 	cmpt, a, b := typeCompare(d[i], d[j])
 	cmpv := valueCompare(a, b)
 	if cmpv == 0 {
@@ -281,7 +281,7 @@ func MapDistinct(input *MapInput) interface{} {
 		return nil
 	}
 
-	results := make(interfaceValues, len(m))
+	results := make(InterfaceValues, len(m))
 	var i int
 	for value, _ := range m {
 		results[i] = value
@@ -299,7 +299,7 @@ func ReduceDistinct(values []interface{}) interface{} {
 		if v == nil {
 			continue
 		}
-		d, ok := v.(interfaceValues)
+		d, ok := v.(InterfaceValues)
 		if !ok {
 			msg := fmt.Sprintf("expected distinctValues, got: %T", v)
 			panic(msg)
@@ -310,7 +310,7 @@ func ReduceDistinct(values []interface{}) interface{} {
 	}
 
 	// convert map keys to an array
-	results := make(interfaceValues, len(index))
+	results := make(InterfaceValues, len(index))
 	var i int
 	for k, _ := range index {
 		results[i] = k
@@ -1153,7 +1153,7 @@ func inferFloat(v reflect.Value) (weight int, value interface{}) {
 	case reflect.String:
 		return stringWeight, v.Interface()
 	}
-	panic(fmt.Sprintf("interfaceValues.Less - unreachable code; type was %T", v.Interface()))
+	panic(fmt.Sprintf("InterfaceValues.Less - unreachable code; type was %T", v.Interface()))
 }
 
 func cmpFloat(a, b float64) int {

--- a/tsdb/functions_test.go
+++ b/tsdb/functions_test.go
@@ -128,7 +128,7 @@ func TestMapDistinct(t *testing.T) {
 		},
 	}
 
-	values := MapDistinct(input).(interfaceValues)
+	values := MapDistinct(input).(InterfaceValues)
 
 	if exp, got := 3, len(values); exp != got {
 		t.Errorf("Wrong number of values. exp %v got %v", exp, got)
@@ -136,7 +136,7 @@ func TestMapDistinct(t *testing.T) {
 
 	sort.Sort(values)
 
-	exp := interfaceValues{
+	exp := InterfaceValues{
 		"1",
 		uint64(1),
 		float64(1),
@@ -156,7 +156,7 @@ func TestMapDistinctNil(t *testing.T) {
 }
 
 func TestReduceDistinct(t *testing.T) {
-	v1 := interfaceValues{
+	v1 := InterfaceValues{
 		"2",
 		"1",
 		float64(2.0),
@@ -167,7 +167,7 @@ func TestReduceDistinct(t *testing.T) {
 		false,
 	}
 
-	expect := interfaceValues{
+	expect := InterfaceValues{
 		"1",
 		"2",
 		false,
@@ -204,11 +204,11 @@ func TestReduceDistinctNil(t *testing.T) {
 		},
 		{
 			name:   "empty mappper (len 1)",
-			values: []interface{}{interfaceValues{}},
+			values: []interface{}{InterfaceValues{}},
 		},
 		{
 			name:   "empty mappper (len 2)",
-			values: []interface{}{interfaceValues{}, interfaceValues{}},
+			values: []interface{}{InterfaceValues{}, InterfaceValues{}},
 		},
 	}
 
@@ -222,7 +222,7 @@ func TestReduceDistinctNil(t *testing.T) {
 }
 
 func Test_distinctValues_Sort(t *testing.T) {
-	values := interfaceValues{
+	values := InterfaceValues{
 		"2",
 		"1",
 		float64(2.0),
@@ -233,7 +233,7 @@ func Test_distinctValues_Sort(t *testing.T) {
 		false,
 	}
 
-	expect := interfaceValues{
+	expect := InterfaceValues{
 		"1",
 		"2",
 		false,


### PR DESCRIPTION
I need to be able to convert the values returned from Reduce function into something meaning full on my end. Since `interfaceValues` was not exported I could not type assert it and then iterate over its values. Exporting it allows for this behavior. Exporting seemed better than iterating over it after sorting in order to return a `[]interface{}`.
