### PR TITLE
More precise error checking

### DIFF
--- a/monitor/service.go
+++ b/monitor/service.go
@@ -330,7 +330,8 @@ func (m *Monitor) createInternalStorage() {
 		return
 	}
 
-	if err := m.MetaStore.DropRetentionPolicy(m.storeDatabase, "default"); err != nil && err != influxdb.ErrRetentionPolicyNotFound("default") {
+	err := m.MetaStore.DropRetentionPolicy(m.storeDatabase, "default")
+	if err != nil && err.Error() != influxdb.ErrRetentionPolicyNotFound("default").Error() {
 		m.Logger.Printf("failed to delete retention policy 'default', failed to created internal storage: %s", err.Error())
 		return
 	}


### PR DESCRIPTION
This is due to currently brittle error "marshalling" in our system, so a more precise compare is required.

Fixes issue #5037.