### PR TITLE
TSM File Compaction

### DIFF
--- a/tsdb/engine.go
+++ b/tsdb/engine.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"sort"
 	"time"
 
@@ -96,6 +97,16 @@ func NewEngine(path string, walPath string, options EngineOptions) (Engine, erro
 			return err
 		}
 		if fi.Mode().IsDir() {
+			files, err := filepath.Glob(filepath.Join(path, fmt.Sprintf("*.%s", "tsm1dev")))
+			if err != nil {
+				return err
+			}
+
+			if len(files) > 0 {
+				format = "tsm1dev"
+				return nil
+			}
+
 			format = "tsm1"
 			return nil
 		}

--- a/tsdb/engine/tsm1/cache.go
+++ b/tsdb/engine/tsm1/cache.go
@@ -227,6 +227,24 @@ func (c *Cache) Checkpoint() uint64 {
 	return c.checkpoint
 }
 
+func (c *Cache) CheckpointRange() (uint64, uint64) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	var min, max uint64
+	for _, v := range c.store {
+		for checkpoint := range v.m {
+			if min == 0 || checkpoint < min {
+				min = checkpoint
+			}
+			if max == 0 || checkpoint > max {
+				max = checkpoint
+			}
+		}
+	}
+	return min, max
+}
+
 // Evict forces the cache to evict.
 func (c *Cache) Evict() {
 	c.mu.Lock()

--- a/tsdb/engine/tsm1/cache.go
+++ b/tsdb/engine/tsm1/cache.go
@@ -288,7 +288,7 @@ func (c *Cache) ValuesRange(key string, min, max uint64) Values {
 	if values == nil {
 		return nil
 	}
-	return values.Deduplicate()
+	return values.Deduplicate(true)
 }
 
 // evict instructs the cache to evict data up to and including the current checkpoint.

--- a/tsdb/engine/tsm1/compact.go
+++ b/tsdb/engine/tsm1/compact.go
@@ -403,7 +403,7 @@ func (m *MergeIterator) Next() bool {
 		}
 
 		if dedup {
-			m.values = Values(m.values).Deduplicate()
+			m.values = Values(m.values).Deduplicate(true)
 		}
 
 		// We need to find the index of the min and max values that are within
@@ -643,7 +643,7 @@ func (k *tsmKeyIterator) Next() bool {
 				} else if values[len(values)-1].Time().Before(existing[0].Time()) {
 					k.values[key] = append(values, existing...)
 				} else {
-					k.values[key] = Values(append(existing, values...)).Deduplicate()
+					k.values[key] = Values(append(existing, values...)).Deduplicate(true)
 				}
 			}
 		}

--- a/tsdb/engine/tsm1/compact_test.go
+++ b/tsdb/engine/tsm1/compact_test.go
@@ -1542,50 +1542,6 @@ func TestDefaultCompactionPlanner_OnlyWAL(t *testing.T) {
 	}
 }
 
-func TestDefaultCompactionPlanner_Max10WAL(t *testing.T) {
-	cp := &tsm1.DefaultPlanner{
-		WAL: &fakeWAL{
-			ClosedSegmentsFn: func() ([]tsm1.SegmentStat, error) {
-				return []tsm1.SegmentStat{
-					tsm1.SegmentStat{Path: "00001.tsm1"},
-					tsm1.SegmentStat{Path: "00002.tsm1"},
-					tsm1.SegmentStat{Path: "00003.tsm1"},
-					tsm1.SegmentStat{Path: "00004.tsm1"},
-					tsm1.SegmentStat{Path: "00005.tsm1"},
-					tsm1.SegmentStat{Path: "00006.tsm1"},
-					tsm1.SegmentStat{Path: "00007.tsm1"},
-					tsm1.SegmentStat{Path: "00008.tsm1"},
-					tsm1.SegmentStat{Path: "00009.tsm1"},
-					tsm1.SegmentStat{Path: "00010.tsm1"},
-					tsm1.SegmentStat{Path: "00011.tsm1"},
-				}, nil
-			},
-		},
-		FileStore: &fakeFileStore{
-			PathsFn: func() []tsm1.FileStat {
-				return []tsm1.FileStat{
-					tsm1.FileStat{
-						Path: "000001.tsm",
-					},
-				}
-			},
-		},
-	}
-
-	tsm, wal, err := cp.Plan()
-	if err != nil {
-		t.Fatalf("unexpected error running plan: %v", err)
-	}
-
-	if exp, got := 0, len(tsm); got != exp {
-		t.Fatalf("tsm file length mismatch: got %v, exp %v", got, exp)
-	}
-
-	if exp, got := 10, len(wal); got != exp {
-		t.Fatalf("wal file length mismatch: got %v, exp %v", got, exp)
-	}
-}
-
 func TestDefaultCompactionPlanner_OnlyTSM_MaxSize(t *testing.T) {
 	cp := &tsm1.DefaultPlanner{
 		WAL: &fakeWAL{
@@ -1707,7 +1663,7 @@ func TestDefaultCompactionPlanner_NoRewrite_MaxWAL(t *testing.T) {
 		t.Fatalf("tsm file length mismatch: got %v, exp %v", got, exp)
 	}
 
-	if exp, got := 10, len(wal); got != exp {
+	if exp, got := 11, len(wal); got != exp {
 		t.Fatalf("wal file length mismatch: got %v, exp %v", got, exp)
 	}
 }

--- a/tsdb/engine/tsm1/compact_test.go
+++ b/tsdb/engine/tsm1/compact_test.go
@@ -1513,6 +1513,8 @@ func TestKeyIterator_Cache_Duplicate(t *testing.T) {
 }
 
 func TestDefaultCompactionPlanner_OnlyWAL(t *testing.T) {
+	c := tsm1.NewCache(0)
+
 	cp := &tsm1.DefaultPlanner{
 		WAL: &fakeWAL{
 			ClosedSegmentsFn: func() ([]tsm1.SegmentStat, error) {
@@ -1526,6 +1528,7 @@ func TestDefaultCompactionPlanner_OnlyWAL(t *testing.T) {
 				return nil
 			},
 		},
+		Cache: c,
 	}
 
 	tsm, wal, err := cp.Plan()
@@ -1543,6 +1546,8 @@ func TestDefaultCompactionPlanner_OnlyWAL(t *testing.T) {
 }
 
 func TestDefaultCompactionPlanner_OnlyTSM_MaxSize(t *testing.T) {
+	c := tsm1.NewCache(0)
+
 	cp := &tsm1.DefaultPlanner{
 		WAL: &fakeWAL{
 			ClosedSegmentsFn: func() ([]tsm1.SegmentStat, error) {
@@ -1553,17 +1558,21 @@ func TestDefaultCompactionPlanner_OnlyTSM_MaxSize(t *testing.T) {
 			PathsFn: func() []tsm1.FileStat {
 				return []tsm1.FileStat{
 					tsm1.FileStat{
+						Path: "1.tsm1",
 						Size: 1 * 1024 * 1024,
 					},
 					tsm1.FileStat{
+						Path: "2.tsm1",
 						Size: 1 * 1024 * 1024,
 					},
 					tsm1.FileStat{
-						Size: 51 * 1024 * 1024,
+						Path: "3.tsm",
+						Size: 251 * 1024 * 1024,
 					},
 				}
 			},
 		},
+		Cache: c,
 	}
 
 	tsm, wal, err := cp.Plan()
@@ -1581,6 +1590,8 @@ func TestDefaultCompactionPlanner_OnlyTSM_MaxSize(t *testing.T) {
 }
 
 func TestDefaultCompactionPlanner_TSM_Rewrite(t *testing.T) {
+	c := tsm1.NewCache(0)
+
 	cp := &tsm1.DefaultPlanner{
 		WAL: &fakeWAL{
 			ClosedSegmentsFn: func() ([]tsm1.SegmentStat, error) {
@@ -1591,17 +1602,20 @@ func TestDefaultCompactionPlanner_TSM_Rewrite(t *testing.T) {
 			PathsFn: func() []tsm1.FileStat {
 				return []tsm1.FileStat{
 					tsm1.FileStat{
+						Path: "0001.tsm1",
 						Size: 1 * 1024 * 1024,
 					},
 					tsm1.FileStat{
+						Path: "0002.tsm1",
 						Size: 1 * 1024 * 1024,
 					},
 					tsm1.FileStat{
-						Size: 51 * 1024 * 1024,
+						Size: 251 * 1024 * 1024,
 					},
 				}
 			},
 		},
+		Cache: c,
 	}
 
 	tsm, wal, err := cp.Plan()
@@ -1619,6 +1633,8 @@ func TestDefaultCompactionPlanner_TSM_Rewrite(t *testing.T) {
 }
 
 func TestDefaultCompactionPlanner_NoRewrite_MaxWAL(t *testing.T) {
+	c := tsm1.NewCache(0)
+
 	cp := &tsm1.DefaultPlanner{
 		WAL: &fakeWAL{
 			ClosedSegmentsFn: func() ([]tsm1.SegmentStat, error) {
@@ -1641,17 +1657,20 @@ func TestDefaultCompactionPlanner_NoRewrite_MaxWAL(t *testing.T) {
 			PathsFn: func() []tsm1.FileStat {
 				return []tsm1.FileStat{
 					tsm1.FileStat{
+						Path: "0001.tsm1",
 						Size: 1 * 1024 * 1024,
 					},
 					tsm1.FileStat{
+						Path: "0002.tsm1",
 						Size: 1 * 1024 * 1024,
 					},
 					tsm1.FileStat{
-						Size: 51 * 1024 * 1024,
+						Size: 251 * 1024 * 1024,
 					},
 				}
 			},
 		},
+		Cache: c,
 	}
 
 	tsm, wal, err := cp.Plan()
@@ -1663,21 +1682,23 @@ func TestDefaultCompactionPlanner_NoRewrite_MaxWAL(t *testing.T) {
 		t.Fatalf("tsm file length mismatch: got %v, exp %v", got, exp)
 	}
 
-	if exp, got := 11, len(wal); got != exp {
+	if exp, got := 10, len(wal); got != exp {
 		t.Fatalf("wal file length mismatch: got %v, exp %v", got, exp)
 	}
 }
 
 func TestDefaultCompactionPlanner_Rewrite_MixWAL(t *testing.T) {
+	c := tsm1.NewCache(0)
+
 	cp := &tsm1.DefaultPlanner{
 		WAL: &fakeWAL{
 			ClosedSegmentsFn: func() ([]tsm1.SegmentStat, error) {
 				return []tsm1.SegmentStat{
-					tsm1.SegmentStat{Path: "00001.tsm1"},
-					tsm1.SegmentStat{Path: "00002.tsm1"},
-					tsm1.SegmentStat{Path: "00003.tsm1"},
-					tsm1.SegmentStat{Path: "00004.tsm1"},
-					tsm1.SegmentStat{Path: "00005.tsm1"},
+					tsm1.SegmentStat{Path: "00001.wal"},
+					tsm1.SegmentStat{Path: "00002.wal"},
+					tsm1.SegmentStat{Path: "00003.wal"},
+					tsm1.SegmentStat{Path: "00004.wal"},
+					tsm1.SegmentStat{Path: "00005.wal"},
 				}, nil
 			},
 		},
@@ -1685,17 +1706,20 @@ func TestDefaultCompactionPlanner_Rewrite_MixWAL(t *testing.T) {
 			PathsFn: func() []tsm1.FileStat {
 				return []tsm1.FileStat{
 					tsm1.FileStat{
+						Path: "0001.tsm1",
 						Size: 1 * 1024 * 1024,
 					},
 					tsm1.FileStat{
+						Path: "0002.tsm1",
 						Size: 1 * 1024 * 1024,
 					},
 					tsm1.FileStat{
-						Size: 51 * 1024 * 1024,
+						Size: 251 * 1024 * 1024,
 					},
 				}
 			},
 		},
+		Cache: c,
 	}
 
 	tsm, wal, err := cp.Plan()
@@ -1713,6 +1737,8 @@ func TestDefaultCompactionPlanner_Rewrite_MixWAL(t *testing.T) {
 }
 
 func TestDefaultCompactionPlanner_Rewrite_WALOverlap(t *testing.T) {
+	c := tsm1.NewCache(0)
+
 	cp := &tsm1.DefaultPlanner{
 		WAL: &fakeWAL{
 			ClosedSegmentsFn: func() ([]tsm1.SegmentStat, error) {
@@ -1748,6 +1774,7 @@ func TestDefaultCompactionPlanner_Rewrite_WALOverlap(t *testing.T) {
 				}
 			},
 		},
+		Cache: c,
 	}
 
 	tsm, wal, err := cp.Plan()
@@ -1765,37 +1792,34 @@ func TestDefaultCompactionPlanner_Rewrite_WALOverlap(t *testing.T) {
 }
 
 func TestDefaultCompactionPlanner_Rewrite_Deletes(t *testing.T) {
+	c := tsm1.NewCache(0)
+
 	cp := &tsm1.DefaultPlanner{
 		WAL: &fakeWAL{
 			ClosedSegmentsFn: func() ([]tsm1.SegmentStat, error) {
 				return []tsm1.SegmentStat{
-					tsm1.SegmentStat{Path: "00001.tsm1"},
-					tsm1.SegmentStat{Path: "00002.tsm1"},
-					tsm1.SegmentStat{Path: "00003.tsm1"},
-					tsm1.SegmentStat{Path: "00004.tsm1"},
-					tsm1.SegmentStat{Path: "00005.tsm1"},
+					tsm1.SegmentStat{Path: "00001.wal"},
+					tsm1.SegmentStat{Path: "00002.wal"},
+					tsm1.SegmentStat{Path: "00003.wal"},
+					tsm1.SegmentStat{Path: "00004.wal"},
+					tsm1.SegmentStat{Path: "00005.wal"},
 				}, nil
 			},
 		},
 		FileStore: &fakeFileStore{
 			PathsFn: func() []tsm1.FileStat {
 				return []tsm1.FileStat{
-					tsm1.FileStat{Path: "000001.tsm1"},
-					tsm1.FileStat{Path: "000002.tsm1"},
-					tsm1.FileStat{Path: "000003.tsm1"},
-					tsm1.FileStat{Path: "000004.tsm1"},
-					tsm1.FileStat{Path: "000005.tsm1"},
-					tsm1.FileStat{Path: "000006.tsm1"},
 					tsm1.FileStat{
 						Path:         "000007.tsm1",
 						HasTombstone: true,
 					},
 					tsm1.FileStat{
-						Size: 51 * 1024 * 1024,
+						Size: 251 * 1024 * 1024,
 					},
 				}
 			},
 		},
+		Cache: c,
 	}
 
 	tsm, wal, err := cp.Plan()

--- a/tsdb/engine/tsm1/compact_test.go
+++ b/tsdb/engine/tsm1/compact_test.go
@@ -1053,7 +1053,8 @@ func TestCompactor_SingleWALSegment(t *testing.T) {
 	}
 
 	compactor := &tsm1.Compactor{
-		Dir: dir,
+		Dir:       dir,
+		FileStore: &fakeFileStore{},
 	}
 
 	files, err := compactor.Compact(nil, []string{f.Name()})
@@ -1167,7 +1168,8 @@ func TestCompactor_MultipleWALSegment(t *testing.T) {
 	}
 
 	compactor := &tsm1.Compactor{
-		Dir: dir,
+		Dir:       dir,
+		FileStore: &fakeFileStore{},
 	}
 
 	files, err := compactor.Compact(nil, []string{f1.Name(), f2.Name()})
@@ -1850,4 +1852,8 @@ type fakeFileStore struct {
 
 func (w *fakeFileStore) Stats() []tsm1.FileStat {
 	return w.PathsFn()
+}
+
+func (w *fakeFileStore) NextID() int {
+	return 1
 }

--- a/tsdb/engine/tsm1/data_file.go
+++ b/tsdb/engine/tsm1/data_file.go
@@ -869,12 +869,27 @@ func (t *TSMReader) TimeRange() (time.Time, time.Time) {
 	return min, max
 }
 
+// KeyRange returns the min and max key across all keys in the file.
+func (t *TSMReader) KeyRange() (string, string) {
+	min, max := "", ""
+	if t.index.KeyCount() > 0 {
+		min = t.index.Key(0)
+		max = t.index.Key(t.index.KeyCount() - 1)
+	}
+	return min, max
+}
+
 func (t *TSMReader) Entries(key string) []*IndexEntry {
 	return t.index.Entries(key)
 }
 
 func (t *TSMReader) IndexSize() int {
 	return t.index.Size()
+}
+
+func (t *TSMReader) Size() int {
+	// FIXME: Implement this
+	return 0
 }
 
 // fileAccessor is file IO based block accessor.  It provides access to blocks

--- a/tsdb/engine/tsm1/data_file_test.go
+++ b/tsdb/engine/tsm1/data_file_test.go
@@ -416,7 +416,7 @@ func TestIndirectIndex_Entries_NonExistent(t *testing.T) {
 		t.Fatalf("unexpected error unmarshaling index: %v", err)
 	}
 
-	// mem has not been added to the index so we should get now entries back
+	// mem has not been added to the index so we should get no entries back
 	// for both
 	exp := index.Entries("mem")
 	entries := indirect.Entries("mem")

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -65,6 +65,7 @@ func NewDevEngine(path string, walPath string, opt tsdb.EngineOptions) tsdb.Engi
 		CompactionPlan: &DefaultPlanner{
 			WAL:       w,
 			FileStore: fs,
+			Cache:     cache,
 		},
 		RotateFileSize:    DefaultRotateFileSize,
 		MaxFileSize:       MaxDataFileSize,

--- a/tsdb/engine/tsm1/file_store_test.go
+++ b/tsdb/engine/tsm1/file_store_test.go
@@ -279,5 +279,5 @@ func fatal(t *testing.T, msg string, err error) {
 }
 
 func tsmFileName(id int) string {
-	return fmt.Sprintf("%07d.tsm1", id)
+	return fmt.Sprintf("%07d.tsm1dev", id)
 }

--- a/tsdb/engine/tsm1/mmap_unix.go
+++ b/tsdb/engine/tsm1/mmap_unix.go
@@ -1,0 +1,35 @@
+// +build !windows,!plan9,!solaris
+
+package tsm1
+
+import (
+	"os"
+	"syscall"
+	"unsafe"
+)
+
+func mmap(f *os.File, offset int64, length int) ([]byte, error) {
+	mmap, err := syscall.Mmap(int(f.Fd()), 0, length, syscall.PROT_READ, syscall.MAP_SHARED)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := madvise(mmap, syscall.MADV_RANDOM); err != nil {
+		return nil, err
+	}
+
+	return mmap, nil
+}
+
+func munmap(b []byte) (err error) {
+	return syscall.Munmap(b)
+}
+
+// From: github.com/boltdb/bolt/bolt_unix.go
+func madvise(b []byte, advice int) (err error) {
+	_, _, e1 := syscall.Syscall(syscall.SYS_MADVISE, uintptr(unsafe.Pointer(&b[0])), uintptr(len(b)), uintptr(advice))
+	if e1 != 0 {
+		err = e1
+	}
+	return
+}

--- a/tsdb/engine/tsm1/mmap_windows.go
+++ b/tsdb/engine/tsm1/mmap_windows.go
@@ -1,0 +1,14 @@
+package tsm1
+
+import (
+	"fmt"
+	"os"
+)
+
+func mmap(f *os.File, offset int64, length int) ([]byte, error) {
+	return nil, fmt.Errorf("mmap file not supported windows")
+}
+
+func munmap(b []byte) (err error) {
+	return nil, fmt.Errorf("munmap file not supported on windows")
+}

--- a/tsdb/engine/tsm1/wal_test.go
+++ b/tsdb/engine/tsm1/wal_test.go
@@ -365,7 +365,7 @@ func TestWAL_ClosedSegments_Stats(t *testing.T) {
 		t.Fatalf("close segment length mismatch: got %v, exp %v", got, exp)
 	}
 
-	if err := w.WritePoints(map[string][]tsm1.Value{
+	if _, err := w.WritePoints(map[string][]tsm1.Value{
 		"cpu,host=A#!~#value": []tsm1.Value{
 			tsm1.NewValue(time.Unix(1, 0), 1.1),
 		},
@@ -376,7 +376,7 @@ func TestWAL_ClosedSegments_Stats(t *testing.T) {
 		t.Fatalf("error writing points: %v", err)
 	}
 
-	if err := w.WritePoints(map[string][]tsm1.Value{
+	if _, err := w.WritePoints(map[string][]tsm1.Value{
 		"mem,host=A#!~#value": []tsm1.Value{
 			tsm1.NewValue(time.Unix(2, 0), 1.1),
 		},

--- a/tsdb/engine/tsm1/wal_test.go
+++ b/tsdb/engine/tsm1/wal_test.go
@@ -347,6 +347,80 @@ func TestWAL_Delete(t *testing.T) {
 	}
 }
 
+func TestWAL_ClosedSegments_Stats(t *testing.T) {
+	dir := MustTempDir()
+	defer os.RemoveAll(dir)
+
+	w := tsm1.NewWAL(dir)
+	if err := w.Open(); err != nil {
+		t.Fatalf("error opening WAL: %v", err)
+	}
+
+	files, err := w.ClosedSegments()
+	if err != nil {
+		t.Fatalf("error getting closed segments: %v", err)
+	}
+
+	if got, exp := len(files), 0; got != exp {
+		t.Fatalf("close segment length mismatch: got %v, exp %v", got, exp)
+	}
+
+	if err := w.WritePoints(map[string][]tsm1.Value{
+		"cpu,host=A#!~#value": []tsm1.Value{
+			tsm1.NewValue(time.Unix(1, 0), 1.1),
+		},
+		"mem,host=A#!~#value": []tsm1.Value{
+			tsm1.NewValue(time.Unix(0, 0), 1.1),
+		},
+	}); err != nil {
+		t.Fatalf("error writing points: %v", err)
+	}
+
+	if err := w.WritePoints(map[string][]tsm1.Value{
+		"mem,host=A#!~#value": []tsm1.Value{
+			tsm1.NewValue(time.Unix(2, 0), 1.1),
+		},
+	}); err != nil {
+		t.Fatalf("error writing points: %v", err)
+	}
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("error closing wal: %v", err)
+	}
+
+	// Re-open the WAL
+	w = tsm1.NewWAL(dir)
+	defer w.Close()
+	if err := w.Open(); err != nil {
+		t.Fatalf("error opening WAL: %v", err)
+	}
+
+	files, err = w.ClosedSegments()
+	if err != nil {
+		t.Fatalf("error getting closed segments: %v", err)
+	}
+	if got, exp := len(files), 1; got != exp {
+		t.Fatalf("close segment length mismatch: got %v, exp %v", got, exp)
+	}
+
+	// First segment stats
+	if got, exp := files[0].MinKey, "cpu,host=A#!~#value"; got != exp {
+		t.Fatalf("min key mismatch: got %v, exp %v", got, exp)
+	}
+
+	if got, exp := files[0].MaxKey, "mem,host=A#!~#value"; got != exp {
+		t.Fatalf("max key mismatch: got %v, exp %v", got, exp)
+	}
+
+	if got, exp := files[0].MinTime, time.Unix(0, 0); got != exp {
+		t.Fatalf("min time mismatch: got %v, exp %v", got, exp)
+	}
+
+	if got, exp := files[0].MaxTime, time.Unix(2, 0); got != exp {
+		t.Fatalf("max time mismatch: got %v, exp %v", got, exp)
+	}
+}
+
 func BenchmarkWALSegmentWriter(b *testing.B) {
 	points := map[string][]tsm1.Value{}
 	for i := 0; i < 5000; i++ {


### PR DESCRIPTION
This changes the tsm1dev engine as follows:

* WAL segment compactions now work off of the cache instead of reading the segments off of disk - this is faster but the cache needs optimizations to reduce sorting/allocations.  Compactions still lag writes right now.
* Existing TSM files can now be re-compacted into one or more TSM files - Still analyzing the resulting files to understand this, but the compression ratios seem to be better than the existing tsm engine by ~25%.
* Basic MMAP TSM file reader - could not test this on other platforms, but hopefully still compiles.

There is problem with the current compaction process in that the files that are written are optimal from a final storage perspective, but problematic when writes into the past (or on the boundary) are still occurring.  For now, I've disabled rewriting TSM files until there are no more WAL segments to compact.  This will fixed in a later PR.