### PR TITLE
Fix aggregate output across the cluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - [#4766](https://github.com/influxdb/influxdb/pull/4766): Update CLI usage output. Thanks @aneshas
 - [#4804](https://github.com/influxdb/influxdb/pull/4804): Complete lint for services/admin. Thanks @nii236
 - [#4796](https://github.com/influxdb/influxdb/pull/4796): Check point without fields. Thanks @CrazyJvm
+- [#4815](https://github.com/influxdb/influxdb/pull/4815): Added `Time` field into aggregate output across the cluster. Thanks @li-ang
 
 ## v0.9.5 [unreleased]
 

--- a/cluster/shard_mapper.go
+++ b/cluster/shard_mapper.go
@@ -231,6 +231,7 @@ func (r *RemoteMapper) NextChunk() (chunk interface{}, err error) {
 			aggValues = append(aggValues, v)
 		}
 		mo.Values = []*tsdb.MapperValue{&tsdb.MapperValue{
+			Time:  mvj[0].Time,
 			Value: aggValues,
 			Tags:  mvj[0].Tags,
 		}}


### PR DESCRIPTION
fix #4801
Ignoring time for aggregate output would lead to get wrong result when influxdb is working in cluster.
So, when the time of aggregate output isn't equal to zore, we shouldn't ignore time and return it in result.

- [x] CHANGELOG.md updated
- [x] Rebased/mergable
- [x] Tests pass
- [x] Sign [CLA](http://influxdb.com/community/cla.html) 