### PR TITLE
Fixed #5078 to support Inserts in non-interactive mode.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ With this release InfluxDB is moving to Go 1.5.
 - [#5064](https://github.com/influxdb/influxdb/pull/5064): Full support for parenthesis in SELECT clause, fixes [#5054](https://github.com/influxdb/influxdb/issues/5054). Thanks @mengjinglei
 - [#5079](https://github.com/influxdb/influxdb/pull/5079): Ensure tsm WAL encoding buffer can handle large batches.
 - [#4303](https://github.com/influxdb/influxdb/issues/4303): Don't drop measurements or series from multiple databases.
+- [#5078](https://github.com/influxdb/influxdb/issues/5078): influx non-interactive mode - INSERT must be handled.
 
 ## v0.9.6 [2015-12-09]
 

--- a/cmd/influx/cli/cli.go
+++ b/cmd/influx/cli/cli.go
@@ -116,10 +116,14 @@ func (c *CommandLine) Run() {
 	if c.Execute != "" {
 		// Modify precision before executing query
 		c.SetPrecision(c.Precision)
-		if err := c.ExecuteQuery(c.Execute); err != nil {
-			c.Line.Close()
-			os.Exit(1)
+
+		// Make the non-interactive mode send everything through the CLI's parser
+		// the same way the interactive mode works
+		lines := strings.Split(c.Execute, "\n")
+		for _, line := range lines {
+			c.ParseCommand(line)
 		}
+		
 		c.Line.Close()
 		os.Exit(0)
 	}

--- a/cmd/influx/cli/cli.go
+++ b/cmd/influx/cli/cli.go
@@ -123,7 +123,7 @@ func (c *CommandLine) Run() {
 		for _, line := range lines {
 			c.ParseCommand(line)
 		}
-		
+
 		c.Line.Close()
 		os.Exit(0)
 	}

--- a/cmd/influx/cli/cli_test.go
+++ b/cmd/influx/cli/cli_test.go
@@ -46,6 +46,21 @@ func TestRunCLI(t *testing.T) {
 	c.Run()
 }
 
+func TestRunCLI_ExecuteInsert(t *testing.T) {
+    t.Parallel()
+    ts := emptyTestServer()
+    defer ts.Close()
+
+    u, _ := url.Parse(ts.URL)
+    h, p, _ := net.SplitHostPort(u.Host)
+    c := cli.New(CLIENT_VERSION)
+    c.Host = h
+    c.Port, _ = strconv.Atoi(p)
+    c.Precision = "ms"
+    c.Execute = "INSERT sensor,floor=1 value=2"
+    c.Run() 
+}
+
 func TestConnect(t *testing.T) {
 	t.Parallel()
 	ts := emptyTestServer()

--- a/cmd/influx/cli/cli_test.go
+++ b/cmd/influx/cli/cli_test.go
@@ -47,18 +47,18 @@ func TestRunCLI(t *testing.T) {
 }
 
 func TestRunCLI_ExecuteInsert(t *testing.T) {
-    t.Parallel()
-    ts := emptyTestServer()
-    defer ts.Close()
+	t.Parallel()
+	ts := emptyTestServer()
+	defer ts.Close()
 
-    u, _ := url.Parse(ts.URL)
-    h, p, _ := net.SplitHostPort(u.Host)
-    c := cli.New(CLIENT_VERSION)
-    c.Host = h
-    c.Port, _ = strconv.Atoi(p)
-    c.Precision = "ms"
-    c.Execute = "INSERT sensor,floor=1 value=2"
-    c.Run() 
+	u, _ := url.Parse(ts.URL)
+	h, p, _ := net.SplitHostPort(u.Host)
+	c := cli.New(CLIENT_VERSION)
+	c.Host = h
+	c.Port, _ = strconv.Atoi(p)
+	c.Precision = "ms"
+	c.Execute = "INSERT sensor,floor=1 value=2"
+	c.Run()
 }
 
 func TestConnect(t *testing.T) {


### PR DESCRIPTION
Changed non-interactive mode to send everything through the CLI's parser the same way the interactive mode works as per suggestion from gunnaraasen.
Added multiline support for -execute flag.

- [x] CHANGELOG.md updated
- [X] Rebased/mergable
- [X] Tests pass
- [X] Signed [CLA](http://influxdb.com/community/cla.html)