### PR TITLE
Show shard group ID on SHOW SHARDS

### DIFF
--- a/meta/statement_executor.go
+++ b/meta/statement_executor.go
@@ -360,7 +360,7 @@ func (e *StatementExecutor) executeShowShardsStatement(stmt *influxql.ShowShards
 
 	rows := []*models.Row{}
 	for _, di := range dis {
-		row := &models.Row{Columns: []string{"id", "database", "retention_policy", "start_time", "end_time", "expiry_time", "owners"}, Name: di.Name}
+		row := &models.Row{Columns: []string{"id", "database", "retention_policy", "shard_group", "start_time", "end_time", "expiry_time", "owners"}, Name: di.Name}
 		for _, rpi := range di.RetentionPolicies {
 			for _, sgi := range rpi.ShardGroups {
 				for _, si := range sgi.Shards {
@@ -373,6 +373,7 @@ func (e *StatementExecutor) executeShowShardsStatement(stmt *influxql.ShowShards
 						si.ID,
 						di.Name,
 						rpi.Name,
+						sgi.ID,
 						sgi.StartTime.UTC().Format(time.RFC3339),
 						sgi.EndTime.UTC().Format(time.RFC3339),
 						sgi.EndTime.Add(rpi.Duration).UTC().Format(time.RFC3339),

--- a/meta/statement_executor_test.go
+++ b/meta/statement_executor_test.go
@@ -978,6 +978,7 @@ func TestStatementExecutor_ExecuteStatement_ShowShards(t *testing.T) {
 						Duration: time.Second,
 						ShardGroups: []meta.ShardGroupInfo{
 							{
+								ID:        66,
 								StartTime: time.Unix(0, 0),
 								EndTime:   time.Unix(1, 0),
 								Shards: []meta.ShardInfo{
@@ -1006,10 +1007,10 @@ func TestStatementExecutor_ExecuteStatement_ShowShards(t *testing.T) {
 	} else if !reflect.DeepEqual(res.Series, models.Rows{
 		{
 			Name:    "foo",
-			Columns: []string{"id", "database", "retention_policy", "start_time", "end_time", "expiry_time", "owners"},
+			Columns: []string{"id", "database", "retention_policy", "shard_group", "start_time", "end_time", "expiry_time", "owners"},
 			Values: [][]interface{}{
-				{uint64(1), "foo", "rpi_foo", "1970-01-01T00:00:00Z", "1970-01-01T00:00:01Z", "1970-01-01T00:00:02Z", "1,2,3"},
-				{uint64(2), "foo", "rpi_foo", "1970-01-01T00:00:00Z", "1970-01-01T00:00:01Z", "1970-01-01T00:00:02Z", ""},
+				{uint64(1), "foo", "rpi_foo", uint64(66), "1970-01-01T00:00:00Z", "1970-01-01T00:00:01Z", "1970-01-01T00:00:02Z", "1,2,3"},
+				{uint64(2), "foo", "rpi_foo", uint64(66), "1970-01-01T00:00:00Z", "1970-01-01T00:00:01Z", "1970-01-01T00:00:02Z", ""},
 			},
 		},
 	}) {


### PR DESCRIPTION
Let's include all useful diagnostic information with this important command.

```
> show shards
name: _internal
---------------
id      database        retention_policy        shard_group     start_time              end_time                expiry_time             owners
1       _internal       monitor                 1               2015-11-09T00:00:00Z    2015-11-10T00:00:00Z    2015-11-17T00:00:00Z    1
3       _internal       monitor                 3               2015-11-10T00:00:00Z    2015-11-11T00:00:00Z    2015-11-18T00:00:00Z    1
```