### PR TITLE
moving UDP payload size to config option, improve throughput performance

### DIFF
--- a/etc/config.sample.toml
+++ b/etc/config.sample.toml
@@ -330,7 +330,9 @@ reporting-disabled = false
   # batch-pending = 5 # number of batches that may be pending in memory
   # batch-timeout = "1s" # will flush at least this often even if we haven't hit buffer limit
   # read-buffer = 0 # UDP Read buffer size, 0 means OS default. UDP listener will fail if set above OS max.
-  # udp-payload-size = 1500 # set the expected UDP payload size, default: 65536
+ 
+  # set the expected UDP payload size; lower values tend to yield better performance, default is max UDP size 65536
+  # udp-payload-size = 65536
 
 ###
 ### [continuous_queries]

--- a/etc/config.sample.toml
+++ b/etc/config.sample.toml
@@ -330,6 +330,7 @@ reporting-disabled = false
   # batch-pending = 5 # number of batches that may be pending in memory
   # batch-timeout = "1s" # will flush at least this often even if we haven't hit buffer limit
   # read-buffer = 0 # UDP Read buffer size, 0 means OS default. UDP listener will fail if set above OS max.
+  # udp-payload-size = 1500 # set the expected UDP payload size, default: 65536
 
 ###
 ### [continuous_queries]

--- a/services/udp/config.go
+++ b/services/udp/config.go
@@ -39,7 +39,7 @@ const (
 	//
 	// https://en.wikipedia.org/wiki/User_Datagram_Protocol#Packet_structure
 	//
-	// Reading packets from a UDP socket in golang actually only pulls
+	// Reading packets from a UDP socket in go actually only pulls
 	// one packet at a time, requiring a very fast reader to keep up with
 	// incoming data at scale. Reducing the overhead of the expected packet
 	// helps allocate memory faster (~10-25µs --> ~150ns with go1.5.2), thereby

--- a/services/udp/config_test.go
+++ b/services/udp/config_test.go
@@ -19,6 +19,7 @@ retention-policy = "awesomerp"
 batch-size = 100
 batch-pending = 9
 batch-timeout = "10ms"
+udp-payload-size = 1500
 `, &c); err != nil {
 		t.Fatal(err)
 	}
@@ -38,5 +39,7 @@ batch-timeout = "10ms"
 		t.Fatalf("unexpected batch pending: %d", c.BatchPending)
 	} else if time.Duration(c.BatchTimeout) != (10 * time.Millisecond) {
 		t.Fatalf("unexpected batch timeout: %v", c.BatchTimeout)
+	} else if c.UDPPayloadSize != 1500 {
+		t.Fatalf("unexpected udp-payload-size: %d", c.UDPPayloadSize)
 	}
 }

--- a/services/udp/service.go
+++ b/services/udp/service.go
@@ -18,10 +18,6 @@ import (
 )
 
 const (
-	// UDPBufferSize is the maximum UDP packet size
-	// see https://en.wikipedia.org/wiki/User_Datagram_Protocol#Packet_structure
-	UDPBufferSize = 65536
-
 	// Arbitrary, testing indicated that this doesn't typically get over 10
 	parserChanLen = 1000
 )
@@ -163,7 +159,7 @@ func (s *Service) serve() {
 			return
 		default:
 			// Keep processing.
-			buf := make([]byte, UDPBufferSize)
+			buf := make([]byte, s.config.UDPPayloadSize)
 			n, _, err := s.conn.ReadFromUDP(buf)
 			if err != nil {
 				s.statMap.Add(statReadFail, 1)


### PR DESCRIPTION
Current UDP service alloc's a byte slice at max theoretical UDP packet size for each iteration of reading from the socket. This is inefficient in terms of memory allocation (ReadFromUDP pulls one packet at a time, so it's largely overkill for 95% of use cases) and execution time (inordinate about of time spent in alloc, causes backpressure on UDP socket at scale + extra overhead for GC).

Proposed changes add UDP payload size as a config option (default is UDP max) and help speed up throughput when closely aligned with payload size sent from metrics source (e.g. udp_payload in telegraf).

To test/prove this, you can use this tester script (thanks @daviesalex) with different slice sizes. Testing with max UDP at 65536, alloc times hover around 10-20us but **drop to ~120-130ns** when size dropped to match typical udp_payload at 1500.

```
package main

import (
        "fmt"
        "time"

func main() {
        for { 
                start := time.Now()

                foo := make([]byte, 1500)

                now := time.Now()
                diff := now.Sub(start)
                fmt.Printf("ndiff: %v (%d)\n", diff, len(foo))
        } 
}
```