### PR TITLE
Fix statement strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - [#4796](https://github.com/influxdb/influxdb/pull/4796): Check point without fields. Thanks @CrazyJvm
 - [#4815](https://github.com/influxdb/influxdb/pull/4815): Added `Time` field into aggregate output across the cluster. Thanks @li-ang
 - [#4817](https://github.com/influxdb/influxdb/pull/4817): Fix Min,Max,Top,Bottom function when query distributed node. Thanks @mengjinglei
+- [#4878](https://github.com/influxdb/influxdb/pull/4878): Fix String() function for several InfluxQL statement types
 
 ## v0.9.5 [2015-11-20]
 

--- a/influxql/ast.go
+++ b/influxql/ast.go
@@ -2097,16 +2097,24 @@ type CreateSubscriptionStatement struct {
 
 // String returns a string representation of the CreateSubscriptionStatement.
 func (s *CreateSubscriptionStatement) String() string {
-	var destinations bytes.Buffer
+	var buf bytes.Buffer
+	_, _ = buf.WriteString("CREATE SUBSCRIPTION ")
+	_, _ = buf.WriteString(QuoteIdent(s.Name))
+	_, _ = buf.WriteString(" ON ")
+	_, _ = buf.WriteString(QuoteIdent(s.Database))
+	_, _ = buf.WriteString(".")
+	_, _ = buf.WriteString(QuoteIdent(s.RetentionPolicy))
+	_, _ = buf.WriteString(" DESTINATIONS ")
+	_, _ = buf.WriteString(s.Mode)
+	_, _ = buf.WriteString(" ")
 	for i, dest := range s.Destinations {
 		if i != 0 {
-			destinations.Write([]byte(`, `))
+			_, _ = buf.WriteString(", ")
 		}
-		destinations.Write([]byte(`'`))
-		destinations.Write([]byte(dest))
-		destinations.Write([]byte(`'`))
+		_, _ = buf.WriteString(QuoteString(dest))
 	}
-	return fmt.Sprintf(`CREATE SUBSCRIPTION "%s" ON "%s"."%s" DESTINATIONS %s %s `, s.Name, s.Database, s.RetentionPolicy, s.Mode, string(destinations.Bytes()))
+
+	return buf.String()
 }
 
 // RequiredPrivileges returns the privilege required to execute a CreateSubscriptionStatement
@@ -2123,7 +2131,7 @@ type DropSubscriptionStatement struct {
 
 // String returns a string representation of the DropSubscriptionStatement.
 func (s *DropSubscriptionStatement) String() string {
-	return fmt.Sprintf(`DROP SUBSCRIPTION "%s" ON "%s"."%s"`, s.Name, s.Database, s.RetentionPolicy)
+	return fmt.Sprintf(`DROP SUBSCRIPTION %s ON %s.%s`, QuoteIdent(s.Name), QuoteIdent(s.Database), QuoteIdent(s.RetentionPolicy))
 }
 
 // RequiredPrivileges returns the privilege required to execute a DropSubscriptionStatement

--- a/influxql/ast.go
+++ b/influxql/ast.go
@@ -1958,6 +1958,15 @@ func (s *ShowMeasurementsStatement) String() string {
 	var buf bytes.Buffer
 	_, _ = buf.WriteString("SHOW MEASUREMENTS")
 
+	if s.Source != nil {
+		_, _ = buf.WriteString(" WITH MEASUREMENT ")
+		if m, ok := s.Source.(*Measurement); ok && m.Regex != nil {
+			_, _ = buf.WriteString("=~ ")
+		} else {
+			_, _ = buf.WriteString("= ")
+		}
+		_, _ = buf.WriteString(s.Source.String())
+	}
 	if s.Condition != nil {
 		_, _ = buf.WriteString(" WHERE ")
 		_, _ = buf.WriteString(s.Condition.String())

--- a/influxql/ast.go
+++ b/influxql/ast.go
@@ -329,7 +329,7 @@ func (s *CreateDatabaseStatement) String() string {
 	if s.IfNotExists {
 		_, _ = buf.WriteString("IF NOT EXISTS ")
 	}
-	_, _ = buf.WriteString(s.Name)
+	_, _ = buf.WriteString(QuoteIdent(s.Name))
 	return buf.String()
 }
 
@@ -428,7 +428,7 @@ type DropUserStatement struct {
 func (s *DropUserStatement) String() string {
 	var buf bytes.Buffer
 	_, _ = buf.WriteString("DROP USER ")
-	_, _ = buf.WriteString(s.Name)
+	_, _ = buf.WriteString(QuoteIdent(s.Name))
 	return buf.String()
 }
 
@@ -487,9 +487,9 @@ func (s *GrantStatement) String() string {
 	_, _ = buf.WriteString("GRANT ")
 	_, _ = buf.WriteString(s.Privilege.String())
 	_, _ = buf.WriteString(" ON ")
-	_, _ = buf.WriteString(s.On)
+	_, _ = buf.WriteString(QuoteIdent(s.On))
 	_, _ = buf.WriteString(" TO ")
-	_, _ = buf.WriteString(s.User)
+	_, _ = buf.WriteString(QuoteIdent(s.User))
 	return buf.String()
 }
 
@@ -508,7 +508,7 @@ type GrantAdminStatement struct {
 func (s *GrantAdminStatement) String() string {
 	var buf bytes.Buffer
 	_, _ = buf.WriteString("GRANT ALL PRIVILEGES TO ")
-	_, _ = buf.WriteString(s.User)
+	_, _ = buf.WriteString(QuoteIdent(s.User))
 	return buf.String()
 }
 
@@ -530,7 +530,7 @@ type SetPasswordUserStatement struct {
 func (s *SetPasswordUserStatement) String() string {
 	var buf bytes.Buffer
 	_, _ = buf.WriteString("SET PASSWORD FOR ")
-	_, _ = buf.WriteString(s.Name)
+	_, _ = buf.WriteString(QuoteIdent(s.Name))
 	_, _ = buf.WriteString(" = ")
 	_, _ = buf.WriteString("[REDACTED]")
 	return buf.String()
@@ -559,9 +559,9 @@ func (s *RevokeStatement) String() string {
 	_, _ = buf.WriteString("REVOKE ")
 	_, _ = buf.WriteString(s.Privilege.String())
 	_, _ = buf.WriteString(" ON ")
-	_, _ = buf.WriteString(s.On)
+	_, _ = buf.WriteString(QuoteIdent(s.On))
 	_, _ = buf.WriteString(" FROM ")
-	_, _ = buf.WriteString(s.User)
+	_, _ = buf.WriteString(QuoteIdent(s.User))
 	return buf.String()
 }
 
@@ -580,7 +580,7 @@ type RevokeAdminStatement struct {
 func (s *RevokeAdminStatement) String() string {
 	var buf bytes.Buffer
 	_, _ = buf.WriteString("REVOKE ALL PRIVILEGES FROM ")
-	_, _ = buf.WriteString(s.User)
+	_, _ = buf.WriteString(QuoteIdent(s.User))
 	return buf.String()
 }
 
@@ -1843,7 +1843,7 @@ type ShowGrantsForUserStatement struct {
 func (s *ShowGrantsForUserStatement) String() string {
 	var buf bytes.Buffer
 	_, _ = buf.WriteString("SHOW GRANTS FOR ")
-	_, _ = buf.WriteString(s.Name)
+	_, _ = buf.WriteString(QuoteIdent(s.Name))
 
 	return buf.String()
 }
@@ -2491,15 +2491,12 @@ type Measurement struct {
 func (m *Measurement) String() string {
 	var buf bytes.Buffer
 	if m.Database != "" {
-		_, _ = buf.WriteString(`"`)
-		_, _ = buf.WriteString(m.Database)
-		_, _ = buf.WriteString(`".`)
+		_, _ = buf.WriteString(QuoteIdent(m.Database))
+		_, _ = buf.WriteString(".")
 	}
 
 	if m.RetentionPolicy != "" {
-		_, _ = buf.WriteString(`"`)
-		_, _ = buf.WriteString(m.RetentionPolicy)
-		_, _ = buf.WriteString(`"`)
+		_, _ = buf.WriteString(QuoteIdent(m.RetentionPolicy))
 	}
 
 	if m.Database != "" || m.RetentionPolicy != "" {

--- a/influxql/ast_test.go
+++ b/influxql/ast_test.go
@@ -601,6 +601,9 @@ func TestParseString(t *testing.T) {
 			stmt: `SELECT "cpu load" FROM "my\"series"`,
 		},
 		{
+			stmt: `SELECT "field with spaces" FROM "\"ugly\" db"."\"ugly\" rp"."\"ugly\" measurement"`,
+		},
+		{
 			stmt: `SELECT * FROM myseries`,
 		},
 		{
@@ -638,6 +641,27 @@ func TestParseString(t *testing.T) {
 		},
 		{
 			stmt: `SHOW MEASUREMENTS WITH MEASUREMENT = "and/or"`,
+		},
+		{
+			stmt: `DROP USER "user with spaces"`,
+		},
+		{
+			stmt: `GRANT ALL PRIVILEGES ON "db with spaces" TO "user with spaces"`,
+		},
+		{
+			stmt: `GRANT ALL PRIVILEGES TO "user with spaces"`,
+		},
+		{
+			stmt: `SHOW GRANTS FOR "user with spaces"`,
+		},
+		{
+			stmt: `REVOKE ALL PRIVILEGES ON "db with spaces" FROM "user with spaces"`,
+		},
+		{
+			stmt: `REVOKE ALL PRIVILEGES FROM "user with spaces"`,
+		},
+		{
+			stmt: `CREATE DATABASE "db with spaces"`,
 		},
 	}
 

--- a/influxql/ast_test.go
+++ b/influxql/ast_test.go
@@ -603,6 +603,30 @@ func TestParseString(t *testing.T) {
 		{
 			stmt: `SELECT * FROM myseries`,
 		},
+		{
+			stmt: `DROP DATABASE "!"`,
+		},
+		{
+			stmt: `DROP RETENTION POLICY "my rp" ON "a database"`,
+		},
+		{
+			stmt: `CREATE RETENTION POLICY "my rp" ON "a database" DURATION 1d REPLICATION 1`,
+		},
+		{
+			stmt: `ALTER RETENTION POLICY "my rp" ON "a database" DEFAULT`,
+		},
+		{
+			stmt: `SHOW RETENTION POLICIES ON "a database"`,
+		},
+		{
+			stmt: `SHOW TAG VALUES WITH KEY IN ("a long name", short)`,
+		},
+		{
+			stmt: `DROP CONTINUOUS QUERY "my query" ON "my database"`,
+		},
+		{
+			stmt: `DELETE FROM "my db"."my rp"."my measurement"`,
+		},
 	}
 
 	for _, tt := range tests {

--- a/influxql/ast_test.go
+++ b/influxql/ast_test.go
@@ -627,6 +627,12 @@ func TestParseString(t *testing.T) {
 		{
 			stmt: `DELETE FROM "my db"."my rp"."my measurement"`,
 		},
+		{
+			stmt: `DROP SUBSCRIPTION "ugly \"subscription\" name" ON "\"my\" db"."\"my\" rp"`,
+		},
+		{
+			stmt: `CREATE SUBSCRIPTION "ugly \"subscription\" name" ON "\"my\" db"."\"my\" rp" DESTINATIONS ALL 'my host', 'my other host'`,
+		},
 	}
 
 	for _, tt := range tests {

--- a/influxql/ast_test.go
+++ b/influxql/ast_test.go
@@ -633,6 +633,12 @@ func TestParseString(t *testing.T) {
 		{
 			stmt: `CREATE SUBSCRIPTION "ugly \"subscription\" name" ON "\"my\" db"."\"my\" rp" DESTINATIONS ALL 'my host', 'my other host'`,
 		},
+		{
+			stmt: `SHOW MEASUREMENTS WITH MEASUREMENT =~ /foo/`,
+		},
+		{
+			stmt: `SHOW MEASUREMENTS WITH MEASUREMENT = "and/or"`,
+		},
 	}
 
 	for _, tt := range tests {
@@ -642,9 +648,13 @@ func TestParseString(t *testing.T) {
 			t.Fatalf("invalid statement: %q: %s", tt.stmt, err)
 		}
 
-		_, err = influxql.NewParser(strings.NewReader(stmt.String())).ParseStatement()
+		stmtCopy, err := influxql.NewParser(strings.NewReader(stmt.String())).ParseStatement()
 		if err != nil {
 			t.Fatalf("failed to parse string: %v\norig: %v\ngot: %v", err, tt.stmt, stmt.String())
+		}
+
+		if !reflect.DeepEqual(stmt, stmtCopy) {
+			t.Fatalf("statement changed after stringifying and re-parsing:\noriginal : %v\nre-parsed: %v\n", tt.stmt, stmtCopy.String())
 		}
 	}
 }

--- a/influxql/parser.go
+++ b/influxql/parser.go
@@ -1196,7 +1196,7 @@ func (p *Parser) parseTagKeys() ([]string, error) {
 
 		// Parse required ) token.
 		if tok, pos, lit = p.scanIgnoreWhitespace(); tok != RPAREN {
-			return nil, newParseError(tokstr(tok, lit), []string{"("}, pos)
+			return nil, newParseError(tokstr(tok, lit), []string{")"}, pos)
 		}
 	} else if tok == EQ {
 		// Parse required tag key.


### PR DESCRIPTION
This PR mostly adds a lot of missing `QuoteIdent` calls, but there were some other small changes to ensure that a statement can be converted to a string and re-parsed without differing from the original parse result.