### PR TITLE
Revert to Go 1.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Release Notes
 - Field names for the internal stats have been changed to be more inline with Go style.
+- 0.9.5 is reverting to Go 1.4.2 due to unresolved issues with Go 1.5.1.
 
 ### Features
 - [#4098](https://github.com/influxdb/influxdb/pull/4702): Support 'history' command at CLI

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,7 +73,7 @@ second to sign our CLA, which can be found
 
 Installing Go
 -------------
-InfluxDB requires Go 1.5 or greater.
+InfluxDB requires Go 1.4 or greater.
 
 At InfluxDB we find gvm, a Go version manager, useful for installing Go. For instructions
 on how to install it see [the gvm page on github](https://github.com/moovweb/gvm).
@@ -81,8 +81,8 @@ on how to install it see [the gvm page on github](https://github.com/moovweb/gvm
 After installing gvm you can install and set the default go version by
 running the following:
 
-    gvm install go1.5.1
-    gvm use go1.5.1 --default
+    gvm install go1.4.2
+    gvm use go1.4.2 --default
 
 Revision Control Systems
 -------------
@@ -158,7 +158,7 @@ go install ./...
 To set the version and commit flags during the build pass the following to the build command:
 
 ```bash
--ldflags="-X main.version=$VERSION -X main.branch=$BRANCH -X main.commit=$COMMIT -X main.buildTime=$TIME"
+-ldflags="-X main.version $VERSION -X main.branch $BRANCH -X main.commit $COMMIT -X main.buildTime $TIME"
 ```
 
 where `$VERSION` is the version, `$BRANCH` is the branch, `$COMMIT` is the git commit hash, and `$TIME` is the build timestamp.

--- a/Dockerfile_test_ubuntu32
+++ b/Dockerfile_test_ubuntu32
@@ -1,7 +1,7 @@
 FROM 32bit/ubuntu:14.04
 
 RUN apt-get update && apt-get install -y python-software-properties software-properties-common git
-RUN add-apt-repository ppa:evarlast/golang1.5
+RUN add-apt-repository ppa:evarlast/golang1.4
 RUN apt-get update && apt-get install -y -o Dpkg::Options::="--force-overwrite" golang-go
 
 ENV GOPATH=/root/go

--- a/circle-test.sh
+++ b/circle-test.sh
@@ -5,7 +5,7 @@
 # build process for InfluxDB.
 
 BUILD_DIR=$HOME/influxdb-build
-GO_VERSION=go1.5.1
+GO_VERSION=go1.4.2
 PARALLELISM="-parallel 256"
 TIMEOUT="-timeout 480s"
 

--- a/circle.yml
+++ b/circle.yml
@@ -3,7 +3,7 @@ machine:
         - docker
     pre:
         - bash < <(curl -s -S -L https://raw.githubusercontent.com/moovweb/gvm/master/binscripts/gvm-installer)
-        - source $HOME/.gvm/scripts/gvm; gvm install go1.5.1 --binary
+        - source $HOME/.gvm/scripts/gvm; gvm install go1.4.2 --binary
 
 dependencies:
     override:

--- a/client/v2/example_test.go
+++ b/client/v2/example_test.go
@@ -12,17 +12,16 @@ import (
 )
 
 // Create a new client
-func ExampleClient() client.Client {
+func ExampleClient() {
 	u, _ := url.Parse("http://localhost:8086")
 
 	// NOTE: this assumes you've setup a user and have setup shell env variables,
 	// namely INFLUX_USER/INFLUX_PWD. If not just omit Username/Password below.
-	client := client.NewClient(client.Config{
+	_ = client.NewClient(client.Config{
 		URL:      u,
 		Username: os.Getenv("INFLUX_USER"),
 		Password: os.Getenv("INFLUX_PWD"),
 	})
-	return client
 }
 
 // Write a point using the UDP client

--- a/cmd/influxd/run/command.go
+++ b/cmd/influxd/run/command.go
@@ -72,6 +72,9 @@ func (cmd *Command) Run(args ...string) error {
 		cmd.Version, cmd.Branch, cmd.Commit, cmd.BuildTime)
 	log.Printf("Go version %s, GOMAXPROCS set to %d", runtime.Version(), runtime.GOMAXPROCS(0))
 
+	// Set parallelism.
+	runtime.GOMAXPROCS(runtime.NumCPU())
+
 	// Write the PID file.
 	if err := cmd.writePIDFile(options.PIDFile); err != nil {
 		return fmt.Errorf("write pid file: %s", err)

--- a/package.sh
+++ b/package.sh
@@ -63,7 +63,7 @@ if [ -z "$FPM" ]; then
     FPM=`which fpm`
 fi
 
-GO_VERSION="go1.5.1"
+GO_VERSION="go1.4.2"
 GOPATH_INSTALL=
 BINS=(
     influxd
@@ -267,7 +267,7 @@ do_build() {
     fi
 
     date=`date -u --iso-8601=seconds`
-    go install $RACE -a -ldflags="-X main.version=$version -X main.branch=$branch -X main.commit=$commit -X main.buildTime=$date" ./...
+    go install $RACE -a -ldflags="-X main.version $version -X main.branch $branch -X main.commit $commit -X main.buildTime $date" ./...
     if [ $? -ne 0 ]; then
         echo "Build failed, unable to create package -- aborting"
         cleanup_exit 1


### PR DESCRIPTION
This is not passing 'go vet' under 1.4.2.