### PR TITLE
fix raw math query panic

### DIFF
--- a/influxql/ast.go
+++ b/influxql/ast.go
@@ -2365,14 +2365,14 @@ func (a Fields) AliasNames() []string {
 func (a Fields) Names() []string {
 	names := []string{}
 	for _, f := range a {
-		var name string
 		switch expr := f.Expr.(type) {
 		case *Call:
-			name = expr.Name
+			names = append(names, expr.Name)
 		case *VarRef:
-			name = expr.Val
+			names = append(names, expr.Val)
+		case *BinaryExpr:
+			names = append(names, walkNames(expr)...)
 		}
-		names = append(names, name)
 	}
 	return names
 }

--- a/influxql/result.go
+++ b/influxql/result.go
@@ -95,6 +95,9 @@ type Processor func(values []interface{}) interface{}
 
 func newEchoProcessor(index int) Processor {
 	return func(values []interface{}) interface{} {
+		if index > len(values)-1 {
+			return nil
+		}
 		return values[index]
 	}
 }

--- a/tsdb/query_executor_test.go
+++ b/tsdb/query_executor_test.go
@@ -48,6 +48,24 @@ func TestWritePointsAndExecuteQuery(t *testing.T) {
 		t.Fatalf("\nexp: %s\ngot: %s", exepected, got)
 	}
 
+	got = executeAndGetJSON("SELECT mean(value) + mean(value) as value FROM cpu", executor)
+	exepected = `[{"series":[{"name":"cpu","columns":["time","value"],"values":[["1970-01-01T00:00:00Z",2]]}]}]`
+	if exepected != got {
+		t.Fatalf("\nexp: %s\ngot: %s", exepected, got)
+	}
+
+	got = executeAndGetJSON("SELECT value + value FROM cpu", executor)
+	exepected = `[{"series":[{"name":"cpu","columns":["time",""],"values":[["1970-01-01T00:00:01.000000002Z",2],["1970-01-01T00:00:02.000000003Z",2]]}]}]`
+	if exepected != got {
+		t.Fatalf("\nexp: %s\ngot: %s", exepected, got)
+	}
+
+	got = executeAndGetJSON("SELECT value + value as sum FROM cpu", executor)
+	exepected = `[{"series":[{"name":"cpu","columns":["time","sum"],"values":[["1970-01-01T00:00:01.000000002Z",2],["1970-01-01T00:00:02.000000003Z",2]]}]}]`
+	if exepected != got {
+		t.Fatalf("\nexp: %s\ngot: %s", exepected, got)
+	}
+
 	got = executeAndGetJSON("SELECT * FROM cpu GROUP BY *", executor)
 	exepected = `[{"series":[{"name":"cpu","tags":{"host":"server"},"columns":["time","value"],"values":[["1970-01-01T00:00:01.000000002Z",1],["1970-01-01T00:00:02.000000003Z",1]]}]}]`
 	if exepected != got {

--- a/tsdb/raw.go
+++ b/tsdb/raw.go
@@ -483,9 +483,13 @@ func (r *limitedRowWriter) processValues(values []*MapperValue) *models.Row {
 	selectFields := make([]string, 0, len(selectNames))
 	aliasFields := make([]string, 0, len(selectNames))
 
-	for i, n := range selectNames {
+	for _, n := range selectNames {
 		if _, found := r.tags[n]; !found {
 			selectFields = append(selectFields, n)
+		}
+	}
+	for i, n := range aliasNames {
+		if _, found := r.tags[n]; !found {
 			aliasFields = append(aliasFields, aliasNames[i])
 		}
 	}


### PR DESCRIPTION
influxDB will panic when apply math query like:
`select value + value from cpu`
this pr fix this, in addition, this pr make `select value + value from cpu` return the correct value