### PR TITLE
Fix panic when merging empty series

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ With this release InfluxDB is moving to Go 1.5.
 
 ### Bugfixes
 - [#5042](https://github.com/influxdb/influxdb/issues/5042): Count with fill(none) will drop 0 valued intervals.
+- [#4735](https://github.com/influxdb/influxdb/issues/4735): Fix panic when merging empty results.
 - [#5016](https://github.com/influxdb/influxdb/pull/5016): Don't panic if Meta data directory not writable. Thanks @oiooj
 - [#5059](https://github.com/influxdb/influxdb/pull/5059): Fix unmarshal of database error by client code. Thanks @farshidtz
 - [#4940](https://github.com/influxdb/influxdb/pull/4940): Fix distributed aggregate query query error. Thanks @li-ang

--- a/services/httpd/handler.go
+++ b/services/httpd/handler.go
@@ -328,17 +328,19 @@ func (h *Handler) serveQuery(w http.ResponseWriter, r *http.Request, user *meta.
 			resp.Results = append(resp.Results, r)
 		} else if resp.Results[l-1].StatementID == r.StatementID {
 			cr := resp.Results[l-1]
-			lastSeries := cr.Series[len(cr.Series)-1]
 			rowsMerged := 0
+			if len(cr.Series) > 0 {
+				lastSeries := cr.Series[len(cr.Series)-1]
 
-			for _, row := range r.Series {
-				if !lastSeries.SameSeries(row) {
-					// Next row is for a different series than last.
-					break
+				for _, row := range r.Series {
+					if !lastSeries.SameSeries(row) {
+						// Next row is for a different series than last.
+						break
+					}
+					// Values are for the same series, so append them.
+					lastSeries.Values = append(lastSeries.Values, row.Values...)
+					rowsMerged++
 				}
-				// Values are for the same series, so append them.
-				lastSeries.Values = append(lastSeries.Values, row.Values...)
-				rowsMerged++
 			}
 
 			// Append remaining rows as new rows.


### PR DESCRIPTION
Still not sure how multiple empty results are being returned but this adds some basic defensive steps to prevent the panic.

All that was required to trigger the panic is to have an empty result return for a statement followed by an empty or non empty result for the same statement.
