### PR TITLE
Add support for cache querying

### DIFF
--- a/tsdb/engine/tsm1/cache.go
+++ b/tsdb/engine/tsm1/cache.go
@@ -198,8 +198,8 @@ func (c *Cache) Evict() {
 	c.evict()
 }
 
-// Values returns a copy of all values, deduped and sorted, for the given key.
-func (c *Cache) Values(key string) Values {
+// Values returns a copy of all values, deduped and sorted as requested, for the given key.
+func (c *Cache) Values(key string, ascending bool) Values {
 	values := func() Values {
 		c.mu.RLock()
 		defer c.mu.RUnlock()
@@ -215,7 +215,7 @@ func (c *Cache) Values(key string) Values {
 	if values == nil {
 		return nil
 	}
-	return values.Deduplicate(true)
+	return values.Deduplicate(ascending)
 }
 
 // evict instructs the cache to evict data up to and including the current checkpoint.

--- a/tsdb/engine/tsm1/cache_test.go
+++ b/tsdb/engine/tsm1/cache_test.go
@@ -171,7 +171,7 @@ func Test_CacheValues(t *testing.T) {
 	v4 := NewValue(time.Unix(4, 0).UTC(), 4.0)
 
 	c := MustNewCache(512)
-	if deduped := c.Values("no such key"); deduped != nil {
+	if deduped := c.Values("no such key", true); deduped != nil {
 		t.Fatalf("Values returned for no such key")
 	}
 
@@ -182,9 +182,14 @@ func Test_CacheValues(t *testing.T) {
 		t.Fatalf("failed to write 1 value, key foo to cache: %s", err.Error())
 	}
 
-	expValues := Values{v3, v1, v2, v4}
-	if deduped := c.Values("foo"); !reflect.DeepEqual(expValues, deduped) {
-		t.Fatalf("deduped values for foo incorrect, exp: %v, got %v", expValues, deduped)
+	expAscValues := Values{v3, v1, v2, v4}
+	if deduped := c.Values("foo", true); !reflect.DeepEqual(expAscValues, deduped) {
+		t.Fatalf("deduped ascending values for foo incorrect, exp: %v, got %v", expAscValues, deduped)
+	}
+
+	expDescValues := Values{v4, v2, v1, v3}
+	if deduped := c.Values("foo", false); !reflect.DeepEqual(expDescValues, deduped) {
+		t.Fatalf("deduped descending values for foo incorrect, exp: %v, got %v", expDescValues, deduped)
 	}
 }
 

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -214,7 +214,7 @@ type devTx struct {
 // Cursor returns a cursor for all cached and TSM-based data.
 func (t *devTx) Cursor(series string, fields []string, dec *tsdb.FieldCodec, ascending bool) tsdb.Cursor {
 	return &devCursor{
-		cache:     t.engine.Cache.Values(SeriesFieldKey(series, fields[0])),
+		cache:     t.engine.Cache.Values(SeriesFieldKey(series, fields[0]), ascending),
 		ascending: ascending,
 	}
 }

--- a/tsdb/engine/tsm1/engine_test.go
+++ b/tsdb/engine/tsm1/engine_test.go
@@ -1,0 +1,83 @@
+package tsm1
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/influxdb/influxdb/models"
+	"github.com/influxdb/influxdb/tsdb"
+)
+
+// Ensure an engine containing cached values responds correctly to queries.
+func Test_DevEngineCacheQueryAscending(t *testing.T) {
+	// Generate temporary file.
+	f, _ := ioutil.TempFile("", "tsm1dev")
+	f.Close()
+	os.Remove(f.Name())
+	walPath := filepath.Join(f.Name(), "wal")
+	os.MkdirAll(walPath, 0777)
+	defer os.RemoveAll(f.Name())
+
+	// Create a few points.
+	p1 := parsePoint("cpu,host=A value=1.1 1000000000")
+	p2 := parsePoint("cpu,host=A value=1.2 2000000000")
+	p3 := parsePoint("cpu,host=A value=1.3 3000000000")
+
+	// Write those points to the engine.
+	e := NewDevEngine(f.Name(), walPath, tsdb.NewEngineOptions())
+	if err := e.Open(); err != nil {
+		t.Fatalf("failed to open tsm1dev engine: %s", err.Error())
+	}
+	if err := e.WritePoints([]models.Point{p1, p2, p3}, nil, nil); err != nil {
+		t.Fatalf("failed to write points: %s", err.Error())
+	}
+
+	// Start a query transactions and get a cursor.
+	tx := devTx{engine: e.(*DevEngine)}
+	ascCursor := tx.Cursor("cpu,host=A", []string{"value"}, nil, true)
+
+	k, v := ascCursor.SeekTo(1)
+	if k != 1000000000 {
+		t.Fatalf("failed to seek to before first key: %v %v", k, v)
+	}
+
+	k, v = ascCursor.SeekTo(1000000000)
+	if k != 1000000000 {
+		t.Fatalf("failed to seek to first key: %v %v", k, v)
+	}
+
+	k, v = ascCursor.Next()
+	if k != 2000000000 {
+		t.Fatalf("failed to get next key: %v %v", k, v)
+	}
+
+	k, v = ascCursor.Next()
+	if k != 3000000000 {
+		t.Fatalf("failed to get next key: %v %v", k, v)
+	}
+
+	k, v = ascCursor.Next()
+	if k != -1 {
+		t.Fatalf("failed to get next key: %v %v", k, v)
+	}
+
+	k, v = ascCursor.SeekTo(4000000000)
+	if k != -1 {
+		t.Fatalf("failed to seek to past last key: %v %v", k, v)
+	}
+}
+
+func parsePoints(buf string) []models.Point {
+	points, err := models.ParsePointsString(buf)
+	if err != nil {
+		panic(fmt.Sprintf("couldn't parse points: %s", err.Error()))
+	}
+	return points
+}
+
+func parsePoint(buf string) models.Point {
+	return parsePoints(buf)[0]
+}

--- a/tsdb/engine/tsm1/engine_test.go
+++ b/tsdb/engine/tsm1/engine_test.go
@@ -70,6 +70,40 @@ func Test_DevEngineCacheQueryAscending(t *testing.T) {
 	}
 }
 
+// Ensure an engine containing cached values responds correctly to queries.
+func Test_DevEngineCacheQueryDescending(t *testing.T) {
+	// Generate temporary file.
+	f, _ := ioutil.TempFile("", "tsm1dev")
+	f.Close()
+	os.Remove(f.Name())
+	walPath := filepath.Join(f.Name(), "wal")
+	os.MkdirAll(walPath, 0777)
+	defer os.RemoveAll(f.Name())
+
+	// Create a few points.
+	p1 := parsePoint("cpu,host=A value=1.1 1000000000")
+	p2 := parsePoint("cpu,host=A value=1.2 2000000000")
+	p3 := parsePoint("cpu,host=A value=1.3 3000000000")
+
+	// Write those points to the engine.
+	e := NewDevEngine(f.Name(), walPath, tsdb.NewEngineOptions())
+	if err := e.Open(); err != nil {
+		t.Fatalf("failed to open tsm1dev engine: %s", err.Error())
+	}
+	if err := e.WritePoints([]models.Point{p1, p2, p3}, nil, nil); err != nil {
+		t.Fatalf("failed to write points: %s", err.Error())
+	}
+
+	// Start a query transactions and get a cursor.
+	tx := devTx{engine: e.(*DevEngine)}
+	ascCursor := tx.Cursor("cpu,host=A", []string{"value"}, nil, false)
+
+	k, v := ascCursor.SeekTo(4000000000)
+	if k != 3000000000 {
+		t.Fatalf("failed to seek to before last key: %v %v", k, v)
+	}
+}
+
 func parsePoints(buf string) []models.Point {
 	points, err := models.ParsePointsString(buf)
 	if err != nil {

--- a/tsdb/engine/tsm1/engine_test.go
+++ b/tsdb/engine/tsm1/engine_test.go
@@ -96,11 +96,21 @@ func Test_DevEngineCacheQueryDescending(t *testing.T) {
 
 	// Start a query transactions and get a cursor.
 	tx := devTx{engine: e.(*DevEngine)}
-	ascCursor := tx.Cursor("cpu,host=A", []string{"value"}, nil, false)
+	descCursor := tx.Cursor("cpu,host=A", []string{"value"}, nil, false)
 
-	k, v := ascCursor.SeekTo(4000000000)
+	k, v := descCursor.SeekTo(4000000000)
 	if k != 3000000000 {
 		t.Fatalf("failed to seek to before last key: %v %v", k, v)
+	}
+
+	k, v = descCursor.Next()
+	if k != 2000000000 {
+		t.Fatalf("failed to get next key: %v %v", k, v)
+	}
+
+	k, v = descCursor.SeekTo(1)
+	if k != -1 {
+		t.Fatalf("failed to seek to after first key: %v %v", k, v)
 	}
 }
 


### PR DESCRIPTION
This change adds support for querying the tsm1dev engine, assuming no data in the tsm1 files -- in other words, all data resides just in the cache. Both ascending and descending cursors are supported.

To simplify development, a small new unit-test file has been created. This code should eventually be replaced by existing tsm1 unit test code. Normally I would add more unit-tests, but test coverage should be sufficient due to the existing tsm1 unit test code.