### PR TITLE
TSM file reader/writers

### DIFF
--- a/tsdb/engine/tsm1/DESIGN.md
+++ b/tsdb/engine/tsm1/DESIGN.md
@@ -137,6 +137,36 @@ One option is to MMAP the index into memory and record the pointers to the start
 
 A variation of this can also be done without MMAPs by seeking and reading in the file.  The underlying file cache will still be utilized in this approach as well.
 
+As an example, if we have an index structure in memory such as:
+
+ ```
+┌────────────────────────────────────────────────────────────────────┐
+│                               Index                                │
+├─┬──────────────────────┬──┬───────────────────────┬───┬────────────┘
+│0│                      │62│                       │145│
+├─┴───────┬─────────┬────┼──┴──────┬─────────┬──────┼───┴─────┬──────┐
+│Key 1 Len│   Key   │... │Key 2 Len│  Key 2  │ ...  │  Key 3  │ ...  │
+│ 2 bytes │ N bytes │    │ 2 bytes │ N bytes │      │ 2 bytes │      │
+└─────────┴─────────┴────┴─────────┴─────────┴──────┴─────────┴──────┘
+```
+
+We would build an `offsets` slices where each element pointers to the byte location for the first key in then index slice.
+
+```
+┌────────────────────────────────────────────────────────────────────┐
+│                              Offsets                               │
+├────┬────┬────┬─────────────────────────────────────────────────────┘
+│ 0  │ 62 │145 │
+└────┴────┴────┘
+ ```
+
+
+Using this offset slice we can find `Key 2` by doing a binary search over the offsets slice.  Instead of comparing the value in the offsets (e.g. `62`), we use that as an index into the underlying index to retrieve the key at postion `62` and perform our comparisons with that.
+
+When we have identified the correct position in the index for a given key, we could perform another binary search or a linear scan.  This should be fast as well since each index entry is 28 bytes and all contiguous in memory.
+
+The size of the offsets slice would be proportional to the number of unique series.  If we we limit file sizes to 4GB, we would use 4 bytes for each pointer.
+
 ### LRU/Lazy Load
 
 A second option could be to have the index work as a memory bounded, lazy-load style cache.  When a cache miss occurs, the index structure is scanned to find the the key and the entries are load and added to the cache which causes the least-recently used entries to be evicted.

--- a/tsdb/engine/tsm1/DESIGN.md
+++ b/tsdb/engine/tsm1/DESIGN.md
@@ -296,6 +296,8 @@ The current block indexing assumes that all block indexes entries will be loaded
 
 One option is to MMAP the index into memory and record the pointers to the start of each index entry in a slice.  When searching for a given key, the pointers are used to perform a binary search on the underlying mmap data.  When the matching key is found, the block entries can be loaded and search or a subsequent binary search on the blocks can be performed.
 
+A variation of this can also be done without MMAPs by seeking and reading in the file.  The underlying file cache will still be utilized in this approach as well.
+
 ### LRU/Lazy Load
 
 A second option could be to have the index work as a memory bounded, lazy-load style cache.  When a cache miss occurs, the index structure is scanned to find the the key and the entries are load and added to the cache which causes the least-recently used entries to be evicted.

--- a/tsdb/engine/tsm1/DESIGN.md
+++ b/tsdb/engine/tsm1/DESIGN.md
@@ -1,0 +1,282 @@
+# File Structure
+
+A TSM file is composed for four sections: header, blocks, index and the footer.
+
+```
+┌────────┬────────────────────────────────────┬─────────────┬──────────────┐
+│ Header │               Blocks               │    Index    │    Footer    │
+│5 bytes │              N bytes               │   N bytes   │   4 bytes    │
+└────────┴────────────────────────────────────┴─────────────┴──────────────┘
+```
+Header is composed of a magic number to identify the file type and a version number.
+
+```
+┌───────────────────┐
+│      Header       │
+├─────────┬─────────┤
+│  Magic  │ Version │
+│ 4 bytes │ 1 byte  │
+└─────────┴─────────┘
+```
+
+Blocks are sequences of block CRC32 and data.  The block data is opaque to the file and CRC32 is used for recovery to ensure blocks have not been corrupted due to bugs outside of our control.  The length of the blocks is stored in the index.
+
+```
+┌───────────────────────────────────────────────────────────┐
+│                          Blocks                           │
+├───────────────────┬───────────────────┬───────────────────┤
+│      Block 1      │      Block 2      │      Block N      │
+├─────────┬─────────┼─────────┬─────────┼─────────┬─────────┤
+│  CRC    │  Data   │  CRC    │  Data   │  CRC    │  Data   │
+│ 4 bytes │ N bytes │ 4 bytes │ N bytes │ 4 bytes │ N bytes │
+└─────────┴─────────┴─────────┴─────────┴─────────┴─────────┘
+```
+
+Following the blocks is the index for the blocks in the file.  The index is composed of a sequence of index entries ordered lexicographically by key and then by time.  Each index entry starts with a key length and key followed by a count of the number of blocks in the file.  Each block entry is composed of the min and max time for the block, the offset into the file where the block is located and the the size of the block.
+
+The index structure can provide efficient access to all blocks as well as the ability to determine the cost associated with acessing given key.  Given a key and timestamp, we know exactly which file contains the block for that timestamp as well as where that block resides and how much data to read to retrieve the block.  If we know we need to read all or multiple blocks in a file, we can use the size to determine how much to read in a given IO.
+
+_TBD: The block length stored in the block data could probably be dropped since we store it in the index._
+
+```
+┌──────────────────────────────────────────────────────────────────────────┐
+│                                  Index                                   │
+├─────────┬─────────┬───────┬─────────┬─────────┬─────────┬─────────┬──────┤
+│ Key Len │   Key   │ Count │Min Time │Max Time │ Offset  │  Size   │ ...  │
+│ 2 bytes │ N bytes │2 bytes│ 8 bytes │ 8 bytes │ 8 bytes │ 4 bytes │      │
+└─────────┴─────────┴───────┴─────────┴─────────┴─────────┴─────────┴──────┘
+```
+
+The last section is the footer that stores the offset of the start of the index.
+
+```
+┌─────────┐
+│ Footer  │
+├─────────┤
+│Index Ofs│
+│ 8 bytes │
+└─────────┘
+```
+
+# File System Layout
+
+The file system is organized a directory per shard where each shard is integer number.  Within the shard dir exists a set of other directories and files:
+
+* `wal` Dir - Contains a set numerically increasing files WAL segment files name ######.wal.
+* TSM files - A set of numerically increasing TSM files containing compressed series data.
+* Tombstone files - Files named after the corresponding TSM file as #####.tombstone.  These contain measurement and series keys that have been deleted.  These are removed during compactions.
+
+# Data Flow
+
+Writes are appended to the current WAL segment and are also added to the Cache.  Each WAL segment is size bounded and rolls-over to a new file after it fills up.  The cache is also size bounded and older entries are evicted as new entries are added to maintain the size.  The WAL and Cache are separate entities and do not interact with each other.  The Engine coordinates the writes to both.
+
+When WAL segments a filled up and closed, the Compactor reads the WAL entries and combines then with one or more existing TSM files.  This process runs continously until all WAL files are compacted and there is a minimum number of TSM files.  As each TSM file is completed, it is loaded and referenced by the FileStore.
+
+Queries are executed by constructing Cursors for keys.  The Cursors iterate of slices of Values.  When the current Values are exhausted, a cursor requests a the next set of Values from the Engine.  The Engine returns a slice of Values by querying the FileStore and Cache.  The Values in the Cache are overlayed on top of the values returned from the FileStore.  The FileStore reads and decodes blocks of Values according to the index for the file.
+
+Updates (writing a newer value for a point that already exists) occur as normal writes.  Since cached values overwrite existing values, newer writes take precedence.
+
+Deletes occur by writing a delete entry for the measurement or series to the WAL and then update the Cache and FileStore.  The Cache evicts all relevant entries.  The FileStore writes a tombstone file for each TSM file that contains relevent data.  These tombstone files are used at startup time to ignore blocks as well as during compactions to remove deleted entries.
+
+# Compactions
+
+Compactions are a serial and continously running process that iteratively optimizes the storage for queries.  Specifically, it does the following:
+
+* Converts closed WAL files into TSM files and removes the closed WAL files
+* Combines smaller TSM files into larger ones to improve compression ratios
+* Rewrites existing files that contain series data that has been deleted
+* Rewrites existing files that contain writes with more recent data to ensure a point exists in only one TSM file.
+
+The compaction algorithm is continously running and always selects files to compact based on a priority.
+
+1. If there are closed WAL files, the 5 oldest WAL segments are added to the set of compaction files.
+2. If any TSM files contain points with older timestamps that also exist in the WAL files, those TSM files are added to the compaction set.
+3. If any TSM files have a tombstone marker, those TSM files are added to the compaction set.
+
+The compaction is used to generate a set of SeriesIterators that return a sequence of `key`, `Values` where each `key` returned is lexicographically greater than the previous one.  The iterators are ordered such that WAL iterators will override any values return the TSM file iterators.  WAL iterators read and cache the WAL segment so that deletes later in the log can be processed correctly.  TSM file iterators use the tombstone files to ensure that deleted series are not returned during iteration.  As each key is processed, the Values slice is grown, sorted, and then written to a new block in the new TSM file.  The blocks can be split based on number of points or size of the block.  If the total size of the current TSM file would exceed the maximum file size, a new file is created.
+
+Deletions can occur while a new file is being written.  Since the new TSM file is not complete a tombstone would not be written for it. This could result in deleted values getting written into a new file.  To prevent this, if a compaction is running and a delete occurs, the current compaction is aborted and new compaction is started.
+
+When all files are processed and succesfully written, completion checkpoint markers are created and files are renamed.
+
+This process then runs again until there are no more WAL files and the minimum number of TSM files exists that are also under the maximum file size.
+
+# Components
+
+## WAL
+
+* Append-only log composed of a fixed size segment files.
+* Writes are appended to the current segment
+* Roll-over to new segment after filling the the current segment
+* Closed segments are never modified and used for startup and recovery as well as compactions.
+
+## Compactor
+
+* Continously running, iterative file storage optimizer
+* Takes closed WAL files, existing TSM files and combines into one or more new TSM files
+
+## Cache
+
+* Hold recently written series data
+* Has max memory limit
+* When limit is crossed, old entries are expired (writes are not blocked)
+
+# Engine
+
+* Maintains references to Cache, FileStore, WAL, etc..
+* Creates a cursor
+* Receives writes, coordinates queries
+* Hides underlying files and types from clients
+
+## Cursor
+
+* Iterates forward or reverse for given key
+* Requests values from Engine for key and timestamp
+* Has no knowledge of TSM files or WAL - delegates to Engine to request next set of Values
+
+## FileStore
+
+* Manages TSM files
+* Maintains the file indexes and references to active files
+* A TSM file that is opened entails reading in and adding the index section to the `FileIndex`.  The block data is then MMAPed up to the index offset to avoid having the index in memory twice.
+
+## FileIndex
+* Provides location information to a file and block for a given key and timestamp.  
+
+## Interfaces
+
+```
+SeriesIterator returns the key and []Value such that a key is only returned
+once and subsequent calls to Next() do not return the same key twice.
+type SeriesIterator interace {
+   func Next() (key, []Value, error)
+}
+```
+
+## Types
+
+```
+TSMWriter writes a sets of key and Values to a TSM file.
+type TSMWriter struct {}
+func (t *TSMWriter) Write(key string, values []Value) error {}
+func (t *TSMWriter) Close() error
+```
+
+
+```
+// WALIterator returns the key and []Values for a set of WAL segment files. 
+type WALIterator struct{
+    Files *os.File
+}
+func (r *WALReader) Next() (key, []Value, error)
+```
+
+
+```
+TSMIterator returns the key and values from a TSM file.
+type TSMIterator struct {}
+funct (r *TSMIterator) Next() (key, []Value, error)
+```
+
+```
+type Compactor struct {}
+func (c *Compactor) Compact(iters ...SeriesIterators) error
+```
+
+```
+type Engine struct {
+    wal *WAL
+    cache *Cache
+    fileStore *FileStore
+    compactor *Compactor
+}
+
+func (e *Engine) ValuesBefore(key string, timstamp time.Time) ([]Value, error)
+func (e *Engine) ValuesAfter(key string, timstamp time.Time) ([]Value, error)
+```
+
+```
+type Cursor struct{
+    engine *Engine
+}
+...
+```
+
+```
+// FileStore maintains references
+type FileStore struct {}
+func (f *FileStore) ValuesBefore(key string, timstamp time.Time) ([]Value, error)
+func (f *FileStore) ValuesAfter(key string, timstamp time.Time) ([]Value, error)
+
+```
+
+```
+type FileIndex struct {}
+
+// Returns a file and offset for a block located in the return file that contains the requested key and timestamp.
+func (f *FileIndex) Location(key, timestamp) (*os.File, uint64, error)
+```
+
+```
+type Cache struct {}
+func (c *Cache) Write(key string, values []Value) error
+```
+
+```
+type WAL struct {}
+func (w *WAL) Write(key string, values []Value)
+func (w *WAL) ClosedSegments() ([]*os.File, error)
+```
+
+
+# Concerns
+
+## Performance
+
+There are three categories of performance this design is concerned with:
+
+* Write Throughput/Latency
+* Query Throughput/Latency
+* Startup time
+* Compaction Throughput/Latency
+
+### Writes
+
+Write throughput is bounded by the time to process the write on the CPU (parsing, sorting, etc..), adding and evicting to the Cache and appending the write to the WAL.  The first two items are CPU bound and can be tuned and optimized if they become a bottleneck.  The WAL write can be tuned such that in the worst case every write requires at least 2 IOPS (write + fysnc) or batched so that multiple writes are queued and fysnc'd in sizes matching one or more disk blocks.  Performing more work with each IO will improve throughput
+
+Write latency is minimal for the WAL write since there are no seeks.  The latency is bounded by the time to complete any write and fysnc calls.
+
+### Queries
+
+Query throughput is directly related to how many blocks can be read in a period of time.  The index structure contains enough information to determine if one or multiple blocks can be read in a single IO.
+
+Query latency is determine by how long it takes to find and read the relevant blocks.  The in-memory index structure contains the offsets and sizes of all blocks for a key.  This allows every block to be read in 2 IOPS (seek + read) regardless of position, structure or size of file.  
+
+### Startup
+
+Startup time is proportional to the number of WAL files, TSM files and tombstone files.  WAL files can be read and process in large batches using the WALIterators.  TSM files require reading the index block into memory (5 IOPS/file).  Tombstone files are expected to be small and infrequent and would require approximately 2 IOPS/file.
+
+### Compactions
+
+Compactions are IO intensive in that they may need to read multiple, large TSM files to rewrite them.  The throughput of a compactions (MB/s) as well as the latency for each compaction is important to keep consistent even as data sizes grow.  
+
+The performance of compactions also has an effect on what data is visible during queries.  If the Cache fills up and evicts old entries faster than the compactions can process old WAL files, queries could return return gaps until compactions catch up.
+
+To address these concerns, compactions prioritize old WAL files over optimizing storage/compression to avoid data being hidden overload situations.  This also accounts for the fact that shards will eventually become cold for writes so that existing data will be able to be optimized.  To maintain consistent performance, the number of each type of file processed as well as the size of each file processed is bounded.  
+
+## Concurrency
+
+The main concern with concurrency is that reads and writes should not block each other.  Writes add entries to the Cache and append entries to the WAL.  During queries, the contention points will be the Cache and existing TSM files.  Since the Cache and TSM file data is only access through the engine by the cursors, several strategies can be used to improve concurrency.
+
+1. Cache series data can be returned to cursors as a copy.  Since cache entries are evicted on writes, cursors iteration and writes to the same series could block each other.  Iterating over copies of the values can relieve some of this contention.
+2. TSM data values returned by the engine are new references to Values and not access to the actual TSM files.  This means that the `Engine`, through the `FileStore` can limit contention.
+3. Compactions are the only place where new TSM files are added and removed.  Since this is a serial, continously running process, file contention is minimized. 
+
+## Robustness
+
+The two robustness concerns considered by this design are writes filling the cache and crash recovery.
+
+Writes filling up cache faster than the WAL segments can be processed result in the oldest entries being evicted from the cache.  This is the normal operation for the cache.  Old entries are always evicited to make room for new entries.  In the case where WAL segements are slow to be processed, writes are not blocked or errored so timeouts should not occur due to IO issues.  A side effect of this is that queries for recent data will always be served from memory.  The size of the in-memory cache can also be tuned so that if IO does because a bottleneck the window of time for queries with recent data can be tuned.
+
+Crash recovery is handled by using copy-on-write style updates along with checkpoint marker files.  Existing data is never updated.  Updates and deletes to existing data are recored as new changes and processed at compaction and query time. 
+  

--- a/tsdb/engine/tsm1/DESIGN.md
+++ b/tsdb/engine/tsm1/DESIGN.md
@@ -62,7 +62,7 @@ The last section is the footer that stores the offset of the start of the index.
 
 The file system is organized a directory per shard where each shard is integer number.  Within the shard dir exists a set of other directories and files:
 
-* wal Dir - Contains a set numerically increasing files WAL segment files name ######.wal.  The wal dir will be a separate location from the TSM data files so that different different types can be used if necessary.
+* wal Dir - Contains a set numerically increasing files WAL segment files name ######.wal.  The wal dir will be a separate location from the TSM data files so that different types can be used if necessary.
 * TSM files - A set of numerically increasing TSM files containing compressed series data.
 * Tombstone files - Files named after the corresponding TSM file as #####.tombstone.  These contain measurement and series keys that have been deleted.  These are removed during compactions.
 

--- a/tsdb/engine/tsm1/data_file.go
+++ b/tsdb/engine/tsm1/data_file.go
@@ -108,7 +108,7 @@ type TSMIndex interface {
 	Entries(key string) []*IndexEntry
 
 	// Entry returns the index entry for the specified key and timestamp.  If no entry
-	// matches the key an timestamp, nil is returned.
+	// matches the key and timestamp, nil is returned.
 	Entry(key string, timestamp time.Time) *IndexEntry
 
 	// MarshalBinary returns a byte slice encoded version of the index.

--- a/tsdb/engine/tsm1/data_file.go
+++ b/tsdb/engine/tsm1/data_file.go
@@ -1,0 +1,478 @@
+package tsm1
+
+/*
+A TSM file is composed for four sections: header, blocks, index and the footer.
+
+┌────────┬────────────────────────────────────┬─────────────┬──────────────┐
+│ Header │               Blocks               │    Index    │    Footer    │
+│5 bytes │              N bytes               │   N bytes   │   4 bytes    │
+└────────┴────────────────────────────────────┴─────────────┴──────────────┘
+
+Header is composed of a magic number to identify the file type and a version
+number.
+
+┌───────────────────┐
+│      Header       │
+├─────────┬─────────┤
+│  Magic  │ Version │
+│ 4 bytes │ 1 byte  │
+└─────────┴─────────┘
+
+Blocks are sequences of pairs of CRC32 and data.  The block data is opaque to the
+file.  The CRC32 is used for block level error detection.  The length of the blocks
+is stored in the index.
+
+┌───────────────────────────────────────────────────────────┐
+│                          Blocks                           │
+├───────────────────┬───────────────────┬───────────────────┤
+│      Block 1      │      Block 2      │      Block N      │
+├─────────┬─────────┼─────────┬─────────┼─────────┬─────────┤
+│  CRC    │  Data   │  CRC    │  Data   │  CRC    │  Data   │
+│ 4 bytes │ N bytes │ 4 bytes │ N bytes │ 4 bytes │ N bytes │
+└─────────┴─────────┴─────────┴─────────┴─────────┴─────────┘
+
+Following the blocks is the index for the blocks in the file.  The index is
+composed of a sequence of index entries ordered lexicographically by key and
+then by time.  Each index entry starts with a key length and key followed by a
+count of the number of blocks in the file.  Each block entry is composed of
+the min and max time for the block, the offset into the file where the block
+is located and the the size of the block.
+
+The index structure can provide efficient access to all blocks as well as the
+ability to determine the cost associated with acessing a given key.  Given a key
+and timestamp, we can determine whether a file contains the block for that
+timestamp as well as where that block resides and how much data to read to
+retrieve the block.  If we know we need to read all or multiple blocks in a
+file, we can use the size to determine how much to read in a given IO.
+
+┌──────────────────────────────────────────────────────────────────────────┐
+│                                  Index                                   │
+├─────────┬─────────┬───────┬─────────┬─────────┬─────────┬─────────┬──────┤
+│ Key Len │   Key   │ Count │Min Time │Max Time │ Offset  │  Size   │ ...  │
+│ 2 bytes │ N bytes │2 bytes│ 8 bytes │ 8 bytes │ 8 bytes │ 4 bytes │      │
+└─────────┴─────────┴───────┴─────────┴─────────┴─────────┴─────────┴──────┘
+
+The last section is the footer that stores the offset of the start of the index.
+
+┌─────────┐
+│ Footer  │
+├─────────┤
+│Index Ofs│
+│ 8 bytes │
+└─────────┘
+*/
+
+import (
+	"encoding/binary"
+	"fmt"
+	"hash/crc32"
+	"io"
+	"os"
+	"sort"
+	"time"
+)
+
+const (
+	// MagicNumber is written as the first 4 bytes of a data file to
+	// identify the file as a tsm1 formatted file
+	MagicNumber uint32 = 0x16D116D1
+
+	Version byte = 1
+
+	indexEntrySize = 28
+)
+
+// TSMWriter writes TSM formatted key and values.
+type TSMWriter interface {
+	// Write writes a new block for key containing and values.  Writes append
+	// blocks in the order that the Write function is called.  The caller is
+	// responsible for ensuring keys and blocks or sorted appropriately.
+	// Values are encoded as a full block.  The caller is responsible for
+	// ensuring a fixed number of values are encoded in each block as wells as
+	// ensuring the Values are sorted. The first and last timestamp values are
+	// used as the minimum and maximum values for the index entry.
+	Write(key string, values Values) error
+
+	// Close finishes the TSM write streams and writes the index.
+	Close() error
+}
+
+// TSMIndex represent the index section of a TSM file.  The index records all
+// blocks, their locations, sizes, min and max times.
+type TSMIndex interface {
+
+	// Add records a new block entry for a key in the index.
+	Add(key string, minTime, maxTime time.Time, offset int64, size uint32)
+
+	// Entries returns all index entries for a key.
+	Entries(key string) []*IndexEntry
+
+	// Entry returns the index entry for the specified key and timestamp.  If no entry
+	// matches the key an timestamp, nil is returned.
+	Entry(key string, timestamp time.Time) *IndexEntry
+
+	// MarshalBinary returns a byte slice encoded version of the index.
+	MarshalBinary() ([]byte, error)
+
+	// UnmarshalBinary populates an index from an encoded byte slice
+	// representation of an index.
+	UnmarshalBinary(b []byte) error
+}
+
+// IndexEntry is the index information for a given block in a TSM file.
+type IndexEntry struct {
+
+	// The min and max time of all points stored in the block.
+	MinTime, MaxTime time.Time
+
+	// The absolute position in the file where this block is located.
+	Offset int64
+
+	// The size in bytes of the block in the file.
+	Size uint32
+}
+
+func (e *IndexEntry) UnmarshalBinary(b []byte) error {
+	if len(b) != indexEntrySize {
+		return fmt.Errorf("unmarshalBinary: short buf: %v != %v", indexEntrySize, len(b))
+	}
+	e.MinTime = time.Unix(0, int64(btou64(b[:8])))
+	e.MaxTime = time.Unix(0, int64(btou64(b[8:16])))
+	e.Offset = int64(btou64(b[16:24]))
+	e.Size = btou32(b[24:28])
+	return nil
+}
+
+// directIndex is a simple in-memory index implementation for a TSM file.  The full index
+// must fit in memory.
+type directIndex struct {
+	blocks map[string]indexEntries
+}
+
+func (d *directIndex) Add(key string, minTime, maxTime time.Time, offset int64, size uint32) {
+	d.blocks[key] = append(d.blocks[key], &IndexEntry{
+		MinTime: minTime,
+		MaxTime: maxTime,
+		Offset:  offset,
+		Size:    size,
+	})
+}
+
+func (d *directIndex) Entries(key string) []*IndexEntry {
+	return d.blocks[key]
+}
+
+func (d *directIndex) Entry(key string, timestamp time.Time) *IndexEntry {
+	entries := d.Entries(key)
+	for _, entry := range entries {
+		if entry.MinTime.Equal(timestamp) || entry.MinTime.Before(timestamp) &&
+			entry.MaxTime.Equal(timestamp) || entry.MaxTime.After(timestamp) {
+			return entry
+		}
+	}
+	return nil
+}
+
+func (d *directIndex) addEntries(key string, entries indexEntries) {
+	d.blocks[key] = append(d.blocks[key], entries...)
+}
+
+func (d *directIndex) Write(w io.Writer) error {
+	b, err := d.MarshalBinary()
+	if err != nil {
+		return fmt.Errorf("write: marshal error: %v", err)
+	}
+
+	// Write out the index bytes
+	_, err = w.Write(b)
+	if err != nil {
+		return fmt.Errorf("write: writer error: %v", err)
+	}
+	return nil
+}
+
+func (d *directIndex) MarshalBinary() ([]byte, error) {
+	// Index blocks are writtens sorted by key
+	var keys []string
+	for k := range d.blocks {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	// Buffer to build up the index and write in bulk
+	var b []byte
+
+	// For each key, individual entries are sorted by time
+	for _, key := range keys {
+		entries := d.blocks[key]
+		sort.Sort(entries)
+
+		// Append the key length and key
+		b = append(b, u16tob(uint16(len(key)))...)
+		b = append(b, key...)
+
+		// Append the index block count
+		b = append(b, u16tob(uint16(len(entries)))...)
+
+		// Append each index entry for all blocks for this key
+		for _, entry := range entries {
+			b = append(b, u64tob(uint64(entry.MinTime.UnixNano()))...)
+			b = append(b, u64tob(uint64(entry.MaxTime.UnixNano()))...)
+			b = append(b, u64tob(uint64(entry.Offset))...)
+			b = append(b, u32tob(entry.Size)...)
+		}
+	}
+	return b, nil
+}
+
+func (d *directIndex) UnmarshalBinary(b []byte) error {
+	var pos int
+	for pos < len(b) {
+		n, key, err := d.readKey(b[pos:])
+		if err != nil {
+			return fmt.Errorf("readIndex: read key error: %v", err)
+		}
+
+		pos += n
+		n, entries, err := d.readEntries(b[pos:])
+		if err != nil {
+			return fmt.Errorf("readIndex: read entries error: %v", err)
+		}
+
+		pos += n
+		d.addEntries(key, entries)
+	}
+	return nil
+}
+
+func (d *directIndex) readKey(b []byte) (n int, key string, err error) {
+	// 2 byte size of key
+	n, size := 2, int(btou16(b[:2]))
+
+	// N byte key
+	key = string(b[n : n+size])
+	n += len(key)
+	return
+}
+
+func (d *directIndex) readEntries(b []byte) (n int, entries indexEntries, err error) {
+	// 2 byte count of index entries
+	n, count := 2, int(btou16(b[:2]))
+
+	for i := 0; i < count; i++ {
+		ie := &IndexEntry{}
+		if err := ie.UnmarshalBinary(b[i*indexEntrySize+2 : i*indexEntrySize+2+indexEntrySize]); err != nil {
+			return 0, nil, fmt.Errorf("readEntries: unmarshal error: %v", err)
+		}
+		entries = append(entries, ie)
+		n += indexEntrySize
+	}
+	return
+}
+
+// tsmWriter writes keys and values in the TSM format
+type tsmWriter struct {
+	w     io.Writer
+	index TSMIndex
+	n     int64
+}
+
+func NewTSMWriter(w io.Writer) (TSMWriter, error) {
+	n, err := w.Write(append(u32tob(MagicNumber), Version))
+	if err != nil {
+		return nil, err
+	}
+
+	index := &directIndex{
+		blocks: map[string]indexEntries{},
+	}
+
+	return &tsmWriter{w: w, index: index, n: int64(n)}, nil
+}
+
+func (t *tsmWriter) Write(key string, values Values) error {
+	block, err := values.Encode(nil)
+	if err != nil {
+		return err
+	}
+
+	checksum := crc32.ChecksumIEEE(block)
+
+	n, err := t.w.Write(append(u32tob(checksum), block...))
+	if err != nil {
+		return err
+	}
+
+	// Record this block in index
+	t.index.Add(key, values[0].Time(), values[len(values)-1].Time(), t.n, uint32(n))
+
+	// Increment file position pointer
+	t.n += int64(n)
+	return nil
+}
+
+func (t *tsmWriter) Close() error {
+	indexPos := t.n
+
+	// Generate the index bytes
+	b, err := t.index.MarshalBinary()
+	if err != nil {
+		return err
+	}
+
+	// Write the index followed by index position
+	_, err = t.w.Write(append(b, u64tob(uint64(indexPos))...))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+type tsmReader struct {
+	r                    io.ReadSeeker
+	indexStart, indexEnd int64
+	index                TSMIndex
+}
+
+func NewTSMReader(r io.ReadSeeker) (*tsmReader, error) {
+	t := &tsmReader{r: r}
+	if err := t.init(); err != nil {
+		return nil, err
+	}
+
+	return t, nil
+}
+
+func (t *tsmReader) init() error {
+	// Current the readers size
+	size, err := t.r.Seek(0, os.SEEK_END)
+	if err != nil {
+		return fmt.Errorf("init: failed to seek: %v", err)
+	}
+
+	t.indexEnd = size - 8
+
+	// Seek to index location pointer
+	_, err = t.r.Seek(-8, os.SEEK_END)
+	if err != nil {
+		return fmt.Errorf("init: failed to seek to index ptr: %v", err)
+	}
+
+	// Read the absolute position of the start of the index
+	b := make([]byte, 8)
+	_, err = t.r.Read(b)
+	if err != nil {
+		return fmt.Errorf("init: failed to read index ptr: %v", err)
+
+	}
+
+	t.indexStart = int64(btou64(b))
+
+	_, err = t.r.Seek(t.indexStart, os.SEEK_SET)
+	if err != nil {
+		return fmt.Errorf("init: failed to seek to index: %v", err)
+	}
+
+	b = make([]byte, t.indexEnd-t.indexStart)
+	t.index = &directIndex{
+		blocks: map[string]indexEntries{},
+	}
+	_, err = t.r.Read(b)
+	if err != nil {
+		return fmt.Errorf("init: read index: %v", err)
+	}
+
+	if err := t.index.UnmarshalBinary(b); err != nil {
+		return fmt.Errorf("init: unmarshal error: %v", err)
+	}
+
+	return nil
+}
+
+func (t *tsmReader) Read(key string, timestamp time.Time) ([]Value, error) {
+	block := t.index.Entry(key, timestamp)
+	if block == nil {
+		return nil, nil
+	}
+
+	// TODO: remove this allocation
+	b := make([]byte, 16*1024)
+	_, err := t.r.Seek(block.Offset, os.SEEK_SET)
+	if err != nil {
+		return nil, err
+	}
+
+	if int(block.Size) > len(b) {
+		b = make([]byte, block.Size)
+	}
+
+	n, err := t.r.Read(b)
+	if err != nil {
+		return nil, err
+	}
+
+	//TODO: Validate checksum
+	var values []Value
+	err = DecodeBlock(b[4:n], &values)
+	if err != nil {
+		return nil, err
+	}
+
+	return values, nil
+}
+
+// ReadAll returns all values for a key in all blocks.
+func (t *tsmReader) ReadAll(key string) ([]Value, error) {
+	var values []Value
+	blocks := t.index.Entries(key)
+	if len(blocks) == 0 {
+		return values, nil
+	}
+
+	var temp []Value
+	// TODO: we can determine the max block size when loading the file create/re-use
+	// a reader level buf then.
+	b := make([]byte, 16*1024)
+	for _, block := range blocks {
+		_, err := t.r.Seek(block.Offset, os.SEEK_SET)
+		if err != nil {
+			return nil, err
+		}
+
+		if int(block.Size) > len(b) {
+			b = make([]byte, block.Size)
+		}
+
+		n, err := t.r.Read(b)
+		if err != nil {
+			return nil, err
+		}
+
+		//TODO: Validate checksum
+		temp = temp[:0]
+		err = DecodeBlock(b[4:n], &temp)
+		if err != nil {
+			return nil, err
+		}
+		values = append(values, temp...)
+	}
+
+	return values, nil
+}
+
+type indexEntries []*IndexEntry
+
+func (a indexEntries) Len() int           { return len(a) }
+func (a indexEntries) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a indexEntries) Less(i, j int) bool { return a[i].MinTime.UnixNano() < a[j].MinTime.UnixNano() }
+
+func u16tob(v uint16) []byte {
+	b := make([]byte, 2)
+	binary.BigEndian.PutUint16(b, v)
+	return b
+}
+
+func btou16(b []byte) uint16 {
+	return uint16(binary.BigEndian.Uint16(b))
+}

--- a/tsdb/engine/tsm1/data_file_test.go
+++ b/tsdb/engine/tsm1/data_file_test.go
@@ -1,0 +1,360 @@
+package tsm1_test
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+	"time"
+
+	"github.com/influxdb/influxdb/tsdb/engine/tsm1"
+)
+
+func TestTSMWriter_Write_Empty(t *testing.T) {
+	var b bytes.Buffer
+	w, err := tsm1.NewTSMWriter(&b)
+	if err != nil {
+		t.Fatalf("unexpected error created writer: %v", err)
+	}
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("unexpeted error closing: %v", err)
+	}
+
+	if got, exp := len(b.Bytes()), 5; got < exp {
+		t.Fatalf("file size mismatch: got %v, exp %v", got, exp)
+	}
+	if got := binary.BigEndian.Uint32(b.Bytes()[0:4]); got != tsm1.MagicNumber {
+		t.Fatalf("magic number mismatch: got %v, exp %v", got, tsm1.MagicNumber)
+	}
+}
+
+func TestTSMWriter_Write_Single(t *testing.T) {
+	var b bytes.Buffer
+	w, err := tsm1.NewTSMWriter(&b)
+	if err != nil {
+		t.Fatalf("unexpected error creating writer: %v", err)
+	}
+
+	values := []tsm1.Value{tsm1.NewValue(time.Unix(0, 0), 1.0)}
+	if err := w.Write("cpu", values); err != nil {
+		t.Fatalf("unexpeted error writing: %v", err)
+
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("unexpeted error closing: %v", err)
+	}
+
+	if got, exp := len(b.Bytes()), 5; got < exp {
+		t.Fatalf("file size mismatch: got %v, exp %v", got, exp)
+	}
+	if got := binary.BigEndian.Uint32(b.Bytes()[0:4]); got != tsm1.MagicNumber {
+		t.Fatalf("magic number mismatch: got %v, exp %v", got, tsm1.MagicNumber)
+	}
+
+	r, err := tsm1.NewTSMReader(bytes.NewReader(b.Bytes()))
+	if err != nil {
+		t.Fatalf("unexpected error created reader: %v", err)
+	}
+
+	readValues, err := r.ReadAll("cpu")
+	if err != nil {
+		t.Fatalf("unexpeted error readin: %v", err)
+	}
+
+	if len(readValues) != len(values) {
+		t.Fatalf("read values length mismatch: got %v, exp %v", len(readValues), len(values))
+	}
+
+	for i, v := range values {
+		if v.Value() != readValues[i].Value() {
+			t.Fatalf("read value mismatch(%d): got %v, exp %d", i, readValues[i].Value(), v.Value())
+		}
+	}
+}
+
+func TestTSMWriter_Write_Multiple(t *testing.T) {
+	var b bytes.Buffer
+	w, err := tsm1.NewTSMWriter(&b)
+	if err != nil {
+		t.Fatalf("unexpected error creating writer: %v", err)
+	}
+
+	var data = []struct {
+		key    string
+		values []tsm1.Value
+	}{
+		{"cpu", []tsm1.Value{tsm1.NewValue(time.Unix(0, 0), 1.0)}},
+		{"mem", []tsm1.Value{tsm1.NewValue(time.Unix(1, 0), 2.0)}},
+	}
+
+	for _, d := range data {
+		if err := w.Write(d.key, d.values); err != nil {
+			t.Fatalf("unexpeted error writing: %v", err)
+		}
+	}
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("unexpeted error closing: %v", err)
+	}
+
+	r, err := tsm1.NewTSMReader(bytes.NewReader(b.Bytes()))
+	if err != nil {
+		t.Fatalf("unexpected error created reader: %v", err)
+	}
+
+	for _, d := range data {
+		readValues, err := r.ReadAll(d.key)
+		if err != nil {
+			t.Fatalf("unexpeted error readin: %v", err)
+		}
+
+		if exp := len(d.values); exp != len(readValues) {
+			t.Fatalf("read values length mismatch: got %v, exp %v", len(readValues), exp)
+		}
+
+		for i, v := range d.values {
+			if v.Value() != readValues[i].Value() {
+				t.Fatalf("read value mismatch(%d): got %v, exp %d", i, readValues[i].Value(), v.Value())
+			}
+		}
+	}
+}
+
+func TestTSMWriter_Write_MultipleKeyValues(t *testing.T) {
+	var b bytes.Buffer
+	w, err := tsm1.NewTSMWriter(&b)
+	if err != nil {
+		t.Fatalf("unexpected error creating writer: %v", err)
+	}
+
+	var data = []struct {
+		key    string
+		values []tsm1.Value
+	}{
+		{"cpu", []tsm1.Value{
+			tsm1.NewValue(time.Unix(0, 0), 1.0),
+			tsm1.NewValue(time.Unix(1, 0), 2.0)},
+		},
+		{"mem", []tsm1.Value{
+			tsm1.NewValue(time.Unix(0, 0), 1.5),
+			tsm1.NewValue(time.Unix(1, 0), 2.5)},
+		},
+	}
+
+	for _, d := range data {
+		if err := w.Write(d.key, d.values); err != nil {
+			t.Fatalf("unexpeted error writing: %v", err)
+		}
+	}
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("unexpeted error closing: %v", err)
+	}
+
+	r, err := tsm1.NewTSMReader(bytes.NewReader(b.Bytes()))
+	if err != nil {
+		t.Fatalf("unexpected error created reader: %v", err)
+	}
+
+	for _, d := range data {
+		readValues, err := r.ReadAll(d.key)
+		if err != nil {
+			t.Fatalf("unexpeted error readin: %v", err)
+		}
+
+		if exp := len(d.values); exp != len(readValues) {
+			t.Fatalf("read values length mismatch: got %v, exp %v", len(readValues), exp)
+		}
+
+		for i, v := range d.values {
+			if v.Value() != readValues[i].Value() {
+				t.Fatalf("read value mismatch(%d): got %v, exp %d", i, readValues[i].Value(), v.Value())
+			}
+		}
+	}
+}
+
+// Tests that writing keys in reverse is able to read them back.
+func TestTSMWriter_Write_ReverseKeys(t *testing.T) {
+	var b bytes.Buffer
+	w, err := tsm1.NewTSMWriter(&b)
+	if err != nil {
+		t.Fatalf("unexpected error creating writer: %v", err)
+	}
+
+	var data = []struct {
+		key    string
+		values []tsm1.Value
+	}{
+		{"mem", []tsm1.Value{
+			tsm1.NewValue(time.Unix(0, 0), 1.5),
+			tsm1.NewValue(time.Unix(1, 0), 2.5)},
+		},
+		{"cpu", []tsm1.Value{
+			tsm1.NewValue(time.Unix(0, 0), 1.0),
+			tsm1.NewValue(time.Unix(1, 0), 2.0)},
+		},
+	}
+
+	for _, d := range data {
+		if err := w.Write(d.key, d.values); err != nil {
+			t.Fatalf("unexpeted error writing: %v", err)
+		}
+	}
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("unexpeted error closing: %v", err)
+	}
+
+	r, err := tsm1.NewTSMReader(bytes.NewReader(b.Bytes()))
+	if err != nil {
+		t.Fatalf("unexpected error created reader: %v", err)
+	}
+
+	for _, d := range data {
+		readValues, err := r.ReadAll(d.key)
+		if err != nil {
+			t.Fatalf("unexpeted error readin: %v", err)
+		}
+
+		if exp := len(d.values); exp != len(readValues) {
+			t.Fatalf("read values length mismatch: got %v, exp %v", len(readValues), exp)
+		}
+
+		for i, v := range d.values {
+			if v.Value() != readValues[i].Value() {
+				t.Fatalf("read value mismatch(%d): got %v, exp %d", i, readValues[i].Value(), v.Value())
+			}
+		}
+	}
+}
+
+// Tests that writing keys in reverse is able to read them back.
+func TestTSMWriter_Write_SameKey(t *testing.T) {
+	var b bytes.Buffer
+	w, err := tsm1.NewTSMWriter(&b)
+	if err != nil {
+		t.Fatalf("unexpected error creating writer: %v", err)
+	}
+
+	var data = []struct {
+		key    string
+		values []tsm1.Value
+	}{
+		{"cpu", []tsm1.Value{
+			tsm1.NewValue(time.Unix(0, 0), 1.0),
+			tsm1.NewValue(time.Unix(1, 0), 2.0)},
+		},
+		{"cpu", []tsm1.Value{
+			tsm1.NewValue(time.Unix(2, 0), 3.0),
+			tsm1.NewValue(time.Unix(3, 0), 4.0)},
+		},
+	}
+
+	for _, d := range data {
+		if err := w.Write(d.key, d.values); err != nil {
+			t.Fatalf("unexpeted error writing: %v", err)
+		}
+	}
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("unexpeted error closing: %v", err)
+	}
+
+	r, err := tsm1.NewTSMReader(bytes.NewReader(b.Bytes()))
+	if err != nil {
+		t.Fatalf("unexpected error created reader: %v", err)
+	}
+
+	values := append(data[0].values, data[1].values...)
+
+	readValues, err := r.ReadAll("cpu")
+	if err != nil {
+		t.Fatalf("unexpeted error readin: %v", err)
+	}
+
+	if exp := len(values); exp != len(readValues) {
+		t.Fatalf("read values length mismatch: got %v, exp %v", len(readValues), exp)
+	}
+
+	for i, v := range values {
+		if v.Value() != readValues[i].Value() {
+			t.Fatalf("read value mismatch(%d): got %v, exp %d", i, readValues[i].Value(), v.Value())
+		}
+	}
+}
+
+// Tests that calling Read returns all the values for block matching the key
+// and timestamp
+func TestTSMWriter_Read_Multiple(t *testing.T) {
+	var b bytes.Buffer
+	w, err := tsm1.NewTSMWriter(&b)
+	if err != nil {
+		t.Fatalf("unexpected error creating writer: %v", err)
+	}
+
+	var data = []struct {
+		key    string
+		values []tsm1.Value
+	}{
+		{"cpu", []tsm1.Value{
+			tsm1.NewValue(time.Unix(0, 0), 1.0),
+			tsm1.NewValue(time.Unix(1, 0), 2.0)},
+		},
+		{"cpu", []tsm1.Value{
+			tsm1.NewValue(time.Unix(2, 0), 3.0),
+			tsm1.NewValue(time.Unix(3, 0), 4.0)},
+		},
+	}
+
+	for _, d := range data {
+		if err := w.Write(d.key, d.values); err != nil {
+			t.Fatalf("unexpeted error writing: %v", err)
+		}
+	}
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("unexpeted error closing: %v", err)
+	}
+
+	r, err := tsm1.NewTSMReader(bytes.NewReader(b.Bytes()))
+	if err != nil {
+		t.Fatalf("unexpected error created reader: %v", err)
+	}
+
+	for _, values := range data {
+		// Try the first timestamp
+		readValues, err := r.Read("cpu", values.values[0].Time())
+		if err != nil {
+			t.Fatalf("unexpeted error readin: %v", err)
+		}
+
+		if exp := len(values.values); exp != len(readValues) {
+			t.Fatalf("read values length mismatch: got %v, exp %v", len(readValues), exp)
+		}
+
+		for i, v := range values.values {
+			if v.Value() != readValues[i].Value() {
+				t.Fatalf("read value mismatch(%d): got %v, exp %d", i, readValues[i].Value(), v.Value())
+			}
+		}
+
+		// Try the last timestamp too
+		readValues, err = r.Read("cpu", values.values[1].Time())
+		if err != nil {
+			t.Fatalf("unexpeted error readin: %v", err)
+		}
+
+		if exp := len(values.values); exp != len(readValues) {
+			t.Fatalf("read values length mismatch: got %v, exp %v", len(readValues), exp)
+		}
+
+		for i, v := range values.values {
+			if v.Value() != readValues[i].Value() {
+				t.Fatalf("read value mismatch(%d): got %v, exp %d", i, readValues[i].Value(), v.Value())
+			}
+		}
+
+	}
+
+}

--- a/tsdb/engine/tsm1/tsm1.go
+++ b/tsdb/engine/tsm1/tsm1.go
@@ -82,10 +82,6 @@ const (
 
 	// MAP_POPULATE is for the mmap syscall. For some reason this isn't defined in golang's syscall
 	MAP_POPULATE = 0x8000
-
-	// magicNumber is written as the first 4 bytes of a data file to
-	// identify the file as a tsm1 formatted file
-	magicNumber uint32 = 0x16D116D1
 )
 
 // Ensure Engine implements the interface.
@@ -2302,7 +2298,7 @@ func openFileAndCheckpoint(fileName string) (*os.File, error) {
 	}
 
 	// write the header, which is just the magic number
-	if _, err := f.Write(u32tob(magicNumber)); err != nil {
+	if _, err := f.Write(u32tob(MagicNumber)); err != nil {
 		f.Close()
 		return nil, err
 	}


### PR DESCRIPTION
This adds some initial TSM file reader and writers based on the design discussion doc in this PR.  The implementation of these is using basic file operations with an in-memory index.  During a design review, we discussed some changes that will be implemented in subsequent PRs to allow a given file index to be loaded and accessed a part of a file MMAP (as before).

The main changes to the TSM file are:

* Index section now has a reference to all blocks in a file - This allows for more consistent IO when accessing blocks regardless of the shape of the data.
* Index contains the key - This allows files to be fully self-contained as well as limits the IO to load a file at startup.  A file can be loaded using single pass over the index sections. 

Note: this code is not integrated into the engine yet.