### PR TITLE
Checkpointed WAL tsm1 cache

### DIFF
--- a/tsdb/engine/tsm1/cache.go
+++ b/tsdb/engine/tsm1/cache.go
@@ -1,0 +1,320 @@
+package tsm1
+
+import (
+	"container/list"
+	"fmt"
+	"sort"
+	"sync"
+
+	"github.com/influxdb/influxdb/tsdb"
+)
+
+var ErrCacheMemoryExceeded = fmt.Errorf("cache maximum memory size exceeded")
+var ErrCacheInvalidCheckpoint = fmt.Errorf("invalid checkpoint")
+
+// lru orders string keys from least-recently used to most-recently used. It is not
+// goroutine safe.
+type lru struct {
+	list     *list.List
+	elements map[string]*list.Element
+}
+
+// newLRU returns an initialized LRU.
+func newLRU() *lru {
+	return &lru{
+		list:     list.New(),
+		elements: make(map[string]*list.Element),
+	}
+}
+
+// MoveToFront marks key as the most recently used key.
+func (l *lru) MoveToFront(key string) {
+	e, ok := l.elements[key]
+	if !ok {
+		l.elements[key] = l.list.PushFront(key)
+		return
+	}
+	l.list.MoveToFront(e)
+}
+
+// Remove removes key from the LRU. If the key does not exist nothing happens.
+func (l *lru) Remove(key string) {
+	if _, ok := l.elements[key]; ok {
+		l.list.Remove(l.elements[key])
+		delete(l.elements, key)
+	}
+}
+
+// Front returns the most-recently used key. If there is no such key, then "" is returned.
+func (l *lru) Front() string {
+	e := l.list.Front()
+	if e == nil {
+		return ""
+	}
+	return e.Value.(string)
+}
+
+// Back returns the least-recently used key. If there is no such key, then "" is returned.
+func (l *lru) Back() string {
+	e := l.list.Back()
+	if e == nil {
+		return ""
+	}
+	return e.Value.(string)
+}
+
+// DoFromLeast iterates through the LRU, from least-recently used to most-recently used,
+// calling the given function with each key.
+func (l *lru) DoFromLeast(f func(key string)) {
+	for e := l.list.Back(); e != nil; e = e.Prev() {
+		f(e.Value.(string))
+	}
+}
+
+// entry is the set of all values received for a given key.
+type entry struct {
+	values   Values // All stored values.
+	unsorted bool   // Whether the data requires sorting and deduping before query.
+	size     uint64 // Total Number of point-calculated bytes stored by this entry.
+}
+
+// newEntry returns a new instance of entry.
+func newEntry() *entry {
+	return &entry{}
+}
+
+// add adds the given values to the entry.
+func (e *entry) add(values []Value) {
+	for _, v := range values {
+		// Only mark unsorted if not already marked.
+		if !e.unsorted && len(e.values) > 1 {
+			e.unsorted = e.values[len(e.values)-1].Time().UnixNano() >= v.Time().UnixNano()
+		}
+		e.values = append(e.values, v)
+		e.size += uint64(v.Size())
+	}
+}
+
+// dedupe remove duplicate entries for the same timestamp and sorts the entries.
+func (e *entry) dedupe() {
+	if !e.unsorted {
+		return
+	}
+	e.values = e.values.Deduplicate()
+	e.unsorted = false
+
+	// Update size.
+	e.size = 0
+	for _, v := range e.values {
+		e.size += uint64(v.Size())
+	}
+}
+
+type entries struct {
+	ee map[uint64]*entry
+}
+
+func newEntries() entries {
+	return entries{
+		ee: make(map[uint64]*entry),
+	}
+}
+
+func (a entries) add(values []Value, checkpoint uint64) {
+	e, ok := a.ee[checkpoint]
+	if !ok {
+		e = newEntry()
+		a.ee[checkpoint] = e
+	}
+	e.add(values)
+}
+
+// purge deletes all data that is as old as the checkpoint. Returns point-calculated
+// space freed-up.
+func (a entries) purge(checkpoint uint64) uint64 {
+	var size uint64
+	for k, v := range a.ee {
+		if k > checkpoint {
+			continue
+		}
+		size += v.size
+		delete(a.ee, k)
+	}
+	return size
+}
+
+// size returns point-calcuated storage size.
+func (a entries) size() uint64 {
+	var size uint64
+	for _, v := range a.ee {
+		size += v.size
+	}
+	return size
+}
+
+// clone returns the values for all entries under management, deduped and ordered by time.
+func (a entries) clone() Values {
+	var values Values
+	for _, v := range a.ee {
+		v.dedupe()
+		values = append(values, v.values...)
+	}
+	// XXX TO CONSIDER: it might be worth memoizing this.
+	return values.Deduplicate()
+}
+
+// Cache maintains an in-memory store of Values for a set of keys. As data is added to the cache
+// it will evict older data as necessary to make room for the new entries.
+type Cache struct {
+	mu         sync.RWMutex
+	store      map[string]entries
+	checkpoint uint64
+	size       uint64
+	maxSize    uint64
+
+	lru *lru // List of entry keys from most recently accessed to least.
+}
+
+// NewCache returns an instance of a cache which will use a maximum of maxSize bytes of memory.
+func NewCache(maxSize uint64) *Cache {
+	return &Cache{
+		maxSize: maxSize,
+		store:   make(map[string]entries),
+		lru:     newLRU(),
+	}
+}
+
+// WriteKey writes the set of values for the key to the cache. It associates the data with
+// the given checkpoint. This function is goroutine-safe.
+//
+// TODO: This function is a significant potential bottleneck. It is possible that keys could
+// be modified while an eviction process was taking place, so a big cache-level lock is in place.
+// Need to revisit this. It's correct but may not be performant (it is the same as the existing
+// design however)
+func (c *Cache) Write(key string, values []Value, checkpoint uint64) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if checkpoint < c.checkpoint {
+		return ErrCacheInvalidCheckpoint
+	}
+
+	newSize := c.size + uint64(Values(values).Size())
+	if newSize >= c.maxSize {
+		c.evict(newSize - c.maxSize)
+	}
+
+	// Size OK now?
+	if c.size >= c.maxSize {
+		return ErrCacheMemoryExceeded
+	}
+
+	e, ok := c.store[key]
+	if !ok {
+		e = newEntries()
+		c.store[key] = e
+	}
+	e.add(values, checkpoint)
+	c.size = newSize
+
+	// Mark entry as most-recently used.
+	c.lru.MoveToFront(key)
+
+	return nil
+}
+
+// SetCheckpoint informs the cache that updates received up to and including checkpoint
+// can be safely evicted. Setting a checkpoint does not mean that eviction up to that
+// point will actually occur.
+func (c *Cache) SetCheckpoint(checkpoint uint64) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if checkpoint < c.checkpoint {
+		return ErrCacheInvalidCheckpoint
+	}
+	c.checkpoint = checkpoint
+	return nil
+}
+
+// Size returns the number of bytes the cache currently uses.
+func (c *Cache) Size() uint64 {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.size
+}
+
+// MaxSize returns the maximum number of bytes the cache may consume.
+func (c *Cache) MaxSize() uint64 {
+	return c.maxSize
+}
+
+// Keys returns a sorted slice of all keys under management by the cache.
+func (c *Cache) Keys() []string {
+	var a []string
+	for k, _ := range c.store {
+		a = append(a, k)
+	}
+	sort.Strings(a)
+	return a
+}
+
+// Checkpoint returns the current checkpoint for the cache.
+func (c *Cache) Checkpoint() uint64 {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.checkpoint
+}
+
+// Evict instructs the cache to evict.
+func (c *Cache) Evict(size uint64) uint64 {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.evict(size)
+}
+
+// Cursor returns a cursor for the given key.
+func (c *Cache) Cursor(key string) tsdb.Cursor {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	// e, ok := c.store[key]
+	// if !ok {
+	// 	return nil
+	// }
+
+	// // Mark entry as most-recently used.
+	// c.lru.MoveToFront(key)
+
+	// e.dedupe()
+	// _ = e.clone()
+	// // Actually return a cursor
+
+	// Mark entry as most-recently used.
+	c.lru.MoveToFront(key)
+	return nil
+}
+
+// evict instructs the cache to evict data until all data with an associated checkpoint
+// before the last checkpoint was set, or memory footprint decreases by the given size,
+// whichever happens first. Returns the number of point-calculated bytes that were
+// actually evicted.
+func (c *Cache) evict(size uint64) uint64 {
+	var freed uint64
+	defer func() {
+		c.size -= freed
+	}()
+
+	c.lru.DoFromLeast(func(key string) {
+		e := c.store[key]
+		freed += e.purge(c.checkpoint)
+		if e.size() == 0 {
+			// If the entry for the key is empty, remove all reference from the store.
+			delete(c.store, key)
+		}
+
+		if freed >= size {
+			return
+		}
+	})
+
+	return freed
+}

--- a/tsdb/engine/tsm1/cache_test.go
+++ b/tsdb/engine/tsm1/cache_test.go
@@ -1,0 +1,321 @@
+package tsm1
+
+import (
+	"reflect"
+	"testing"
+	"time"
+)
+
+func Test_LRU(t *testing.T) {
+	lru := newLRU()
+	if lru == nil {
+		t.Fatalf("failed to create LRU")
+	}
+
+	// Test adding various elements to the LRU.
+
+	lru.MoveToFront("A")
+	if f := lru.Front(); f != "A" {
+		t.Fatalf("first inserted key not at front, got: %s", f)
+	}
+	if f := lru.Back(); f != "A" {
+		t.Fatalf("first inserted key not at back, got: %s", f)
+	}
+
+	lru.MoveToFront("B")
+	if f := lru.Front(); f != "B" {
+		t.Fatalf("second inserted key not at front, got: %s", f)
+	}
+	if f := lru.Back(); f != "A" {
+		t.Fatalf("second inserted key not at back, got: %s", f)
+	}
+
+	lru.MoveToFront("C")
+	if f := lru.Front(); f != "C" {
+		t.Fatalf("second inserted key not at front, got: %s", f)
+	}
+	if f := lru.Back(); f != "A" {
+		t.Fatalf("second inserted key not at back, got: %s", f)
+	}
+
+	lru.MoveToFront("A")
+	if f := lru.Front(); f != "A" {
+		t.Fatalf("second inserted key not at front, got: %s", f)
+	}
+	if f := lru.Back(); f != "B" {
+		t.Fatalf("second inserted key not at back, got: %s", f)
+	}
+
+	// Ensure that LRU ordering is correct.
+	expectedOrder, gotOrder := []string{"B", "C", "A"}, []string{}
+	lru.DoFromLeast(func(key string) {
+		gotOrder = append(gotOrder, key)
+	})
+	if !reflect.DeepEqual(expectedOrder, gotOrder) {
+		t.Fatalf("expected LRU order not correct, got %v, exp %v", gotOrder, expectedOrder)
+	}
+
+	// Ensure ordering is still correct after various remove operations.
+	lru.Remove("A")
+	lru.Remove("X")
+	expectedOrder, gotOrder = []string{"B", "C"}, []string{}
+	lru.DoFromLeast(func(key string) {
+		gotOrder = append(gotOrder, key)
+	})
+	if !reflect.DeepEqual(expectedOrder, gotOrder) {
+		t.Fatalf("expected LRU order not correct post remove, got %v, exp %v", gotOrder, expectedOrder)
+	}
+}
+
+func Test_EntryAdd(t *testing.T) {
+	e := newEntry()
+	v1 := NewValue(time.Unix(2, 0).UTC(), 1.0)
+	v2 := NewValue(time.Unix(3, 0).UTC(), 2.0)
+	v3 := NewValue(time.Unix(1, 0).UTC(), 2.0)
+
+	e.add([]Value{v1, v2})
+	if e.size != uint64(v1.Size()+v2.Size()) {
+		t.Fatal("adding points to entry, wrong size")
+	}
+	if e.unsorted {
+		t.Fatal("adding ordered points resulted in unordered entry")
+	}
+	e.add([]Value{v3})
+	if e.size != uint64(v1.Size()+v2.Size()+v3.Size()) {
+		t.Fatal("adding point to entry, wrong size")
+	}
+	if !e.unsorted {
+		t.Fatal("adding unordered point resulted in ordered entry")
+	}
+}
+
+func Test_EntryDedupe(t *testing.T) {
+	e := newEntry()
+	v1 := NewValue(time.Unix(1, 0).UTC(), 1.0)
+	v2 := NewValue(time.Unix(2, 0).UTC(), 2.0)
+	v3 := NewValue(time.Unix(1, 0).UTC(), 2.0)
+
+	e.add([]Value{v1, v2})
+	if e.size != uint64(v1.Size()+v2.Size()) {
+		t.Fatal("adding points to entry, wrong size")
+	}
+	if !reflect.DeepEqual(e.values, Values{v1, v2}) {
+		t.Fatal("entry values not as expected")
+	}
+	e.dedupe()
+	if !reflect.DeepEqual(e.values, Values{v1, v2}) {
+		t.Fatal("entry values not as expected after dedupe")
+	}
+
+	e.add([]Value{v3})
+	if !reflect.DeepEqual(e.values, Values{v1, v2, v3}) {
+		t.Fatal("entry values not as expected after v3")
+	}
+	if e.size != uint64(v1.Size()+v2.Size()+v3.Size()) {
+		t.Fatal("adding points to entry, wrong size")
+	}
+	e.dedupe()
+	if e.size != uint64(v3.Size()+v2.Size()) {
+		t.Fatal("adding points to entry, wrong size")
+	}
+	if !reflect.DeepEqual(e.values, Values{v3, v2}) {
+		t.Fatal("entry values not as expected dedupe of v3")
+	}
+}
+
+func Test_EntriesAdd(t *testing.T) {
+	e := newEntries()
+	v1 := NewValue(time.Unix(2, 0).UTC(), 1.0)
+	v2 := NewValue(time.Unix(3, 0).UTC(), 2.0)
+	v3 := NewValue(time.Unix(1, 0).UTC(), 2.0)
+
+	e.add([]Value{v1, v2}, uint64(100))
+	if e.size() != uint64(v1.Size()+v2.Size()) {
+		t.Fatal("adding points to entry, wrong size")
+	}
+	e.add([]Value{v3}, uint64(100))
+	if e.size() != uint64(v1.Size()+v2.Size()+v3.Size()) {
+		t.Fatal("adding point to entry, wrong size")
+	}
+}
+
+func Test_EntriesClone(t *testing.T) {
+	e := newEntries()
+	v0 := NewValue(time.Unix(4, 0).UTC(), 1.0)
+	v1 := NewValue(time.Unix(2, 0).UTC(), 2.0)
+	v2 := NewValue(time.Unix(3, 0).UTC(), 3.0)
+	v3 := NewValue(time.Unix(3, 0).UTC(), 4.0)
+
+	e.add([]Value{v0, v1}, uint64(100))
+	e.add([]Value{v2}, uint64(200))
+	e.add([]Value{v3}, uint64(400))
+
+	values := e.clone()
+	if len(values) != 3 {
+		t.Fatalf("cloned values is wrong length, got %d", len(values))
+	}
+	if !reflect.DeepEqual(values[0], v1) {
+		t.Fatal("0th point does not equal v1:", values[0], v1)
+	}
+	if !reflect.DeepEqual(values[1], v3) {
+		t.Fatal("1st point does not equal v3:", values[0], v3)
+	}
+	if !reflect.DeepEqual(values[2], v0) {
+		t.Fatal("2nd point does not equal v0:", values[0], v0)
+	}
+
+	if n := e.purge(100); n != uint64(v0.Size()+v1.Size()) {
+		t.Fatal("wrong size of points purged:", n)
+	}
+}
+
+func Test_EntriesPurge(t *testing.T) {
+	e := newEntries()
+	v0 := NewValue(time.Unix(1, 0).UTC(), 1.0)
+	v1 := NewValue(time.Unix(2, 0).UTC(), 2.0)
+	v2 := NewValue(time.Unix(3, 0).UTC(), 3.0)
+
+	e.add([]Value{v0, v1}, uint64(100))
+	e.add([]Value{v2}, uint64(200))
+
+	values := e.clone()
+	if len(values) != 3 {
+		t.Fatalf("cloned values is wrong length, got %d", len(values))
+	}
+	if !reflect.DeepEqual(values[0], v0) {
+		t.Fatal("0th point does not equal v0:", values[0], v0)
+	}
+	if !reflect.DeepEqual(values[1], v1) {
+		t.Fatal("1st point does not equal v1:", values[0], v1)
+	}
+	if !reflect.DeepEqual(values[2], v2) {
+		t.Fatal("2nd point does not equal v2:", values[0], v2)
+	}
+
+	if n := e.purge(100); n != uint64(v0.Size()+v1.Size()) {
+		t.Fatal("wrong size of points purged:", n)
+	}
+
+	values = e.clone()
+	if len(values) != 1 {
+		t.Fatalf("purged cloned values is wrong length, got %d", len(values))
+	}
+	if !reflect.DeepEqual(values[0], v2) {
+		t.Fatal("0th point does not equal v1:", values[0], v2)
+	}
+
+	if n := e.purge(200); n != uint64(v2.Size()) {
+		t.Fatal("wrong size of points purged:", n)
+	}
+	values = e.clone()
+	if len(values) != 0 {
+		t.Fatalf("purged cloned values is wrong length, got %d", len(values))
+	}
+}
+
+func Test_NewCache(t *testing.T) {
+	c := NewCache(100)
+	if c == nil {
+		t.Fatalf("failed to create new cache")
+	}
+
+	if c.MaxSize() != 100 {
+		t.Fatalf("new cache max size not correct")
+	}
+	if c.Size() != 0 {
+		t.Fatalf("new cache size not correct")
+	}
+	if c.Checkpoint() != 0 {
+		t.Fatalf("new checkpoint not correct")
+	}
+	if len(c.Keys()) != 0 {
+		t.Fatalf("new cache keys not correct: %v", c.Keys())
+	}
+}
+
+func Test_CacheWrite(t *testing.T) {
+	v0 := NewValue(time.Unix(1, 0).UTC(), 1.0)
+	v1 := NewValue(time.Unix(2, 0).UTC(), 2.0)
+	v2 := NewValue(time.Unix(3, 0).UTC(), 3.0)
+	values := Values{v0, v1, v2}
+	valuesSize := uint64(v0.Size() + v1.Size() + v2.Size())
+
+	c := MustNewCache(3 * valuesSize)
+
+	if err := c.Write("foo", values, 100); err != nil {
+		t.Fatalf("failed to write key foo to cache: %s", err.Error())
+	}
+	if err := c.Write("bar", values, 100); err != nil {
+		t.Fatalf("failed to write key foo to cache: %s", err.Error())
+	}
+	if n := c.Size(); n != 2*valuesSize {
+		t.Fatalf("cache size incorrect after 2 writes, exp %d, got %d", 2*valuesSize, n)
+	}
+
+	if exp, keys := []string{"bar", "foo"}, c.Keys(); !reflect.DeepEqual(keys, exp) {
+		t.Fatalf("cache keys incorrect after 2 writes, exp %v, got %v", exp, keys)
+	}
+}
+
+func Test_CacheCheckpoint(t *testing.T) {
+	v0 := NewValue(time.Unix(1, 0).UTC(), 1.0)
+
+	c := MustNewCache(1024)
+
+	if err := c.SetCheckpoint(50); err != nil {
+		t.Fatalf("failed to set checkpoint: %s", err.Error())
+	}
+	if err := c.Write("foo", Values{v0}, 100); err != nil {
+		t.Fatalf("failed to write key foo to cache: %s", err.Error())
+	}
+	if err := c.SetCheckpoint(25); err != ErrCacheInvalidCheckpoint {
+		t.Fatalf("unexpectedly set checkpoint")
+	}
+	if err := c.Write("foo", Values{v0}, 30); err != ErrCacheInvalidCheckpoint {
+		t.Fatalf("unexpectedly wrote key foo to cache")
+	}
+}
+
+func Test_CacheWriteMemoryExceeded(t *testing.T) {
+	v0 := NewValue(time.Unix(1, 0).UTC(), 1.0)
+	v1 := NewValue(time.Unix(2, 0).UTC(), 2.0)
+
+	c := MustNewCache(uint64(v1.Size()))
+
+	if err := c.Write("foo", Values{v0}, 100); err != nil {
+		t.Fatalf("failed to write key foo to cache: %s", err.Error())
+	}
+	if exp, keys := []string{"foo"}, c.Keys(); !reflect.DeepEqual(keys, exp) {
+		t.Fatalf("cache keys incorrect after writes, exp %v, got %v", exp, keys)
+	}
+	if err := c.Write("bar", Values{v1}, 100); err != ErrCacheMemoryExceeded {
+		t.Fatalf("wrong error writing key bar to cache")
+	}
+
+	// Set too-early checkpoint, write should still fail.
+	if err := c.SetCheckpoint(50); err != nil {
+		t.Fatalf("failed to set checkpoint: %s", err.Error())
+	}
+	if err := c.Write("bar", Values{v1}, 100); err != ErrCacheMemoryExceeded {
+		t.Fatalf("wrong error writing key bar to cache")
+	}
+
+	// Set later checkpoint, write should then succeed.
+	if err := c.SetCheckpoint(100); err != nil {
+		t.Fatalf("failed to set checkpoint: %s", err.Error())
+	}
+	if err := c.Write("bar", Values{v1}, 100); err != nil {
+		t.Fatalf("failed to write key bar to checkpointed cache: %s", err.Error())
+	}
+	if exp, keys := []string{"bar"}, c.Keys(); !reflect.DeepEqual(keys, exp) {
+		t.Fatalf("cache keys incorrect after writes, exp %v, got %v", exp, keys)
+	}
+}
+
+func MustNewCache(size uint64) *Cache {
+	c := NewCache(size)
+	if c == nil {
+		panic("failed to create cache")
+	}
+	return c
+}

--- a/tsdb/engine/tsm1/encoding.go
+++ b/tsdb/engine/tsm1/encoding.go
@@ -69,6 +69,14 @@ func (a Values) MaxTime() int64 {
 	return a[len(a)-1].Time().UnixNano()
 }
 
+func (a Values) Size() int {
+	sz := 0
+	for _, v := range a {
+		sz += v.Size()
+	}
+	return sz
+}
+
 // Encode converts the values to a byte slice.  If there are no values,
 // this function panics.
 func (a Values) Encode(buf []byte) ([]byte, error) {


### PR DESCRIPTION
This work shows the tsm1 cache taking shape. The idea behind this cache is that it is the queryable version of the data that exists in the WAL. In fact it may be a super-set of data in the WAL, and even data in the WAL has been compacted into tsm files data in the cache may be queried instead of hitting tsm files. Systems with large amounts of RAM may use this to increase query performance.

Of course all caches must have an eviction policy, and this is where checkpoints come in. When the WAL compacts data into tsm files, it informs the cache via the checkpoint mechanism. This allows the cache to evict data received up to and including the checkpoint, if necessary.

If data cannot be added to the cache, because its maximum memory footprint has been reached, it will reject additions.

Performance is critical in this code, and this code will be carefully tested and benchmarked. Some distinct types have been introduced to help with construction, but these types must not impact performance.

Please consult the changes to `DESIGN.md` for more details.
