### PR TITLE
Fix flush deadlock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - [#4815](https://github.com/influxdb/influxdb/pull/4815): Added `Time` field into aggregate output across the cluster. Thanks @li-ang
 - [#4817](https://github.com/influxdb/influxdb/pull/4817): Fix Min,Max,Top,Bottom function when query distributed node. Thanks @mengjinglei
 - [#4878](https://github.com/influxdb/influxdb/pull/4878): Fix String() function for several InfluxQL statement types
+- [#4913](https://github.com/influxdb/influxdb/pull/4913): Fix b1 flush deadlock
 
 ## v0.9.5 [2015-11-20]
 


### PR DESCRIPTION
## Overview

This commit fixes a deadlock that occurs during b1 flushes. It's caused by taking locks in a different order. In the flush, b1 locks the engine and then bolt. However, in the query cursor, a lock is obtained on bolt first (via `DB.Begin()`) and then the engine is locked while reading from the engine's cache.

/cc @corylanou @pauldix @beckettsean 