### PR TITLE
fix build on Solaris

### DIFF
--- a/tsdb/engine/tsm1/mmap_plan9.go
+++ b/tsdb/engine/tsm1/mmap_plan9.go
@@ -1,0 +1,11 @@
+// portability wrapper for Mmap/Munmap
+// +build plan9
+
+package tsm1
+
+import (
+	"golang.org/x/sys/plan9"
+)
+
+var Mmap = plan9.Mmap
+var Munmap = plan9.Munmap

--- a/tsdb/engine/tsm1/mmap_unix.go
+++ b/tsdb/engine/tsm1/mmap_unix.go
@@ -1,0 +1,11 @@
+// portability wrapper for Mmap/Munmap
+// +build !windows,!plan9
+
+package tsm1
+
+import (
+	"golang.org/x/sys/unix"
+)
+
+var Mmap = unix.Mmap
+var Munmap = unix.Munmap

--- a/tsdb/engine/tsm1/mmap_windows.go
+++ b/tsdb/engine/tsm1/mmap_windows.go
@@ -1,0 +1,11 @@
+// portability wrapper for Mmap/Munmap
+// +build windows
+
+package tsm1
+
+import (
+	"golang.org/x/sys/windows"
+)
+
+var Mmap = windows.Mmap
+var Munmap = windows.Munmap

--- a/tsdb/engine/tsm1/tsm1.go
+++ b/tsdb/engine/tsm1/tsm1.go
@@ -4,7 +4,6 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
-	"golang.org/x/sys/unix"
 	"hash/fnv"
 	"io"
 	"io/ioutil"
@@ -1972,7 +1971,7 @@ func NewDataFile(f *os.File) (*dataFile, error) {
 	if err != nil {
 		return nil, err
 	}
-	mmap, err := unix.Mmap(int(f.Fd()), 0, int(fInfo.Size()), syscall.PROT_READ, syscall.MAP_SHARED|MAP_POPULATE)
+	mmap, err := Mmap(int(f.Fd()), 0, int(fInfo.Size()), syscall.PROT_READ, syscall.MAP_SHARED|MAP_POPULATE)
 	if err != nil {
 		return nil, err
 	}
@@ -2031,7 +2030,7 @@ func (d *dataFile) close() error {
 	if d.mmap == nil {
 		return nil
 	}
-	err := unix.Munmap(d.mmap)
+	err := Munmap(d.mmap)
 	if err != nil {
 		return err
 	}

--- a/tsdb/engine/tsm1/tsm1.go
+++ b/tsdb/engine/tsm1/tsm1.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
+	"golang.org/x/sys/unix"
 	"hash/fnv"
 	"io"
 	"io/ioutil"
@@ -15,7 +16,6 @@ import (
 	"strings"
 	"sync"
 	"syscall"
-	"golang.org/x/sys/unix"
 	"time"
 
 	"github.com/golang/snappy"

--- a/tsdb/engine/tsm1/tsm1.go
+++ b/tsdb/engine/tsm1/tsm1.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"sync"
 	"syscall"
+	"golang.org/x/sys/unix"
 	"time"
 
 	"github.com/golang/snappy"
@@ -1971,7 +1972,7 @@ func NewDataFile(f *os.File) (*dataFile, error) {
 	if err != nil {
 		return nil, err
 	}
-	mmap, err := syscall.Mmap(int(f.Fd()), 0, int(fInfo.Size()), syscall.PROT_READ, syscall.MAP_SHARED|MAP_POPULATE)
+	mmap, err := unix.Mmap(int(f.Fd()), 0, int(fInfo.Size()), syscall.PROT_READ, syscall.MAP_SHARED|MAP_POPULATE)
 	if err != nil {
 		return nil, err
 	}
@@ -2030,7 +2031,7 @@ func (d *dataFile) close() error {
 	if d.mmap == nil {
 		return nil
 	}
-	err := syscall.Munmap(d.mmap)
+	err := unix.Munmap(d.mmap)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Fix of #4787.
Not sure if Windows portability is a constraint for InfluxDB, in which case we would have to implement something a little more involved using conditional compilation.