### PR TITLE
check point without fields when NewPoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [#4768](https://github.com/influxdb/influxdb/pull/4768): CLI history skips blank lines. Thanks @pires
 - [#4766](https://github.com/influxdb/influxdb/pull/4766): Update CLI usage output. Thanks @aneshas
 - [#4804](https://github.com/influxdb/influxdb/pull/4804): Complete lint for services/admin. Thanks @nii236
+- [#4796](https://github.com/influxdb/influxdb/pull/4796): Check point without fields. Thanks @CrazyJvm
 
 ## v0.9.5 [unreleased]
 

--- a/models/points.go
+++ b/models/points.go
@@ -962,6 +962,10 @@ func unescapeStringField(in string) string {
 // NewPoint returns a new point with the given measurement name, tags, fields and timestamp.  If
 // an unsupported field value (NaN) is passed, this function returns an error.
 func NewPoint(name string, tags Tags, fields Fields, time time.Time) (Point, error) {
+	if len(fields) == 0 {
+		return nil, fmt.Errorf("Point without fields is unsupported")
+	}
+
 	for key, value := range fields {
 		if fv, ok := value.(float64); ok {
 			// Ensure the caller validates and handles invalid field values

--- a/models/points_test.go
+++ b/models/points_test.go
@@ -202,7 +202,7 @@ func TestParsePointNoFields(t *testing.T) {
 }
 
 func TestParsePointNoTimestamp(t *testing.T) {
-	test(t, "cpu value=1", models.MustNewPoint("cpu", nil, nil, time.Unix(0, 0)))
+	test(t, "cpu value=1", models.MustNewPoint("cpu", nil, models.Fields{"value": 1.0}, time.Unix(0, 0)))
 }
 
 func TestParsePointMissingQuote(t *testing.T) {
@@ -520,7 +520,6 @@ func TestParsePointScientificIntInvalid(t *testing.T) {
 	if err == nil {
 		t.Errorf(`ParsePoints("%s") mismatch. got nil, exp error`, `cpu,host=serverA,region=us-west value=9e10i`)
 	}
-
 }
 
 func TestParsePointUnescape(t *testing.T) {
@@ -1399,6 +1398,13 @@ func TestNewPointEscaped(t *testing.T) {
 	pt = models.MustNewPoint("cpu=main", models.Tags{"tag=bar": "value=foo"}, models.Fields{"name=bar": 1.0}, time.Unix(0, 0))
 	if exp := `cpu=main,tag\=bar=value\=foo name\=bar=1 0`; pt.String() != exp {
 		t.Errorf("NewPoint().String() mismatch.\ngot %v\nexp %v", pt.String(), exp)
+	}
+}
+
+func TestNewPointWithoutField(t *testing.T) {
+	_, err := models.NewPoint("cpu", models.Tags{"tag": "bar"}, models.Fields{}, time.Unix(0, 0))
+	if err == nil {
+		t.Fatalf(`NewPoint() expected error. got nil`)
 	}
 }
 

--- a/tsdb/engine/bz1/bz1_test.go
+++ b/tsdb/engine/bz1/bz1_test.go
@@ -99,11 +99,11 @@ func TestEngine_WritePoints_PointsWriter(t *testing.T) {
 
 	// Points to be inserted.
 	points := []models.Point{
-		models.MustNewPoint("cpu", models.Tags{}, models.Fields{}, time.Unix(0, 1)),
-		models.MustNewPoint("cpu", models.Tags{}, models.Fields{}, time.Unix(0, 0)),
-		models.MustNewPoint("cpu", models.Tags{}, models.Fields{}, time.Unix(1, 0)),
+		models.MustNewPoint("cpu", models.Tags{}, models.Fields{"foo": "bar"}, time.Unix(0, 1)),
+		models.MustNewPoint("cpu", models.Tags{}, models.Fields{"foo": "bar"}, time.Unix(0, 0)),
+		models.MustNewPoint("cpu", models.Tags{}, models.Fields{"foo": "bar"}, time.Unix(1, 0)),
 
-		models.MustNewPoint("cpu", models.Tags{"host": "serverA"}, models.Fields{}, time.Unix(0, 0)),
+		models.MustNewPoint("cpu", models.Tags{"host": "serverA"}, models.Fields{"foo": "bar"}, time.Unix(0, 0)),
 	}
 
 	// Mock points writer to ensure points are passed through.


### PR DESCRIPTION
we saw influxdb panic when we use continuous queries in cluster mode, the panic code is :

```
func (w *WriteShardRequest) unmarshalPoints() []models.Point {
    points := make([]models.Point, len(w.pb.GetPoints()))
    for i, p := range w.pb.GetPoints() {
        pt, err := models.ParsePoints(p)
        if err != nil {
            // A error here means that one node parsed the point correctly but sent an
            // unparseable version to another node.  We could log and drop the point and allow
            // anti-entropy to resolve the discrepancy but this shouldn't ever happen.
            panic(fmt.Sprintf("failed to parse point: `%v`: %v", string(p), err))
        }
        points[i] = pt[0]
    }
    return points
}
```

after investigation , we found the root cause is lack of field check when new point, the current code will not throw any errors but will make above code panic. The reason why there may exist point without fields is that when cq calculate all points in an interval which there's no point in this interval at all.

```
func NewPoint(name string, tags Tags, fields Fields, time time.Time) (Point, error) {
    for key, value := range fields {
        if fv, ok := value.(float64); ok {
            // Ensure the caller validates and handles invalid field values
            if math.IsNaN(fv) {
                return nil, fmt.Errorf("NaN is an unsupported value for field %s", key)
            }
        }
    }

    return &point{
        key:    MakeKey([]byte(name), tags),
        time:   time,
        fields: fields.MarshalBinary(),
    }, nil
}
```

this PR add field check.

- [x] CHANGELOG.md updated
- [x] Rebased/mergable
- [x] Tests pass
- [x] Sign [CLA](http://influxdb.com/community/cla.html) (if not already signed)