### PR TITLE
Add a mock client to the cli test for Use

### DIFF
--- a/cmd/influx/main.go
+++ b/cmd/influx/main.go
@@ -99,5 +99,8 @@ Examples:
 		os.Exit(0)
 	}
 
-	c.Run()
+	if err := c.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "%s\n", err)
+		os.Exit(1)
+	}
 }


### PR DESCRIPTION
PR #5183 added a validation for `use` to only be able to select public
databases so `_internal` couldn't be chosen. To implement this, the
`SHOW DATABASES` command was used by the internal client.

Some of the unit tests in `cli_test.go` don't set the client to
anything. `TestParseCommand_Use` previous didn't, but now it needs to
have a client in the unit test with an empty test server.