### PR TITLE
Handle tsm2 WAL corruption

### DIFF
--- a/tsdb/engine/tsm1/cache.go
+++ b/tsdb/engine/tsm1/cache.go
@@ -2,6 +2,8 @@ package tsm1
 
 import (
 	"fmt"
+	"log"
+	"os"
 	"sort"
 	"sync"
 )
@@ -298,4 +300,75 @@ func (c *Cache) write(key string, values []Value) {
 		c.store[key] = e
 	}
 	e.add(values)
+}
+
+// CacheLoader processes a set of WAL segment files, and loads a cache with the data
+// contained within those files.  Processing of the supplied files take place in the
+// order they exist in the files slice.
+type CacheLoader struct {
+	files []string
+
+	Logger *log.Logger
+}
+
+// NewCacheLoader returns a new instance of a CacheLoader.
+func NewCacheLoader(files []string) *CacheLoader {
+	return &CacheLoader{
+		files:  files,
+		Logger: log.New(os.Stderr, "[cacheloader] ", log.LstdFlags),
+	}
+}
+
+// Load returns a cache loaded with the data contained within the segment files.
+// If, during reading of a segment file, corruption is encountered, that segment
+// file is truncated up to and including the last valid byte, and processing
+// continues with the next segment file.
+func (cl *CacheLoader) Load(cache *Cache) error {
+	for _, fn := range cl.files {
+		if err := func() error {
+			f, err := os.OpenFile(fn, os.O_CREATE|os.O_RDWR, 0666)
+			if err != nil {
+				return err
+			}
+
+			// Log some information about the segments.
+			stat, err := os.Stat(f.Name())
+			if err != nil {
+				return err
+			}
+			cl.Logger.Printf("reading file %s, size %d", f.Name(), stat.Size())
+
+			r := NewWALSegmentReader(f)
+			defer r.Close()
+
+			for r.Next() {
+				entry, err := r.Read()
+				if err != nil {
+					n := r.Count()
+					cl.Logger.Printf("file %s corrupt at position %d, truncating", f.Name(), n)
+					if err := f.Truncate(n); err != nil {
+						return err
+					}
+					break
+				}
+
+				switch t := entry.(type) {
+				case *WriteWALEntry:
+					if err := cache.WriteMulti(t.Values); err != nil {
+						return err
+					}
+				case *DeleteWALEntry:
+					// FIXME: Implement this
+					// if err := e.Cache.Delete(t.Keys); err != nil {
+					// 	return err
+					// }
+				}
+			}
+
+			return nil
+		}(); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -24,7 +24,9 @@ var _ tsdb.Engine = &DevEngine{}
 
 // Engine represents a storage engine with compressed blocks.
 type DevEngine struct {
-	mu sync.RWMutex
+	mu   sync.RWMutex
+	done chan struct{}
+	wg   sync.WaitGroup
 
 	path   string
 	logger *log.Logger
@@ -93,6 +95,8 @@ func (e *DevEngine) Format() tsdb.EngineFormat {
 
 // Open opens and initializes the engine.
 func (e *DevEngine) Open() error {
+	e.done = make(chan struct{})
+
 	if err := os.MkdirAll(e.path, 0777); err != nil {
 		return err
 	}
@@ -113,6 +117,7 @@ func (e *DevEngine) Open() error {
 		return err
 	}
 
+	e.wg.Add(2)
 	go e.compactCache()
 	go e.compactTSM()
 
@@ -121,12 +126,15 @@ func (e *DevEngine) Open() error {
 
 // Close closes the engine.
 func (e *DevEngine) Close() error {
+	// Shutdown goroutines and wait.
+	close(e.done)
+	e.wg.Wait()
+
+	// Lock now and close everything else down.
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
-	e.WAL.Close()
-
-	return nil
+	return e.WAL.Close()
 }
 
 // SetLogOutput is a no-op.
@@ -330,11 +338,18 @@ func (e *DevEngine) writeSnapshotAndCommit(closedFiles []string, snapshot *Cache
 }
 
 func (e *DevEngine) compactCache() {
+	defer e.wg.Done()
 	for {
-		if e.Cache.Size() > e.CacheFlushMemorySizeThreshold {
-			err := e.WriteSnapshot()
-			if err != nil {
-				e.logger.Printf("error writing snapshot: %v", err)
+		select {
+		case <-e.done:
+			return
+
+		default:
+			if e.Cache.Size() > e.CacheFlushMemorySizeThreshold {
+				err := e.WriteSnapshot()
+				if err != nil {
+					e.logger.Printf("error writing snapshot: %v", err)
+				}
 			}
 		}
 		time.Sleep(time.Second)
@@ -342,40 +357,44 @@ func (e *DevEngine) compactCache() {
 }
 
 func (e *DevEngine) compactTSM() {
+	defer e.wg.Done()
 	for {
-		tsmFiles := e.CompactionPlan.Plan()
+		select {
+		case <-e.done:
+			return
 
-		if len(tsmFiles) == 0 {
-			time.Sleep(time.Second)
-			continue
+		default:
+			tsmFiles := e.CompactionPlan.Plan()
+
+			if len(tsmFiles) == 0 {
+				time.Sleep(time.Second)
+				continue
+			}
+
+			start := time.Now()
+			e.logger.Printf("compacting %d TSM files", len(tsmFiles))
+
+			files, err := e.Compactor.Compact(tsmFiles)
+			if err != nil {
+				e.logger.Printf("error compacting TSM files: %v", err)
+				time.Sleep(time.Second)
+				continue
+			}
+
+			if err := e.FileStore.Replace(tsmFiles, files); err != nil {
+				e.logger.Printf("error replacing new TSM files: %v", err)
+				time.Sleep(time.Second)
+				continue
+			}
+
+			e.logger.Printf("compacted %d tsm into %d files in %s",
+				len(tsmFiles), len(files), time.Since(start))
 		}
-
-		start := time.Now()
-		e.logger.Printf("compacting %d TSM files", len(tsmFiles))
-
-		files, err := e.Compactor.Compact(tsmFiles)
-		if err != nil {
-			e.logger.Printf("error compacting TSM files: %v", err)
-			time.Sleep(time.Second)
-			continue
-		}
-
-		if err := e.FileStore.Replace(tsmFiles, files); err != nil {
-			e.logger.Printf("error replacing new TSM files: %v", err)
-			time.Sleep(time.Second)
-			continue
-		}
-
-		e.logger.Printf("compacted %d tsm into %d files in %s",
-			len(tsmFiles), len(files), time.Since(start))
 	}
 }
 
 // reloadCache reads the WAL segment files and loads them into the cache.
 func (e *DevEngine) reloadCache() error {
-	e.Cache.Lock()
-	defer e.Cache.Unlock()
-
 	files, err := segmentFileNames(e.WAL.Path())
 	if err != nil {
 		return err

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -371,45 +371,21 @@ func (e *DevEngine) compactTSM() {
 	}
 }
 
-// reloadCache reads the WAL segment files and loads them into the cache. It also stores
-// the measurements, series and fields defined in the WAL so that it can be used in the
-// LoadMetadataFromIndex function.
+// reloadCache reads the WAL segment files and loads them into the cache.
 func (e *DevEngine) reloadCache() error {
+	e.Cache.Lock()
+	defer e.Cache.Unlock()
+
 	files, err := segmentFileNames(e.WAL.Path())
 	if err != nil {
 		return err
 	}
 
-	for _, fn := range files {
-		f, err := os.Open(fn)
-		if err != nil {
-			return err
-		}
-
-		r := NewWALSegmentReader(f)
-		defer r.Close()
-
-		// Iterate over each reader in order.  Later readers will overwrite earlier ones if values
-		// overlap.
-		for r.Next() {
-			entry, err := r.Read()
-			if err != nil {
-				return err
-			}
-
-			switch t := entry.(type) {
-			case *WriteWALEntry:
-				if err := e.Cache.WriteMulti(t.Values); err != nil {
-					return err
-				}
-			case *DeleteWALEntry:
-				// FIXME: Implement this
-				// if err := e.Cache.Delete(t.Keys); err != nil {
-				// 	return err
-				// }
-			}
-		}
+	loader := NewCacheLoader(files)
+	if err := loader.Load(e.Cache); err != nil {
+		return err
 	}
+
 	return nil
 }
 

--- a/tsdb/engine/tsm1/wal.go
+++ b/tsdb/engine/tsm1/wal.go
@@ -638,11 +638,6 @@ func (r *WALSegmentReader) Next() bool {
 	}
 
 	_, err = io.ReadFull(r.r, b[:length])
-	if err == io.EOF || err == io.ErrUnexpectedEOF {
-		r.err = err
-		return true
-	}
-
 	if err != nil {
 		r.err = err
 		return true


### PR DESCRIPTION
With the change, when WAL segments are being read for the purposes of loading the cache, if corruption is detected during reading, the WAL segment is truncated such that the file contains everything up to and including the last valid byte.

The key change was the addition of a new method to the `WALSegmentReader`. That type can now be interrogated for how many bytes it has read successfully. This allows client code to truncate the underlying file as needed, if and when `WALSegmentReader` returns an error.

A new type has also been introduced -- the `CacheLoader`. This takes a slice of WAL segment file names, and a pre-existing cache. It reads the segments and loads the data into the given cache, truncating corrupted segments as required. The engine then uses this new type.

Finally, because I was hitting races in existing code, I added proper shutdown of the engine's goroutines. Goroutines were being left up-and-running when the engine was opened-closed-opened back-to-back during testing.