### PR TITLE
Fix serveQuery panic

### DIFF
--- a/services/httpd/handler.go
+++ b/services/httpd/handler.go
@@ -314,6 +314,9 @@ func (h *Handler) serveQuery(w http.ResponseWriter, r *http.Request, user *meta.
 			resp.Results = append(resp.Results, r)
 		} else if resp.Results[l-1].StatementID == r.StatementID {
 			cr := resp.Results[l-1]
+			if len(cr.Series) == 0 {
+				continue
+			}
 			lastSeries := cr.Series[len(cr.Series)-1]
 			rowsMerged := 0
 


### PR DESCRIPTION
Fix: #4735 

```
2015/11/10 13:34:08 127.0.0.1 - root [10/Nov/2015:13:34:08 +0000] GET /query?db=leads_cluster&epoch=ms&q=SELECT+sum%28%22value%22%29%2F53687091200+%2B+12+%2A+0.14+AS+%22value%22+FROM+%22iptables_value%22+WHERE+%22type_instance%22+%3D+%27to_outside_microcloud%27+AND+%22type%22+%3D+%27ipt_bytes%27+AND+%22instance%22+%3D+%27filter-LEADS_ACCOUNT_OUT%27+AND+time+%3E+1447039444s+and+time+%3C+now%28%29+GROUP+BY+time%281h%29 HTTP/1.1 200 286 http://80.156.222.79:8080/dashboard/db/leads-cluster Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_1) AppleWebKit/601.2.7 (KHTML, like Gecko) Version/9.0.1 Safari/601.2.7 b8674ef4-87af-11e5-828c-000000000000 90.894353ms
2015/11/10 13:34:08 http: panic serving 127.0.0.1:40862: runtime error: index out of range
goroutine 2852 [running]:
net/http.(*conn).serve.func1(0xc8200c4580, 0x7f3a1f952098, 0xc821d47a78)
        /home/philip/.gvm/gos/go1.5/src/net/http/server.go:1287 +0xb5
github.com/influxdb/influxdb/services/httpd.(*Handler).serveQuery(0xc820085400, 0x7f3a1f952328, 0xc821c7a580, 0xc82008b6c0, 0x0)
        /tmp/build/src/github.com/influxdb/influxdb/services/httpd/handler.go:316 +0x16ef
github.com/influxdb/influxdb/services/httpd.(*Handler).(github.com/influxdb/influxdb/services/httpd.serveQuery)-fm(0x7f3a1f952328, 0xc821c7a580, 0xc82008b6c0, 0x0)
        /tmp/build/src/github.com/influxdb/influxdb/services/httpd/handler.go:98 +0x48
github.com/influxdb/influxdb/services/httpd.authenticate.func1(0x7f3a1f952328, 0xc821c7a580, 0xc82008b6c0)
        /tmp/build/src/github.com/influxdb/influxdb/services/httpd/handler.go:673 +0x70
net/http.HandlerFunc.ServeHTTP(0xc8201360c0, 0x7f3a1f952328, 0xc821c7a580, 0xc82008b6c0)
        /home/philip/.gvm/gos/go1.5/src/net/http/server.go:1422 +0x3a
github.com/influxdb/influxdb/services/httpd.gzipFilter.func1(0x7f3a1f952250, 0xc821c7a540, 0xc82008b6c0)
        /tmp/build/src/github.com/influxdb/influxdb/services/httpd/handler.go:734 +0x2af
net/http.HandlerFunc.ServeHTTP(0xc8201360e0, 0x7f3a1f952250, 0xc821c7a540, 0xc82008b6c0)
        /home/philip/.gvm/gos/go1.5/src/net/http/server.go:1422 +0x3a
```


`lastSeries := cr.Series[len(cr.Series)-1]` maybe panic

- [ ] CHANGELOG.md updated
- [x] Rebased/mergable
- [x] Tests pass
- [x] Sign CLA