### PR TITLE
Add FileStore for TSM files

### DIFF
--- a/tsdb/engine/tsm1/data_file.go
+++ b/tsdb/engine/tsm1/data_file.go
@@ -93,8 +93,11 @@ type TSMWriter interface {
 	// used as the minimum and maximum values for the index entry.
 	Write(key string, values Values) error
 
-	// Close finishes the TSM write streams and writes the index.
+	// WriteIndex finishes the TSM write streams and writes the index.
 	WriteIndex() error
+
+	// Closes any underlying file resources.
+	Close() error
 }
 
 // TSMIndex represent the index section of a TSM file.  The index records all
@@ -536,6 +539,13 @@ func (t *tsmWriter) WriteIndex() error {
 		return err
 	}
 
+	return nil
+}
+
+func (t *tsmWriter) Close() error {
+	if c, ok := t.w.(io.Closer); ok {
+		return c.Close()
+	}
 	return nil
 }
 

--- a/tsdb/engine/tsm1/data_file_test.go
+++ b/tsdb/engine/tsm1/data_file_test.go
@@ -437,3 +437,27 @@ func TestIndirectIndex_MaxBlocks(t *testing.T) {
 		println(err.Error())
 	}
 }
+
+func TestIndirectIndex_Keys(t *testing.T) {
+	index := tsm1.NewDirectIndex()
+	index.Add("cpu", time.Unix(0, 0), time.Unix(1, 0), 10, 20)
+	index.Add("mem", time.Unix(0, 0), time.Unix(1, 0), 10, 20)
+	index.Add("cpu", time.Unix(1, 0), time.Unix(2, 0), 20, 30)
+
+	keys := index.Keys()
+
+	// 2 distinct keys
+	if got, exp := len(keys), 2; got != exp {
+		t.Fatalf("length mismatch: got %v, exp %v", got, exp)
+	}
+
+	// Keys should be sorted
+	if got, exp := keys[0], "cpu"; got != exp {
+		t.Fatalf("key mismatch: got %v, exp %v", got, exp)
+	}
+
+	if got, exp := keys[1], "mem"; got != exp {
+		t.Fatalf("key mismatch: got %v, exp %v", got, exp)
+	}
+
+}

--- a/tsdb/engine/tsm1/data_file_test.go
+++ b/tsdb/engine/tsm1/data_file_test.go
@@ -424,3 +424,16 @@ func TestIndirectIndex_Entries_NonExistent(t *testing.T) {
 		t.Fatalf("entries length mismatch: got %v, exp %v", got, exp)
 	}
 }
+
+func TestIndirectIndex_MaxBlocks(t *testing.T) {
+	index := tsm1.NewDirectIndex()
+	for i := 0; i < 1<<16; i++ {
+		index.Add("cpu", time.Unix(0, 0), time.Unix(1, 0), 10, 20)
+	}
+
+	if _, err := index.MarshalBinary(); err == nil {
+		t.Fatalf("expected max block count error. got nil")
+	} else {
+		println(err.Error())
+	}
+}

--- a/tsdb/engine/tsm1/data_file_test.go
+++ b/tsdb/engine/tsm1/data_file_test.go
@@ -16,7 +16,7 @@ func TestTSMWriter_Write_Empty(t *testing.T) {
 		t.Fatalf("unexpected error created writer: %v", err)
 	}
 
-	if err := w.Close(); err != nil {
+	if err := w.WriteIndex(); err != nil {
 		t.Fatalf("unexpeted error closing: %v", err)
 	}
 
@@ -40,7 +40,7 @@ func TestTSMWriter_Write_Single(t *testing.T) {
 		t.Fatalf("unexpeted error writing: %v", err)
 
 	}
-	if err := w.Close(); err != nil {
+	if err := w.WriteIndex(); err != nil {
 		t.Fatalf("unexpeted error closing: %v", err)
 	}
 
@@ -93,7 +93,7 @@ func TestTSMWriter_Write_Multiple(t *testing.T) {
 		}
 	}
 
-	if err := w.Close(); err != nil {
+	if err := w.WriteIndex(); err != nil {
 		t.Fatalf("unexpeted error closing: %v", err)
 	}
 
@@ -147,7 +147,7 @@ func TestTSMWriter_Write_MultipleKeyValues(t *testing.T) {
 		}
 	}
 
-	if err := w.Close(); err != nil {
+	if err := w.WriteIndex(); err != nil {
 		t.Fatalf("unexpeted error closing: %v", err)
 	}
 
@@ -202,7 +202,7 @@ func TestTSMWriter_Write_ReverseKeys(t *testing.T) {
 		}
 	}
 
-	if err := w.Close(); err != nil {
+	if err := w.WriteIndex(); err != nil {
 		t.Fatalf("unexpeted error closing: %v", err)
 	}
 
@@ -257,7 +257,7 @@ func TestTSMWriter_Write_SameKey(t *testing.T) {
 		}
 	}
 
-	if err := w.Close(); err != nil {
+	if err := w.WriteIndex(); err != nil {
 		t.Fatalf("unexpeted error closing: %v", err)
 	}
 
@@ -313,7 +313,7 @@ func TestTSMWriter_Read_Multiple(t *testing.T) {
 		}
 	}
 
-	if err := w.Close(); err != nil {
+	if err := w.WriteIndex(); err != nil {
 		t.Fatalf("unexpeted error closing: %v", err)
 	}
 

--- a/tsdb/engine/tsm1/encoding.go
+++ b/tsdb/engine/tsm1/encoding.go
@@ -76,14 +76,14 @@ func (a Values) Encode(buf []byte) ([]byte, error) {
 		panic("unable to encode block type")
 	}
 
-	switch a[0].(type) {
-	case *FloatValue:
+	switch a[0].Value().(type) {
+	case float64:
 		return encodeFloatBlock(buf, a)
-	case *Int64Value:
+	case int64:
 		return encodeInt64Block(buf, a)
-	case *BoolValue:
+	case bool:
 		return encodeBoolBlock(buf, a)
-	case *StringValue:
+	case string:
 		return encodeStringBlock(buf, a)
 	}
 
@@ -173,7 +173,7 @@ func encodeFloatBlock(buf []byte, values []Value) ([]byte, error) {
 
 	for _, v := range values {
 		tsenc.Write(v.Time())
-		venc.Push(v.(*FloatValue).value)
+		venc.Push(v.Value().(float64))
 	}
 	venc.Finish()
 
@@ -271,7 +271,7 @@ func encodeBoolBlock(buf []byte, values []Value) ([]byte, error) {
 
 	for _, v := range values {
 		tsenc.Write(v.Time())
-		venc.Write(v.(*BoolValue).value)
+		venc.Write(v.Value().(bool))
 	}
 
 	// Encoded timestamp values
@@ -356,7 +356,7 @@ func encodeInt64Block(buf []byte, values []Value) ([]byte, error) {
 	vEnc := NewInt64Encoder()
 	for _, v := range values {
 		tsEnc.Write(v.Time())
-		vEnc.Write(v.(*Int64Value).value)
+		vEnc.Write(v.Value().(int64))
 	}
 
 	// Encoded timestamp values
@@ -440,7 +440,7 @@ func encodeStringBlock(buf []byte, values []Value) ([]byte, error) {
 	vEnc := NewStringEncoder()
 	for _, v := range values {
 		tsEnc.Write(v.Time())
-		vEnc.Write(v.(*StringValue).value)
+		vEnc.Write(v.Value().(string))
 	}
 
 	// Encoded timestamp values

--- a/tsdb/engine/tsm1/file_store.go
+++ b/tsdb/engine/tsm1/file_store.go
@@ -1,0 +1,144 @@
+package tsm1
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+type TSMFile interface {
+	// Read returns all the values in the block where time t resides
+	Read(key string, t time.Time) ([]Value, error)
+
+	// Returns true if the TSMFile may contain a value with the specified
+	// key and time
+	Contains(key string, t time.Time) bool
+
+	// Close the underlying file resources
+	Close() error
+}
+
+type FileStore struct {
+	mu sync.RWMutex
+
+	currentFileID int
+	dir           string
+
+	files []TSMFile
+}
+
+func NewFileStore(dir string) *FileStore {
+	return &FileStore{
+		dir: dir,
+	}
+}
+
+// Returns the number of TSM files currently loaded
+func (f *FileStore) Count() int {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	return len(f.files)
+}
+
+// CurrentID returns the max file ID + 1
+func (f *FileStore) CurrentID() int {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	return f.currentFileID
+}
+
+func (f *FileStore) Add(files ...TSMFile) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.files = append(f.files, files...)
+}
+
+func (f *FileStore) Open() error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	// Not loading files from disk so nothing to do
+	if f.dir == "" {
+		return nil
+	}
+
+	files, err := filepath.Glob(filepath.Join(f.dir, fmt.Sprintf("*.%s", Format)))
+	if err != nil {
+		return err
+	}
+	for _, fn := range files {
+
+		// Keep track of the latest ID
+		id, err := f.idFromFileName(fn)
+		if err != nil {
+			return err
+		}
+		if id >= f.currentFileID {
+			f.currentFileID = id + 1
+		}
+
+		file, err := os.OpenFile(fn, os.O_RDONLY, 0666)
+		if err != nil {
+			return fmt.Errorf("error opening file %s: %v", fn, err)
+		}
+
+		df, err := NewTSMReader(file)
+		if err != nil {
+			return fmt.Errorf("error opening memory map for file %s: %v", fn, err)
+		}
+		f.files = append(f.files, df)
+	}
+	return nil
+}
+
+func (f *FileStore) Close() error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	for _, f := range f.files {
+		f.Close()
+	}
+
+	f.files = nil
+	return nil
+}
+
+func (f *FileStore) Read(key string, t time.Time) ([]Value, error) {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+
+	var values []Value
+	for _, f := range f.files {
+		// Can this file possibly contain this key and timestamp?
+		if !f.Contains(key, t) {
+			continue
+		}
+
+		// May have the key and time we are looking for so try to find
+		v, err := f.Read(key, t)
+		if err != nil {
+			return nil, err
+		}
+
+		if len(v) > 0 {
+			return v, nil
+		}
+	}
+	return values, nil
+}
+
+// idFromFileName parses the segment file ID from its name
+func (f *FileStore) idFromFileName(name string) (int, error) {
+	parts := strings.Split(filepath.Base(name), ".")
+	if len(parts) != 2 {
+		return 0, fmt.Errorf("file %s is named incorrectly", name)
+	}
+
+	id, err := strconv.ParseUint(parts[0], 10, 32)
+
+	return int(id), err
+}

--- a/tsdb/engine/tsm1/file_store.go
+++ b/tsdb/engine/tsm1/file_store.go
@@ -119,7 +119,6 @@ func (f *FileStore) Delete(key string) error {
 
 	for _, file := range f.files {
 		if file.Contains(key) {
-
 			if err := file.Delete(key); err != nil {
 				return err
 			}
@@ -142,7 +141,6 @@ func (f *FileStore) Open() error {
 		return err
 	}
 	for _, fn := range files {
-
 		// Keep track of the latest ID
 		id, err := f.idFromFileName(fn)
 		if err != nil {
@@ -183,7 +181,6 @@ func (f *FileStore) Read(key string, t time.Time) ([]Value, error) {
 	f.mu.RLock()
 	defer f.mu.RUnlock()
 
-	var values []Value
 	for _, f := range f.files {
 		// Can this file possibly contain this key and timestamp?
 		if !f.ContainsValue(key, t) {
@@ -200,7 +197,7 @@ func (f *FileStore) Read(key string, t time.Time) ([]Value, error) {
 			return v, nil
 		}
 	}
-	return values, nil
+	return nil, nil
 }
 
 // idFromFileName parses the segment file ID from its name

--- a/tsdb/engine/tsm1/file_store.go
+++ b/tsdb/engine/tsm1/file_store.go
@@ -72,6 +72,28 @@ func (f *FileStore) Add(files ...TSMFile) {
 	f.files = append(f.files, files...)
 }
 
+// Remove removes the files with matching paths from the set of active files.  It does
+// not remove the paths from disk.
+func (f *FileStore) Remove(paths ...string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	var active []TSMFile
+	for _, file := range f.files {
+		keep := true
+		for _, remove := range paths {
+			if remove == file.Path() {
+				keep = false
+				break
+			}
+		}
+
+		if keep {
+			active = append(active, file)
+		}
+	}
+	f.files = active
+}
+
 func (f *FileStore) Keys() []string {
 	f.mu.RLock()
 	defer f.mu.RUnlock()

--- a/tsdb/engine/tsm1/file_store_test.go
+++ b/tsdb/engine/tsm1/file_store_test.go
@@ -78,6 +78,47 @@ func TestFileStore_Open(t *testing.T) {
 	}
 }
 
+func TestFileStore_Remove(t *testing.T) {
+	dir := MustTempDir()
+	defer os.RemoveAll(dir)
+
+	// Create 3 TSM files...
+	data := []keyValues{
+		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(time.Unix(0, 0), 1.0)}},
+		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(time.Unix(1, 0), 2.0)}},
+		keyValues{"mem", []tsm1.Value{tsm1.NewValue(time.Unix(0, 0), 1.0)}},
+	}
+
+	files, err := newFileDir(dir, data...)
+	if err != nil {
+		fatal(t, "creating test files", err)
+	}
+
+	fs := tsm1.NewFileStore(dir)
+	if err := fs.Open(); err != nil {
+		fatal(t, "opening file store", err)
+	}
+	defer fs.Close()
+
+	if got, exp := fs.Count(), 3; got != exp {
+		t.Fatalf("file count mismatch: got %v, exp %v", got, exp)
+	}
+
+	if got, exp := fs.CurrentID(), 4; got != exp {
+		t.Fatalf("current ID mismatch: got %v, exp %v", got, exp)
+	}
+
+	fs.Remove(files[2])
+
+	if got, exp := fs.Count(), 2; got != exp {
+		t.Fatalf("file count mismatch: got %v, exp %v", got, exp)
+	}
+
+	if got, exp := fs.CurrentID(), 4; got != exp {
+		t.Fatalf("current ID mismatch: got %v, exp %v", got, exp)
+	}
+}
+
 func TestFileStore_Open_Deleted(t *testing.T) {
 	dir := MustTempDir()
 	defer os.RemoveAll(dir)

--- a/tsdb/engine/tsm1/file_store_test.go
+++ b/tsdb/engine/tsm1/file_store_test.go
@@ -1,0 +1,169 @@
+package tsm1_test
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/influxdb/influxdb/tsdb/engine/tsm1"
+)
+
+func TestFileStore_Read(t *testing.T) {
+	fs := tsm1.NewFileStore("")
+
+	// Setup 3 files
+	data := []keyValues{
+		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(time.Unix(0, 0), 1.0)}},
+		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(time.Unix(1, 0), 2.0)}},
+		keyValues{"mem", []tsm1.Value{tsm1.NewValue(time.Unix(0, 0), 1.0)}},
+	}
+
+	files, err := newFiles(data...)
+	if err != nil {
+		t.Fatalf("unexpected error creating files: %v", err)
+	}
+
+	fs.Add(files...)
+
+	// Search for an entry that exists in the second file
+	values, err := fs.Read("cpu", time.Unix(1, 0))
+	if err != nil {
+		t.Fatalf("unexpected error reading values: %v", err)
+	}
+
+	exp := data[1]
+	if got, exp := len(values), len(exp.values); got != exp {
+		t.Fatalf("value length mismatch: got %v, exp %v", got, exp)
+	}
+
+	for i, v := range exp.values {
+		if got, exp := values[i].Value(), v.Value(); got != exp {
+			t.Fatalf("read value mismatch(%d): got %v, exp %d", i, got, exp)
+		}
+	}
+}
+
+func TestFileStore_Open(t *testing.T) {
+	dir := MustTempDir()
+	defer os.RemoveAll(dir)
+
+	// Create 3 TSM files...
+	data := []keyValues{
+		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(time.Unix(0, 0), 1.0)}},
+		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(time.Unix(1, 0), 2.0)}},
+		keyValues{"mem", []tsm1.Value{tsm1.NewValue(time.Unix(0, 0), 1.0)}},
+	}
+
+	_, err := newFileDir(dir, data...)
+	if err != nil {
+		fatal(t, "creating test files", err)
+	}
+
+	fs := tsm1.NewFileStore(dir)
+	if err := fs.Open(); err != nil {
+		fatal(t, "opening file store", err)
+	}
+	defer fs.Close()
+
+	if got, exp := fs.Count(), 3; got != exp {
+		t.Fatalf("file count mismatch: got %v, exp %v", got, exp)
+	}
+
+	if got, exp := fs.CurrentID(), 4; got != exp {
+		t.Fatalf("current ID mismatch: got %v, exp %v", got, exp)
+	}
+}
+
+func newFileDir(dir string, values ...keyValues) ([]string, error) {
+	var files []string
+
+	id := 1
+	for _, v := range values {
+		f := MustTempFile(dir)
+		w, err := tsm1.NewTSMWriter(f)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := w.Write(v.key, v.values); err != nil {
+			return nil, err
+		}
+
+		if err := w.WriteIndex(); err != nil {
+			return nil, err
+		}
+
+		if err := f.Close(); err != nil {
+			return nil, err
+		}
+		newName := filepath.Join(filepath.Dir(f.Name()), tsmFileName(id))
+		if err := os.Rename(f.Name(), newName); err != nil {
+			return nil, err
+		}
+		id++
+
+		files = append(files, newName)
+	}
+	return files, nil
+
+}
+
+func newFiles(values ...keyValues) ([]tsm1.TSMFile, error) {
+	var files []tsm1.TSMFile
+
+	for _, v := range values {
+		var b bytes.Buffer
+		w, err := tsm1.NewTSMWriter(&b)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := w.Write(v.key, v.values); err != nil {
+			return nil, err
+		}
+
+		if err := w.WriteIndex(); err != nil {
+			return nil, err
+		}
+
+		r, err := tsm1.NewTSMReader(bytes.NewReader(b.Bytes()))
+		if err != nil {
+			return nil, err
+		}
+		files = append(files, r)
+	}
+	return files, nil
+}
+
+type keyValues struct {
+	key    string
+	values []tsm1.Value
+}
+
+func MustTempDir() string {
+	dir, err := ioutil.TempDir("", "tsm1-test")
+	if err != nil {
+		panic(fmt.Sprintf("failed to create temp dir: %v", err))
+	}
+	return dir
+}
+
+func MustTempFile(dir string) *os.File {
+	f, err := ioutil.TempFile(dir, "tsm1test")
+	if err != nil {
+		panic(fmt.Sprintf("failed to create temp file: %v", err))
+	}
+	return f
+}
+
+func fatal(t *testing.T, msg string, err error) {
+	t.Fatalf("unexpected error %s: %v", msg, err)
+}
+
+func tsmFileName(id int) string {
+	return fmt.Sprintf("%07d.tsm1", id)
+}

--- a/tsdb/engine/tsm1/tombstone.go
+++ b/tsdb/engine/tsm1/tombstone.go
@@ -1,0 +1,116 @@
+package tsm1
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+)
+
+type Tombstoner struct {
+	mu sync.Mutex
+
+	// Path is the location of the file to record tombstone. This should be the
+	// full path to a TSM file.
+	Path string
+}
+
+func (t *Tombstoner) Add(key string) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	// If this TSMFile has not been written (mainly in tests), don't write a
+	// tombstone because the keys will not be written when it's actually saved.
+	if t.Path == "" {
+		return nil
+	}
+
+	tombstones, err := t.readTombstone()
+	if err != nil {
+		return nil
+	}
+
+	tombstones = append(tombstones, key)
+
+	return t.writeTombstone(tombstones)
+}
+
+func (t *Tombstoner) ReadAll() ([]string, error) {
+	return t.readTombstone()
+}
+
+func (t *Tombstoner) Delete() error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if err := os.RemoveAll(t.tombstonePath()); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (t *Tombstoner) writeTombstone(tombstones []string) error {
+	tmp, err := ioutil.TempFile(filepath.Dir(t.Path), "tombstone")
+	if err != nil {
+		return err
+	}
+	defer tmp.Close()
+
+	if _, err := tmp.Write([]byte(strings.Join(tombstones, "\n"))); err != nil {
+		return err
+	}
+
+	// fsync the file to flush the write
+	if err := tmp.Sync(); err != nil {
+		return err
+	}
+
+	if err := os.Rename(tmp.Name(), t.tombstonePath()); err != nil {
+		return err
+	}
+
+	// fsync the dir to flush the rename
+	dir, err := os.OpenFile(filepath.Dir(t.tombstonePath()), os.O_RDONLY, os.ModeDir)
+	if err != nil {
+		return err
+	}
+	defer dir.Close()
+	return dir.Sync()
+}
+
+func (t *Tombstoner) readTombstone() ([]string, error) {
+	var b []byte
+	tf, err := os.Open(t.tombstonePath())
+	defer tf.Close()
+	if !os.IsNotExist(err) {
+		b, err = ioutil.ReadAll(tf)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	lines := strings.TrimSpace(string(b))
+	if lines == "" {
+		return nil, nil
+	}
+
+	return strings.Split(string(b), "\n"), nil
+}
+
+func (t *Tombstoner) tombstonePath() string {
+	if strings.HasSuffix(t.Path, "tombstone") {
+		return t.Path
+	}
+
+	// Filename is 0000001.tsm1
+	filename := filepath.Base(t.Path)
+
+	// Strip off the tsm1
+	ext := filepath.Ext(filename)
+	if ext != "" {
+		filename = strings.TrimSuffix(filename, ext)
+	}
+
+	// Append the "tombstone" suffix to create a 0000001.tombstone file
+	return filepath.Join(filepath.Dir(t.Path), filename+".tombstone")
+}

--- a/tsdb/engine/tsm1/tombstone_test.go
+++ b/tsdb/engine/tsm1/tombstone_test.go
@@ -1,0 +1,95 @@
+package tsm1_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/influxdb/influxdb/tsdb/engine/tsm1"
+)
+
+func TestTombstoner_Add(t *testing.T) {
+	dir := MustTempDir()
+	defer func() { os.RemoveAll(dir) }()
+
+	f := MustTempFile(dir)
+	ts := &tsm1.Tombstoner{Path: f.Name()}
+
+	entries, err := ts.ReadAll()
+	if err != nil {
+		fatal(t, "ReadAll", err)
+	}
+
+	if got, exp := len(entries), 0; got != exp {
+		t.Fatalf("length mismatch: got %v, exp %v", got, exp)
+	}
+
+	ts.Add("foo")
+
+	entries, err = ts.ReadAll()
+	if err != nil {
+		fatal(t, "ReadAll", err)
+	}
+
+	if got, exp := len(entries), 1; got != exp {
+		t.Fatalf("length mismatch: got %v, exp %v", got, exp)
+	}
+
+	if got, exp := entries[0], "foo"; got != exp {
+		t.Fatalf("value mismatch: got %v, exp %v", got, exp)
+	}
+
+	// Use a new Tombstoner to verify values are persisted
+	ts = &tsm1.Tombstoner{Path: f.Name()}
+	entries, err = ts.ReadAll()
+	if err != nil {
+		fatal(t, "ReadAll", err)
+	}
+
+	if got, exp := len(entries), 1; got != exp {
+		t.Fatalf("length mismatch: got %v, exp %v", got, exp)
+	}
+
+	if got, exp := entries[0], "foo"; got != exp {
+		t.Fatalf("value mismatch: got %v, exp %v", got, exp)
+	}
+}
+
+func TestTombstoner_Delete(t *testing.T) {
+	dir := MustTempDir()
+	defer func() { os.RemoveAll(dir) }()
+
+	f := MustTempFile(dir)
+	ts := &tsm1.Tombstoner{Path: f.Name()}
+
+	ts.Add("foo")
+
+	// Use a new Tombstoner to verify values are persisted
+	ts = &tsm1.Tombstoner{Path: f.Name()}
+	entries, err := ts.ReadAll()
+	if err != nil {
+		fatal(t, "ReadAll", err)
+	}
+
+	if got, exp := len(entries), 1; got != exp {
+		t.Fatalf("length mismatch: got %v, exp %v", got, exp)
+	}
+
+	if got, exp := entries[0], "foo"; got != exp {
+		t.Fatalf("value mismatch: got %v, exp %v", got, exp)
+	}
+
+	if err := ts.Delete(); err != nil {
+		fatal(t, "delete tombstone", err)
+	}
+
+	ts = &tsm1.Tombstoner{Path: f.Name()}
+	entries, err = ts.ReadAll()
+	if err != nil {
+		fatal(t, "ReadAll", err)
+	}
+
+	if got, exp := len(entries), 0; got != exp {
+		t.Fatalf("length mismatch: got %v, exp %v", got, exp)
+	}
+
+}


### PR DESCRIPTION
This adds an initial FileStore implementation that manages references to active TSM files on disk.  It provides functionality to load existing TSM files from a directory, add new files, remove existing ones and handle key deletion using tombstone files.