### PR TITLE
Cancel writing TSM files when engine closes

### DIFF
--- a/tsdb/engine/tsm1/compact.go
+++ b/tsdb/engine/tsm1/compact.go
@@ -230,7 +230,8 @@ func (c *DefaultPlanner) findGenerations() map[int]*tsmGeneration {
 // Compactor merges multiple TSM files into new files or
 // writes a Cache into 1 or more TSM files
 type Compactor struct {
-	Dir string
+	Dir    string
+	Cancel chan struct{}
 
 	FileStore interface {
 		NextGeneration() int
@@ -301,6 +302,7 @@ func (c *Compactor) Clone() *Compactor {
 	return &Compactor{
 		Dir:       c.Dir,
 		FileStore: c.FileStore,
+		Cancel:    c.Cancel,
 	}
 }
 
@@ -365,6 +367,12 @@ func (c *Compactor) write(path string, iter KeyIterator) error {
 	defer w.Close()
 
 	for iter.Next() {
+		select {
+		case <-c.Cancel:
+			return fmt.Errorf("compaction aborted")
+		default:
+		}
+
 		// Each call to read returns the next sorted key (or the prior one if there are
 		// more values to write).  The size of values will be less than or equal to our
 		// chunk size (1000)

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -108,6 +108,7 @@ func (e *DevEngine) Format() tsdb.EngineFormat {
 // Open opens and initializes the engine.
 func (e *DevEngine) Open() error {
 	e.done = make(chan struct{})
+	e.Compactor.Cancel = e.done
 
 	if err := os.MkdirAll(e.path, 0777); err != nil {
 		return err


### PR DESCRIPTION
If the engine is closed (due to `drop database`) while a compaction is going on, the close call
blocks until the goroutine exits.  This could be several minutes because
the control does not return back up to the channel selector while there is
still data to write.  