### PR TITLE
Fixed bash syntax error in influxdb.service

### DIFF
--- a/scripts/influxdb.service
+++ b/scripts/influxdb.service
@@ -12,7 +12,7 @@ LimitNOFILE=65536
 Environment='STDOUT=/dev/null'
 Environment='STDERR=/var/log/influxdb/influxd.log'
 EnvironmentFile=-/etc/default/influxdb
-ExecStart=/bin/sh -c "/usr/bin/influxd -config /etc/influxdb/influxdb.conf ${INFLUXD_OPTS} >> ${STDOUT} 2>> ${STDERR}"
+ExecStart=/bin/sh -c "/usr/bin/influxd -config /etc/influxdb/influxdb.conf ${INFLUXD_OPTS} >>${STDOUT} 2>>${STDERR}"
 KillMode=control-group
 Restart=on-failure
 


### PR DESCRIPTION
Updated: Removed erroneous spaces for stdout and stderr redirect which resulted in a broken forward.

As discussed in https://github.com/influxdb/influxdb/pull/5111