### PR TITLE
Fix distributed aggregative query error

### DIFF
--- a/cluster/shard_mapper.go
+++ b/cluster/shard_mapper.go
@@ -213,9 +213,10 @@ func (r *RemoteMapper) NextChunk() (chunk interface{}, err error) {
 
 	// Prep the non-JSON version of Mapper output.
 	mo := &tsdb.MapperOutput{
-		Name:   moj.Name,
-		Tags:   moj.Tags,
-		Fields: moj.Fields,
+		Name:      moj.Name,
+		Tags:      moj.Tags,
+		Fields:    moj.Fields,
+		CursorKey: moj.CursorKey,
 	}
 
 	if len(mvj) == 1 && len(mvj[0].AggData) > 0 {

--- a/tsdb/aggregate.go
+++ b/tsdb/aggregate.go
@@ -860,8 +860,9 @@ func readMapItems(cursors []*TagsCursor, field string, seek, tmin, tmax int64) [
 				Tags:      c.tags,
 			})
 		}
-		seeked = false
 	}
+	sort.Sort(MapItems(items))
+
 	return items
 }
 

--- a/tsdb/aggregate.go
+++ b/tsdb/aggregate.go
@@ -757,7 +757,7 @@ func (m *AggregateMapper) NextChunk() (interface{}, error) {
 		Name:      cursorSet.Measurement,
 		Tags:      cursorSet.Tags,
 		Fields:    m.selectFields,
-		cursorKey: cursorSet.Key,
+		CursorKey: cursorSet.Key,
 	}
 
 	// Always clamp tmin and tmax. This can happen as bucket-times are bucketed to the nearest

--- a/tsdb/functions.go
+++ b/tsdb/functions.go
@@ -38,6 +38,12 @@ type MapItem struct {
 	Tags   map[string]string
 }
 
+type MapItems []MapItem
+
+func (a MapItems) Len() int           { return len(a) }
+func (a MapItems) Less(i, j int) bool { return a[i].Timestamp < a[j].Timestamp }
+func (a MapItems) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+
 // mapFunc represents a function used for mapping over a sequential series of data.
 // The iterator represents a single group by interval
 type mapFunc func(*MapInput) interface{}

--- a/tsdb/mapper.go
+++ b/tsdb/mapper.go
@@ -96,26 +96,28 @@ func (a MapperValues) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
 type MapperOutput struct {
 	Name      string            `json:"name,omitempty"`
 	Tags      map[string]string `json:"tags,omitempty"`
-	Fields    []string          `json:"fields,omitempty"` // Field names of returned data.
-	Values    []*MapperValue    `json:"values,omitempty"` // For aggregates contains a single value at [0]
-	cursorKey string            // Tagset-based key for the source cursor. Cached for performance reasons.
+	Fields    []string          `json:"fields,omitempty"`    // Field names of returned data.
+	Values    []*MapperValue    `json:"values,omitempty"`    // For aggregates contains a single value at [0]
+	CursorKey string            `json:"cursorkey,omitempty"` // Tagset-based key for the source cursor. Cached for performance reasons.
 }
 
 // MapperOutputJSON is the JSON-encoded representation of MapperOutput. The query data is represented
 // as a raw JSON message, so decode is delayed, and can proceed in a custom manner.
 type MapperOutputJSON struct {
-	Name   string            `json:"name,omitempty"`
-	Tags   map[string]string `json:"tags,omitempty"`
-	Fields []string          `json:"fields,omitempty"` // Field names of returned data.
-	Values json.RawMessage   `json:"values,omitempty"`
+	Name      string            `json:"name,omitempty"`
+	Tags      map[string]string `json:"tags,omitempty"`
+	Fields    []string          `json:"fields,omitempty"`    // Field names of returned data.
+	CursorKey string            `json:"cursorkey,omitempty"` // Tagset-based key for the source cursor.
+	Values    json.RawMessage   `json:"values,omitempty"`
 }
 
 // MarshalJSON returns the JSON-encoded representation of a MapperOutput.
 func (mo *MapperOutput) MarshalJSON() ([]byte, error) {
 	o := &MapperOutputJSON{
-		Name:   mo.Name,
-		Tags:   mo.Tags,
-		Fields: mo.Fields,
+		Name:      mo.Name,
+		Tags:      mo.Tags,
+		Fields:    mo.Fields,
+		CursorKey: mo.CursorKey,
 	}
 	data, err := json.Marshal(mo.Values)
 	if err != nil {
@@ -127,7 +129,7 @@ func (mo *MapperOutput) MarshalJSON() ([]byte, error) {
 }
 
 func (mo *MapperOutput) key() string {
-	return mo.cursorKey
+	return mo.CursorKey
 }
 
 // uniqueStrings returns a slice of unique strings from all lists in a.

--- a/tsdb/raw.go
+++ b/tsdb/raw.go
@@ -208,7 +208,7 @@ func (e *RawExecutor) execute(out chan *models.Row, closing <-chan struct{}) {
 				chunkedOutput = &MapperOutput{
 					Name:      m.bufferedChunk.Name,
 					Tags:      m.bufferedChunk.Tags,
-					cursorKey: m.bufferedChunk.key(),
+					CursorKey: m.bufferedChunk.key(),
 				}
 				chunkedOutput.Values = m.bufferedChunk.Values[:ind]
 			} else {
@@ -942,7 +942,7 @@ func (m *RawMapper) NextChunk() (interface{}, error) {
 				Name:      cursor.measurement,
 				Tags:      cursor.tags,
 				Fields:    m.selectFields,
-				cursorKey: cursor.key(),
+				CursorKey: cursor.key(),
 			}
 		}
 


### PR DESCRIPTION
Fix issue #4937  issue #4965 
When distributed aggregative query covers two more `seriesKeys(measurement + tagSets)` in a shard file, the `aggregative query result` which is passed accross cluster,  would has two more `mapperValues`. The node of cluster,  revieving the `aggregative query result`,  could regard the query result as `raw query result`. It will lead to `ERR: unexpected end of JSON input` or double results described by issue #4965 .

- [ ] CHANGELOG.md updated
- [x] Rebased/mergable
- [x] Tests pass
- [x] Sign [CLA](http://influxdb.com/community/cla.html) 