### PR TITLE
USE databasename will work only for existing databases.

### DIFF
--- a/cmd/influx/cli/cli.go
+++ b/cmd/influx/cli/cli.go
@@ -324,8 +324,7 @@ func (c *CommandLine) use(cmd string) {
 	d := args[1]
 
 	// validate if specified database exists
-	query := "SHOW DATABASES"
-	response, err := c.Client.Query(client.Query{Command: query})
+	response, err := c.Client.Query(client.Query{Command: "SHOW DATABASES"})
 	if err != nil {
 		fmt.Printf("ERR: %s\n", err)
 		return
@@ -337,20 +336,22 @@ func (c *CommandLine) use(cmd string) {
 	}
 
 	// verify the provided database exists
-	databaseExists := false
-	for _, result := range response.Results {
-		for _, row := range result.Series {
-			if row.Name == "databases" {
-				for _, values := range row.Values {
-					for _, database := range values {
-						if database == d {
-							databaseExists = true
+	databaseExists := func() bool {
+		for _, result := range response.Results {
+			for _, row := range result.Series {
+				if row.Name == "databases" {
+					for _, values := range row.Values {
+						for _, database := range values {
+							if database == d {
+								return true
+							}
 						}
 					}
 				}
 			}
 		}
-	}
+		return false
+	}()
 	if databaseExists {
 		c.Database = d
 		fmt.Printf("Using database %s\n", d)

--- a/cmd/influx/cli/cli.go
+++ b/cmd/influx/cli/cli.go
@@ -322,8 +322,41 @@ func (c *CommandLine) use(cmd string) {
 		return
 	}
 	d := args[1]
-	c.Database = d
-	fmt.Printf("Using database %s\n", d)
+
+	// validate if specified database exists
+	query := "SHOW DATABASES"
+	response, err := c.Client.Query(client.Query{Command: query})
+	if err != nil {
+		fmt.Printf("ERR: %s\n", err)
+		return
+	}
+
+	if err := response.Error(); err != nil {
+		fmt.Printf("ERR: %s\n", err)
+		return
+	}
+
+	// verify the provided database exists
+	databaseExists := false
+	for _, result := range response.Results {
+		for _, row := range result.Series {
+			if row.Name == "databases" {
+				for _, values := range row.Values {
+					for _, database := range values {
+						if database == d {
+							databaseExists = true
+						}
+					}
+				}
+			}
+		}
+	}
+	if databaseExists {
+		c.Database = d
+		fmt.Printf("Using database %s\n", d)
+	} else {
+		fmt.Printf("ERR: Database %s doesn't exist. Run SHOW DATABASES for a list of existing databases.\n", d)
+	}
 }
 
 // SetPrecision sets client precision


### PR DESCRIPTION
- [ ] CHANGELOG.md updated
- [x] Rebased/mergable
- [x] Tests pass
- [x] Sign CLA (if not already signed)

Fixes #5174

Unfortunately, I don't see a way of testing this without implementing some database behavior on `cli_test.go`, namely to return one existing database.

```
$ influx -host 192.168.99.100
Visit https://enterprise.influxdata.com to register for updates, InfluxDB server management, and monitoring.
Connected to http://192.168.99.100:8086 version 0.9.6.1
InfluxDB shell 0.9
> show databases
name: databases
---------------
name
_internal

> use pires
ERR: Database pires doesn't exist. Run SHOW DATABASES for a list of existing databases.
> use _internal
Using database _internal
```