### PR TITLE
Implement close notifier and timeout on executors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - [#4790](https://github.com/influxdb/influxdb/pull/4790): Allow openTSDB point-level error logging to be disabled
 - [#4728](https://github.com/influxdb/influxdb/pull/4728): SHOW SHARD GROUPS. By @mateuszdyminski
 - [#4841](https://github.com/influxdb/influxdb/pull/4841): Improve point parsing speed. Lint models pacakge. Thanks @e-dard!
+- [#4889](https://github.com/influxdb/influxdb/pull/4889): Implement close notifier and timeout on executors
 
 ### Bugfixes
 - [#4855](https://github.com/influxdb/influxdb/pull/4855): Fix race in TCP proxy shutdown. Thanks @runner-mei!

--- a/services/httpd/response_logger.go
+++ b/services/httpd/response_logger.go
@@ -23,6 +23,14 @@ type responseLogger struct {
 	size   int
 }
 
+func (l *responseLogger) CloseNotify() <-chan bool {
+	if notifier, ok := l.w.(http.CloseNotifier); ok {
+		return notifier.CloseNotify()
+	}
+	// needed for response recorder for testing
+	return make(<-chan bool)
+}
+
 func (l *responseLogger) Header() http.Header {
 	return l.w.Header()
 }

--- a/tsdb/aggregate.go
+++ b/tsdb/aggregate.go
@@ -43,13 +43,13 @@ func (e *AggregateExecutor) close() {
 }
 
 // Execute begins execution of the query and returns a channel to receive rows.
-func (e *AggregateExecutor) Execute() <-chan *models.Row {
+func (e *AggregateExecutor) Execute(closing <-chan struct{}) <-chan *models.Row {
 	out := make(chan *models.Row, 0)
-	go e.execute(out)
+	go e.execute(out, closing)
 	return out
 }
 
-func (e *AggregateExecutor) execute(out chan *models.Row) {
+func (e *AggregateExecutor) execute(out chan *models.Row, closing <-chan struct{}) {
 	// It's important to close all resources when execution completes.
 	defer e.close()
 
@@ -167,7 +167,19 @@ func (e *AggregateExecutor) execute(out chan *models.Row) {
 		}
 
 		row.Values = values
-		out <- row
+
+		// Check to see if our client disconnected, or it has been to long since
+		// we were asked for data...
+		select {
+		case out <- row:
+		case <-closing:
+			out <- &models.Row{Err: fmt.Errorf("execute was closed by caller")}
+			break
+		case <-time.After(30 * time.Second):
+			// This should never happen, so if it does, it is a problem
+			out <- &models.Row{Err: fmt.Errorf("execute was closed by read timeout")}
+			break
+		}
 	}
 
 	close(out)

--- a/tsdb/executor.go
+++ b/tsdb/executor.go
@@ -4,5 +4,5 @@ import "github.com/influxdb/influxdb/models"
 
 // Executor is an interface for a query executor.
 type Executor interface {
-	Execute() <-chan *models.Row
+	Execute(closing <-chan struct{}) <-chan *models.Row
 }

--- a/tsdb/query_executor_test.go
+++ b/tsdb/query_executor_test.go
@@ -372,7 +372,7 @@ func testStoreAndExecutor(storePath string) (*tsdb.Store, *tsdb.QueryExecutor) {
 }
 
 func executeAndGetJSON(query string, executor *tsdb.QueryExecutor) string {
-	ch, err := executor.ExecuteQuery(mustParseQuery(query), "foo", 20)
+	ch, err := executor.ExecuteQuery(mustParseQuery(query), "foo", 20, make(chan struct{}))
 	if err != nil {
 		panic(err.Error())
 	}

--- a/tsdb/raw_test.go
+++ b/tsdb/raw_test.go
@@ -1029,7 +1029,7 @@ func (t *testQEShardMapper) CreateMapper(shard meta.ShardInfo, stmt influxql.Sta
 }
 
 func executeAndGetResults(executor tsdb.Executor) string {
-	ch := executor.Execute()
+	ch := executor.Execute(make(chan struct{}))
 
 	var rows []*models.Row
 	for r := range ch {


### PR DESCRIPTION
This PR does two things:

1. Adds the `CloseNotifier` implementation for our Query handler endpoint.  This will pass in a closing channel to the executors.  If the HTTP client disconnects, we will cancel the query on the server.
1. Added a timeout within the executor loop while retrieving results.  We have a suspicion that we may stop reading on a channel for some reason (short read) and thus the execute never exits.  As a result, it could leave a bolt transaction open and create a deadlock situation.