### PR TITLE
Fix parsing issues in models.scanKey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ There are breaking changes in this release:
   - Scripts are now located in `/usr/lib/influxdb/scripts` (previously `/opt/influxdb`)
 
 ### Features
-- [#4841](https://github.com/influxdb/influxdb/pull/4841): Improve parsing of measurements and tags
+- [#4841](https://github.com/influxdb/influxdb/pull/4841): Improve point parsing speed. Lint models pacakge.
 - [#4098](https://github.com/influxdb/influxdb/pull/4702): Support 'history' command at CLI
 - [#4098](https://github.com/influxdb/influxdb/issues/4098): Enable `golint` on the code base - uuid subpackage
 - [#4141](https://github.com/influxdb/influxdb/pull/4141): Control whether each query should be logged

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ There are breaking changes in this release:
   - Scripts are now located in `/usr/lib/influxdb/scripts` (previously `/opt/influxdb`)
 
 ### Features
+- [#4841](https://github.com/influxdb/influxdb/pull/4841): Improve parsing of measurements and tags
 - [#4098](https://github.com/influxdb/influxdb/pull/4702): Support 'history' command at CLI
 - [#4098](https://github.com/influxdb/influxdb/issues/4098): Enable `golint` on the code base - uuid subpackage
 - [#4141](https://github.com/influxdb/influxdb/pull/4141): Control whether each query should be logged

--- a/models/points_test.go
+++ b/models/points_test.go
@@ -168,6 +168,7 @@ func TestParsePointNoFields(t *testing.T) {
 	examples := []string{
 		"cpu_load_short,host=server01,region=us-west",
 		"cpu",
+		"cpu,host==",
 		"=",
 	}
 
@@ -252,7 +253,6 @@ func TestParsePointMissingTagValue(t *testing.T) {
 func TestParsePointInvalidTagFormat(t *testing.T) {
 	expectedSuffix := "invalid tag format"
 	examples := []string{
-		`cpu,host==`,
 		`cpu,host=f=o,`,
 	}
 

--- a/models/points_test.go
+++ b/models/points_test.go
@@ -163,41 +163,21 @@ func TestParsePointWhitespaceValue(t *testing.T) {
 	}
 }
 
-func TestParsePointSingleEquals(t *testing.T) {
-	pts, err := models.ParsePointsString("=")
-	if err == nil {
-		t.Errorf(`ParsePoints("%s") mismatch. expected error`, "=")
-	}
-
-	if exp := 0; len(pts) != exp {
-		t.Errorf(`ParsePoints("%s") len mismatch. got %v, exp %v`, "", len(pts), exp)
-	}
-}
-
 func TestParsePointNoFields(t *testing.T) {
-	_, err := models.ParsePointsString("cpu_load_short,host=server01,region=us-west")
-	if err == nil {
-		t.Errorf(`ParsePoints("%s") mismatch. got nil, exp error`, "cpu_load_short,host=server01,region=us-west")
+	expectedSuffix := "missing fields"
+	examples := []string{
+		"cpu_load_short,host=server01,region=us-west",
+		"cpu",
+		"=",
 	}
 
-	_, err = models.ParsePointsString("cpu")
-	if err == nil {
-		t.Errorf(`ParsePoints("%s") mismatch. got nil, exp error`, "cpu")
-	}
-
-	_, err = models.ParsePointsString("cpu,")
-	if err == nil {
-		t.Errorf(`ParsePoints("%s") mismatch. got nil, exp error`, "cpu,")
-	}
-
-	_, err = models.ParsePointsString("cpu, value=1")
-	if err == nil {
-		t.Errorf(`ParsePoints("%s") mismatch. got nil, exp error`, "cpu, value=1")
-	}
-
-	_, err = models.ParsePointsString("cpu,,, value=1")
-	if err == nil {
-		t.Errorf(`ParsePoints("%s") mismatch. got nil, exp error`, "cpu,,, value=1")
+	for i, example := range examples {
+		_, err := models.ParsePointsString(example)
+		if err == nil {
+			t.Errorf(`[Example %d] ParsePoints("%s") mismatch. got nil, exp error`, i, example)
+		} else if !strings.HasSuffix(err.Error(), expectedSuffix) {
+			t.Errorf(`[Example %d] ParsePoints("%s") mismatch. got %q, exp suffix %q`, i, example, err, expectedSuffix)
+		}
 	}
 }
 
@@ -206,51 +186,64 @@ func TestParsePointNoTimestamp(t *testing.T) {
 }
 
 func TestParsePointMissingQuote(t *testing.T) {
-	_, err := models.ParsePointsString(`cpu,host=serverA value="test`)
-	if err == nil {
-		t.Errorf(`ParsePoints("%s") mismatch. got nil, exp error`, "cpu")
+	expectedSuffix := "unbalanced quotes"
+	examples := []string{
+		`cpu,host=serverA value="test`,
+		`cpu,host=serverA value="test""`,
+	}
+
+	for i, example := range examples {
+		_, err := models.ParsePointsString(example)
+		if err == nil {
+			t.Errorf(`[Example %d] ParsePoints("%s") mismatch. got nil, exp error`, i, example)
+		} else if !strings.HasSuffix(err.Error(), expectedSuffix) {
+			t.Errorf(`[Example %d] ParsePoints("%s") mismatch. got %q, exp suffix %q`, i, example, err, expectedSuffix)
+		}
 	}
 }
 
 func TestParsePointMissingTagKey(t *testing.T) {
-	_, err := models.ParsePointsString(`cpu,host=serverA,=us-east value=1i`)
-	if err == nil {
-		t.Errorf(`ParsePoints("%s") mismatch. got nil, exp error`, `cpu,host=serverA,=us-east value=1i`)
+	expectedSuffix := "missing tag key"
+	examples := []string{
+		`cpu, value=1`,
+		`cpu,`,
+		`cpu,host=serverA,=us-east value=1i`,
+		`cpu,host=serverAa\,,=us-east value=1i`,
+		`cpu,host=serverA\,,=us-east value=1i`,
+		`cpu, =serverA value=1i`,
 	}
 
-	_, err = models.ParsePointsString(`cpu,host=serverAa\,,=us-east value=1i`)
-	if err == nil {
-		t.Errorf(`ParsePoints("%s") mismatch. got nil, exp error`, `cpu,host=serverAa\,,=us-east value=1i`)
+	for i, example := range examples {
+		_, err := models.ParsePointsString(example)
+		if err == nil {
+			t.Errorf(`[Example %d] ParsePoints("%s") mismatch. got nil, exp error`, i, example)
+		} else if !strings.HasSuffix(err.Error(), expectedSuffix) {
+			t.Errorf(`[Example %d] ParsePoints("%s") mismatch. got %q, exp suffix %q`, i, example, err, expectedSuffix)
+		}
 	}
 
-	_, err = models.ParsePointsString(`cpu,host=serverA\,,=us-east value=1i`)
-	if err == nil {
-		t.Errorf(`ParsePoints("%s") mismatch. got nil, exp error`, `cpu,host=serverA\,,=us-east value=1i`)
-	}
-
-	_, err = models.ParsePointsString(`cpu,host=serverA,\ =us-east value=1i`)
+	_, err := models.ParsePointsString(`cpu,host=serverA,\ =us-east value=1i`)
 	if err != nil {
 		t.Errorf(`ParsePoints("%s") mismatch. got %v, exp nil`, `cpu,host=serverA,\ =us-east value=1i`, err)
 	}
 }
 
 func TestParsePointMissingTagValue(t *testing.T) {
-	_, err := models.ParsePointsString(`cpu,host value=1i`)
-	if err == nil {
-		t.Errorf(`ParsePoints("%s") mismatch. got nil, exp error`, `cpu,host value=1i`)
+	expectedSuffix := "missing tag value"
+	examples := []string{
+		`cpu,host value=1i`,
+		`cpu,host=serverA,region value=1i`,
+		`cpu,host=serverA,region= value=1i`,
+		`cpu,host=serverA,region=,zone=us-west value=1i`,
 	}
 
-	_, err = models.ParsePointsString(`cpu,host=serverA,region value=1i`)
-	if err == nil {
-		t.Errorf(`ParsePoints("%s") mismatch. got nil, exp error`, `cpu,host=serverA,region value=1i`)
-	}
-	_, err = models.ParsePointsString(`cpu,host=serverA,region= value=1i`)
-	if err == nil {
-		t.Errorf(`ParsePoints("%s") mismatch. got nil, exp error`, `cpu,host=serverA,region= value=1i`)
-	}
-	_, err = models.ParsePointsString(`cpu,host=serverA,region=,zone=us-west value=1i`)
-	if err == nil {
-		t.Errorf(`ParsePoints("%s") mismatch. got nil, exp error`, `cpu,host=serverA,region=,zone=us-west value=1i`)
+	for i, example := range examples {
+		_, err := models.ParsePointsString(example)
+		if err == nil {
+			t.Errorf(`[Example %d] ParsePoints("%s") mismatch. got nil, exp error`, i, example)
+		} else if !strings.HasSuffix(err.Error(), expectedSuffix) {
+			t.Errorf(`[Example %d] ParsePoints("%s") mismatch. got %q, exp suffix %q`, i, example, err, expectedSuffix)
+		}
 	}
 }
 
@@ -543,7 +536,6 @@ func TestParsePointUnescape(t *testing.T) {
 				"value": 1.0,
 			},
 			time.Unix(0, 0)))
-
 	// spaces in measurement name
 	test(t, `cpu\ load,region=east value=1.0`,
 		models.MustNewPoint(
@@ -572,6 +564,17 @@ func TestParsePointUnescape(t *testing.T) {
 		models.MustNewPoint("cpu",
 			models.Tags{
 				"region zone": "east", // comma in the tag key
+			},
+			models.Fields{
+				"value": 1.0,
+			},
+			time.Unix(0, 0)))
+
+	// space is tag name
+	test(t, `cpu,\ =east value=1.0`,
+		models.MustNewPoint("cpu",
+			models.Tags{
+				" ": "east", // tag key is single space
 			},
 			models.Fields{
 				"value": 1.0,
@@ -651,6 +654,18 @@ func TestParsePointUnescape(t *testing.T) {
 			"cpu",
 			models.Tags{
 				"regions": "eas\\t",
+			},
+			models.Fields{
+				"value": 1.0,
+			},
+			time.Unix(0, 0)))
+
+	// backslash literal followed by escaped character
+	test(t, `cpu,regions=\\,east value=1.0`,
+		models.MustNewPoint(
+			"cpu",
+			models.Tags{
+				"regions": `\,east`,
 			},
 			models.Fields{
 				"value": 1.0,

--- a/models/points_test.go
+++ b/models/points_test.go
@@ -231,10 +231,29 @@ func TestParsePointMissingTagKey(t *testing.T) {
 func TestParsePointMissingTagValue(t *testing.T) {
 	expectedSuffix := "missing tag value"
 	examples := []string{
+		`cpu,host`,
+		`cpu,host,`,
 		`cpu,host value=1i`,
 		`cpu,host=serverA,region value=1i`,
 		`cpu,host=serverA,region= value=1i`,
 		`cpu,host=serverA,region=,zone=us-west value=1i`,
+	}
+
+	for i, example := range examples {
+		_, err := models.ParsePointsString(example)
+		if err == nil {
+			t.Errorf(`[Example %d] ParsePoints("%s") mismatch. got nil, exp error`, i, example)
+		} else if !strings.HasSuffix(err.Error(), expectedSuffix) {
+			t.Errorf(`[Example %d] ParsePoints("%s") mismatch. got %q, exp suffix %q`, i, example, err, expectedSuffix)
+		}
+	}
+}
+
+func TestParsePointInvalidTagFormat(t *testing.T) {
+	expectedSuffix := "invalid tag format"
+	examples := []string{
+		`cpu,host==`,
+		`cpu,host=f=o,`,
 	}
 
 	for i, example := range examples {
@@ -1141,7 +1160,7 @@ func TestNewPointLargeNumberOfTags(t *testing.T) {
 	}
 
 	if len(pt[0].Tags()) != 255 {
-		t.Fatalf("ParsePoints() with max tags failed: %v", err)
+		t.Fatalf("expected %d tags, got %d", 255, len(pt[0].Tags()))
 	}
 }
 
@@ -1181,7 +1200,7 @@ func TestParsePointKeyUnsorted(t *testing.T) {
 	pt := pts[0]
 
 	if exp := "cpu,first=2,last=1"; string(pt.Key()) != exp {
-		t.Errorf("ParsePoint key not sorted. got %v, exp %v", pt.Key(), exp)
+		t.Errorf("ParsePoint key not sorted. got %v, exp %v", string(pt.Key()), exp)
 	}
 }
 

--- a/models/rows.go
+++ b/models/rows.go
@@ -40,6 +40,7 @@ func (r *Row) tagsKeys() []string {
 	return a
 }
 
+// Rows represents a collection of rows. Rows implements sort.Interface.
 type Rows []*Row
 
 func (p Rows) Len() int { return len(p) }


### PR DESCRIPTION
The PR refactors `models.scanKey`, which is used to parse the measurements and tags. It:

 - Simplifies the `scanKey` logic by broadly modelling it as a state machine;
 - Fixes issues #3070 and #4770 (and some other non-documented incorrect error messages);
 - Refactors some tests to add coverage and improve robustness, e.g., checking correct errors returned, rather than _an_ error returned;
 - Removes redundant conditionals in the `scanKey` function.

Initially I planned on simply fixing  #3070 and #4770, but I felt that the `scanKey` function was pretty complicated, and had had extra conditionals and checks added over time, some of which were redundant, or unreachable. It seemed like it was worth refactoring this function into something easier to understand.

I've ran benchmarks before and after and performance is broadly inline with the previous implementation, if not a little faster for some benchmarks.

(Updated)

```
name                         old time/op    new time/op    delta
Marshal-4                      6.08µs ± 1%    6.10µs ± 1%     ~     (p=0.132 n=6+6)
ParsePointNoTags-4              838ns ± 0%     828ns ± 1%   -1.23%  (p=0.004 n=5+6)
ParsePointsTagsSorted2-4       1.16µs ± 2%    1.14µs ± 0%   -1.95%  (p=0.010 n=6+4)
ParsePointsTagsSorted5-4       1.52µs ± 1%    1.42µs ± 0%   -6.22%  (p=0.004 n=6+5)
ParsePointsTagsSorted10-4      2.28µs ± 1%    2.07µs ± 0%   -9.45%  (p=0.004 n=6+5)
ParsePointsTagsUnSorted2-4     1.42µs ± 0%    1.41µs ± 1%   -1.18%  (p=0.010 n=4+6)
ParsePointsTagsUnSorted5-4     1.55µs ± 1%    1.44µs ± 0%   -7.24%  (p=0.002 n=6+6)
ParsePointsTagsUnSorted10-4    3.87µs ± 1%    3.59µs ± 1%   -7.22%  (p=0.002 n=6+6)

name                         old speed      new speed      delta
ParsePointNoTags-4           27.4MB/s ± 0%  27.8MB/s ± 1%   +1.24%  (p=0.004 n=5+6)
ParsePointsTagsSorted2-4     43.8MB/s ± 2%  44.6MB/s ± 0%   +1.98%  (p=0.010 n=6+4)
ParsePointsTagsSorted5-4     54.7MB/s ± 1%  58.3MB/s ± 0%   +6.62%  (p=0.004 n=6+5)
ParsePointsTagsSorted10-4    62.6MB/s ± 1%  69.1MB/s ± 0%  +10.44%  (p=0.004 n=6+5)
ParsePointsTagsUnSorted2-4   35.8MB/s ± 0%  36.2MB/s ± 1%   +1.29%  (p=0.004 n=5+6)
ParsePointsTagsUnSorted5-4   53.6MB/s ± 1%  57.8MB/s ± 0%   +7.79%  (p=0.002 n=6+6)
ParsePointsTagsUnSorted10-4  36.9MB/s ± 1%  39.8MB/s ± 1%   +7.77%  (p=0.002 n=6+6)
```

- [x] CHANGELOG.md updated
- [ ] Rebased/mergable
- [x] Tests pass
- [x] Sign [CLA](http://influxdb.com/community/cla.html) (if not already signed)