### PR TITLE
Fix leaking TSM files when compacting

### DIFF
--- a/tsdb/engine/tsm1/compact.go
+++ b/tsdb/engine/tsm1/compact.go
@@ -280,6 +280,7 @@ func (c *Compactor) Compact(tsmFiles []string) ([]string, error) {
 		if err != nil {
 			return nil, err
 		}
+		defer tr.Close()
 		trs = append(trs, tr)
 	}
 


### PR DESCRIPTION
The files being read were not closed after the compaction ran causing
them to leak.

Fixes #5046