### PR TITLE
tsm1 WAL cache

### DIFF
--- a/tsdb/engine/tsm1/cache.go
+++ b/tsdb/engine/tsm1/cache.go
@@ -142,7 +142,8 @@ func (c *Cache) Write(key string, values []Value, checkpoint uint64) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if c.size > c.maxSize {
-		c.evict(c.maxSize)
+		// XXX should really also adjust by size of incoming data.
+		c.evict(c.size - c.maxSize)
 	}
 
 	// Size OK now?

--- a/tsdb/engine/tsm1/cache.go
+++ b/tsdb/engine/tsm1/cache.go
@@ -153,11 +153,8 @@ func (c *Cache) Write(key string, values []Value, checkpoint uint64) error {
 
 	e, ok := c.store[key]
 	if !ok {
-		e, ok = c.store[key]
-		if !ok {
-			e := newEntry()
-			c.store[key] = e
-		}
+		e := newEntry()
+		c.store[key] = e
 	}
 	c.size += e.add(values, checkpoint)
 

--- a/tsdb/engine/tsm1/cache.go
+++ b/tsdb/engine/tsm1/cache.go
@@ -67,7 +67,6 @@ func (l *lru) Do(f func(key string)) {
 // entry is the set of all values received for a given key. It's analogous to a cache-line
 // in the sense that it is the smallest unit that can be evicted from the cache.
 type entry struct {
-	mu         sync.Mutex
 	values     Values // All stored values.
 	checkpoint uint64 // The checkpoint associated with the latest addition to values
 	unsorted   bool   // Whether the data requires sorting and deduping before query.

--- a/tsdb/engine/tsm1/cache.go
+++ b/tsdb/engine/tsm1/cache.go
@@ -105,6 +105,13 @@ func (e *entry) dedupe() {
 	return
 }
 
+// clone returns a copy of the values for this entry.
+func (e *entry) clone() []Value {
+	a := make([]Value, len(e.values))
+	copy(a, e.values)
+	return a
+}
+
 // Cache maintains an in-memory store of Values for a set of keys. As data is added to the cache
 // it will evict older data as necessary to make room for the new entries.
 type Cache struct {
@@ -197,7 +204,15 @@ func (c *Cache) Evict(size uint64) uint64 {
 }
 
 // Cursor returns a cursor for the given key.
-func (c *Cache) Cursor() tsdb.Cursor {
+func (c *Cache) Cursor(key string) tsdb.Cursor {
+	e, ok := c.store[key]
+	if !ok {
+		return nil
+	}
+
+	e.dedupe()
+	_ = e.clone()
+	// Actually return a cursor
 	return nil
 }
 

--- a/tsdb/engine/tsm1/cache.go
+++ b/tsdb/engine/tsm1/cache.go
@@ -1,0 +1,140 @@
+package tsm1
+
+import (
+	"fmt"
+	"sync"
+)
+
+// entry is the set of all values received for a given key.
+type entry struct {
+	mu         sync.Mutex
+	values     Values // All stored values.
+	checkpoint uint64 // The checkpoint associated with the latest addition to values
+	unsorted   bool   // Whether the data requires sorting and deduping before query.
+	size       uint64 // Total Number of point-calculated bytes stored by this entry.
+}
+
+func newEntry() *entry {
+	return &entry{}
+}
+
+// add adds the given values to the entry. Returns the increase in storage footprint.
+func (e *entry) add(values []Value, chk uint64) uint64 {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	var inc uint64
+	for _, v := range values {
+		e.values = append(e.values, v)
+		inc += uint64(v.Size())
+		// Only mark unsorted if not already marked.
+		if !e.unsorted {
+			e.unsorted = e.values[len(values)-1].Time().UnixNano() >= v.Time().UnixNano()
+		}
+	}
+	e.checkpoint = chk
+	e.size += inc
+	return inc
+}
+
+// dedupe prepares the entry for query.
+func (e *entry) dedupe() {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	if !e.unsorted {
+		// Nothing to do.
+		return
+	}
+
+	return
+}
+
+// Cache maintains an in-memory store of Values for a set of keys. As data is added to the cache
+// it will evict older data as necessary to make room for the new entries.
+type Cache struct {
+	mu sync.RWMutex
+
+	checkpoint uint64
+	store      map[string]*entry
+	size       uint64
+	maxSize    uint64
+}
+
+// NewCache returns an instance of a cache which will use a maximum of maxSize bytes of memory.
+func NewCache(maxSize uint64) *Cache {
+	return &Cache{
+		store:   make(map[string]*entry),
+		maxSize: maxSize,
+	}
+}
+
+// WriteKey writes the set of values for the key to the cache. It associates the data with
+// the given checkpoint. This function is goroutine-safe and different keys can be updated
+// concurrently.
+func (c *Cache) Write(key string, values []Value, checkpoint uint64) error {
+	if c.Size() > c.maxSize {
+		// Try eviction.
+		return fmt.Errorf("maximum memory usage exceeded")
+	}
+
+	c.mu.RLock()
+	e, ok := c.store[key]
+	c.mu.RUnlock()
+	if !ok {
+		// Check again under the write lock
+		c.mu.Lock()
+		e, ok = c.store[key]
+		if !ok {
+			e = newEntry()
+			c.store[key] = e
+		}
+		c.mu.Unlock()
+	}
+	c.incrementSize(e.add(values, checkpoint))
+
+	return nil
+
+}
+
+// SetCheckpoint informs the cache that updates received up to and including checkpoint can be
+// safely evicted. Setting a checkpoint does not mean that eviction will actually occur.
+func (c *Cache) SetCheckpoint(checkpoint uint64) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.checkpoint = checkpoint
+	return nil
+}
+
+// Evict forces the cache to evict all data with an associated checkpoint before the last
+// checkpoint that was set. It returns the number of point-based bytes freed as a result.
+// Eviction should normally be left to the cache itself.
+func (c *Cache) Evict() (uint64, error) {
+	return 0, nil
+}
+
+// Size returns the number of bytes the cache currently uses.
+func (c *Cache) Size() uint64 {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.size
+}
+
+// MaxSize returns the maximum number of bytes the cache may consume.
+func (c *Cache) MaxSize() uint64 {
+	return c.maxSize
+}
+
+// Checkpoint returns the current checkpoint for the cache.
+func (c *Cache) Checkpoint() uint64 {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.checkpoint
+}
+
+// incrementSize increments the bookeeping of current memory storage.
+func (c *Cache) incrementSize(n uint64) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.size += n
+}

--- a/tsdb/engine/tsm1/cache.go
+++ b/tsdb/engine/tsm1/cache.go
@@ -11,7 +11,6 @@ import (
 // lru orders string keys from least-recently used to most-recently used. It is not
 // goroutine safe.
 type lru struct {
-	mu       sync.Mutex
 	list     *list.List
 	elements map[string]*list.Element
 }

--- a/tsdb/engine/tsm1/cache.go
+++ b/tsdb/engine/tsm1/cache.go
@@ -47,7 +47,7 @@ func (l *lru) Front() string {
 	return e.Value.(string)
 }
 
-// Back returns the most-recently used key. If there is no such key, then "" is returned.
+// Back returns the least-recently used key. If there is no such key, then "" is returned.
 func (l *lru) Back() string {
 	e := l.list.Back()
 	if e == nil {
@@ -57,7 +57,7 @@ func (l *lru) Back() string {
 }
 
 // Do iterates through the LRU, from least-recently used to most-recently used,
-// calling the given function with the key.
+// calling the given function with each key.
 func (l *lru) Do(f func(key string)) {
 	for e := l.list.Back(); e != nil; e = e.Prev() {
 		f(e.Value.(string))

--- a/tsdb/engine/tsm1/cache.go
+++ b/tsdb/engine/tsm1/cache.go
@@ -101,6 +101,7 @@ func (e *entry) dedupe() {
 		return
 	}
 
+	e.unsorted = false
 	return
 }
 

--- a/tsdb/engine/tsm1/cache.go
+++ b/tsdb/engine/tsm1/cache.go
@@ -206,6 +206,9 @@ func (c *Cache) Cursor(key string) tsdb.Cursor {
 		return nil
 	}
 
+	// Mark entry as most-recently used.
+	c.lru.MoveToFront(key)
+
 	e.dedupe()
 	_ = e.clone()
 	// Actually return a cursor

--- a/tsdb/engine/tsm1/cache.go
+++ b/tsdb/engine/tsm1/cache.go
@@ -201,6 +201,9 @@ func (c *Cache) Evict(size uint64) uint64 {
 
 // Cursor returns a cursor for the given key.
 func (c *Cache) Cursor(key string) tsdb.Cursor {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
 	e, ok := c.store[key]
 	if !ok {
 		return nil

--- a/tsdb/engine/tsm1/cache.go
+++ b/tsdb/engine/tsm1/cache.go
@@ -165,7 +165,7 @@ func (c *Cache) Write(key string, values []Value, checkpoint uint64) error {
 }
 
 // SetCheckpoint informs the cache that updates received up to and including checkpoint can be
-// safely evicted. Setting a checkpoint does not mean that eviction will actually occur.
+// safely evicted. Setting a checkpoint does not mean that eviction up to that point will actually occur.
 func (c *Cache) SetCheckpoint(checkpoint uint64) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()

--- a/tsdb/engine/tsm1/cache.go
+++ b/tsdb/engine/tsm1/cache.go
@@ -36,6 +36,7 @@ func (l *lru) MoveToFront(key string) {
 // Remove removes key from the LRU. If the key does not exist nothing happens.
 func (l *lru) Remove(key string) {
 	l.list.Remove(l.elements[key])
+	delete(l.elements, key)
 }
 
 // Front returns the most-recently used key. If there is no such key, then "" is returned.

--- a/tsdb/engine/tsm1/cache_test.go
+++ b/tsdb/engine/tsm1/cache_test.go
@@ -1,0 +1,23 @@
+package tsm1
+
+import (
+	"testing"
+)
+
+func Test_NewCache(t *testing.T) {
+	c := NewCache(100)
+	if c == nil {
+		t.Fatalf("failed to create new cache")
+	}
+
+	if c.MaxSize() != 100 {
+		t.Fatalf("new cache max size not correct")
+	}
+	if c.Size() != 0 {
+		t.Fatalf("new cache size not correct")
+	}
+	if c.Checkpoint() != 0 {
+		t.Fatalf("new checkpoint not correct")
+	}
+	return
+}


### PR DESCRIPTION
This work shows the tsm1 cache taking shape. The idea behind this cache is that it is the queryable version of the data that exists in the WAL. In fact it may be a super-set of data in the WAL, and even data in the WAL has been compacted into tsm files data in the cache may be queried instead of hitting tsm files. Systems with large amounts of RAM may use this to increase query performance.

Of course all caches must have an eviction policy, and this is where checkpoints come in. When the WAL compacts data into tsm files, it informs the cache via the checkpoint mechanism. This allows the cache to evict data received up to and including the checkpoint, if necessary.

If data cannot be added to the cache, because its maximum memory footprint has been reached, it will reject additions.

Performance is critical in this code, and this code will be carefully tested and benchmarked. Some distinct types have been introduced to help with construction, but these types must not impact performance.