### PR TITLE
Lint

### DIFF
--- a/monitor/service.go
+++ b/monitor/service.go
@@ -18,6 +18,7 @@ import (
 
 const leaderWaitTimeout = 30 * time.Second
 
+// Policy constants.
 const (
 	MonitorRetentionPolicy         = "monitor"
 	MonitorRetentionPolicyDuration = 7 * 24 * time.Hour
@@ -50,6 +51,7 @@ type Diagnostic struct {
 	Rows    [][]interface{}
 }
 
+// NewDiagnostic initialises a new Diagnostic with the specified columns.
 func NewDiagnostic(columns []string) *Diagnostic {
 	return &Diagnostic{
 		Columns: columns,
@@ -57,6 +59,7 @@ func NewDiagnostic(columns []string) *Diagnostic {
 	}
 }
 
+// AddRow appends the provided row to the Diagnostic's rows.
 func (d *Diagnostic) AddRow(r []interface{}) {
 	d.Rows = append(d.Rows, r)
 }
@@ -172,7 +175,7 @@ func (m *Monitor) DeregisterDiagnosticsClient(name string) {
 // Statistics returns the combined statistics for all expvar data. The given
 // tags are added to each of the returned statistics.
 func (m *Monitor) Statistics(tags map[string]string) ([]*Statistic, error) {
-	statistics := make([]*Statistic, 0)
+	var statistics []*Statistic
 
 	expvar.Do(func(kv expvar.KeyValue) {
 		// Skip built-in expvar stats.
@@ -281,6 +284,9 @@ func (m *Monitor) Statistics(tags map[string]string) ([]*Statistic, error) {
 	return statistics, nil
 }
 
+// Diagnostics fetches diagnostic information for each registered
+// diagnostic client. It skips any clients that return an error when
+// retrieving their diagnostics.
 func (m *Monitor) Diagnostics() (map[string]*Diagnostic, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -412,7 +418,7 @@ func newStatistic(name string, tags map[string]string, values map[string]interfa
 // valueNames returns a sorted list of the value names, if any.
 func (s *Statistic) valueNames() []string {
 	a := make([]string, 0, len(s.Values))
-	for k, _ := range s.Values {
+	for k := range s.Values {
 		a = append(a, k)
 	}
 	sort.Strings(a)
@@ -423,7 +429,7 @@ func (s *Statistic) valueNames() []string {
 func DiagnosticFromMap(m map[string]interface{}) *Diagnostic {
 	// Display columns in deterministic order.
 	sortedKeys := make([]string, 0, len(m))
-	for k, _ := range m {
+	for k := range m {
 		sortedKeys = append(sortedKeys, k)
 	}
 	sort.Strings(sortedKeys)

--- a/monitor/statement_executor.go
+++ b/monitor/statement_executor.go
@@ -33,8 +33,8 @@ func (s *StatementExecutor) executeShowStatistics(module string) *influxql.Resul
 	if err != nil {
 		return &influxql.Result{Err: err}
 	}
-	rows := make([]*models.Row, 0)
 
+	var rows []*models.Row
 	for _, stat := range stats {
 		if module != "" && stat.Name != module {
 			continue
@@ -61,7 +61,7 @@ func (s *StatementExecutor) executeShowDiagnostics(module string) *influxql.Resu
 
 	// Get a sorted list of diagnostics keys.
 	sortedKeys := make([]string, 0, len(diags))
-	for k, _ := range diags {
+	for k := range diags {
 		sortedKeys = append(sortedKeys, k)
 	}
 	sort.Strings(sortedKeys)

--- a/services/continuous_querier/config.go
+++ b/services/continuous_querier/config.go
@@ -6,14 +6,12 @@ import (
 	"github.com/influxdb/influxdb/toml"
 )
 
+// Default values for aspects of interval computation.
 const (
-	DefaultRecomputePreviousN = 2
-
-	DefaultRecomputeNoOlderThan = 10 * time.Minute
-
+	DefaultRecomputePreviousN     = 2
+	DefaultRecomputeNoOlderThan   = 10 * time.Minute
 	DefaultComputeRunsPerInterval = 10
-
-	DefaultComputeNoMoreThan = 2 * time.Minute
+	DefaultComputeNoMoreThan      = 2 * time.Minute
 )
 
 // Config represents a configuration for the continuous query service.

--- a/services/continuous_querier/service.go
+++ b/services/continuous_querier/service.go
@@ -17,7 +17,9 @@ import (
 )
 
 const (
-	// When planning a select statement, passing zero tells it not to chunk results. Only applies to raw queries
+	// NoChunkingSize specifies when not to chunk results. When planning
+	// a select statement, passing zero tells it not to chunk results.
+	// Only applies to raw queries.
 	NoChunkingSize = 0
 )
 

--- a/services/continuous_querier/service_test.go
+++ b/services/continuous_querier/service_test.go
@@ -16,8 +16,8 @@ import (
 )
 
 var (
-	expectedErr   = errors.New("expected error")
-	unexpectedErr = errors.New("unexpected error")
+	errExpected   = errors.New("expected error")
+	errUnexpected = errors.New("unexpected error")
 )
 
 // Test closing never opened, open, open already open, close, and close already closed.
@@ -104,7 +104,7 @@ func TestContinuousQueryService_NotLeader(t *testing.T) {
 	// Set a callback for ExecuteQuery. Shouldn't get called because we're not the leader.
 	qe.ExecuteQueryFn = func(query *influxql.Query, database string, chunkSize int) (<-chan *influxql.Result, error) {
 		done <- struct{}{}
-		return nil, unexpectedErr
+		return nil, errUnexpected
 	}
 
 	s.Open()
@@ -122,14 +122,14 @@ func TestContinuousQueryService_MetaStoreFailsToGetDatabases(t *testing.T) {
 	s := NewTestService(t)
 	// Set RunInterval high so we can test triggering with the RunCh below.
 	s.RunInterval = 10 * time.Second
-	s.MetaStore.(*MetaStore).Err = expectedErr
+	s.MetaStore.(*MetaStore).Err = errExpected
 
 	done := make(chan struct{})
 	qe := s.QueryExecutor.(*QueryExecutor)
 	// Set ExecuteQuery callback, which shouldn't get called because of meta store failure.
 	qe.ExecuteQueryFn = func(query *influxql.Query, database string, chunkSize int) (<-chan *influxql.Result, error) {
 		done <- struct{}{}
-		return nil, unexpectedErr
+		return nil, errUnexpected
 	}
 
 	s.Open()
@@ -174,15 +174,15 @@ func TestExecuteContinuousQuery_InvalidQueries(t *testing.T) {
 func TestExecuteContinuousQuery_QueryExecutor_Error(t *testing.T) {
 	s := NewTestService(t)
 	qe := s.QueryExecutor.(*QueryExecutor)
-	qe.Err = expectedErr
+	qe.Err = errExpected
 
 	dbis, _ := s.MetaStore.Databases()
 	dbi := dbis[0]
 	cqi := dbi.ContinuousQueries[0]
 
 	err := s.ExecuteContinuousQuery(&dbi, &cqi, time.Now())
-	if err != expectedErr {
-		t.Errorf("exp = %s, got = %v", expectedErr, err)
+	if err != errExpected {
+		t.Errorf("exp = %s, got = %v", errExpected, err)
 	}
 }
 

--- a/services/graphite/config.go
+++ b/services/graphite/config.go
@@ -99,6 +99,7 @@ func (c *Config) WithDefaults() *Config {
 	return &d
 }
 
+// DefaultTags returns the config's tags.
 func (c *Config) DefaultTags() models.Tags {
 	tags := models.Tags{}
 	for _, t := range c.Tags {
@@ -108,6 +109,7 @@ func (c *Config) DefaultTags() models.Tags {
 	return tags
 }
 
+// Validate validates the config's templates and tags.
 func (c *Config) Validate() error {
 	if err := c.validateTemplates(); err != nil {
 		return err

--- a/services/graphite/errors.go
+++ b/services/graphite/errors.go
@@ -2,11 +2,13 @@ package graphite
 
 import "fmt"
 
-type ErrUnsupportedValue struct {
+// An UnsupposedValueError is returned when a parsed value is not
+// supposed.
+type UnsupposedValueError struct {
 	Field string
 	Value float64
 }
 
-func (err *ErrUnsupportedValue) Error() string {
+func (err *UnsupposedValueError) Error() string {
 	return fmt.Sprintf(`field "%s" value: "%v" is unsupported`, err.Field, err.Value)
 }

--- a/services/graphite/parser.go
+++ b/services/graphite/parser.go
@@ -159,7 +159,7 @@ func (p *Parser) Parse(line string) (models.Point, error) {
 	return models.NewPoint(measurement, tags, fieldValues, timestamp)
 }
 
-// ApplyTemplate extracts the template fields form the given line and
+// ApplyTemplate extracts the template fields from the given line and
 // returns the measurement name and tags.
 func (p *Parser) ApplyTemplate(line string) (string, map[string]string, string, error) {
 	// Break line into fields (name, value, timestamp), only name is used
@@ -210,7 +210,7 @@ func NewTemplate(pattern string, defaultTags models.Tags, separator string) (*te
 	return template, nil
 }
 
-// Apply extracts the template fields form the given line and returns the measurement
+// Apply extracts the template fields from the given line and returns the measurement
 // name and tags
 func (t *template) Apply(line string) (string, map[string]string, string, error) {
 	fields := strings.Split(line, ".")

--- a/services/graphite/parser.go
+++ b/services/graphite/parser.go
@@ -11,11 +11,13 @@ import (
 	"github.com/influxdb/influxdb/models"
 )
 
+// Minimum and maximum supported dates for timestamps.
 var (
-	defaultTemplate *template
-	MinDate         = time.Date(1901, 12, 13, 0, 0, 0, 0, time.UTC)
-	MaxDate         = time.Date(2038, 1, 19, 0, 0, 0, 0, time.UTC)
+	MinDate = time.Date(1901, 12, 13, 0, 0, 0, 0, time.UTC)
+	MaxDate = time.Date(2038, 1, 19, 0, 0, 0, 0, time.UTC)
 )
+
+var defaultTemplate *template
 
 func init() {
 	var err error
@@ -117,7 +119,7 @@ func (p *Parser) Parse(line string) (models.Point, error) {
 	}
 
 	if math.IsNaN(v) || math.IsInf(v, 0) {
-		return nil, &ErrUnsupportedValue{Field: fields[0], Value: v}
+		return nil, &UnsupposedValueError{Field: fields[0], Value: v}
 	}
 
 	fieldValues := map[string]interface{}{}
@@ -157,8 +159,8 @@ func (p *Parser) Parse(line string) (models.Point, error) {
 	return models.NewPoint(measurement, tags, fieldValues, timestamp)
 }
 
-// Apply extracts the template fields form the given line and returns the
-// measurement name and tags
+// ApplyTemplate extracts the template fields form the given line and
+// returns the measurement name and tags.
 func (p *Parser) ApplyTemplate(line string) (string, map[string]string, string, error) {
 	// Break line into fields (name, value, timestamp), only name is used
 	fields := strings.Fields(line)
@@ -185,6 +187,8 @@ type template struct {
 	separator         string
 }
 
+// NewTemplate returns a new template ensuring it has a measurement
+// specified.
 func NewTemplate(pattern string, defaultTags models.Tags, separator string) (*template, error) {
 	tags := strings.Split(pattern, ".")
 	hasMeasurement := false
@@ -231,9 +235,8 @@ func (t *template) Apply(line string) (string, map[string]string, string, error)
 		} else if tag == "field" {
 			if len(field) != 0 {
 				return "", nil, "", fmt.Errorf("'field' can only be used once in each template: %q", line)
-			} else {
-				field = fields[i]
 			}
+			field = fields[i]
 		} else if tag == "measurement*" {
 			measurement = append(measurement, fields[i:]...)
 			break
@@ -331,7 +334,7 @@ func (n *node) search(lineParts []string) *template {
 	// the slice is sorted.
 	length := len(n.children)
 	if n.children[length-1].value == "*" {
-		length -= 1
+		length--
 	}
 
 	// Find the index of child with an exact match

--- a/services/graphite/parser_test.go
+++ b/services/graphite/parser_test.go
@@ -229,7 +229,7 @@ func TestParseNaN(t *testing.T) {
 		t.Fatalf("expected error. got nil")
 	}
 
-	if _, ok := err.(*graphite.ErrUnsupportedValue); !ok {
+	if _, ok := err.(*graphite.UnsupposedValueError); !ok {
 		t.Fatalf("expected *graphite.ErrUnsupportedValue, got %v", reflect.TypeOf(err))
 	}
 }

--- a/services/graphite/service.go
+++ b/services/graphite/service.go
@@ -47,6 +47,7 @@ func (c *tcpConnection) Close() {
 	c.conn.Close()
 }
 
+// Service represents a Graphite service.
 type Service struct {
 	mu sync.Mutex
 
@@ -211,6 +212,7 @@ func (s *Service) SetLogger(l *log.Logger) {
 	s.logger = l
 }
 
+// Addr returns the address the Service binds to.
 func (s *Service) Addr() net.Addr {
 	return s.addr
 }
@@ -337,7 +339,7 @@ func (s *Service) handleLine(line string) {
 	point, err := s.parser.Parse(line)
 	if err != nil {
 		switch err := err.(type) {
-		case *ErrUnsupportedValue:
+		case *UnsupposedValueError:
 			// Graphite ignores NaN values with no error.
 			if math.IsNaN(err.Value) {
 				s.statMap.Add(statPointsNaNFail, 1)
@@ -377,6 +379,7 @@ func (s *Service) processBatches(batcher *tsdb.PointBatcher) {
 	}
 }
 
+// Diagnostics returns diagnositics of the graphite service.
 func (s *Service) Diagnostics() (*monitor.Diagnostic, error) {
 	s.tcpConnectionsMu.Lock()
 	defer s.tcpConnectionsMu.Unlock()

--- a/services/graphite/service.go
+++ b/services/graphite/service.go
@@ -379,7 +379,7 @@ func (s *Service) processBatches(batcher *tsdb.PointBatcher) {
 	}
 }
 
-// Diagnostics returns diagnositics of the graphite service.
+// Diagnostics returns diagnostics of the graphite service.
 func (s *Service) Diagnostics() (*monitor.Diagnostic, error) {
 	s.tcpConnectionsMu.Lock()
 	defer s.tcpConnectionsMu.Unlock()

--- a/services/hh/config.go
+++ b/services/hh/config.go
@@ -34,6 +34,7 @@ const (
 	DefaultPurgeInterval = time.Hour
 )
 
+// Config is a hinted handoff configuration.
 type Config struct {
 	Enabled          bool          `toml:"enabled"`
 	Dir              string        `toml:"dir"`
@@ -45,6 +46,7 @@ type Config struct {
 	PurgeInterval    toml.Duration `toml:"purge-interval"`
 }
 
+// NewConfig returns a new Config.
 func NewConfig() Config {
 	return Config{
 		Enabled:          false,

--- a/services/hh/node_processor.go
+++ b/services/hh/node_processor.go
@@ -247,6 +247,7 @@ func (n *NodeProcessor) SendWrite() (int, error) {
 	return len(buf), nil
 }
 
+// Head returns the head of the processor's queue.
 func (n *NodeProcessor) Head() string {
 	qp, err := n.queue.Position()
 	if err != nil {
@@ -255,6 +256,7 @@ func (n *NodeProcessor) Head() string {
 	return qp.head
 }
 
+// Tail returns the tail of the processor's queue.
 func (n *NodeProcessor) Tail() string {
 	qp, err := n.queue.Position()
 	if err != nil {

--- a/services/hh/node_processor_test.go
+++ b/services/hh/node_processor_test.go
@@ -39,7 +39,7 @@ func TestNodeProcessorSendBlock(t *testing.T) {
 
 	sh := &fakeShardWriter{
 		ShardWriteFn: func(shardID, nodeID uint64, points []models.Point) error {
-			count += 1
+			count++
 			if shardID != expShardID {
 				t.Errorf("SendWrite() shardID mismatch: got %v, exp %v", shardID, expShardID)
 			}

--- a/services/hh/queue.go
+++ b/services/hh/queue.go
@@ -12,6 +12,7 @@ import (
 	"time"
 )
 
+// Possible errors returned by a hinted handoff queue.
 var (
 	ErrNotOpen     = fmt.Errorf("queue not open")
 	ErrQueueFull   = fmt.Errorf("queue is full")

--- a/services/hh/service.go
+++ b/services/hh/service.go
@@ -18,8 +18,8 @@ import (
 	"github.com/influxdb/influxdb/monitor"
 )
 
-// ErrHintedHandoffDisabled is returned when attempted to write to a
-// shard with hinted handoff disabled.
+// ErrHintedHandoffDisabled is returned when attempting to use a
+// disabled hinted handoff service.
 var ErrHintedHandoffDisabled = fmt.Errorf("hinted handoff disabled")
 
 const (
@@ -75,7 +75,7 @@ func NewService(c Config, w shardWriter, m metaStore) *Service {
 	}
 }
 
-// Open attempts to start the hinted handoff service.
+// Open opens the hinted handoff service.
 func (s *Service) Open() error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -123,7 +123,7 @@ func (s *Service) Open() error {
 	return nil
 }
 
-// Close attempts to gracefully shutdown the hinted handoff service.
+// Close closes the hinted handoff service.
 func (s *Service) Close() error {
 	s.Logger.Println("shutting down hh service")
 	s.mu.Lock()

--- a/services/hh/service.go
+++ b/services/hh/service.go
@@ -18,6 +18,8 @@ import (
 	"github.com/influxdb/influxdb/monitor"
 )
 
+// ErrHintedHandoffDisabled is returned when attempted to write to a
+// shard with hinted handoff disabled.
 var ErrHintedHandoffDisabled = fmt.Errorf("hinted handoff disabled")
 
 const (
@@ -28,6 +30,7 @@ const (
 	writeNodeReqPoints  = "writeNodeReqPoints"
 )
 
+// Service represents a hinted handoff service.
 type Service struct {
 	mu      sync.RWMutex
 	wg      sync.WaitGroup
@@ -72,6 +75,7 @@ func NewService(c Config, w shardWriter, m metaStore) *Service {
 	}
 }
 
+// Open attempts to start the hinted handoff service.
 func (s *Service) Open() error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -119,6 +123,7 @@ func (s *Service) Open() error {
 	return nil
 }
 
+// Close attempts to gracefully shutdown the hinted handoff service.
 func (s *Service) Close() error {
 	s.Logger.Println("shutting down hh service")
 	s.mu.Lock()

--- a/services/httpd/config.go
+++ b/services/httpd/config.go
@@ -1,5 +1,6 @@
 package httpd
 
+// Config represents a configuration for a HTTP service.
 type Config struct {
 	Enabled          bool   `toml:"enabled"`
 	BindAddress      string `toml:"bind-address"`
@@ -11,6 +12,7 @@ type Config struct {
 	HTTPSCertificate string `toml:"https-certificate"`
 }
 
+// NewConfig returns a new Config with default settings.
 func NewConfig() Config {
 	return Config{
 		Enabled:          true,

--- a/services/httpd/handler.go
+++ b/services/httpd/handler.go
@@ -29,8 +29,11 @@ import (
 )
 
 const (
-	// With raw data queries, mappers will read up to this amount before sending results back to the engine.
-	// This is the default size in the number of values returned in a raw query. Could be many more bytes depending on fields returned.
+	// DefaultChunkSize specified the amount of data mappers will read
+	// up to, before sending results back to the engine. This is the
+	// default size in the number of values returned in a raw query.
+	//
+	// Could be many more bytes depending on fields returned.
 	DefaultChunkSize = 10000
 )
 
@@ -123,6 +126,7 @@ func NewHandler(requireAuthentication, loggingEnabled, writeTrace bool, statMap 
 	return h
 }
 
+// SetRoutes sets the provided routes on the handler.
 func (h *Handler) SetRoutes(routes []route) {
 	for _, r := range routes {
 		var handler http.Handler
@@ -465,7 +469,7 @@ func (h *Handler) serveWriteLine(w http.ResponseWriter, r *http.Request, body []
 			if body[i] > 32 || i >= len(body)-1 {
 				break
 			}
-			i += 1
+			i++
 		}
 	}
 
@@ -617,6 +621,7 @@ func MarshalJSON(v interface{}, pretty bool) []byte {
 	return b
 }
 
+// Point represents an influx point.
 type Point struct {
 	Name   string                 `json:"name"`
 	Time   time.Time              `json:"time"`
@@ -624,6 +629,8 @@ type Point struct {
 	Fields map[string]interface{} `json:"fields"`
 }
 
+// Batch is a collection of points belonging to a database, with a
+// certain retention policy.
 type Batch struct {
 	Database        string  `json:"database"`
 	RetentionPolicy string  `json:"retentionPolicy"`

--- a/services/httpd/handler.go
+++ b/services/httpd/handler.go
@@ -29,7 +29,7 @@ import (
 )
 
 const (
-	// DefaultChunkSize specified the amount of data mappers will read
+	// DefaultChunkSize specifies the amount of data mappers will read
 	// up to, before sending results back to the engine. This is the
 	// default size in the number of values returned in a raw query.
 	//
@@ -621,7 +621,7 @@ func MarshalJSON(v interface{}, pretty bool) []byte {
 	return b
 }
 
-// Point represents an influx point.
+// Point represents an InfluxDB point.
 type Point struct {
 	Name   string                 `json:"name"`
 	Time   time.Time              `json:"time"`
@@ -629,7 +629,7 @@ type Point struct {
 	Fields map[string]interface{} `json:"fields"`
 }
 
-// Batch is a collection of points belonging to a database, with a
+// Batch is a collection of points associated with a database, having a
 // certain retention policy.
 type Batch struct {
 	Database        string  `json:"database"`

--- a/services/opentsdb/config.go
+++ b/services/opentsdb/config.go
@@ -29,6 +29,7 @@ const (
 	DefaultBatchPending = 5
 )
 
+// Config represents the configuration of the opentstb service.
 type Config struct {
 	Enabled          bool          `toml:"enabled"`
 	BindAddress      string        `toml:"bind-address"`
@@ -43,6 +44,7 @@ type Config struct {
 	LogPointErrors   bool          `toml:"log-point-errors"`
 }
 
+// NewConfig returns a new config for the service.
 func NewConfig() Config {
 	return Config{
 		BindAddress:      DefaultBindAddress,

--- a/services/opentsdb/config.go
+++ b/services/opentsdb/config.go
@@ -29,7 +29,7 @@ const (
 	DefaultBatchPending = 5
 )
 
-// Config represents the configuration of the opentstb service.
+// Config represents the configuration of the OpenTSDB service.
 type Config struct {
 	Enabled          bool          `toml:"enabled"`
 	BindAddress      string        `toml:"bind-address"`

--- a/services/opentsdb/handler.go
+++ b/services/opentsdb/handler.go
@@ -16,6 +16,7 @@ import (
 	"github.com/influxdb/influxdb/models"
 )
 
+// Handler is an http.Handler for the service.
 type Handler struct {
 	Database         string
 	RetentionPolicy  string


### PR DESCRIPTION
Supports #4098. Lints the following packages:

- `monitor`;
- `services/continuous_querier` :exclamation:;
- `services/graphite` :exclamation:;
- `services/hh` :exclamation:;
- `services/httpd`;
- `services/graphite`; and
- `services/opentsdb`.

`services` also contains the `copier/internal` package, which is generated, so that's obvious not been linted.

Packages with :exclamation: have outstanding lint issues. Specifically:
```
continuous_querier/config.go:1:1: don't use an underscore in package name
continuous_querier/service.go:1:1: don't use an underscore in package name
continuous_querier/service_test.go:1:1: don't use an underscore in package name
graphite/parser.go:192:78: exported func NewTemplate returns unexported type *graphite.template, which can be annoying to use
hh/limiter.go:15:34: exported func NewRateLimiter returns unexported type *hh.limiter, which can be annoying to use
```

Because the tests in these packages use the exported test package idiom, the `NewX` functions cannot be unexported as it stands. I'm not sure whether they're supposed to be part of the external API or not regardless. 

In terms of the `continuous_querier` package I can rename this if it suits—depends on if it's name is underscored for a reason.

If anyone wants the remaining issues resolved: chime up, otherwise these packages are done.
