### PR TITLE
Switch Circle testing of tsm1 to tsm2

### DIFF
--- a/circle-test.sh
+++ b/circle-test.sh
@@ -75,7 +75,7 @@ case $CIRCLE_NODE_INDEX in
         rc=${PIPESTATUS[0]}
         ;;
     1)
-        INFLUXDB_DATA_ENGINE="tsm1" go test $PARALLELISM $TIMEOUT -v ./... 2>&1 | tee $CIRCLE_ARTIFACTS/test_logs.txt
+        INFLUXDB_DATA_ENGINE="tsm1dev" go test $PARALLELISM $TIMEOUT -v ./... 2>&1 | tee $CIRCLE_ARTIFACTS/test_logs.txt
         rc=${PIPESTATUS[0]}
         ;;
     2)


### PR DESCRIPTION
During tsm1 development, Circle ran the entire test-suite against tsm1. This was necessary since tsm1 was not the default.

With the advent of tsm2, this testing should be switched to tsm2. The entire test suite must pass with tsm2 before it is ready for wider release.