### PR TITLE
Handle error when point doesnt have a shard group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [#5016](https://github.com/influxdb/influxdb/pull/5016): Don't panic if Meta data directory not writable. Thanks @oiooj
 - [#5059](https://github.com/influxdb/influxdb/pull/5059): Fix unmarshal of database error by client code. Thanks @farshidtz
 - [#4940](https://github.com/influxdb/influxdb/pull/4940): Fix distributed aggregate query query error. Thanks @li-ang
+- [#4622](https://github.com/influxdb/influxdb/issues/4622): Fix panic when passing too large of timestamps to OpenTSDB input.
 
 ## v0.9.6 [2015-12-09]
 

--- a/models/points_test.go
+++ b/models/points_test.go
@@ -43,6 +43,24 @@ func BenchmarkParsePointNoTags(b *testing.B) {
 	}
 }
 
+func BenchmarkParsePointWithPrecisionN(b *testing.B) {
+	line := `cpu value=1i 1000000000`
+	defaultTime := time.Now().UTC()
+	for i := 0; i < b.N; i++ {
+		models.ParsePointsWithPrecision([]byte(line), defaultTime, "n")
+		b.SetBytes(int64(len(line)))
+	}
+}
+
+func BenchmarkParsePointWithPrecisionU(b *testing.B) {
+	line := `cpu value=1i 1000000000`
+	defaultTime := time.Now().UTC()
+	for i := 0; i < b.N; i++ {
+		models.ParsePointsWithPrecision([]byte(line), defaultTime, "u")
+		b.SetBytes(int64(len(line)))
+	}
+}
+
 func BenchmarkParsePointsTagsSorted2(b *testing.B) {
 	line := `cpu,host=serverA,region=us-west value=1i 1000000000`
 	for i := 0; i < b.N; i++ {

--- a/models/time.go
+++ b/models/time.go
@@ -1,0 +1,52 @@
+package models
+
+// Helper time methods since parsing time can easily overflow and we only support a
+// specific time range.
+
+import (
+	"fmt"
+	"math"
+	"time"
+)
+
+var (
+	// Maximum time that can be represented via int64 nanoseconds since the epoch.
+	MaxNanoTime = time.Unix(0, math.MaxInt64).UTC()
+	// Minumum time that can be represented via int64 nanoseconds since the epoch.
+	MinNanoTime = time.Unix(0, math.MinInt64).UTC()
+
+	// The time is out of the representable range using int64 nanoseconds since the epoch.
+	ErrTimeOutOfRange = fmt.Errorf("time outside range %s - %s", MinNanoTime, MaxNanoTime)
+)
+
+// Safely calculate the time given. Will return error if the time is outside the
+// supported range.
+func SafeCalcTime(timestamp int64, precision string) (time.Time, error) {
+	mult := GetPrecisionMultiplier(precision)
+	if t, ok := safeSignedMult(timestamp, mult); ok {
+		return time.Unix(0, t).UTC(), nil
+	} else {
+		return time.Time{}, ErrTimeOutOfRange
+	}
+
+}
+
+// Check that a time is within the safe range.
+func CheckTime(t time.Time) error {
+	if t.Before(MinNanoTime) || t.After(MaxNanoTime) {
+		return ErrTimeOutOfRange
+	}
+	return nil
+}
+
+// Perform the multiplication and check to make sure it didn't overflow.
+func safeSignedMult(a, b int64) (int64, bool) {
+	if a == 0 || b == 0 || a == 1 || b == 1 {
+		return a * b, true
+	}
+	if a == math.MinInt64 || b == math.MaxInt64 {
+		return 0, false
+	}
+	c := a * b
+	return c, c/b == a
+}

--- a/services/collectd/service.go
+++ b/services/collectd/service.go
@@ -22,13 +22,14 @@ const leaderWaitTimeout = 30 * time.Second
 
 // statistics gathered by the collectd service.
 const (
-	statPointsReceived      = "pointsRx"
-	statBytesReceived       = "bytesRx"
-	statPointsParseFail     = "pointsParseFail"
-	statReadFail            = "readFail"
-	statBatchesTrasmitted   = "batchesTx"
-	statPointsTransmitted   = "pointsTx"
-	statBatchesTransmitFail = "batchesTxFail"
+	statPointsReceived       = "pointsRx"
+	statBytesReceived        = "bytesRx"
+	statPointsParseFail      = "pointsParseFail"
+	statReadFail             = "readFail"
+	statBatchesTrasmitted    = "batchesTx"
+	statPointsTransmitted    = "pointsTx"
+	statBatchesTransmitFail  = "batchesTxFail"
+	statDroppedPointsInvalid = "droppedPointsInvalid"
 )
 
 // pointsWriter is an internal interface to make testing easier.
@@ -233,7 +234,7 @@ func (s *Service) handleMessage(buffer []byte) {
 		return
 	}
 	for _, packet := range *packets {
-		points := Unmarshal(&packet)
+		points := s.UnmarshalCollectd(&packet)
 		for _, p := range points {
 			s.batcher.In() <- p
 		}
@@ -266,7 +267,7 @@ func (s *Service) writePoints() {
 }
 
 // Unmarshal translates a collectd packet into InfluxDB data points.
-func Unmarshal(packet *gollectd.Packet) []models.Point {
+func (s *Service) UnmarshalCollectd(packet *gollectd.Packet) []models.Point {
 	// Prefer high resolution timestamp.
 	var timestamp time.Time
 	if packet.TimeHR > 0 {
@@ -302,8 +303,10 @@ func Unmarshal(packet *gollectd.Packet) []models.Point {
 			tags["type_instance"] = packet.TypeInstance
 		}
 		p, err := models.NewPoint(name, tags, fields, timestamp)
-		// Drop points values of NaN since they are not supported
+		// Drop invalid points
 		if err != nil {
+			s.Logger.Printf("Dropping point %v: %v", p.Name, err)
+			s.statMap.Add(statDroppedPointsInvalid, 1)
 			continue
 		}
 

--- a/services/opentsdb/handler.go
+++ b/services/opentsdb/handler.go
@@ -5,6 +5,7 @@ import (
 	"compress/gzip"
 	"encoding/json"
 	"errors"
+	"expvar"
 	"io"
 	"log"
 	"net"
@@ -27,6 +28,8 @@ type Handler struct {
 	}
 
 	Logger *log.Logger
+
+	statMap *expvar.Map
 }
 
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -113,6 +116,7 @@ func (h *Handler) servePut(w http.ResponseWriter, r *http.Request) {
 		pt, err := models.NewPoint(p.Metric, p.Tags, map[string]interface{}{"value": p.Value}, ts)
 		if err != nil {
 			h.Logger.Printf("Dropping point %v: %v", p.Metric, err)
+			h.statMap.Add(statDroppedPointsInvalid, 1)
 			continue
 		}
 		points = append(points, pt)

--- a/services/opentsdb/service.go
+++ b/services/opentsdb/service.go
@@ -42,6 +42,7 @@ const (
 	statBatchesTransmitFail      = "batchesTxFail"
 	statConnectionsActive        = "connsActive"
 	statConnectionsHandled       = "connsHandled"
+	statDroppedPointsInvalid     = "droppedPointsInvalid"
 )
 
 // Service manages the listener and handler for an HTTP endpoint.
@@ -367,6 +368,7 @@ func (s *Service) serveHTTP() {
 		ConsistencyLevel: s.ConsistencyLevel,
 		PointsWriter:     s.PointsWriter,
 		Logger:           s.Logger,
+		statMap:          s.statMap,
 	}}
 	srv.Serve(s.httpln)
 }


### PR DESCRIPTION
Fixes #4622

The OpenTSDB protocol interprets timestamps as microseconds so the time 12345678901234 is in the year 2361 but the maximum year that can be represented as an int64 nanoseconds timestamp is 2262 so during the protobuf seriealization we created an overflow that introduced odd behavior that later results in a panic. Both a sanity check for timestamps and shard group creating have been added so we do not panic.