### PR TITLE
Avoid repetitive index searches when iterating over cursors

### DIFF
--- a/tsdb/engine/tsm1/encoding.go
+++ b/tsdb/engine/tsm1/encoding.go
@@ -132,7 +132,7 @@ func DecodeBlock(block []byte, vals []Value) ([]Value, error) {
 		for i := range decoded {
 			vals[i] = decoded[i]
 		}
-		return vals, err
+		return vals[:len(decoded)], err
 	case BlockInt64:
 		decoded, err := DecodeInt64Block(block, nil)
 		if len(vals) < len(decoded) {
@@ -141,7 +141,7 @@ func DecodeBlock(block []byte, vals []Value) ([]Value, error) {
 		for i := range decoded {
 			vals[i] = decoded[i]
 		}
-		return vals, err
+		return vals[:len(decoded)], err
 
 	case BlockBool:
 		decoded, err := DecodeBoolBlock(block, nil)
@@ -151,7 +151,7 @@ func DecodeBlock(block []byte, vals []Value) ([]Value, error) {
 		for i := range decoded {
 			vals[i] = decoded[i]
 		}
-		return vals, err
+		return vals[:len(decoded)], err
 
 	case BlockString:
 		decoded, err := DecodeStringBlock(block, nil)
@@ -161,7 +161,7 @@ func DecodeBlock(block []byte, vals []Value) ([]Value, error) {
 		for i := range decoded {
 			vals[i] = decoded[i]
 		}
-		return vals, err
+		return vals[:len(decoded)], err
 
 	default:
 		panic(fmt.Sprintf("unknown block type: %d", blockType))

--- a/tsdb/engine/tsm1/engine_test.go
+++ b/tsdb/engine/tsm1/engine_test.go
@@ -92,10 +92,10 @@ func TestDevEngine_QueryTSM_Ascending(t *testing.T) {
 
 	// Start a query transactions and get a cursor.
 	ascCursor := devCursor{
-		tsm:       fs,
-		series:    "cpu,host=A",
-		fields:    []string{"value"},
-		ascending: true,
+		tsmKeyCursor: fs.KeyCursor("cpu,host=A#!~#value"),
+		series:       "cpu,host=A",
+		fields:       []string{"value"},
+		ascending:    true,
 	}
 
 	k, v := ascCursor.SeekTo(1)
@@ -193,10 +193,10 @@ func TestDevEngine_QueryTSM_Descending(t *testing.T) {
 
 	// Start a query transactions and get a cursor.
 	descCursor := devCursor{
-		tsm:       fs,
-		series:    "cpu,host=A",
-		fields:    []string{"value"},
-		ascending: false,
+		tsmKeyCursor: fs.KeyCursor("cpu,host=A#!~#value"),
+		series:       "cpu,host=A",
+		fields:       []string{"value"},
+		ascending:    false,
 	}
 
 	k, v := descCursor.SeekTo(4000000000)

--- a/tsdb/engine/tsm1/file_store.go
+++ b/tsdb/engine/tsm1/file_store.go
@@ -22,7 +22,7 @@ type TSMFile interface {
 	// Read returns all the values in the block identified by entry.
 	ReadAt(entry *IndexEntry, values []Value) ([]Value, error)
 
-	// Entries returns the index entrieds for all blocks for the given key.
+	// Entries returns the index entries for all blocks for the given key.
 	Entries(key string) []*IndexEntry
 
 	// Returns true if the TSMFile may contain a value with the specified


### PR DESCRIPTION
First pass at TSM cursor iteration ended up searching the file indexes
too frequently and hurt performance.  This changes that to search it once
and then have the cursor hold onto the block locations to seek
to.  Doubles the query performance from the first iteration, but still a lot
of room for improvement.