### PR TITLE
WHERE fields must be decoded during aggregates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ There are breaking changes in this release:
 - [#4685](https://github.com/influxdb/influxdb/pull/4685): Automatically promote node to raft peer if drop server results in removing a raft peer.
 
 ### Bugfixes
+- [#4789](https://github.com/influxdb/influxdb/pull/4789): Decode WHERE fields during aggregates. Fix [issue #4701](https://github.com/influxdb/influxdb/issues/4701).
 - [#4778](https://github.com/influxdb/influxdb/pull/4778): If there are no points to count, count is 0. Fixes [#4701](https://github.com/influxdb/influxdb/issues/4701)
 - [#4715](https://github.com/influxdb/influxdb/pull/4715): Fix panic during Raft-close. Fix [issue #4707](https://github.com/influxdb/influxdb/issues/4707). Thanks @oiooj
 - [#4643](https://github.com/influxdb/influxdb/pull/4643): Fix panic during backup restoration. Thanks @oiooj

--- a/tsdb/aggregate.go
+++ b/tsdb/aggregate.go
@@ -649,7 +649,7 @@ func (m *AggregateMapper) openMeasurement(mm *Measurement) error {
 		}
 
 		for i, key := range t.SeriesKeys {
-			fields := slices.Union(selectFields, m.fieldNames, false)
+			fields := slices.Union(slices.Union(selectFields, m.fieldNames, false), m.whereFields, false)
 			c := m.tx.Cursor(key, fields, m.shard.FieldCodec(mm.Name), true)
 			if c == nil {
 				continue


### PR DESCRIPTION
This change ensures that if there are any fields in the WHERE clause of an aggregate that are different from the fields in the SELECT clause, that the cursors also decode those fields. Otherwise WHERE clauses of the form `SELECT f(w) FROM x WHERE y=z` will return incorrect results