### PR TITLE
Stub out DELETE in parser to return better error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Bugfixes
 - [#4984](https://github.com/influxdb/influxdb/pull/4984): Allow math on fields, fixes regression. Thanks @mengjinglei
 - [#4666](https://github.com/influxdb/influxdb/issues/4666): Fix panic in derivative with invalid values.
+- [#4404](https://github.com/influxdb/influxdb/issues/4404): Return better error for currently unsupported DELETE queries.
 - [#4858](https://github.com/influxdb/influxdb/pull/4858): Validate nested aggregations in queries. Thanks @viru
 - [#4921](https://github.com/influxdb/influxdb/pull/4921): Error responses should be JSON-formatted. Thanks @pires
 - [#4974](https://github.com/influxdb/influxdb/issues/4974) Fix Data Race in TSDB when setting measurement field name

--- a/influxql/ast_test.go
+++ b/influxql/ast_test.go
@@ -627,9 +627,11 @@ func TestParseString(t *testing.T) {
 		{
 			stmt: `DROP CONTINUOUS QUERY "my query" ON "my database"`,
 		},
-		{
-			stmt: `DELETE FROM "my db"."my rp"."my measurement"`,
-		},
+		// See issues https://github.com/influxdb/influxdb/issues/1647
+		// and https://github.com/influxdb/influxdb/issues/4404
+		//{
+		//	stmt: `DELETE FROM "my db"."my rp"."my measurement"`,
+		//},
 		{
 			stmt: `DROP SUBSCRIPTION "ugly \"subscription\" name" ON "\"my\" db"."\"my\" rp"`,
 		},

--- a/influxql/parser.go
+++ b/influxql/parser.go
@@ -948,26 +948,30 @@ func (p *Parser) parseTarget(tr targetRequirement) (*Target, error) {
 // parseDeleteStatement parses a delete string and returns a DeleteStatement.
 // This function assumes the DELETE token has already been consumed.
 func (p *Parser) parseDeleteStatement() (*DeleteStatement, error) {
-	stmt := &DeleteStatement{}
+	// TODO remove and do not skip test once we wire up DELETE FROM.
+	// See issues https://github.com/influxdb/influxdb/issues/1647
+	// and https://github.com/influxdb/influxdb/issues/4404
+	return nil, errors.New("DELETE FROM is currently not supported. Use DROP SERIES or DROP MEASUREMENT instead")
+	//stmt := &DeleteStatement{}
 
-	// Parse source
-	if tok, pos, lit := p.scanIgnoreWhitespace(); tok != FROM {
-		return nil, newParseError(tokstr(tok, lit), []string{"FROM"}, pos)
-	}
-	source, err := p.parseSource()
-	if err != nil {
-		return nil, err
-	}
-	stmt.Source = source
+	//// Parse source
+	//if tok, pos, lit := p.scanIgnoreWhitespace(); tok != FROM {
+	//	return nil, newParseError(tokstr(tok, lit), []string{"FROM"}, pos)
+	//}
+	//source, err := p.parseSource()
+	//if err != nil {
+	//	return nil, err
+	//}
+	//stmt.Source = source
 
-	// Parse condition: "WHERE EXPR".
-	condition, err := p.parseCondition()
-	if err != nil {
-		return nil, err
-	}
-	stmt.Condition = condition
+	//// Parse condition: "WHERE EXPR".
+	//condition, err := p.parseCondition()
+	//if err != nil {
+	//	return nil, err
+	//}
+	//stmt.Condition = condition
 
-	return stmt, nil
+	//return stmt, nil
 }
 
 // parseShowSeriesStatement parses a string and returns a ShowSeriesStatement.

--- a/influxql/parser_test.go
+++ b/influxql/parser_test.go
@@ -644,18 +644,20 @@ func TestParser_ParseStatement(t *testing.T) {
 			},
 		},
 
+		// See issues https://github.com/influxdb/influxdb/issues/1647
+		// and https://github.com/influxdb/influxdb/issues/4404
 		// DELETE statement
-		{
-			s: `DELETE FROM myseries WHERE host = 'hosta.influxdb.org'`,
-			stmt: &influxql.DeleteStatement{
-				Source: &influxql.Measurement{Name: "myseries"},
-				Condition: &influxql.BinaryExpr{
-					Op:  influxql.EQ,
-					LHS: &influxql.VarRef{Val: "host"},
-					RHS: &influxql.StringLiteral{Val: "hosta.influxdb.org"},
-				},
-			},
-		},
+		//{
+		//	s: `DELETE FROM myseries WHERE host = 'hosta.influxdb.org'`,
+		//	stmt: &influxql.DeleteStatement{
+		//		Source: &influxql.Measurement{Name: "myseries"},
+		//		Condition: &influxql.BinaryExpr{
+		//			Op:  influxql.EQ,
+		//			LHS: &influxql.VarRef{Val: "host"},
+		//			RHS: &influxql.StringLiteral{Val: "hosta.influxdb.org"},
+		//		},
+		//	},
+		//},
 
 		// SHOW SERVERS
 		{
@@ -1679,9 +1681,14 @@ func TestParser_ParseStatement(t *testing.T) {
 		{s: `SELECT value > 2 FROM cpu`, err: `invalid operator > in SELECT clause at line 1, char 8; operator is intended for WHERE clause`},
 		{s: `SELECT value = 2 FROM cpu`, err: `invalid operator = in SELECT clause at line 1, char 8; operator is intended for WHERE clause`},
 		{s: `SELECT s =~ /foo/ FROM cpu`, err: `invalid operator =~ in SELECT clause at line 1, char 8; operator is intended for WHERE clause`},
-		{s: `DELETE`, err: `found EOF, expected FROM at line 1, char 8`},
-		{s: `DELETE FROM`, err: `found EOF, expected identifier at line 1, char 13`},
-		{s: `DELETE FROM myseries WHERE`, err: `found EOF, expected identifier, string, number, bool at line 1, char 28`},
+		// See issues https://github.com/influxdb/influxdb/issues/1647
+		// and https://github.com/influxdb/influxdb/issues/4404
+		//{s: `DELETE`, err: `found EOF, expected FROM at line 1, char 8`},
+		//{s: `DELETE FROM`, err: `found EOF, expected identifier at line 1, char 13`},
+		//{s: `DELETE FROM myseries WHERE`, err: `found EOF, expected identifier, string, number, bool at line 1, char 28`},
+		{s: `DELETE`, err: `DELETE FROM is currently not supported. Use DROP SERIES or DROP MEASUREMENT instead`},
+		{s: `DELETE FROM`, err: `DELETE FROM is currently not supported. Use DROP SERIES or DROP MEASUREMENT instead`},
+		{s: `DELETE FROM myseries WHERE`, err: `DELETE FROM is currently not supported. Use DROP SERIES or DROP MEASUREMENT instead`},
 		{s: `DROP MEASUREMENT`, err: `found EOF, expected identifier at line 1, char 18`},
 		{s: `DROP SERIES`, err: `found EOF, expected FROM, WHERE at line 1, char 13`},
 		{s: `DROP SERIES FROM`, err: `found EOF, expected identifier at line 1, char 18`},


### PR DESCRIPTION
Fixes #4404

Stub out DELETE FROM queries in parser so that a 400 - Bad Request is returned to client with help error message about using DROP queries. 