### PR TITLE
Add option to disable logging for meta service. useful for testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [#4889](https://github.com/influxdb/influxdb/pull/4889): Implement close notifier and timeout on executors
 - [#2676](https://github.com/influxdb/influxdb/issues/2676), [#4866](https://github.com/influxdb/influxdb/pull/4866): Add support for specifying default retention policy in database create. Thanks @pires!
 - [#4848](https://github.com/influxdb/influxdb/pull/4848): Added framework for cluster integration testing.
+- [#4872](https://github.com/influxdb/influxdb/pull/4872): Add option to disable logging for meta service.
 
 ### Bugfixes
 - [#4876](https://github.com/influxdb/influxdb/pull/4876): Complete lint for monitor and services packages. Thanks @e-dard!

--- a/cmd/influxd/run/server_helpers_test.go
+++ b/cmd/influxd/run/server_helpers_test.go
@@ -223,6 +223,10 @@ func NewConfig() *run.Config {
 	c.Meta.LeaderLeaseTimeout = toml.Duration(50 * time.Millisecond)
 	c.Meta.CommitTimeout = toml.Duration(5 * time.Millisecond)
 
+	if !testing.Verbose() {
+		c.Meta.LoggingEnabled = false
+	}
+
 	c.Data.Dir = MustTempFile()
 	c.Data.WALDir = MustTempFile()
 	c.Data.WALLoggingEnabled = false
@@ -417,7 +421,6 @@ func configureLogging(s *Server) {
 			SetLogger(*log.Logger)
 		}
 		nullLogger := log.New(ioutil.Discard, "", 0)
-		s.MetaStore.SetLogger(nullLogger)
 		s.TSDBStore.Logger = nullLogger
 		s.HintedHandoff.SetLogger(nullLogger)
 		s.Monitor.SetLogger(nullLogger)

--- a/meta/config.go
+++ b/meta/config.go
@@ -27,6 +27,9 @@ const (
 
 	// DefaultRaftPromotionEnabled is the default for auto promoting a node to a raft node when needed
 	DefaultRaftPromotionEnabled = true
+
+	// DefaultLoggingEnabled determines if log messages are printed for the meta service
+	DefaultLoggingEnabled = true
 )
 
 // Config represents the meta configuration.
@@ -42,6 +45,7 @@ type Config struct {
 	CommitTimeout        toml.Duration `toml:"commit-timeout"`
 	ClusterTracing       bool          `toml:"cluster-tracing"`
 	RaftPromotionEnabled bool          `toml:"raft-promotion-enabled"`
+	LoggingEnabled       bool          `toml:"logging-enabled"`
 }
 
 // NewConfig builds a new configuration with default values.
@@ -55,5 +59,6 @@ func NewConfig() *Config {
 		LeaderLeaseTimeout:   toml.Duration(DefaultLeaderLeaseTimeout),
 		CommitTimeout:        toml.Duration(DefaultCommitTimeout),
 		RaftPromotionEnabled: DefaultRaftPromotionEnabled,
+		LoggingEnabled:       DefaultLoggingEnabled,
 	}
 }

--- a/meta/config_test.go
+++ b/meta/config_test.go
@@ -18,6 +18,7 @@ heartbeat-timeout = "20s"
 leader-lease-timeout = "30h"
 commit-timeout = "40m"
 raft-promotion-enabled = false
+logging-enabled = false
 `, &c); err != nil {
 		t.Fatal(err)
 	}
@@ -35,5 +36,7 @@ raft-promotion-enabled = false
 		t.Fatalf("unexpected commit timeout: %v", c.CommitTimeout)
 	} else if c.RaftPromotionEnabled {
 		t.Fatalf("unexpected raft promotion enabled: %v", c.RaftPromotionEnabled)
+	} else if c.LoggingEnabled {
+		t.Fatalf("unexpected logging enabled: %v", c.LoggingEnabled)
 	}
 }

--- a/meta/store.go
+++ b/meta/store.go
@@ -160,7 +160,12 @@ func NewStore(c *Config) *Store {
 		hashPassword: func(password string) ([]byte, error) {
 			return bcrypt.GenerateFromPassword([]byte(password), BcryptCost)
 		},
-		Logger: log.New(os.Stderr, "[metastore] ", log.LstdFlags),
+	}
+
+	if c.LoggingEnabled {
+		s.Logger = log.New(os.Stderr, "[metastore] ", log.LstdFlags)
+	} else {
+		s.Logger = log.New(ioutil.Discard, "", 0)
 	}
 
 	s.raftState = &localRaft{store: s}
@@ -170,14 +175,6 @@ func NewStore(c *Config) *Store {
 		logger:         s.Logger,
 	}
 	return s
-}
-
-// SetLogger sets the internal logger to the logger passed in.
-func (s *Store) SetLogger(l *log.Logger) {
-	s.Logger = l
-	if s.rpc != nil {
-		s.rpc.logger = l
-	}
 }
 
 // Path returns the root path when open.


### PR DESCRIPTION
We can't use the standard `SetLogger` for the meta service as the logger is used in numerous go routines, so we get massive race detections in our test suite if we try to set it.  This is the easiest way to disable logging.  It will still be on by default, but now allows end users to explicitly turn it off if they want in the config.