### PR TITLE
Added framework for cluster integration testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [#4841](https://github.com/influxdb/influxdb/pull/4841): Improve point parsing speed. Lint models pacakge. Thanks @e-dard!
 - [#4889](https://github.com/influxdb/influxdb/pull/4889): Implement close notifier and timeout on executors
 - [#2676](https://github.com/influxdb/influxdb/issues/2676), [#4866](https://github.com/influxdb/influxdb/pull/4866): Add support for specifying default retention policy in database create. Thanks @pires!
+- [#4848](https://github.com/influxdb/influxdb/pull/4848): Added framework for cluster integration testing.
 
 ### Bugfixes
 - [#4876](https://github.com/influxdb/influxdb/pull/4876): Complete lint for monitor and services packages. Thanks @e-dard!

--- a/circle-test.sh
+++ b/circle-test.sh
@@ -6,7 +6,7 @@
 
 BUILD_DIR=$HOME/influxdb-build
 GO_VERSION=go1.4.2
-PARALLELISM="-parallel 256"
+PARALLELISM="-parallel 1"
 TIMEOUT="-timeout 480s"
 
 # Executes the given statement, and exits if the command returns a non-zero code.

--- a/cmd/influxd/run/server.go
+++ b/cmd/influxd/run/server.go
@@ -363,6 +363,7 @@ func (s *Server) Open() error {
 		// The port 0 is used, we need to retrieve the port assigned by the kernel
 		if strings.HasSuffix(s.BindAddress, ":0") {
 			s.MetaStore.Addr = ln.Addr()
+			s.MetaStore.RemoteAddr = ln.Addr()
 		}
 
 		// Multiplex listener.

--- a/cmd/influxd/run/server_cluster_test.go
+++ b/cmd/influxd/run/server_cluster_test.go
@@ -322,3 +322,34 @@ func TestCluster_RetentionPolicyCommands(t *testing.T) {
 		}
 	}
 }
+
+func TestCluster_DatabaseRetentionPolicyAutoCreate(t *testing.T) {
+	t.Parallel()
+	t.Skip()
+	c, err := NewCluster(5)
+	if err != nil {
+		t.Fatalf("error creating cluster: %s", err)
+	}
+	defer c.Close()
+
+	test := tests.load(t, "retention_policy_auto_create")
+
+	for _, query := range test.queries {
+		if query.skip {
+			t.Logf("SKIP:: %s", query.name)
+			continue
+		}
+		t.Logf("Running %s", query.name)
+		if query.once {
+			if _, err := c.Query(query); err != nil {
+				t.Error(query.Error(err))
+			} else if !query.success() {
+				t.Error(query.failureMessage())
+			}
+			continue
+		}
+		if err := c.QueryAll(query); err != nil {
+			t.Error(query.Error(err))
+		}
+	}
+}

--- a/cmd/influxd/run/server_cluster_test.go
+++ b/cmd/influxd/run/server_cluster_test.go
@@ -1,0 +1,221 @@
+package run_test
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestCluster_CreateDatabase(t *testing.T) {
+	t.Parallel()
+
+	c, err := NewClusterWithDefaults(5)
+	defer c.Close()
+	if err != nil {
+		t.Fatalf("error creating cluster: %s", err)
+	}
+}
+
+func TestCluster_Write(t *testing.T) {
+	t.Parallel()
+
+	c, err := NewClusterWithDefaults(5)
+	if err != nil {
+		t.Fatalf("error creating cluster: %s", err)
+	}
+	defer c.Close()
+
+	writes := []string{
+		fmt.Sprintf(`cpu,host=serverA,region=uswest val=23.2 %d`, mustParseTime(time.RFC3339Nano, "2000-01-01T00:00:00Z").UnixNano()),
+	}
+
+	_, err = c.Servers[0].Write("db", "default", strings.Join(writes, "\n"), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	q := &Query{
+		name:    "write",
+		command: `SELECT * FROM db."default".cpu`,
+		exp:     `{"results":[{"series":[{"name":"cpu","columns":["time","host","region","val"],"values":[["2000-01-01T00:00:00Z","serverA","uswest",23.2]]}]}]}`,
+	}
+	err = c.QueryAll(q)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+func TestCluster_DatabaseCommands(t *testing.T) {
+	t.Parallel()
+	c, err := NewCluster(5)
+	if err != nil {
+		t.Fatalf("error creating cluster: %s", err)
+	}
+
+	defer c.Close()
+
+	test := Test{
+		queries: []*Query{
+			&Query{
+				name:    "create database should succeed",
+				command: `CREATE DATABASE db0`,
+				exp:     `{"results":[{}]}`,
+				once:    true,
+			},
+			&Query{
+				name:    "create database should error with bad name",
+				command: `CREATE DATABASE 0xdb0`,
+				exp:     `{"error":"error parsing query: found 0, expected identifier at line 1, char 17"}`,
+			},
+			&Query{
+				name:    "show database should succeed",
+				command: `SHOW DATABASES`,
+				exp:     `{"results":[{"series":[{"name":"databases","columns":["name"],"values":[["db0"]]}]}]}`,
+			},
+			&Query{
+				name:    "create database should error if it already exists",
+				command: `CREATE DATABASE db0`,
+				exp:     `{"results":[{"error":"database already exists"}]}`,
+			},
+			&Query{
+				name:    "create database should not error with existing database with IF NOT EXISTS",
+				command: `CREATE DATABASE IF NOT EXISTS db0`,
+				exp:     `{"results":[{}]}`,
+			},
+			&Query{
+				name:    "create database should create non-existing database with IF NOT EXISTS",
+				command: `CREATE DATABASE IF NOT EXISTS db1`,
+				exp:     `{"results":[{}]}`,
+			},
+			&Query{
+				name:    "show database should succeed",
+				command: `SHOW DATABASES`,
+				exp:     `{"results":[{"series":[{"name":"databases","columns":["name"],"values":[["db0"],["db1"]]}]}]}`,
+			},
+			&Query{
+				name:    "drop database db0 should succeed",
+				command: `DROP DATABASE db0`,
+				exp:     `{"results":[{}]}`,
+				once:    true,
+			},
+			&Query{
+				name:    "drop database db1 should succeed",
+				command: `DROP DATABASE db1`,
+				exp:     `{"results":[{}]}`,
+				once:    true,
+			},
+			&Query{
+				name:    "drop database should error if it does not exists",
+				command: `DROP DATABASE db1`,
+				exp:     `{"results":[{"error":"database not found: db1"}]}`,
+			},
+			&Query{
+				name:    "drop database should not error with non-existing database db1 WITH IF EXISTS",
+				command: `DROP DATABASE IF EXISTS db1`,
+				exp:     `{"results":[{}]}`,
+			},
+			&Query{
+				name:    "show database should have no results",
+				command: `SHOW DATABASES`,
+				exp:     `{"results":[{"series":[{"name":"databases","columns":["name"]}]}]}`,
+			},
+			&Query{
+				name:    "drop database should error if it doesn't exist",
+				command: `DROP DATABASE db0`,
+				exp:     `{"results":[{"error":"database not found: db0"}]}`,
+			},
+		},
+	}
+
+	for _, query := range test.queries {
+		if query.skip {
+			t.Logf("SKIP:: %s", query.name)
+			continue
+		}
+		t.Logf("Running %s", query.name)
+		if query.once {
+			if _, err := c.Query(query); err != nil {
+				t.Error(query.Error(err))
+			} else if !query.success() {
+				t.Error(query.failureMessage())
+			}
+			continue
+		}
+		if err := c.QueryAll(query); err != nil {
+			t.Error(query.Error(err))
+		}
+	}
+}
+
+func TestCluster_Query_DropAndRecreateDatabase(t *testing.T) {
+	t.Parallel()
+	c, err := NewClusterWithDefaults(5)
+	if err != nil {
+		t.Fatalf("error creating cluster: %s", err)
+	}
+	defer c.Close()
+
+	writes := []string{
+		fmt.Sprintf(`cpu,host=serverA,region=uswest val=23.2 %d`, mustParseTime(time.RFC3339Nano, "2000-01-01T00:00:00Z").UnixNano()),
+	}
+
+	_, err = c.Servers[0].Write("db", "default", strings.Join(writes, "\n"), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	test := Test{
+		queries: []*Query{
+			&Query{
+				name:    "Drop database after data write",
+				command: `DROP DATABASE db`,
+				exp:     `{"results":[{}]}`,
+				once:    true,
+			},
+			&Query{
+				name:    "Recreate database",
+				command: `CREATE DATABASE db`,
+				exp:     `{"results":[{}]}`,
+				once:    true,
+			},
+			&Query{
+				name:    "Recreate retention policy",
+				command: `CREATE RETENTION POLICY rp0 ON db DURATION 365d REPLICATION 1 DEFAULT`,
+				exp:     `{"results":[{}]}`,
+				once:    true,
+			},
+			&Query{
+				name:    "Show measurements after recreate",
+				command: `SHOW MEASUREMENTS`,
+				exp:     `{"results":[{}]}`,
+				params:  url.Values{"db": []string{"db"}},
+			},
+			&Query{
+				name:    "Query data after recreate",
+				command: `SELECT * FROM cpu`,
+				exp:     `{"results":[{}]}`,
+				params:  url.Values{"db": []string{"db"}},
+			},
+		},
+	}
+
+	for _, query := range test.queries {
+		if query.skip {
+			t.Logf("SKIP:: %s", query.name)
+			continue
+		}
+		t.Logf("Running %s", query.name)
+		if query.once {
+			if _, err := c.Query(query); err != nil {
+				t.Error(query.Error(err))
+			} else if !query.success() {
+				t.Error(query.failureMessage())
+			}
+			continue
+		}
+		if err := c.QueryAll(query); err != nil {
+			t.Error(query.Error(err))
+		}
+	}
+
+}

--- a/cmd/influxd/run/server_cluster_test.go
+++ b/cmd/influxd/run/server_cluster_test.go
@@ -2,7 +2,6 @@ package run_test
 
 import (
 	"fmt"
-	"net/url"
 	"strings"
 	"testing"
 	"time"
@@ -31,14 +30,14 @@ func TestCluster_Write(t *testing.T) {
 		fmt.Sprintf(`cpu,host=serverA,region=uswest val=23.2 %d`, mustParseTime(time.RFC3339Nano, "2000-01-01T00:00:00Z").UnixNano()),
 	}
 
-	_, err = c.Servers[0].Write("db", "default", strings.Join(writes, "\n"), nil)
+	_, err = c.Servers[0].Write("db0", "default", strings.Join(writes, "\n"), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	q := &Query{
 		name:    "write",
-		command: `SELECT * FROM db."default".cpu`,
+		command: `SELECT * FROM db0."default".cpu`,
 		exp:     `{"results":[{"series":[{"name":"cpu","columns":["time","host","region","val"],"values":[["2000-01-01T00:00:00Z","serverA","uswest",23.2]]}]}]}`,
 	}
 	err = c.QueryAll(q)
@@ -46,6 +45,7 @@ func TestCluster_Write(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
 func TestCluster_DatabaseCommands(t *testing.T) {
 	t.Parallel()
 	c, err := NewCluster(5)
@@ -55,78 +55,7 @@ func TestCluster_DatabaseCommands(t *testing.T) {
 
 	defer c.Close()
 
-	test := Test{
-		queries: []*Query{
-			&Query{
-				name:    "create database should succeed",
-				command: `CREATE DATABASE db0`,
-				exp:     `{"results":[{}]}`,
-				once:    true,
-			},
-			&Query{
-				name:    "create database should error with bad name",
-				command: `CREATE DATABASE 0xdb0`,
-				exp:     `{"error":"error parsing query: found 0, expected identifier at line 1, char 17"}`,
-			},
-			&Query{
-				name:    "show database should succeed",
-				command: `SHOW DATABASES`,
-				exp:     `{"results":[{"series":[{"name":"databases","columns":["name"],"values":[["db0"]]}]}]}`,
-			},
-			&Query{
-				name:    "create database should error if it already exists",
-				command: `CREATE DATABASE db0`,
-				exp:     `{"results":[{"error":"database already exists"}]}`,
-			},
-			&Query{
-				name:    "create database should not error with existing database with IF NOT EXISTS",
-				command: `CREATE DATABASE IF NOT EXISTS db0`,
-				exp:     `{"results":[{}]}`,
-			},
-			&Query{
-				name:    "create database should create non-existing database with IF NOT EXISTS",
-				command: `CREATE DATABASE IF NOT EXISTS db1`,
-				exp:     `{"results":[{}]}`,
-			},
-			&Query{
-				name:    "show database should succeed",
-				command: `SHOW DATABASES`,
-				exp:     `{"results":[{"series":[{"name":"databases","columns":["name"],"values":[["db0"],["db1"]]}]}]}`,
-			},
-			&Query{
-				name:    "drop database db0 should succeed",
-				command: `DROP DATABASE db0`,
-				exp:     `{"results":[{}]}`,
-				once:    true,
-			},
-			&Query{
-				name:    "drop database db1 should succeed",
-				command: `DROP DATABASE db1`,
-				exp:     `{"results":[{}]}`,
-				once:    true,
-			},
-			&Query{
-				name:    "drop database should error if it does not exists",
-				command: `DROP DATABASE db1`,
-				exp:     `{"results":[{"error":"database not found: db1"}]}`,
-			},
-			&Query{
-				name:    "drop database should not error with non-existing database db1 WITH IF EXISTS",
-				command: `DROP DATABASE IF EXISTS db1`,
-				exp:     `{"results":[{}]}`,
-			},
-			&Query{
-				name:    "show database should have no results",
-				command: `SHOW DATABASES`,
-				exp:     `{"results":[{"series":[{"name":"databases","columns":["name"]}]}]}`,
-			},
-			&Query{
-				name:    "drop database should error if it doesn't exist",
-				command: `DROP DATABASE db0`,
-				exp:     `{"results":[{"error":"database not found: db0"}]}`,
-			},
-		},
-	}
+	test := tests.load(t, "database_commands")
 
 	for _, query := range test.queries {
 		if query.skip {
@@ -156,47 +85,11 @@ func TestCluster_Query_DropAndRecreateDatabase(t *testing.T) {
 	}
 	defer c.Close()
 
-	writes := []string{
-		fmt.Sprintf(`cpu,host=serverA,region=uswest val=23.2 %d`, mustParseTime(time.RFC3339Nano, "2000-01-01T00:00:00Z").UnixNano()),
-	}
+	test := tests.load(t, "drop_and_recreate_database")
 
-	_, err = c.Servers[0].Write("db", "default", strings.Join(writes, "\n"), nil)
+	_, err = c.Servers[0].Write(test.database(), test.retentionPolicy(), test.write, nil)
 	if err != nil {
 		t.Fatal(err)
-	}
-	test := Test{
-		queries: []*Query{
-			&Query{
-				name:    "Drop database after data write",
-				command: `DROP DATABASE db`,
-				exp:     `{"results":[{}]}`,
-				once:    true,
-			},
-			&Query{
-				name:    "Recreate database",
-				command: `CREATE DATABASE db`,
-				exp:     `{"results":[{}]}`,
-				once:    true,
-			},
-			&Query{
-				name:    "Recreate retention policy",
-				command: `CREATE RETENTION POLICY rp0 ON db DURATION 365d REPLICATION 1 DEFAULT`,
-				exp:     `{"results":[{}]}`,
-				once:    true,
-			},
-			&Query{
-				name:    "Show measurements after recreate",
-				command: `SHOW MEASUREMENTS`,
-				exp:     `{"results":[{}]}`,
-				params:  url.Values{"db": []string{"db"}},
-			},
-			&Query{
-				name:    "Query data after recreate",
-				command: `SELECT * FROM cpu`,
-				exp:     `{"results":[{}]}`,
-				params:  url.Values{"db": []string{"db"}},
-			},
-		},
 	}
 
 	for _, query := range test.queries {
@@ -217,5 +110,50 @@ func TestCluster_Query_DropAndRecreateDatabase(t *testing.T) {
 			t.Error(query.Error(err))
 		}
 	}
+}
 
+func TestCluster_Query_DropDatabaseIsolated(t *testing.T) {
+	t.Parallel()
+	c, err := NewCluster(5)
+	if err != nil {
+		t.Fatalf("error creating cluster: %s", err)
+	}
+	defer c.Close()
+
+	test := tests.load(t, "drop_database_isolated")
+
+	s := c.Servers[0]
+	if err := s.CreateDatabaseAndRetentionPolicy("db0", newRetentionPolicyInfo("rp0", 1, 0)); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.MetaStore.SetDefaultRetentionPolicy("db0", "rp0"); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.CreateDatabaseAndRetentionPolicy("db1", newRetentionPolicyInfo("rp1", 1, 0)); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = s.Write(test.database(), test.retentionPolicy(), test.write, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, query := range test.queries {
+		if query.skip {
+			t.Logf("SKIP:: %s", query.name)
+			continue
+		}
+		t.Logf("Running %s", query.name)
+		if query.once {
+			if _, err := c.Query(query); err != nil {
+				t.Error(query.Error(err))
+			} else if !query.success() {
+				t.Error(query.failureMessage())
+			}
+			continue
+		}
+		if err := c.QueryAll(query); err != nil {
+			t.Error(query.Error(err))
+		}
+	}
 }

--- a/cmd/influxd/run/server_helpers_test.go
+++ b/cmd/influxd/run/server_helpers_test.go
@@ -592,7 +592,7 @@ func (c *Cluster) QueryAll(q *Query) error {
 
 	tick := time.Tick(100 * time.Millisecond)
 	// if we don't reach consensus in 20 seconds, fail the query
-	timeout := time.After(10 * time.Second)
+	timeout := time.After(20 * time.Second)
 
 	if err := queryAll(); err == nil {
 		return nil

--- a/cmd/influxd/run/server_helpers_test.go
+++ b/cmd/influxd/run/server_helpers_test.go
@@ -530,7 +530,7 @@ func (c *Cluster) QueryAll(q *Query) error {
 			}
 			if q.pattern {
 				if !expectPattern(q.exp, r.Val) {
-					return fmt.Errorf("unexpected pattern: %s\n\texp: %s\n\tgot: %s\n", q.pattern, q.exp, r.Val)
+					return fmt.Errorf("unexpected pattern: \n\texp: %s\n\tgot: %s\n", q.exp, r.Val)
 				}
 			} else {
 				if r.Val != q.exp {
@@ -560,6 +560,4 @@ func (c *Cluster) QueryAll(q *Query) error {
 			return fmt.Errorf("timed out waiting for response")
 		}
 	}
-
-	return nil
 }

--- a/cmd/influxd/run/server_helpers_test.go
+++ b/cmd/influxd/run/server_helpers_test.go
@@ -130,11 +130,14 @@ func (s *Server) Query(query string) (results string, err error) {
 
 // Query executes a query against the server and returns the results.
 func (s *Server) QueryWithParams(query string, values url.Values) (results string, err error) {
+	var v url.Values
 	if values == nil {
-		values = url.Values{}
+		v = url.Values{}
+	} else {
+		v, _ = url.ParseQuery(values.Encode())
 	}
-	values.Set("q", query)
-	return s.HTTPGet(s.URL() + "/query?" + values.Encode())
+	v.Set("q", query)
+	return s.HTTPGet(s.URL() + "/query?" + v.Encode())
 }
 
 // HTTPGet makes an HTTP GET request to the server and returns the response.
@@ -589,7 +592,7 @@ func (c *Cluster) QueryAll(q *Query) error {
 
 	tick := time.Tick(100 * time.Millisecond)
 	// if we don't reach consensus in 20 seconds, fail the query
-	timeout := time.After(20 * time.Second)
+	timeout := time.After(10 * time.Second)
 
 	if err := queryAll(); err == nil {
 		return nil

--- a/cmd/influxd/run/server_suite_test.go
+++ b/cmd/influxd/run/server_suite_test.go
@@ -1,0 +1,214 @@
+package run_test
+
+import (
+	"fmt"
+	"net/url"
+	"testing"
+	"time"
+)
+
+var tests Tests
+
+// Load all shared tests
+func init() {
+	tests = make(map[string]Test)
+
+	tests["database_commands"] = Test{
+		queries: []*Query{
+			&Query{
+				name:    "create database should succeed",
+				command: `CREATE DATABASE db0`,
+				exp:     `{"results":[{}]}`,
+				once:    true,
+			},
+			&Query{
+				name:    "create database with retention duration should succeed",
+				command: `CREATE DATABASE db0_r WITH DURATION 24h REPLICATION 2 NAME db0_r_policy`,
+				exp:     `{"results":[{}]}`,
+				once:    true,
+			},
+			&Query{
+				name:    "create database should error with bad name",
+				command: `CREATE DATABASE 0xdb0`,
+				exp:     `{"error":"error parsing query: found 0, expected identifier at line 1, char 17"}`,
+			},
+			&Query{
+				name:    "create database with retention duration should error with bad retention duration",
+				command: `CREATE DATABASE db0 WITH DURATION xyz`,
+				exp:     `{"error":"error parsing query: found xyz, expected duration at line 1, char 35"}`,
+			},
+			&Query{
+				name:    "create database with retention replication should error with bad retention replication number",
+				command: `CREATE DATABASE db0 WITH REPLICATION xyz`,
+				exp:     `{"error":"error parsing query: found xyz, expected number at line 1, char 38"}`,
+			},
+			&Query{
+				name:    "create database with retention name should error with missing retention name",
+				command: `CREATE DATABASE db0 WITH NAME`,
+				exp:     `{"error":"error parsing query: found EOF, expected identifier at line 1, char 31"}`,
+			},
+			&Query{
+				name:    "show database should succeed",
+				command: `SHOW DATABASES`,
+				exp:     `{"results":[{"series":[{"name":"databases","columns":["name"],"values":[["db0"],["db0_r"]]}]}]}`,
+			},
+			&Query{
+				name:    "create database should error if it already exists",
+				command: `CREATE DATABASE db0`,
+				exp:     `{"results":[{"error":"database already exists"}]}`,
+			},
+			&Query{
+				name:    "create database should error if it already exists",
+				command: `CREATE DATABASE db0_r`,
+				exp:     `{"results":[{"error":"database already exists"}]}`,
+			},
+			&Query{
+				name:    "create database should not error with existing database with IF NOT EXISTS",
+				command: `CREATE DATABASE IF NOT EXISTS db0`,
+				exp:     `{"results":[{}]}`,
+			},
+			&Query{
+				name:    "create database should create non-existing database with IF NOT EXISTS",
+				command: `CREATE DATABASE IF NOT EXISTS db1`,
+				exp:     `{"results":[{}]}`,
+			},
+			&Query{
+				name:    "create database with retention duration should not error with existing database with IF NOT EXISTS",
+				command: `CREATE DATABASE IF NOT EXISTS db1 WITH DURATION 24h`,
+				exp:     `{"results":[{}]}`,
+			},
+			&Query{
+				name:    "create database should error IF NOT EXISTS with bad retention duration",
+				command: `CREATE DATABASE IF NOT EXISTS db1 WITH DURATION xyz`,
+				exp:     `{"error":"error parsing query: found xyz, expected duration at line 1, char 49"}`,
+			},
+			&Query{
+				name:    "show database should succeed",
+				command: `SHOW DATABASES`,
+				exp:     `{"results":[{"series":[{"name":"databases","columns":["name"],"values":[["db0"],["db0_r"],["db1"]]}]}]}`,
+			},
+			&Query{
+				name:    "drop database db0 should succeed",
+				command: `DROP DATABASE db0`,
+				exp:     `{"results":[{}]}`,
+				once:    true,
+			},
+			&Query{
+				name:    "drop database db0_r should succeed",
+				command: `DROP DATABASE db0_r`,
+				exp:     `{"results":[{}]}`,
+				once:    true,
+			},
+			&Query{
+				name:    "drop database db1 should succeed",
+				command: `DROP DATABASE db1`,
+				exp:     `{"results":[{}]}`,
+				once:    true,
+			},
+			&Query{
+				name:    "drop database should error if it does not exists",
+				command: `DROP DATABASE db1`,
+				exp:     `{"results":[{"error":"database not found: db1"}]}`,
+			},
+			&Query{
+				name:    "drop database should not error with non-existing database db1 WITH IF EXISTS",
+				command: `DROP DATABASE IF EXISTS db1`,
+				exp:     `{"results":[{}]}`,
+			},
+			&Query{
+				name:    "show database should have no results",
+				command: `SHOW DATABASES`,
+				exp:     `{"results":[{"series":[{"name":"databases","columns":["name"]}]}]}`,
+			},
+			&Query{
+				name:    "drop database should error if it doesn't exist",
+				command: `DROP DATABASE db0`,
+				exp:     `{"results":[{"error":"database not found: db0"}]}`,
+			},
+		},
+	}
+
+	tests["drop_and_recreate_database"] = Test{
+		write: fmt.Sprintf(`cpu,host=serverA,region=uswest val=23.2 %d`, mustParseTime(time.RFC3339Nano, "2000-01-01T00:00:00Z").UnixNano()),
+		queries: []*Query{
+			&Query{
+				name:    "Drop database after data write",
+				command: `DROP DATABASE db0`,
+				exp:     `{"results":[{}]}`,
+				once:    true,
+			},
+			&Query{
+				name:    "Recreate database",
+				command: `CREATE DATABASE db0`,
+				exp:     `{"results":[{}]}`,
+				once:    true,
+			},
+			&Query{
+				name:    "Recreate retention policy",
+				command: `CREATE RETENTION POLICY rp0 ON db0 DURATION 365d REPLICATION 1 DEFAULT`,
+				exp:     `{"results":[{}]}`,
+				once:    true,
+			},
+			&Query{
+				name:    "Show measurements after recreate",
+				command: `SHOW MEASUREMENTS`,
+				exp:     `{"results":[{}]}`,
+				params:  url.Values{"db": []string{"db0"}},
+			},
+			&Query{
+				name:    "Query data after recreate",
+				command: `SELECT * FROM cpu`,
+				exp:     `{"results":[{}]}`,
+				params:  url.Values{"db": []string{"db0"}},
+			},
+		},
+	}
+
+	tests["drop_database_isolated"] = Test{
+		db:    "db0",
+		rp:    "rp0",
+		write: fmt.Sprintf(`cpu,host=serverA,region=uswest val=23.2 %d`, mustParseTime(time.RFC3339Nano, "2000-01-01T00:00:00Z").UnixNano()),
+		queries: []*Query{
+			&Query{
+				name:    "Query data from 1st database",
+				command: `SELECT * FROM cpu`,
+				exp:     `{"results":[{"series":[{"name":"cpu","columns":["time","host","region","val"],"values":[["2000-01-01T00:00:00Z","serverA","uswest",23.2]]}]}]}`,
+				params:  url.Values{"db": []string{"db0"}},
+			},
+			&Query{
+				name:    "Query data from 1st database with GROUP BY *",
+				command: `SELECT * FROM cpu GROUP BY *`,
+				exp:     `{"results":[{"series":[{"name":"cpu","tags":{"host":"serverA","region":"uswest"},"columns":["time","val"],"values":[["2000-01-01T00:00:00Z",23.2]]}]}]}`,
+				params:  url.Values{"db": []string{"db0"}},
+			},
+			&Query{
+				name:    "Drop other database",
+				command: `DROP DATABASE db1`,
+				once:    true,
+				exp:     `{"results":[{}]}`,
+			},
+			&Query{
+				name:    "Query data from 1st database and ensure it's still there",
+				command: `SELECT * FROM cpu`,
+				exp:     `{"results":[{"series":[{"name":"cpu","columns":["time","host","region","val"],"values":[["2000-01-01T00:00:00Z","serverA","uswest",23.2]]}]}]}`,
+				params:  url.Values{"db": []string{"db0"}},
+			},
+			&Query{
+				name:    "Query data from 1st database and ensure it's still there with GROUP BY *",
+				command: `SELECT * FROM cpu GROUP BY *`,
+				exp:     `{"results":[{"series":[{"name":"cpu","tags":{"host":"serverA","region":"uswest"},"columns":["time","val"],"values":[["2000-01-01T00:00:00Z",23.2]]}]}]}`,
+				params:  url.Values{"db": []string{"db0"}},
+			},
+		},
+	}
+
+}
+
+func (tests Tests) load(t *testing.T, key string) Test {
+	test, ok := tests[key]
+	if !ok {
+		t.Fatalf("no test %q", key)
+	}
+
+	return test.duplicate()
+}

--- a/cmd/influxd/run/server_suite_test.go
+++ b/cmd/influxd/run/server_suite_test.go
@@ -384,6 +384,22 @@ func init() {
 		},
 	}
 
+	tests["retention_policy_auto_create"] = Test{
+		queries: []*Query{
+			&Query{
+				name:    "create database should succeed",
+				command: `CREATE DATABASE db0`,
+				exp:     `{"results":[{}]}`,
+				once:    true,
+			},
+			&Query{
+				name:    "show retention policies should return auto-created policy",
+				command: `SHOW RETENTION POLICIES ON db0`,
+				exp:     `{"results":[{"series":[{"columns":["name","duration","replicaN","default"],"values":[["default","0",1,true]]}]}]}`,
+			},
+		},
+	}
+
 }
 
 func (tests Tests) load(t *testing.T, key string) Test {

--- a/cmd/influxd/run/server_suite_test.go
+++ b/cmd/influxd/run/server_suite_test.go
@@ -308,6 +308,82 @@ func init() {
 		},
 	}
 
+	tests["retention_policy_commands"] = Test{
+		db: "db0",
+		queries: []*Query{
+			&Query{
+				name:    "create retention policy should succeed",
+				command: `CREATE RETENTION POLICY rp0 ON db0 DURATION 1h REPLICATION 1`,
+				exp:     `{"results":[{}]}`,
+				once:    true,
+			},
+			&Query{
+				name:    "create retention policy should error if it already exists",
+				command: `CREATE RETENTION POLICY rp0 ON db0 DURATION 1h REPLICATION 1`,
+				exp:     `{"results":[{"error":"retention policy already exists"}]}`,
+			},
+			&Query{
+				name:    "show retention policy should succeed",
+				command: `SHOW RETENTION POLICIES ON db0`,
+				exp:     `{"results":[{"series":[{"columns":["name","duration","replicaN","default"],"values":[["rp0","1h0m0s",1,false]]}]}]}`,
+			},
+			&Query{
+				name:    "alter retention policy should succeed",
+				command: `ALTER RETENTION POLICY rp0 ON db0 DURATION 2h REPLICATION 3 DEFAULT`,
+				exp:     `{"results":[{}]}`,
+				once:    true,
+			},
+			&Query{
+				name:    "show retention policy should have new altered information",
+				command: `SHOW RETENTION POLICIES ON db0`,
+				exp:     `{"results":[{"series":[{"columns":["name","duration","replicaN","default"],"values":[["rp0","2h0m0s",3,true]]}]}]}`,
+			},
+			&Query{
+				name:    "dropping default retention policy should not succeed",
+				command: `DROP RETENTION POLICY rp0 ON db0`,
+				exp:     `{"results":[{"error":"retention policy is default"}]}`,
+			},
+			&Query{
+				name:    "show retention policy should still show policy",
+				command: `SHOW RETENTION POLICIES ON db0`,
+				exp:     `{"results":[{"series":[{"columns":["name","duration","replicaN","default"],"values":[["rp0","2h0m0s",3,true]]}]}]}`,
+			},
+			&Query{
+				name:    "create a second non-default retention policy",
+				command: `CREATE RETENTION POLICY rp2 ON db0 DURATION 1h REPLICATION 1`,
+				exp:     `{"results":[{}]}`,
+				once:    true,
+			},
+			&Query{
+				name:    "show retention policy should show both",
+				command: `SHOW RETENTION POLICIES ON db0`,
+				exp:     `{"results":[{"series":[{"columns":["name","duration","replicaN","default"],"values":[["rp0","2h0m0s",3,true],["rp2","1h0m0s",1,false]]}]}]}`,
+			},
+			&Query{
+				name:    "dropping non-default retention policy succeed",
+				command: `DROP RETENTION POLICY rp2 ON db0`,
+				exp:     `{"results":[{}]}`,
+				once:    true,
+			},
+			&Query{
+				name:    "show retention policy should show just default",
+				command: `SHOW RETENTION POLICIES ON db0`,
+				exp:     `{"results":[{"series":[{"columns":["name","duration","replicaN","default"],"values":[["rp0","2h0m0s",3,true]]}]}]}`,
+			},
+			&Query{
+				name:    "Ensure retention policy with unacceptable retention cannot be created",
+				command: `CREATE RETENTION POLICY rp3 ON db0 DURATION 1s REPLICATION 1`,
+				exp:     `{"results":[{"error":"retention policy duration must be at least 1h0m0s"}]}`,
+				once:    true,
+			},
+			&Query{
+				name:    "Check error when deleting retention policy on non-existent database",
+				command: `DROP RETENTION POLICY rp1 ON mydatabase`,
+				exp:     `{"results":[{"error":"database not found: mydatabase"}]}`,
+			},
+		},
+	}
+
 }
 
 func (tests Tests) load(t *testing.T, key string) Test {

--- a/cmd/influxd/run/server_test.go
+++ b/cmd/influxd/run/server_test.go
@@ -231,20 +231,7 @@ func TestServer_DatabaseRetentionPolicyAutoCreate(t *testing.T) {
 	s := OpenServer(NewConfig(), "")
 	defer s.Close()
 
-	test := Test{
-		queries: []*Query{
-			&Query{
-				name:    "create database should succeed",
-				command: `CREATE DATABASE db0`,
-				exp:     `{"results":[{}]}`,
-			},
-			&Query{
-				name:    "show retention policies should return auto-created policy",
-				command: `SHOW RETENTION POLICIES ON db0`,
-				exp:     `{"results":[{"series":[{"columns":["name","duration","replicaN","default"],"values":[["default","0",1,true]]}]}]}`,
-			},
-		},
-	}
+	test := tests.load(t, "retention_policy_auto_create")
 
 	for _, query := range test.queries {
 		if query.skip {

--- a/cmd/influxd/run/server_test.go
+++ b/cmd/influxd/run/server_test.go
@@ -550,7 +550,7 @@ func TestServer_RetentionPolicyCommands(t *testing.T) {
 			&Query{
 				name:    "Check error when deleting retention policy on non-existent database",
 				command: `DROP RETENTION POLICY rp1 ON mydatabase`,
-				exp:     `{"results":[{"error":"database not found"}]}`,
+				exp:     `{"results":[{"error":"database not found: mydatabase"}]}`,
 			},
 		},
 	}
@@ -1635,7 +1635,7 @@ func TestServer_Query_Common(t *testing.T) {
 		&Query{
 			name:    "selecting a from a non-existent retention policy should error",
 			command: `SELECT value FROM db0.rp1.cpu`,
-			exp:     `{"results":[{"error":"retention policy not found"}]}`,
+			exp:     `{"results":[{"error":"retention policy not found: rp1"}]}`,
 		},
 		&Query{
 			name:    "selecting a valid  measurement and field should succeed",

--- a/cmd/influxd/run/server_test.go
+++ b/cmd/influxd/run/server_test.go
@@ -31,115 +31,7 @@ func TestServer_DatabaseCommands(t *testing.T) {
 	s := OpenServer(NewConfig(), "")
 	defer s.Close()
 
-	test := Test{
-		queries: []*Query{
-			&Query{
-				name:    "create database should succeed",
-				command: `CREATE DATABASE db0`,
-				exp:     `{"results":[{}]}`,
-			},
-			&Query{
-				name:    "create database with retention duration should succeed",
-				command: `CREATE DATABASE db0_r WITH DURATION 24h REPLICATION 2 NAME db0_r_policy`,
-				exp:     `{"results":[{}]}`,
-			},
-			&Query{
-				name:    "create database should error with bad name",
-				command: `CREATE DATABASE 0xdb0`,
-				exp:     `{"error":"error parsing query: found 0, expected identifier at line 1, char 17"}`,
-			},
-			&Query{
-				name:    "create database with retention duration should error with bad retention duration",
-				command: `CREATE DATABASE db0 WITH DURATION xyz`,
-				exp:     `{"error":"error parsing query: found xyz, expected duration at line 1, char 35"}`,
-			},
-			&Query{
-				name:    "create database with retention replication should error with bad retention replication number",
-				command: `CREATE DATABASE db0 WITH REPLICATION xyz`,
-				exp:     `{"error":"error parsing query: found xyz, expected number at line 1, char 38"}`,
-			},
-			&Query{
-				name:    "create database with retention name should error with missing retention name",
-				command: `CREATE DATABASE db0 WITH NAME`,
-				exp:     `{"error":"error parsing query: found EOF, expected identifier at line 1, char 31"}`,
-			},
-			&Query{
-				name:    "show database should succeed",
-				command: `SHOW DATABASES`,
-				exp:     `{"results":[{"series":[{"name":"databases","columns":["name"],"values":[["db0"],["db0_r"]]}]}]}`,
-			},
-			&Query{
-				name:    "create database should error if it already exists",
-				command: `CREATE DATABASE db0`,
-				exp:     `{"results":[{"error":"database already exists"}]}`,
-			},
-			&Query{
-				name:    "create database should error if it already exists",
-				command: `CREATE DATABASE db0_r`,
-				exp:     `{"results":[{"error":"database already exists"}]}`,
-			},
-			&Query{
-				name:    "create database should not error with existing database with IF NOT EXISTS",
-				command: `CREATE DATABASE IF NOT EXISTS db0`,
-				exp:     `{"results":[{}]}`,
-			},
-			&Query{
-				name:    "create database should create non-existing database with IF NOT EXISTS",
-				command: `CREATE DATABASE IF NOT EXISTS db1`,
-				exp:     `{"results":[{}]}`,
-			},
-			&Query{
-				name:    "create database with retention duration should not error with existing database with IF NOT EXISTS",
-				command: `CREATE DATABASE IF NOT EXISTS db1 WITH DURATION 24h`,
-				exp:     `{"results":[{}]}`,
-			},
-			&Query{
-				name:    "create database should error IF NOT EXISTS with bad retention duration",
-				command: `CREATE DATABASE IF NOT EXISTS db1 WITH DURATION xyz`,
-				exp:     `{"error":"error parsing query: found xyz, expected duration at line 1, char 49"}`,
-			},
-			&Query{
-				name:    "show database should succeed",
-				command: `SHOW DATABASES`,
-				exp:     `{"results":[{"series":[{"name":"databases","columns":["name"],"values":[["db0"],["db0_r"],["db1"]]}]}]}`,
-			},
-			&Query{
-				name:    "drop database db0 should succeed",
-				command: `DROP DATABASE db0`,
-				exp:     `{"results":[{}]}`,
-			},
-			&Query{
-				name:    "drop database db0_r should succeed",
-				command: `DROP DATABASE db0_r`,
-				exp:     `{"results":[{}]}`,
-			},
-			&Query{
-				name:    "drop database db1 should succeed",
-				command: `DROP DATABASE db1`,
-				exp:     `{"results":[{}]}`,
-			},
-			&Query{
-				name:    "drop database should error if it does not exists",
-				command: `DROP DATABASE db1`,
-				exp:     `{"results":[{"error":"database not found: db1"}]}`,
-			},
-			&Query{
-				name:    "drop database should not error with non-existing database db1 WITH IF EXISTS",
-				command: `DROP DATABASE IF EXISTS db1`,
-				exp:     `{"results":[{}]}`,
-			},
-			&Query{
-				name:    "show database should have no results",
-				command: `SHOW DATABASES`,
-				exp:     `{"results":[{"series":[{"name":"databases","columns":["name"]}]}]}`,
-			},
-			&Query{
-				name:    "drop database should error if it doesn't exist",
-				command: `DROP DATABASE db0`,
-				exp:     `{"results":[{"error":"database not found: db0"}]}`,
-			},
-		},
-	}
+	test := tests.load(t, "database_commands")
 
 	for _, query := range test.queries {
 		if query.skip {
@@ -166,42 +58,7 @@ func TestServer_Query_DropAndRecreateDatabase(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	writes := []string{
-		fmt.Sprintf(`cpu,host=serverA,region=uswest val=23.2 %d`, mustParseTime(time.RFC3339Nano, "2000-01-01T00:00:00Z").UnixNano()),
-	}
-
-	test := NewTest("db0", "rp0")
-	test.write = strings.Join(writes, "\n")
-
-	test.addQueries([]*Query{
-		&Query{
-			name:    "Drop database after data write",
-			command: `DROP DATABASE db0`,
-			exp:     `{"results":[{}]}`,
-		},
-		&Query{
-			name:    "Recreate database",
-			command: `CREATE DATABASE db0`,
-			exp:     `{"results":[{}]}`,
-		},
-		&Query{
-			name:    "Recreate retention policy",
-			command: `CREATE RETENTION POLICY rp0 ON db0 DURATION 365d REPLICATION 1 DEFAULT`,
-			exp:     `{"results":[{}]}`,
-		},
-		&Query{
-			name:    "Show measurements after recreate",
-			command: `SHOW MEASUREMENTS`,
-			exp:     `{"results":[{}]}`,
-			params:  url.Values{"db": []string{"db0"}},
-		},
-		&Query{
-			name:    "Query data after recreate",
-			command: `SELECT * FROM cpu`,
-			exp:     `{"results":[{}]}`,
-			params:  url.Values{"db": []string{"db0"}},
-		},
-	}...)
+	test := tests.load(t, "drop_and_recreate_database")
 
 	for i, query := range test.queries {
 		if i == 0 {
@@ -236,44 +93,7 @@ func TestServer_Query_DropDatabaseIsolated(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	writes := []string{
-		fmt.Sprintf(`cpu,host=serverA,region=uswest val=23.2 %d`, mustParseTime(time.RFC3339Nano, "2000-01-01T00:00:00Z").UnixNano()),
-	}
-
-	test := NewTest("db0", "rp0")
-	test.write = strings.Join(writes, "\n")
-
-	test.addQueries([]*Query{
-		&Query{
-			name:    "Query data from 1st database",
-			command: `SELECT * FROM cpu`,
-			exp:     `{"results":[{"series":[{"name":"cpu","columns":["time","host","region","val"],"values":[["2000-01-01T00:00:00Z","serverA","uswest",23.2]]}]}]}`,
-			params:  url.Values{"db": []string{"db0"}},
-		},
-		&Query{
-			name:    "Query data from 1st database with GROUP BY *",
-			command: `SELECT * FROM cpu GROUP BY *`,
-			exp:     `{"results":[{"series":[{"name":"cpu","tags":{"host":"serverA","region":"uswest"},"columns":["time","val"],"values":[["2000-01-01T00:00:00Z",23.2]]}]}]}`,
-			params:  url.Values{"db": []string{"db0"}},
-		},
-		&Query{
-			name:    "Drop other database",
-			command: `DROP DATABASE db1`,
-			exp:     `{"results":[{}]}`,
-		},
-		&Query{
-			name:    "Query data from 1st database and ensure it's still there",
-			command: `SELECT * FROM cpu`,
-			exp:     `{"results":[{"series":[{"name":"cpu","columns":["time","host","region","val"],"values":[["2000-01-01T00:00:00Z","serverA","uswest",23.2]]}]}]}`,
-			params:  url.Values{"db": []string{"db0"}},
-		},
-		&Query{
-			name:    "Query data from 1st database and ensure it's still there with GROUP BY *",
-			command: `SELECT * FROM cpu GROUP BY *`,
-			exp:     `{"results":[{"series":[{"name":"cpu","tags":{"host":"serverA","region":"uswest"},"columns":["time","val"],"values":[["2000-01-01T00:00:00Z",23.2]]}]}]}`,
-			params:  url.Values{"db": []string{"db0"}},
-		},
-	}...)
+	test := tests.load(t, "drop_database_isolated")
 
 	for i, query := range test.queries {
 		if i == 0 {
@@ -3313,10 +3133,6 @@ func TestServer_Query_TopInt(t *testing.T) {
 			continue
 		}
 
-		println(">>>>", query.name)
-		if query.name != `top - memory - host tag with limit 2` { // FIXME: temporary
-			continue
-		}
 		if err := query.Execute(s); err != nil {
 			t.Error(query.Error(err))
 		} else if !query.success() {

--- a/meta/data.go
+++ b/meta/data.go
@@ -307,7 +307,7 @@ func (data *Data) ShardGroups(database, policy string) ([]ShardGroupInfo, error)
 	if err != nil {
 		return nil, err
 	} else if rpi == nil {
-		return nil, influxdb.ErrRetentionPolicyNotFound(database)
+		return nil, influxdb.ErrRetentionPolicyNotFound(policy)
 	}
 	groups := make([]ShardGroupInfo, 0, len(rpi.ShardGroups))
 	for _, g := range rpi.ShardGroups {
@@ -327,7 +327,7 @@ func (data *Data) ShardGroupsByTimeRange(database, policy string, tmin, tmax tim
 	if err != nil {
 		return nil, err
 	} else if rpi == nil {
-		return nil, influxdb.ErrRetentionPolicyNotFound(database)
+		return nil, influxdb.ErrRetentionPolicyNotFound(policy)
 	}
 	groups := make([]ShardGroupInfo, 0, len(rpi.ShardGroups))
 	for _, g := range rpi.ShardGroups {
@@ -346,7 +346,7 @@ func (data *Data) ShardGroupByTimestamp(database, policy string, timestamp time.
 	if err != nil {
 		return nil, err
 	} else if rpi == nil {
-		return nil, influxdb.ErrRetentionPolicyNotFound(database)
+		return nil, influxdb.ErrRetentionPolicyNotFound(policy)
 	}
 
 	return rpi.ShardGroupByTimestamp(timestamp), nil
@@ -364,7 +364,7 @@ func (data *Data) CreateShardGroup(database, policy string, timestamp time.Time)
 	if err != nil {
 		return err
 	} else if rpi == nil {
-		return influxdb.ErrRetentionPolicyNotFound(database)
+		return influxdb.ErrRetentionPolicyNotFound(policy)
 	}
 
 	// Verify that shard group doesn't already exist for this timestamp.

--- a/meta/data_test.go
+++ b/meta/data_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/gogo/protobuf/proto"
+	"github.com/influxdb/influxdb"
 	"github.com/influxdb/influxdb/influxql"
 	"github.com/influxdb/influxdb/meta"
 	"github.com/influxdb/influxdb/meta/internal"
@@ -183,7 +184,8 @@ func TestData_CreateRetentionPolicy_ErrReplicationFactorTooLow(t *testing.T) {
 // Ensure that creating a retention policy on a non-existent database returns an error.
 func TestData_CreateRetentionPolicy_ErrDatabaseNotFound(t *testing.T) {
 	data := meta.Data{Nodes: []meta.NodeInfo{{ID: 1}}}
-	if err := data.CreateRetentionPolicy("db0", &meta.RetentionPolicyInfo{Name: "rp0", ReplicaN: 1}); err != meta.ErrDatabaseNotFound {
+	expErr := influxdb.ErrDatabaseNotFound("db0")
+	if err := data.CreateRetentionPolicy("db0", &meta.RetentionPolicyInfo{Name: "rp0", ReplicaN: 1}); err.Error() != expErr.Error() {
 		t.Fatalf("unexpected error: %s", err)
 	}
 }
@@ -249,7 +251,8 @@ func TestData_DropRetentionPolicy(t *testing.T) {
 // Ensure an error is returned when deleting a policy from a non-existent database.
 func TestData_DropRetentionPolicy_ErrDatabaseNotFound(t *testing.T) {
 	var data meta.Data
-	if err := data.DropRetentionPolicy("db0", "rp0"); err != meta.ErrDatabaseNotFound {
+	expErr := influxdb.ErrDatabaseNotFound("db0")
+	if err := data.DropRetentionPolicy("db0", "rp0"); err.Error() != expErr.Error() {
 		t.Fatal(err)
 	}
 }
@@ -260,7 +263,8 @@ func TestData_DropRetentionPolicy_ErrRetentionPolicyNotFound(t *testing.T) {
 	if err := data.CreateDatabase("db0"); err != nil {
 		t.Fatal(err)
 	}
-	if err := data.DropRetentionPolicy("db0", "rp0"); err != meta.ErrRetentionPolicyNotFound {
+	expErr := influxdb.ErrRetentionPolicyNotFound("rp0")
+	if err := data.DropRetentionPolicy("db0", "rp0"); err.Error() != expErr.Error() {
 		t.Fatal(err)
 	}
 }
@@ -290,7 +294,8 @@ func TestData_RetentionPolicy(t *testing.T) {
 // Ensure that retrieving a policy from a non-existent database returns an error.
 func TestData_RetentionPolicy_ErrDatabaseNotFound(t *testing.T) {
 	var data meta.Data
-	if _, err := data.RetentionPolicy("db0", "rp0"); err != meta.ErrDatabaseNotFound {
+	expErr := influxdb.ErrDatabaseNotFound("db0")
+	if _, err := data.RetentionPolicy("db0", "rp0"); err.Error() != expErr.Error() {
 		t.Fatal(err)
 	}
 }

--- a/meta/errors.go
+++ b/meta/errors.go
@@ -39,9 +39,6 @@ var (
 	// ErrDatabaseExists is returned when creating an already existing database.
 	ErrDatabaseExists = newError("database already exists")
 
-	// ErrDatabaseNotFound is returned when mutating a database that doesn't exist.
-	ErrDatabaseNotFound = newError("database not found")
-
 	// ErrDatabaseNameRequired is returned when creating a database without a name.
 	ErrDatabaseNameRequired = newError("database name required")
 )
@@ -53,9 +50,6 @@ var (
 	// ErrRetentionPolicyDefault is returned when attempting a prohibited operation
 	// on a default retention policy.
 	ErrRetentionPolicyDefault = newError("retention policy is default")
-
-	// ErrRetentionPolicyNotFound is returned when mutating a policy that doesn't exist.
-	ErrRetentionPolicyNotFound = newError("retention policy not found")
 
 	// ErrRetentionPolicyNameRequired is returned when creating a policy without a name.
 	ErrRetentionPolicyNameRequired = newError("retention policy name required")

--- a/meta/statement_executor.go
+++ b/meta/statement_executor.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/influxdb/influxdb"
 	"github.com/influxdb/influxdb/influxql"
 	"github.com/influxdb/influxdb/models"
 )
@@ -292,7 +293,7 @@ func (e *StatementExecutor) executeShowRetentionPoliciesStatement(q *influxql.Sh
 	if err != nil {
 		return &influxql.Result{Err: err}
 	} else if di == nil {
-		return &influxql.Result{Err: ErrDatabaseNotFound}
+		return &influxql.Result{Err: influxdb.ErrDatabaseNotFound(q.Database)}
 	}
 
 	row := &models.Row{Columns: []string{"name", "duration", "replicaN", "default"}}

--- a/meta/statement_executor_test.go
+++ b/meta/statement_executor_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/davecgh/go-spew/spew"
+	"github.com/influxdb/influxdb"
 	"github.com/influxdb/influxdb/influxql"
 	"github.com/influxdb/influxdb/meta"
 	"github.com/influxdb/influxdb/models"
@@ -659,7 +660,8 @@ func TestStatementExecutor_ExecuteStatement_ShowRetentionPolicies_ErrDatabaseNot
 		return nil, nil
 	}
 
-	if res := e.ExecuteStatement(influxql.MustParseStatement(`SHOW RETENTION POLICIES ON db0`)); res.Err != meta.ErrDatabaseNotFound {
+	expErr := influxdb.ErrDatabaseNotFound("db0")
+	if res := e.ExecuteStatement(influxql.MustParseStatement(`SHOW RETENTION POLICIES ON db0`)); res.Err.Error() != expErr.Error() {
 		t.Fatalf("unexpected error: %s", res.Err)
 	}
 }

--- a/meta/store.go
+++ b/meta/store.go
@@ -172,6 +172,14 @@ func NewStore(c *Config) *Store {
 	return s
 }
 
+// SetLogger sets the internal logger to the logger passed in.
+func (s *Store) SetLogger(l *log.Logger) {
+	s.Logger = l
+	if s.rpc != nil {
+		s.rpc.logger = l
+	}
+}
+
 // Path returns the root path when open.
 // Returns an empty string when the store is closed.
 func (s *Store) Path() string { return s.path }

--- a/meta/store.go
+++ b/meta/store.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/raft"
+	"github.com/influxdb/influxdb"
 	"github.com/influxdb/influxdb/influxql"
 	"github.com/influxdb/influxdb/meta/internal"
 	"golang.org/x/crypto/bcrypt"
@@ -1105,7 +1106,7 @@ func (s *Store) DefaultRetentionPolicy(database string) (rpi *RetentionPolicyInf
 	err = s.read(func(data *Data) error {
 		di := data.Database(database)
 		if di == nil {
-			return ErrDatabaseNotFound
+			return influxdb.ErrDatabaseNotFound(database)
 		}
 
 		for i := range di.RetentionPolicies {
@@ -1124,7 +1125,7 @@ func (s *Store) RetentionPolicies(database string) (a []RetentionPolicyInfo, err
 	err = s.read(func(data *Data) error {
 		di := data.Database(database)
 		if di != nil {
-			return ErrDatabaseNotFound
+			return influxdb.ErrDatabaseNotFound(database)
 		}
 		a = di.RetentionPolicies
 		return nil

--- a/meta/store_test.go
+++ b/meta/store_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/influxdb/influxdb"
 	"github.com/influxdb/influxdb/meta"
 	"github.com/influxdb/influxdb/tcp"
 	"github.com/influxdb/influxdb/toml"
@@ -240,7 +241,8 @@ func TestStore_DropDatabase_ErrDatabaseNotFound(t *testing.T) {
 	s := MustOpenStore()
 	defer s.Close()
 
-	if err := s.DropDatabase("no_such_database"); err != meta.ErrDatabaseNotFound {
+	expErr := influxdb.ErrDatabaseNotFound("no_such_database")
+	if err := s.DropDatabase("no_such_database"); err.Error() != expErr.Error() {
 		t.Fatalf("unexpected error: %s", err)
 	}
 }

--- a/monitor/service.go
+++ b/monitor/service.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/influxdb/influxdb"
 	"github.com/influxdb/influxdb/cluster"
 	"github.com/influxdb/influxdb/meta"
 	"github.com/influxdb/influxdb/models"
@@ -329,7 +330,7 @@ func (m *Monitor) createInternalStorage() {
 		return
 	}
 
-	if err := m.MetaStore.DropRetentionPolicy(m.storeDatabase, "default"); err != nil && err != meta.ErrRetentionPolicyNotFound {
+	if err := m.MetaStore.DropRetentionPolicy(m.storeDatabase, "default"); err != nil && err != influxdb.ErrRetentionPolicyNotFound("default") {
 		m.Logger.Printf("failed to delete retention policy 'default', failed to created internal storage: %s", err.Error())
 		return
 	}

--- a/services/registration/service.go
+++ b/services/registration/service.go
@@ -85,6 +85,11 @@ func (s *Service) Close() error {
 	return nil
 }
 
+// SetLogger sets the internal logger to the logger passed in.
+func (s *Service) SetLogger(l *log.Logger) {
+	s.logger = l
+}
+
 // Diagnostics returns diagnostics information.
 func (s *Service) Diagnostics() (*monitor.Diagnostic, error) {
 	diagnostics := map[string]interface{}{


### PR DESCRIPTION
This PR adds the framework for cluster integration testing.  It also fixes the following bugs:

- CircleCI intermittent raft consensus failures.  This was due to having the `-parallel` argument passed into our test suite.  Disabling that has no noticeable affect on how long it takes to run tests, but they no longer fail intermittently.
- Starting the raft store we now set the `RemoteAddr`.  This is only necessary for testing due to spinning up on random system ports like `localhost:0`
- `DatabaseNotFound` could return different error text depending on where in the code branch it was determined that there was no database.  This caused intermittent test results.
- Added ability to silence the Metastore RPC listener logging.  This is only used for testing.