### PR TITLE
Fix parsing of functions ending in 'derivative'

### DIFF
--- a/influxql/ast.go
+++ b/influxql/ast.go
@@ -772,7 +772,7 @@ func (s *SelectStatement) SourceNames() []string {
 // derivative aggregate
 func (s *SelectStatement) HasDerivative() bool {
 	for _, f := range s.FunctionCalls() {
-		if strings.HasSuffix(f.Name, "derivative") {
+		if f.Name == "derivative" || f.Name == "non_negative_derivative" {
 			return true
 		}
 	}
@@ -783,7 +783,7 @@ func (s *SelectStatement) HasDerivative() bool {
 // variable ref as the first arg
 func (s *SelectStatement) IsSimpleDerivative() bool {
 	for _, f := range s.FunctionCalls() {
-		if strings.HasSuffix(f.Name, "derivative") {
+		if f.Name == "derivative" || f.Name == "non_negative_derivative" {
 			// it's nested if the first argument is an aggregate function
 			if _, ok := f.Args[0].(*VarRef); ok {
 				return true
@@ -799,7 +799,7 @@ func (s *SelectStatement) HasSimpleCount() bool {
 	// recursively check for a simple count(varref) function
 	var hasCount func(f *Call) bool
 	hasCount = func(f *Call) bool {
-		if strings.HasSuffix(f.Name, "count") {
+		if f.Name == "count" {
 			// it's nested if the first argument is an aggregate function
 			if _, ok := f.Args[0].(*VarRef); ok {
 				return true


### PR DESCRIPTION
Provide a fix for #4773 by using explicit derivative function names not just suffix comparison.

Because the comparison was based on the suffix any function name ending in `derivative` was parsing as a valid query. This obviously can cause confusion. 
