### PR TITLE
Update TSM compaction logic

### DIFF
--- a/tsdb/engine/tsm1/compact.go
+++ b/tsdb/engine/tsm1/compact.go
@@ -145,7 +145,7 @@ func (c *DefaultPlanner) Plan(lastWrite time.Time) []string {
 	}
 
 	// don't plan if nothing has changed in the filestore
-	if c.lastPlanCheck.UnixNano() > c.FileStore.LastModified().UnixNano() {
+	if c.lastPlanCheck.After(c.FileStore.LastModified()) {
 		return nil
 	}
 


### PR DESCRIPTION
This fixes up all the compaction logic. However, if you're running a full stress it usually gets too bogged down to compact past the first step size. But if you kill the stress it grabs the next files and compacts them immediately. Next I'll look into compacting multiple levels at the same time to remove that bottleneck.

* Update compaction to look at newest files of the smallest step first
* Update compaction to look at older files in larger steps if newer files don't have enough small steps to compact
* Changed the TestDefaultCompactionPlanner_CombineSequence test to reflect what's possible now. We'd only have multiple files in the same generation if the all files but one were over the max allowable size.
* Clean up the logic on when full compactions are run and when planning can be skipped

cc @jwilder @otoolep 