### PR TITLE
Fix growing destination buffer during WAL entry encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ With this release InfluxDB is moving to Go 1.5.
 - [#4940](https://github.com/influxdb/influxdb/pull/4940): Fix distributed aggregate query query error. Thanks @li-ang
 - [#4622](https://github.com/influxdb/influxdb/issues/4622): Fix panic when passing too large of timestamps to OpenTSDB input.
 - [#5064](https://github.com/influxdb/influxdb/pull/5064): Full support for parenthesis in SELECT clause, fixes [#5054](https://github.com/influxdb/influxdb/issues/5054). Thanks @mengjinglei
+- [#5079](https://github.com/influxdb/influxdb/pull/5079): Ensure tsm WAL encoding buffer can handle large batches.
 
 ## v0.9.6 [2015-12-09]
 

--- a/tsdb/engine/tsm1/cache_test.go
+++ b/tsdb/engine/tsm1/cache_test.go
@@ -354,7 +354,7 @@ func mustMarshalEntry(entry WALEntry) (WalEntryType, []byte) {
 
 	b, err := entry.Encode(bytes)
 	if err != nil {
-		panic("error encoding")
+		panic(fmt.Sprintf("error encoding: %v", err))
 	}
 
 	return entry.Type(), snappy.Encode(b, b)

--- a/tsdb/engine/tsm1/wal.go
+++ b/tsdb/engine/tsm1/wal.go
@@ -366,6 +366,13 @@ func (w *WriteWALEntry) Encode(dst []byte) ([]byte, error) {
 
 	for k, v := range w.Values {
 
+		// Make sure we have enough space in our buf before copying.  If not,
+		// grow the buf.
+		if len(dst[:n])+2+len(k)+len(v)*8+4 > len(dst) {
+			grow := make([]byte, len(dst)*2)
+			dst = append(dst, grow...)
+		}
+
 		switch v[0].Value().(type) {
 		case float64:
 			dst[n] = float64EntryType
@@ -380,19 +387,19 @@ func (w *WriteWALEntry) Encode(dst []byte) ([]byte, error) {
 		}
 		n++
 
-		// Make sure we have enough space in our buf before copying.  If not,
-		// grow the buf.
-		if len(k)+2+len(v)*8+4 > len(dst)-n {
-			grow := make([]byte, len(dst)*2)
-			dst = append(dst, grow...)
-		}
-
 		n += copy(dst[n:], u16tob(uint16(len(k))))
 		n += copy(dst[n:], []byte(k))
 
 		n += copy(dst[n:], u32tob(uint32(len(v))))
 
 		for _, vv := range v {
+
+			// Grow our slice if needed
+			if len(dst[:n])+16 > len(dst) {
+				grow := make([]byte, len(dst)*2)
+				dst = append(dst, grow...)
+			}
+
 			n += copy(dst[n:], u64tob(uint64(vv.Time().UnixNano())))
 			switch t := vv.Value().(type) {
 			case float64:

--- a/tsdb/engine/tsm1/wal.go
+++ b/tsdb/engine/tsm1/wal.go
@@ -365,7 +365,6 @@ func (w *WriteWALEntry) Encode(dst []byte) ([]byte, error) {
 	var n int
 
 	for k, v := range w.Values {
-
 		// Make sure we have enough space in our buf before copying.  If not,
 		// grow the buf.
 		if len(dst[:n])+2+len(k)+len(v)*8+4 > len(dst) {
@@ -393,8 +392,8 @@ func (w *WriteWALEntry) Encode(dst []byte) ([]byte, error) {
 		n += copy(dst[n:], u32tob(uint32(len(v))))
 
 		for _, vv := range v {
-
-			// Grow our slice if needed
+			// Grow our slice if needed. Enough room is needed for the timestamp (8 bytes)
+			// and the value itself (another 8 bytes).
 			if len(dst[:n])+16 > len(dst) {
 				grow := make([]byte, len(dst)*2)
 				dst = append(dst, grow...)


### PR DESCRIPTION
The test to see if the destination buffer for encoding and decoding a WAL
entry was broken and would cause a panic if there were large batches that
would overflow the buffer size.

Fixes #5075