### PR TITLE
Fix raftState close panic

### DIFF
--- a/meta/state.go
+++ b/meta/state.go
@@ -203,7 +203,9 @@ func (r *localRaft) logLeaderChanges() {
 }
 
 func (r *localRaft) close() error {
-	close(r.closing)
+	if r.closing != nil {
+		close(r.closing)
+	}
 	r.wg.Wait()
 
 	if r.transport != nil {


### PR DESCRIPTION
if meta data directory is not writable，it will panic (I print the error to debug)：

```
2015/12/07 20:15:19 InfluxDB starting, version 0.9, branch unknown, commit unknown, built unknown
2015/12/07 20:15:19 Go version go1.5.1, GOMAXPROCS set to 4
2015/12/07 20:15:20 Using configuration at: /tmp/influxdb.conf
[metastore] 2015/12/07 20:15:20 Using data dir: /root/test
open meta store: mkdir all: mkdir /root: permission denied
[registration] 2015/12/07 20:15:20 registration service terminating
[retention] 2015/12/07 20:15:20 retention policy enforcement terminating
[monitor] 2015/12/07 20:15:20 shutting down monitor system
[handoff] 2015/12/07 20:15:20 shutting down hh service
[subscriber] 2015/12/07 20:15:20 closed service
panic: close of nil channel

goroutine 1 [running]:
github.com/influxdb/influxdb/meta.(*localRaft).close(0xc82014dd60, 0x0, 0x0)
        /Users/Sosara/golang/src/github.com/influxdb/influxdb/meta/state.go:206 +0x35

...

```

and I followed the code:

```

		// Create the root directory if it doesn't already exist.
		if err := s.createRootDir(); err != nil {
			return fmt.Errorf("mkdir all: %s", err)
		}

		// Open the raft store.
		if err := s.openRaft(); err != nil {
			return fmt.Errorf("raft: %s", err)
		}

```

The raftState is not opened yet, so if you want to close the state, check the `r.closing` first.


After fix:

```
2015/12/07 20:19:07 InfluxDB starting, version 0.9, branch unknown, commit unknown, built unknown
2015/12/07 20:19:07 Go version go1.5.1, GOMAXPROCS set to 4
2015/12/07 20:19:08 Using configuration at: /tmp/influxdb.conf
[metastore] 2015/12/07 20:19:08 Using data dir: /root/test
[registration] 2015/12/07 20:19:08 registration service terminating
[retention] 2015/12/07 20:19:08 retention policy enforcement terminating
[monitor] 2015/12/07 20:19:08 shutting down monitor system
[handoff] 2015/12/07 20:19:08 shutting down hh service
[subscriber] 2015/12/07 20:19:08 closed service
run: open server: open meta store: mkdir all: mkdir /root: permission denied

```

no panic
