### PR TITLE
Validate previous value in derivative calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Bugfixes
 - [#4984](https://github.com/influxdb/influxdb/pull/4984): Allow math on fields, fixes regression. Thanks @mengjinglei
+- [#4666](https://github.com/influxdb/influxdb/issues/4666): Fix panic in derivative with invalid values.
 - [#4858](https://github.com/influxdb/influxdb/pull/4858): Validate nested aggregations in queries. Thanks @viru
 - [#4921](https://github.com/influxdb/influxdb/pull/4921): Error responses should be JSON-formatted. Thanks @pires
 - [#4974](https://github.com/influxdb/influxdb/issues/4974) Fix Data Race in TSDB when setting measurement field name

--- a/tsdb/raw.go
+++ b/tsdb/raw.go
@@ -702,15 +702,23 @@ func ProcessAggregateDerivative(results [][]interface{}, isNonNegative bool, int
 
 		// Check the value's type to ensure it's an numeric, if not, return a nil result. We only check the first value
 		// because derivatives cannot be combined with other aggregates currently.
-		validType := false
+		curValidType := false
 		switch cur[1].(type) {
 		case int64:
-			validType = true
+			curValidType = true
 		case float64:
-			validType = true
+			curValidType = true
 		}
 
-		if !validType {
+		prevValidType := false
+		switch prev[1].(type) {
+		case int64:
+			prevValidType = true
+		case float64:
+			prevValidType = true
+		}
+
+		if !curValidType || !prevValidType {
 			derivatives = append(derivatives, []interface{}{
 				cur[0], nil,
 			})


### PR DESCRIPTION
Fixes #4666 

Somehow its possible that a single value in the list of values is invalid which causes a panic.
Added correct validation code and tests.

@jwilder Do you want to take a look at this?