### PR TITLE
Don't display "deleted" shards in SHOW SHARDS output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@
 - [#4278](https://github.com/influxdb/influxdb/pull/4278): Fix error marshalling across the cluster
 - [#4149](https://github.com/influxdb/influxdb/pull/4149): Fix derivative unnecessarily requires aggregate function.  Thanks @peekeri!
 - [#4674](https://github.com/influxdb/influxdb/pull/4674): Fix panic during restore. Thanks @simcap.
+- [#4725](https://github.com/influxdb/influxdb/pull/4725): Don't list deleted shards during SHOW SHARDS.
 - [#4237](https://github.com/influxdb/influxdb/issues/4237): DERIVATIVE() edge conditions
 - [#4263](https://github.com/influxdb/influxdb/issues/4263): derivative does not work when data is missing
 - [#4293](https://github.com/influxdb/influxdb/pull/4293): Ensure shell is invoked when touching PID file. Thanks @christopherjdickson

--- a/meta/errors.go
+++ b/meta/errors.go
@@ -67,7 +67,7 @@ var (
 	// ErrRetentionPolicyDurationTooLow is returned when updating a retention
 	// policy that has a duration lower than the allowed minimum.
 	ErrRetentionPolicyDurationTooLow = newError(fmt.Sprintf("retention policy duration must be at least %s",
-		RetentionPolicyMinDuration))
+		MinRetentionPolicyDuration))
 
 	// ErrReplicationFactorTooLow is returned when the replication factor is not in an
 	// acceptable range.

--- a/meta/statement_executor.go
+++ b/meta/statement_executor.go
@@ -363,6 +363,12 @@ func (e *StatementExecutor) executeShowShardsStatement(stmt *influxql.ShowShards
 		row := &models.Row{Columns: []string{"id", "database", "retention_policy", "start_time", "end_time", "expiry_time", "owners"}, Name: di.Name}
 		for _, rpi := range di.RetentionPolicies {
 			for _, sgi := range rpi.ShardGroups {
+				// Shards associated with deleted shard groups are effectively deleted.
+				// Don't list them.
+				if sgi.Deleted() {
+					continue
+				}
+
 				for _, si := range sgi.Shards {
 					ownerIDs := make([]uint64, len(si.Owners))
 					for i, owner := range si.Owners {

--- a/meta/store.go
+++ b/meta/store.go
@@ -46,7 +46,6 @@ const ExecMagic = "EXEC"
 const (
 	AutoCreateRetentionPolicyName   = "default"
 	AutoCreateRetentionPolicyPeriod = 0
-	RetentionPolicyMinDuration      = time.Hour
 
 	// MaxAutoCreatedRetentionPolicyReplicaN is the maximum replication factor that will
 	// be set for auto-created retention policies.
@@ -1020,7 +1019,7 @@ func (s *Store) RetentionPolicies(database string) (a []RetentionPolicyInfo, err
 
 // CreateRetentionPolicy creates a new retention policy for a database.
 func (s *Store) CreateRetentionPolicy(database string, rpi *RetentionPolicyInfo) (*RetentionPolicyInfo, error) {
-	if rpi.Duration < RetentionPolicyMinDuration && rpi.Duration != 0 {
+	if rpi.Duration < MinRetentionPolicyDuration && rpi.Duration != 0 {
 		return nil, ErrRetentionPolicyDurationTooLow
 	}
 	if err := s.exec(internal.Command_CreateRetentionPolicyCommand, internal.E_CreateRetentionPolicyCommand_Command,


### PR DESCRIPTION
If a shard's "owning" shard group has been marked as deleted, the shard is, or soon will be, deleted. So don't list shards that are effectively deleted.

The constant for minimum retention policy was also duplicated in the code, and this was a mistake. This PR also fixes that, setting the constant in one place. It also enhances logging, as requested by @beckettsean 

Fixes issue https://github.com/influxdb/influxdb/issues/4709.