### PR TITLE
Drop UDP point on bad parse and keep going

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 - [#4878](https://github.com/influxdb/influxdb/pull/4878): Fix String() function for several InfluxQL statement types
 - [#4913](https://github.com/influxdb/influxdb/pull/4913): Fix b1 flush deadlock
 - [#3170](https://github.com/influxdb/influxdb/issues/3170), [#4921](https://github.com/influxdb/influxdb/pull/4921): Database does not exist error is now JSON. Thanks @pires!
+- [#5029](https://github.com/influxdb/influxdb/pull/5029): Drop UDP point on bad parse.
 
 ## v0.9.5 [2015-11-20]
 

--- a/services/udp/service.go
+++ b/services/udp/service.go
@@ -188,7 +188,7 @@ func (s *Service) parser() {
 			if err != nil {
 				s.statMap.Add(statPointsParseFail, 1)
 				s.Logger.Printf("Failed to parse points: %s", err)
-				return
+				continue
 			}
 
 			for _, point := range points {


### PR DESCRIPTION
Before this change, if parsing a point failed, the goroutine servicing the UDP input would exit, resulting in the UDP input blocking. Instead, drop the point and continue.

Fixes issue #4992.