### PR TITLE
Fix Order By Desc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ There are breaking changes in this release:
 - [#4685](https://github.com/influxdb/influxdb/pull/4685): Automatically promote node to raft peer if drop server results in removing a raft peer.
 
 ### Bugfixes
+- [#4235](https://github.com/influxdb/influxdb/issues/4235): "ORDER BY DESC" doesn't properly order
 - [#4789](https://github.com/influxdb/influxdb/pull/4789): Decode WHERE fields during aggregates. Fix [issue #4701](https://github.com/influxdb/influxdb/issues/4701).
 - [#4778](https://github.com/influxdb/influxdb/pull/4778): If there are no points to count, count is 0.
 - [#4715](https://github.com/influxdb/influxdb/pull/4715): Fix panic during Raft-close. Fix [issue #4707](https://github.com/influxdb/influxdb/issues/4707). Thanks @oiooj

--- a/cmd/influxd/run/server_test.go
+++ b/cmd/influxd/run/server_test.go
@@ -5118,6 +5118,11 @@ func TestServer_Query_OrderByTime(t *testing.T) {
 		fmt.Sprintf(`cpu,host=server1 value=1 %d`, mustParseTime(time.RFC3339Nano, "2000-01-01T00:00:01Z").UnixNano()),
 		fmt.Sprintf(`cpu,host=server1 value=2 %d`, mustParseTime(time.RFC3339Nano, "2000-01-01T00:00:02Z").UnixNano()),
 		fmt.Sprintf(`cpu,host=server1 value=3 %d`, mustParseTime(time.RFC3339Nano, "2000-01-01T00:00:03Z").UnixNano()),
+
+		fmt.Sprintf(`power,presence=true value=1 %d`, mustParseTime(time.RFC3339Nano, "2000-01-01T00:00:01Z").UnixNano()),
+		fmt.Sprintf(`power,presence=true value=2 %d`, mustParseTime(time.RFC3339Nano, "2000-01-01T00:00:02Z").UnixNano()),
+		fmt.Sprintf(`power,presence=true value=3 %d`, mustParseTime(time.RFC3339Nano, "2000-01-01T00:00:03Z").UnixNano()),
+		fmt.Sprintf(`power,presence=false value=4 %d`, mustParseTime(time.RFC3339Nano, "2000-01-01T00:00:04Z").UnixNano()),
 	}
 
 	test := NewTest("db0", "rp0")
@@ -5129,6 +5134,13 @@ func TestServer_Query_OrderByTime(t *testing.T) {
 			params:  url.Values{"db": []string{"db0"}},
 			command: `select value from "cpu" ORDER BY time DESC`,
 			exp:     `{"results":[{"series":[{"name":"cpu","columns":["time","value"],"values":[["2000-01-01T00:00:03Z",3],["2000-01-01T00:00:02Z",2],["2000-01-01T00:00:01Z",1]]}]}]}`,
+		},
+
+		&Query{
+			name:    "order desc with tags",
+			params:  url.Values{"db": []string{"db0"}},
+			command: `select value from "power" ORDER BY time DESC`,
+			exp:     `{"results":[{"series":[{"name":"power","columns":["time","value"],"values":[["2000-01-01T00:00:04Z",4],["2000-01-01T00:00:03Z",3],["2000-01-01T00:00:02Z",2],["2000-01-01T00:00:01Z",1]]}]}]}`,
 		},
 	}...)
 

--- a/tsdb/raw.go
+++ b/tsdb/raw.go
@@ -873,7 +873,7 @@ func (m *RawMapper) openMeasurement(mm *Measurement) error {
 			cursors = append(cursors, cm)
 		}
 
-		tsc := NewTagSetCursor(mm.Name, t.Tags, cursors)
+		tsc := NewTagSetCursor(mm.Name, t.Tags, cursors, ascending)
 		tsc.SelectFields = m.selectFields
 		if ascending {
 			tsc.Init(m.qmin)


### PR DESCRIPTION
Used the `heap.Interface` to be able to support a `Reverse` interface on `TagSetCursor` when it is order by `DESC`

fixes #4235.