### PR TITLE
Wire up meta service functionality

### DIFF
--- a/cmd/influxd/run/command.go
+++ b/cmd/influxd/run/command.go
@@ -100,7 +100,7 @@ func (cmd *Command) Run(args ...string) error {
 	}
 
 	if options.Join != "" {
-		config.Meta.Peers = strings.Split(options.Join, ",")
+		config.Meta.JoinPeers = strings.Split(options.Join, ",")
 	}
 
 	// Validate the configuration.

--- a/cmd/influxd/run/config.go
+++ b/cmd/influxd/run/config.go
@@ -45,13 +45,20 @@ type Config struct {
 	OpenTSDB   opentsdb.Config   `toml:"opentsdb"`
 	UDPs       []udp.Config      `toml:"udp"`
 
-	// Snapshot SnapshotConfig `toml:"snapshot"`
 	ContinuousQuery continuous_querier.Config `toml:"continuous_queries"`
-
-	HintedHandoff hh.Config `toml:"hinted-handoff"`
+	HintedHandoff   hh.Config                 `toml:"hinted-handoff"`
 
 	// Server reporting
 	ReportingDisabled bool `toml:"reporting-disabled"`
+
+	Dir string `toml:"dir"`
+
+	// BindAddress is the address that all TCP services use (Raft, Snapshot, Cluster, etc.)
+	BindAddress `toml:"bind-address"`
+
+	// Hostname is the resolvable name for other servers in
+	// the cluster to reach this server
+	Hostname string `toml:"hostname"`
 }
 
 // NewConfig returns an instance of Config with reasonable defaults.

--- a/etc/config.sample.toml
+++ b/etc/config.sample.toml
@@ -8,6 +8,14 @@
 # Change this option to true to disable reporting.
 reporting-disabled = false
 
+# directory where server ID and cluster metaservers information will be kept
+dir = "/var/lib/influxdb"
+
+# we'll try to get the hostname automatically, but if it the os returns something
+# that isn't resolvable by other servers in the cluster, use this option to
+# manually set the hostname
+# hostname = "localhost"
+
 ###
 ### [meta]
 ###
@@ -16,8 +24,12 @@ reporting-disabled = false
 ###
 
 [meta]
+  # Controls if this node should run the metaservice and participate in the Raft group
+  enabled = true
+
+  # Where the metadata/raft database is stored
   dir = "/var/lib/influxdb/meta"
-  hostname = "localhost"
+
   bind-address = ":8088"
   retention-autocreate = true
   election-timeout = "1s"
@@ -25,13 +37,6 @@ reporting-disabled = false
   leader-lease-timeout = "500ms"
   commit-timeout = "50ms"
   cluster-tracing = false
-
-  # If enabled, when a Raft cluster loses a peer due to a `DROP SERVER` command,
-  # the leader will automatically ask a non-raft peer node to promote to a raft
-  # peer. This only happens if there is a non-raft peer node available to promote.
-  # This setting only affects the local node, so to ensure if operates correctly, be sure to set
-  # it in the config of every node.
-  raft-promotion-enabled = true
 
 ###
 ### [data]
@@ -43,6 +48,9 @@ reporting-disabled = false
 ###
 
 [data]
+  # Controls if this node holds time series data shards in the cluster
+  enabled = true
+
   dir = "/var/lib/influxdb/data"
 
   # Controls the storage engine used for new shards. Engines available are b1,

--- a/influxql/ast.go
+++ b/influxql/ast.go
@@ -1884,18 +1884,21 @@ func (s DropSeriesStatement) RequiredPrivileges() ExecutionPrivileges {
 type DropServerStatement struct {
 	// ID of the node to be dropped.
 	NodeID uint64
-	// Force will force the server to drop even it it means losing data
-	Force bool
+
+	// Meta indicates if the server being dropped is a meta or data node
+	Meta bool
 }
 
 // String returns a string representation of the drop series statement.
 func (s *DropServerStatement) String() string {
 	var buf bytes.Buffer
-	_, _ = buf.WriteString("DROP SERVER ")
-	_, _ = buf.WriteString(strconv.FormatUint(s.NodeID, 10))
-	if s.Force {
-		_, _ = buf.WriteString(" FORCE")
+	_, _ = buf.WriteString("DROP ")
+	if s.Meta {
+		_, _ = buf.WriteString(" META SERVER ")
+	} else {
+		_, _ = buf.WriteString(" DATA SERVER ")
 	}
+	_, _ = buf.WriteString(strconv.FormatUint(s.NodeID, 10))
 	return buf.String()
 }
 

--- a/influxql/parser_test.go
+++ b/influxql/parser_test.go
@@ -1035,12 +1035,12 @@ func TestParser_ParseStatement(t *testing.T) {
 
 		// DROP SERVER statement
 		{
-			s:    `DROP SERVER 123`,
-			stmt: &influxql.DropServerStatement{NodeID: 123},
+			s:    `DROP META SERVER 123`,
+			stmt: &influxql.DropServerStatement{NodeID: 123, Meta: true},
 		},
 		{
-			s:    `DROP SERVER 123 FORCE`,
-			stmt: &influxql.DropServerStatement{NodeID: 123, Force: true},
+			s:    `DROP DATA SERVER 123`,
+			stmt: &influxql.DropServerStatement{NodeID: 123, Meta: false},
 		},
 
 		// SHOW CONTINUOUS QUERIES statement
@@ -1693,9 +1693,8 @@ func TestParser_ParseStatement(t *testing.T) {
 		{s: `DROP SERIES`, err: `found EOF, expected FROM, WHERE at line 1, char 13`},
 		{s: `DROP SERIES FROM`, err: `found EOF, expected identifier at line 1, char 18`},
 		{s: `DROP SERIES FROM src WHERE`, err: `found EOF, expected identifier, string, number, bool at line 1, char 28`},
-		{s: `DROP SERVER`, err: `found EOF, expected number at line 1, char 13`},
-		{s: `DROP SERVER abc`, err: `found abc, expected number at line 1, char 13`},
-		{s: `DROP SERVER 1 1`, err: `found 1, expected FORCE at line 1, char 15`},
+		{s: `DROP META SERVER`, err: `found EOF, expected number at line 1, char 18`},
+		{s: `DROP DATA SERVER abc`, err: `found abc, expected number at line 1, char 18`},
 		{s: `SHOW CONTINUOUS`, err: `found EOF, expected QUERIES at line 1, char 17`},
 		{s: `SHOW RETENTION`, err: `found EOF, expected POLICIES at line 1, char 16`},
 		{s: `SHOW RETENTION ON`, err: `found ON, expected POLICIES at line 1, char 16`},

--- a/influxql/token.go
+++ b/influxql/token.go
@@ -65,6 +65,7 @@ const (
 	BY
 	CREATE
 	CONTINUOUS
+	DATA
 	DATABASE
 	DATABASES
 	DEFAULT
@@ -95,6 +96,7 @@ const (
 	KEY
 	KEYS
 	LIMIT
+	META
 	MEASUREMENT
 	MEASUREMENTS
 	NAME
@@ -184,6 +186,7 @@ var tokens = [...]string{
 	BY:            "BY",
 	CREATE:        "CREATE",
 	CONTINUOUS:    "CONTINUOUS",
+	DATA:          "DATA",
 	DATABASE:      "DATABASE",
 	DATABASES:     "DATABASES",
 	DEFAULT:       "DEFAULT",
@@ -216,6 +219,7 @@ var tokens = [...]string{
 	LIMIT:         "LIMIT",
 	MEASUREMENT:   "MEASUREMENT",
 	MEASUREMENTS:  "MEASUREMENTS",
+	META:          "META",
 	NAME:          "NAME",
 	NOT:           "NOT",
 	OFFSET:        "OFFSET",

--- a/node.go
+++ b/node.go
@@ -1,19 +1,47 @@
 package influxdb
 
-import "sync"
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+)
+
+const nodeFile = "node.json"
 
 type Node struct {
-	mu sync.RWMutex
-	id uint64
+	path        string
+	ID          uint64
+	MetaServers []string
 }
 
-func NewNode() *Node {
-	// TODO: (@corylanou): make this load the id properly
-	return &Node{}
+// NewNode will load the node information from disk if present
+func NewNode(path string) (*Node, error) {
+	n := &Node{
+		path: path,
+	}
+
+	f, err := os.Open(filepath.Join(path, nodeFile))
+	if err != nil && !os.IsNotExist(err) {
+		return nil, err
+	}
+	defer f.Close()
+
+	if err := json.NewDecoder(f).Decode(n); err != nil {
+		return nil, err
+	}
+
+	return n, nil
 }
 
-func (n *Node) ID() uint64 {
-	n.mu.RLock()
-	defer n.mu.RUnlock()
-	return n.id
+// Save will save the node file to disk and replace the existing one if present
+func (n *Node) Save() error {
+	tmpFile := filepath.Join(n.path, nodeFile, "tmp")
+
+	f, err := os.Open(tmpFile)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	return json.NewEncoder(f).Encode(n)
 }

--- a/services/meta/config.go
+++ b/services/meta/config.go
@@ -17,8 +17,8 @@ const (
 	// DefaultRaftBindAddress is the default address to bind to.
 	DefaultRaftBindAddress = ":8088"
 
-	// DefaultHTTPdBindAddress is the default address to bind to.
-	DefaultHTTPdBindAddress = ":8091"
+	// DefaultHTTPBindAddress is the default address to bind the API to.
+	DefaultHTTPBindAddress = ":8091"
 
 	// DefaultHeartbeatTimeout is the default heartbeat timeout for the store.
 	DefaultHeartbeatTimeout = 1000 * time.Millisecond
@@ -41,14 +41,20 @@ const (
 
 // Config represents the meta configuration.
 type Config struct {
-	Enabled              bool          `toml:"enabled"`
-	Dir                  string        `toml:"dir"`
-	Hostname             string        `toml:"hostname"`
-	RaftBindAddress      string        `toml:"raft-bind-address"`
-	HTTPdBindAddress     string        `toml:"httpd-bind-address"`
-	HTTPSEnabled         bool          `toml:"https-enabled"`
-	HTTPSCertificate     string        `toml:"https-certificate"`
-	Peers                []string      `toml:"-"`
+	Enabled  bool   `toml:"enabled"`
+	Dir      string `toml:"dir"`
+	Hostname string `toml:"hostname"`
+
+	// this is deprecated. Should use the address from run/config.go
+	BindAddress string `toml:"bind-address"`
+
+	// HTTPBindAddress is the bind address for the metaservice HTTP API
+	HTTPBindAddress  string `toml:"http-bind-address"`
+	HTTPSEnabled     bool   `toml:"https-enabled"`
+	HTTPSCertificate string `toml:"https-certificate"`
+
+	// JoinPeers if specified gives other metastore servers to join this server to the cluster
+	JoinPeers            []string      `toml:"-"`
 	RetentionAutoCreate  bool          `toml:"retention-autocreate"`
 	ElectionTimeout      toml.Duration `toml:"election-timeout"`
 	HeartbeatTimeout     toml.Duration `toml:"heartbeat-timeout"`
@@ -63,9 +69,10 @@ type Config struct {
 // NewConfig builds a new configuration with default values.
 func NewConfig() *Config {
 	return &Config{
+		Enabled:              true, // enabled by default
 		Hostname:             DefaultHostname,
-		RaftBindAddress:      DefaultRaftBindAddress,
-		HTTPdBindAddress:     DefaultHTTPdBindAddress,
+		BindAddress:          DefaultRaftBindAddress,
+		HTTPBindAddress:      DefaultHTTPBindAddress,
 		RetentionAutoCreate:  true,
 		ElectionTimeout:      toml.Duration(DefaultElectionTimeout),
 		HeartbeatTimeout:     toml.Duration(DefaultHeartbeatTimeout),

--- a/services/meta/config_test.go
+++ b/services/meta/config_test.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"github.com/BurntSushi/toml"
-	"github.com/influxdb/influxdb/meta"
+	"github.com/influxdb/influxdb/services/meta"
 )
 
 func TestConfig_Parse(t *testing.T) {

--- a/services/meta/data.go
+++ b/services/meta/data.go
@@ -28,7 +28,8 @@ type Data struct {
 	Term      uint64 // associated raft term
 	Index     uint64 // associated raft index
 	ClusterID uint64
-	Nodes     []NodeInfo
+	MetaNodes []NodeInfo
+	DataNodes []NodeInfo
 	Databases []DatabaseInfo
 	Users     []UserInfo
 
@@ -37,36 +38,28 @@ type Data struct {
 	MaxShardID      uint64
 }
 
-// Node returns a node by id.
-func (data *Data) Node(id uint64) *NodeInfo {
-	for i := range data.Nodes {
-		if data.Nodes[i].ID == id {
-			return &data.Nodes[i]
+// DataNode returns a node by id.
+func (data *Data) DataNode(id uint64) *NodeInfo {
+	for i := range data.DataNodes {
+		if data.DataNodes[i].ID == id {
+			return &data.DataNodes[i]
 		}
 	}
 	return nil
 }
 
-// NodeByHost returns a node by hostname.
-func (data *Data) NodeByHost(host string) *NodeInfo {
-	for i := range data.Nodes {
-		if data.Nodes[i].Host == host {
-			return &data.Nodes[i]
-		}
-	}
-	return nil
-}
-
-// CreateNode adds a node to the metadata.
-func (data *Data) CreateNode(host string) error {
+// CreateDataNode adds a node to the metadata.
+func (data *Data) CreateDataNode(host string) error {
 	// Ensure a node with the same host doesn't already exist.
-	if data.NodeByHost(host) != nil {
-		return ErrNodeExists
+	for _, n := range data.DataNodes {
+		if n.Host == host {
+			return ErrNodeExists
+		}
 	}
 
 	// Append new node.
 	data.MaxNodeID++
-	data.Nodes = append(data.Nodes, NodeInfo{
+	data.DataNodes = append(data.DataNodes, NodeInfo{
 		ID:   data.MaxNodeID,
 		Host: host,
 	})
@@ -75,39 +68,10 @@ func (data *Data) CreateNode(host string) error {
 }
 
 // DeleteNode removes a node from the metadata.
-func (data *Data) DeleteNode(id uint64, force bool) error {
+func (data *Data) DeleteDataNode(id uint64) error {
 	// Node has to be larger than 0 to be real
 	if id == 0 {
 		return ErrNodeIDRequired
-	}
-	// Is this a valid node?
-	nodeInfo := data.Node(id)
-	if nodeInfo == nil {
-		return ErrNodeNotFound
-	}
-
-	// Am I the only node?  If so, nothing to do
-	if len(data.Nodes) == 1 {
-		return ErrNodeUnableToDropFinalNode
-	}
-
-	// Determine if there are any any non-replicated nodes and force was not specified
-	if !force {
-		for _, d := range data.Databases {
-			for _, rp := range d.RetentionPolicies {
-				// ignore replicated retention policies
-				if rp.ReplicaN > 1 {
-					continue
-				}
-				for _, sg := range rp.ShardGroups {
-					for _, s := range sg.Shards {
-						if s.OwnedBy(id) && len(s.Owners) == 1 {
-							return ErrShardNotReplicated
-						}
-					}
-				}
-			}
-		}
 	}
 
 	// Remove node id from all shard infos
@@ -131,14 +95,71 @@ func (data *Data) DeleteNode(id uint64, force bool) error {
 
 	// Remove this node from the in memory nodes
 	var nodes []NodeInfo
-	for _, n := range data.Nodes {
+	for _, n := range data.DataNodes {
 		if n.ID == id {
 			continue
 		}
 		nodes = append(nodes, n)
 	}
-	data.Nodes = nodes
 
+	if len(nodes) == len(data.DataNodes) {
+		return ErrNodeNotFound
+	}
+
+	data.DataNodes = nodes
+	return nil
+}
+
+// MetaNode returns a node by id.
+func (data *Data) MetaNode(id uint64) *NodeInfo {
+	for i := range data.MetaNodes {
+		if data.MetaNodes[i].ID == id {
+			return &data.MetaNodes[i]
+		}
+	}
+	return nil
+}
+
+// CreateMetaNode will add a new meta node to the metastore
+func (data *Data) CreateMetaNode(httpAddr, tcpAddr string) error {
+	// Ensure a node with the same host doesn't already exist.
+	for _, n := range data.MetaNodes {
+		if n.Host == httpAddr {
+			return ErrNodeExists
+		}
+	}
+
+	// Append new node.
+	data.MaxNodeID++
+	data.MetaNodes = append(data.MetaNodes, NodeInfo{
+		ID:      data.MaxNodeID,
+		Host:    httpAddr,
+		TCPHost: tcpAddr,
+	})
+
+	return nil
+}
+
+// DeleteMetaNode will remove the meta node from the store
+func (data *Data) DeleteMetaNode(id uint64) error {
+	// Node has to be larger than 0 to be real
+	if id == 0 {
+		return ErrNodeIDRequired
+	}
+
+	var nodes []NodeInfo
+	for _, n := range data.MetaNodes {
+		if n.ID == id {
+			continue
+		}
+		nodes = append(nodes, n)
+	}
+
+	if len(nodes) == len(data.MetaNodes) {
+		return ErrNodeNotFound
+	}
+
+	data.MetaNodes = nodes
 	return nil
 }
 
@@ -355,7 +376,7 @@ func (data *Data) ShardGroupByTimestamp(database, policy string, timestamp time.
 // CreateShardGroup creates a shard group on a database and policy for a given timestamp.
 func (data *Data) CreateShardGroup(database, policy string, timestamp time.Time) error {
 	// Ensure there are nodes in the metadata.
-	if len(data.Nodes) == 0 {
+	if len(data.DataNodes) == 0 {
 		return ErrNodesRequired
 	}
 
@@ -376,14 +397,14 @@ func (data *Data) CreateShardGroup(database, policy string, timestamp time.Time)
 	replicaN := rpi.ReplicaN
 	if replicaN == 0 {
 		replicaN = 1
-	} else if replicaN > len(data.Nodes) {
-		replicaN = len(data.Nodes)
+	} else if replicaN > len(data.DataNodes) {
+		replicaN = len(data.DataNodes)
 	}
 
 	// Determine shard count by node count divided by replication factor.
 	// This will ensure nodes will get distributed across nodes evenly and
 	// replicated the correct number of times.
-	shardN := len(data.Nodes) / replicaN
+	shardN := len(data.DataNodes) / replicaN
 
 	// Create the shard group.
 	data.MaxShardGroupID++
@@ -401,11 +422,11 @@ func (data *Data) CreateShardGroup(database, policy string, timestamp time.Time)
 
 	// Assign data nodes to shards via round robin.
 	// Start from a repeatably "random" place in the node list.
-	nodeIndex := int(data.Index % uint64(len(data.Nodes)))
+	nodeIndex := int(data.Index % uint64(len(data.DataNodes)))
 	for i := range sgi.Shards {
 		si := &sgi.Shards[i]
 		for j := 0; j < replicaN; j++ {
-			nodeID := data.Nodes[nodeIndex%len(data.Nodes)].ID
+			nodeID := data.DataNodes[nodeIndex%len(data.DataNodes)].ID
 			si.Owners = append(si.Owners, ShardOwner{NodeID: nodeID})
 			nodeIndex++
 		}
@@ -632,10 +653,17 @@ func (data *Data) Clone() *Data {
 	other := *data
 
 	// Copy nodes.
-	if data.Nodes != nil {
-		other.Nodes = make([]NodeInfo, len(data.Nodes))
-		for i := range data.Nodes {
-			other.Nodes[i] = data.Nodes[i].clone()
+	if data.DataNodes != nil {
+		other.DataNodes = make([]NodeInfo, len(data.DataNodes))
+		for i := range data.DataNodes {
+			other.DataNodes[i] = data.DataNodes[i].clone()
+		}
+	}
+
+	if data.MetaNodes != nil {
+		other.MetaNodes = make([]NodeInfo, len(data.MetaNodes))
+		for i := range data.MetaNodes {
+			other.MetaNodes[i] = data.MetaNodes[i].clone()
 		}
 	}
 
@@ -670,9 +698,14 @@ func (data *Data) marshal() *internal.Data {
 		MaxShardID:      proto.Uint64(data.MaxShardID),
 	}
 
-	pb.Nodes = make([]*internal.NodeInfo, len(data.Nodes))
-	for i := range data.Nodes {
-		pb.Nodes[i] = data.Nodes[i].marshal()
+	pb.DataNodes = make([]*internal.NodeInfo, len(data.DataNodes))
+	for i := range data.DataNodes {
+		pb.DataNodes[i] = data.DataNodes[i].marshal()
+	}
+
+	pb.MetaNodes = make([]*internal.NodeInfo, len(data.MetaNodes))
+	for i := range data.MetaNodes {
+		pb.MetaNodes[i] = data.MetaNodes[i].marshal()
 	}
 
 	pb.Databases = make([]*internal.DatabaseInfo, len(data.Databases))
@@ -698,9 +731,22 @@ func (data *Data) unmarshal(pb *internal.Data) {
 	data.MaxShardGroupID = pb.GetMaxShardGroupID()
 	data.MaxShardID = pb.GetMaxShardID()
 
-	data.Nodes = make([]NodeInfo, len(pb.GetNodes()))
-	for i, x := range pb.GetNodes() {
-		data.Nodes[i].unmarshal(x)
+	// TODO: Nodes is deprecated. This is being left here to make migration from 0.9.x to 0.10.0 possible
+	if len(pb.GetNodes()) > 0 {
+		data.DataNodes = make([]NodeInfo, len(pb.GetNodes()))
+		for i, x := range pb.GetNodes() {
+			data.DataNodes[i].unmarshal(x)
+		}
+	} else {
+		data.DataNodes = make([]NodeInfo, len(pb.GetDataNodes()))
+		for i, x := range pb.GetDataNodes() {
+			data.DataNodes[i].unmarshal(x)
+		}
+	}
+
+	data.MetaNodes = make([]NodeInfo, len(pb.GetMetaNodes()))
+	for i, x := range pb.GetMetaNodes() {
+		data.MetaNodes[i].unmarshal(x)
 	}
 
 	data.Databases = make([]DatabaseInfo, len(pb.GetDatabases()))
@@ -731,8 +777,9 @@ func (data *Data) UnmarshalBinary(buf []byte) error {
 
 // NodeInfo represents information about a single node in the cluster.
 type NodeInfo struct {
-	ID   uint64
-	Host string
+	ID      uint64
+	Host    string
+	TCPHost string
 }
 
 // clone returns a deep copy of ni.
@@ -743,6 +790,7 @@ func (ni NodeInfo) marshal() *internal.NodeInfo {
 	pb := &internal.NodeInfo{}
 	pb.ID = proto.Uint64(ni.ID)
 	pb.Host = proto.String(ni.Host)
+	pb.TCPHost = proto.String(ni.TCPHost)
 	return pb
 }
 
@@ -750,6 +798,7 @@ func (ni NodeInfo) marshal() *internal.NodeInfo {
 func (ni *NodeInfo) unmarshal(pb *internal.NodeInfo) {
 	ni.ID = pb.GetID()
 	ni.Host = pb.GetHost()
+	ni.TCPHost = pb.GetTCPHost()
 }
 
 // NodeInfos is a slice of NodeInfo used for sorting

--- a/services/meta/internal/meta.pb.go
+++ b/services/meta/internal/meta.pb.go
@@ -43,15 +43,12 @@ It has these top-level messages:
 	CreateSubscriptionCommand
 	DropSubscriptionCommand
 	RemovePeerCommand
+	CreateMetaNodeCommand
+	CreateDataNodeCommand
+	UpdateDataNodeCommand
+	DeleteMetaNodeCommand
+	DeleteDataNodeCommand
 	Response
-	ResponseHeader
-	ErrorResponse
-	FetchDataRequest
-	FetchDataResponse
-	JoinRequest
-	JoinResponse
-	PromoteRaftRequest
-	PromoteRaftResponse
 */
 package internal
 
@@ -63,45 +60,6 @@ import math "math"
 var _ = proto.Marshal
 var _ = fmt.Errorf
 var _ = math.Inf
-
-type RPCType int32
-
-const (
-	RPCType_Error       RPCType = 1
-	RPCType_FetchData   RPCType = 2
-	RPCType_Join        RPCType = 3
-	RPCType_PromoteRaft RPCType = 4
-)
-
-var RPCType_name = map[int32]string{
-	1: "Error",
-	2: "FetchData",
-	3: "Join",
-	4: "PromoteRaft",
-}
-var RPCType_value = map[string]int32{
-	"Error":       1,
-	"FetchData":   2,
-	"Join":        3,
-	"PromoteRaft": 4,
-}
-
-func (x RPCType) Enum() *RPCType {
-	p := new(RPCType)
-	*p = x
-	return p
-}
-func (x RPCType) String() string {
-	return proto.EnumName(RPCType_name, int32(x))
-}
-func (x *RPCType) UnmarshalJSON(data []byte) error {
-	value, err := proto.UnmarshalJSONEnum(RPCType_value, data, "RPCType")
-	if err != nil {
-		return err
-	}
-	*x = RPCType(value)
-	return nil
-}
 
 type Command_Type int32
 
@@ -128,6 +86,11 @@ const (
 	Command_CreateSubscriptionCommand        Command_Type = 21
 	Command_DropSubscriptionCommand          Command_Type = 22
 	Command_RemovePeerCommand                Command_Type = 23
+	Command_CreateMetaNodeCommand            Command_Type = 24
+	Command_CreateDataNodeCommand            Command_Type = 25
+	Command_UpdateDataNodeCommand            Command_Type = 26
+	Command_DeleteMetaNodeCommand            Command_Type = 27
+	Command_DeleteDataNodeCommand            Command_Type = 28
 )
 
 var Command_Type_name = map[int32]string{
@@ -153,6 +116,11 @@ var Command_Type_name = map[int32]string{
 	21: "CreateSubscriptionCommand",
 	22: "DropSubscriptionCommand",
 	23: "RemovePeerCommand",
+	24: "CreateMetaNodeCommand",
+	25: "CreateDataNodeCommand",
+	26: "UpdateDataNodeCommand",
+	27: "DeleteMetaNodeCommand",
+	28: "DeleteDataNodeCommand",
 }
 var Command_Type_value = map[string]int32{
 	"CreateNodeCommand":                1,
@@ -177,6 +145,11 @@ var Command_Type_value = map[string]int32{
 	"CreateSubscriptionCommand":        21,
 	"DropSubscriptionCommand":          22,
 	"RemovePeerCommand":                23,
+	"CreateMetaNodeCommand":            24,
+	"CreateDataNodeCommand":            25,
+	"UpdateDataNodeCommand":            26,
+	"DeleteMetaNodeCommand":            27,
+	"DeleteDataNodeCommand":            28,
 }
 
 func (x Command_Type) Enum() *Command_Type {
@@ -197,16 +170,19 @@ func (x *Command_Type) UnmarshalJSON(data []byte) error {
 }
 
 type Data struct {
-	Term             *uint64         `protobuf:"varint,1,req,name=Term" json:"Term,omitempty"`
-	Index            *uint64         `protobuf:"varint,2,req,name=Index" json:"Index,omitempty"`
-	ClusterID        *uint64         `protobuf:"varint,3,req,name=ClusterID" json:"ClusterID,omitempty"`
-	Nodes            []*NodeInfo     `protobuf:"bytes,4,rep,name=Nodes" json:"Nodes,omitempty"`
-	Databases        []*DatabaseInfo `protobuf:"bytes,5,rep,name=Databases" json:"Databases,omitempty"`
-	Users            []*UserInfo     `protobuf:"bytes,6,rep,name=Users" json:"Users,omitempty"`
-	MaxNodeID        *uint64         `protobuf:"varint,7,req,name=MaxNodeID" json:"MaxNodeID,omitempty"`
-	MaxShardGroupID  *uint64         `protobuf:"varint,8,req,name=MaxShardGroupID" json:"MaxShardGroupID,omitempty"`
-	MaxShardID       *uint64         `protobuf:"varint,9,req,name=MaxShardID" json:"MaxShardID,omitempty"`
-	XXX_unrecognized []byte          `json:"-"`
+	Term            *uint64         `protobuf:"varint,1,req,name=Term" json:"Term,omitempty"`
+	Index           *uint64         `protobuf:"varint,2,req,name=Index" json:"Index,omitempty"`
+	ClusterID       *uint64         `protobuf:"varint,3,req,name=ClusterID" json:"ClusterID,omitempty"`
+	Nodes           []*NodeInfo     `protobuf:"bytes,4,rep,name=Nodes" json:"Nodes,omitempty"`
+	Databases       []*DatabaseInfo `protobuf:"bytes,5,rep,name=Databases" json:"Databases,omitempty"`
+	Users           []*UserInfo     `protobuf:"bytes,6,rep,name=Users" json:"Users,omitempty"`
+	MaxNodeID       *uint64         `protobuf:"varint,7,req,name=MaxNodeID" json:"MaxNodeID,omitempty"`
+	MaxShardGroupID *uint64         `protobuf:"varint,8,req,name=MaxShardGroupID" json:"MaxShardGroupID,omitempty"`
+	MaxShardID      *uint64         `protobuf:"varint,9,req,name=MaxShardID" json:"MaxShardID,omitempty"`
+	// added for 0.10.0
+	DataNodes        []*NodeInfo `protobuf:"bytes,10,rep,name=DataNodes" json:"DataNodes,omitempty"`
+	MetaNodes        []*NodeInfo `protobuf:"bytes,11,rep,name=MetaNodes" json:"MetaNodes,omitempty"`
+	XXX_unrecognized []byte      `json:"-"`
 }
 
 func (m *Data) Reset()         { *m = Data{} }
@@ -276,9 +252,24 @@ func (m *Data) GetMaxShardID() uint64 {
 	return 0
 }
 
+func (m *Data) GetDataNodes() []*NodeInfo {
+	if m != nil {
+		return m.DataNodes
+	}
+	return nil
+}
+
+func (m *Data) GetMetaNodes() []*NodeInfo {
+	if m != nil {
+		return m.MetaNodes
+	}
+	return nil
+}
+
 type NodeInfo struct {
 	ID               *uint64 `protobuf:"varint,1,req,name=ID" json:"ID,omitempty"`
 	Host             *string `protobuf:"bytes,2,req,name=Host" json:"Host,omitempty"`
+	TCPHost          *string `protobuf:"bytes,3,opt,name=TCPHost" json:"TCPHost,omitempty"`
 	XXX_unrecognized []byte  `json:"-"`
 }
 
@@ -296,6 +287,13 @@ func (m *NodeInfo) GetID() uint64 {
 func (m *NodeInfo) GetHost() string {
 	if m != nil && m.Host != nil {
 		return *m.Host
+	}
+	return ""
+}
+
+func (m *NodeInfo) GetTCPHost() string {
+	if m != nil && m.TCPHost != nil {
+		return *m.TCPHost
 	}
 	return ""
 }
@@ -643,6 +641,8 @@ func (m *Command) GetType() Command_Type {
 	return Command_CreateNodeCommand
 }
 
+// This isn't used in >= 0.10.0. Kept around for upgrade purposes. Instead
+// look at CreateDataNodeCommand and CreateMetaNodeCommand
 type CreateNodeCommand struct {
 	Host             *string `protobuf:"bytes,1,req,name=Host" json:"Host,omitempty"`
 	Rand             *uint64 `protobuf:"varint,2,req,name=Rand" json:"Rand,omitempty"`
@@ -1380,7 +1380,7 @@ var E_DropSubscriptionCommand_Command = &proto.ExtensionDesc{
 }
 
 type RemovePeerCommand struct {
-	ID               *uint64 `protobuf:"varint,1,req,name=ID" json:"ID,omitempty"`
+	ID               *uint64 `protobuf:"varint,1,opt,name=ID" json:"ID,omitempty"`
 	Addr             *string `protobuf:"bytes,2,req,name=Addr" json:"Addr,omitempty"`
 	XXX_unrecognized []byte  `json:"-"`
 }
@@ -1409,6 +1409,158 @@ var E_RemovePeerCommand_Command = &proto.ExtensionDesc{
 	Field:         123,
 	Name:          "internal.RemovePeerCommand.command",
 	Tag:           "bytes,123,opt,name=command",
+}
+
+type CreateMetaNodeCommand struct {
+	HTTPAddr         *string `protobuf:"bytes,1,req,name=HTTPAddr" json:"HTTPAddr,omitempty"`
+	TCPAddr          *string `protobuf:"bytes,2,req,name=TCPAddr" json:"TCPAddr,omitempty"`
+	XXX_unrecognized []byte  `json:"-"`
+}
+
+func (m *CreateMetaNodeCommand) Reset()         { *m = CreateMetaNodeCommand{} }
+func (m *CreateMetaNodeCommand) String() string { return proto.CompactTextString(m) }
+func (*CreateMetaNodeCommand) ProtoMessage()    {}
+
+func (m *CreateMetaNodeCommand) GetHTTPAddr() string {
+	if m != nil && m.HTTPAddr != nil {
+		return *m.HTTPAddr
+	}
+	return ""
+}
+
+func (m *CreateMetaNodeCommand) GetTCPAddr() string {
+	if m != nil && m.TCPAddr != nil {
+		return *m.TCPAddr
+	}
+	return ""
+}
+
+var E_CreateMetaNodeCommand_Command = &proto.ExtensionDesc{
+	ExtendedType:  (*Command)(nil),
+	ExtensionType: (*CreateMetaNodeCommand)(nil),
+	Field:         124,
+	Name:          "internal.CreateMetaNodeCommand.command",
+	Tag:           "bytes,124,opt,name=command",
+}
+
+type CreateDataNodeCommand struct {
+	HTTPAddr         *string `protobuf:"bytes,1,req,name=HTTPAddr" json:"HTTPAddr,omitempty"`
+	TCPAddr          *string `protobuf:"bytes,2,req,name=TCPAddr" json:"TCPAddr,omitempty"`
+	XXX_unrecognized []byte  `json:"-"`
+}
+
+func (m *CreateDataNodeCommand) Reset()         { *m = CreateDataNodeCommand{} }
+func (m *CreateDataNodeCommand) String() string { return proto.CompactTextString(m) }
+func (*CreateDataNodeCommand) ProtoMessage()    {}
+
+func (m *CreateDataNodeCommand) GetHTTPAddr() string {
+	if m != nil && m.HTTPAddr != nil {
+		return *m.HTTPAddr
+	}
+	return ""
+}
+
+func (m *CreateDataNodeCommand) GetTCPAddr() string {
+	if m != nil && m.TCPAddr != nil {
+		return *m.TCPAddr
+	}
+	return ""
+}
+
+var E_CreateDataNodeCommand_Command = &proto.ExtensionDesc{
+	ExtendedType:  (*Command)(nil),
+	ExtensionType: (*CreateDataNodeCommand)(nil),
+	Field:         125,
+	Name:          "internal.CreateDataNodeCommand.command",
+	Tag:           "bytes,125,opt,name=command",
+}
+
+type UpdateDataNodeCommand struct {
+	ID               *uint64 `protobuf:"varint,1,req,name=ID" json:"ID,omitempty"`
+	Host             *string `protobuf:"bytes,2,req,name=Host" json:"Host,omitempty"`
+	TCPHost          *string `protobuf:"bytes,3,req,name=TCPHost" json:"TCPHost,omitempty"`
+	XXX_unrecognized []byte  `json:"-"`
+}
+
+func (m *UpdateDataNodeCommand) Reset()         { *m = UpdateDataNodeCommand{} }
+func (m *UpdateDataNodeCommand) String() string { return proto.CompactTextString(m) }
+func (*UpdateDataNodeCommand) ProtoMessage()    {}
+
+func (m *UpdateDataNodeCommand) GetID() uint64 {
+	if m != nil && m.ID != nil {
+		return *m.ID
+	}
+	return 0
+}
+
+func (m *UpdateDataNodeCommand) GetHost() string {
+	if m != nil && m.Host != nil {
+		return *m.Host
+	}
+	return ""
+}
+
+func (m *UpdateDataNodeCommand) GetTCPHost() string {
+	if m != nil && m.TCPHost != nil {
+		return *m.TCPHost
+	}
+	return ""
+}
+
+var E_UpdateDataNodeCommand_Command = &proto.ExtensionDesc{
+	ExtendedType:  (*Command)(nil),
+	ExtensionType: (*UpdateDataNodeCommand)(nil),
+	Field:         126,
+	Name:          "internal.UpdateDataNodeCommand.command",
+	Tag:           "bytes,126,opt,name=command",
+}
+
+type DeleteMetaNodeCommand struct {
+	ID               *uint64 `protobuf:"varint,1,req,name=ID" json:"ID,omitempty"`
+	XXX_unrecognized []byte  `json:"-"`
+}
+
+func (m *DeleteMetaNodeCommand) Reset()         { *m = DeleteMetaNodeCommand{} }
+func (m *DeleteMetaNodeCommand) String() string { return proto.CompactTextString(m) }
+func (*DeleteMetaNodeCommand) ProtoMessage()    {}
+
+func (m *DeleteMetaNodeCommand) GetID() uint64 {
+	if m != nil && m.ID != nil {
+		return *m.ID
+	}
+	return 0
+}
+
+var E_DeleteMetaNodeCommand_Command = &proto.ExtensionDesc{
+	ExtendedType:  (*Command)(nil),
+	ExtensionType: (*DeleteMetaNodeCommand)(nil),
+	Field:         127,
+	Name:          "internal.DeleteMetaNodeCommand.command",
+	Tag:           "bytes,127,opt,name=command",
+}
+
+type DeleteDataNodeCommand struct {
+	ID               *uint64 `protobuf:"varint,1,req,name=ID" json:"ID,omitempty"`
+	XXX_unrecognized []byte  `json:"-"`
+}
+
+func (m *DeleteDataNodeCommand) Reset()         { *m = DeleteDataNodeCommand{} }
+func (m *DeleteDataNodeCommand) String() string { return proto.CompactTextString(m) }
+func (*DeleteDataNodeCommand) ProtoMessage()    {}
+
+func (m *DeleteDataNodeCommand) GetID() uint64 {
+	if m != nil && m.ID != nil {
+		return *m.ID
+	}
+	return 0
+}
+
+var E_DeleteDataNodeCommand_Command = &proto.ExtensionDesc{
+	ExtendedType:  (*Command)(nil),
+	ExtensionType: (*DeleteDataNodeCommand)(nil),
+	Field:         128,
+	Name:          "internal.DeleteDataNodeCommand.command",
+	Tag:           "bytes,128,opt,name=command",
 }
 
 type Response struct {
@@ -1443,226 +1595,47 @@ func (m *Response) GetIndex() uint64 {
 	return 0
 }
 
-type ResponseHeader struct {
-	OK               *bool   `protobuf:"varint,1,req,name=OK" json:"OK,omitempty"`
-	Error            *string `protobuf:"bytes,2,opt,name=Error" json:"Error,omitempty"`
-	XXX_unrecognized []byte  `json:"-"`
-}
-
-func (m *ResponseHeader) Reset()         { *m = ResponseHeader{} }
-func (m *ResponseHeader) String() string { return proto.CompactTextString(m) }
-func (*ResponseHeader) ProtoMessage()    {}
-
-func (m *ResponseHeader) GetOK() bool {
-	if m != nil && m.OK != nil {
-		return *m.OK
-	}
-	return false
-}
-
-func (m *ResponseHeader) GetError() string {
-	if m != nil && m.Error != nil {
-		return *m.Error
-	}
-	return ""
-}
-
-type ErrorResponse struct {
-	Header           *ResponseHeader `protobuf:"bytes,1,req,name=Header" json:"Header,omitempty"`
-	XXX_unrecognized []byte          `json:"-"`
-}
-
-func (m *ErrorResponse) Reset()         { *m = ErrorResponse{} }
-func (m *ErrorResponse) String() string { return proto.CompactTextString(m) }
-func (*ErrorResponse) ProtoMessage()    {}
-
-func (m *ErrorResponse) GetHeader() *ResponseHeader {
-	if m != nil {
-		return m.Header
-	}
-	return nil
-}
-
-type FetchDataRequest struct {
-	Index            *uint64 `protobuf:"varint,1,req,name=Index" json:"Index,omitempty"`
-	Term             *uint64 `protobuf:"varint,2,req,name=Term" json:"Term,omitempty"`
-	Blocking         *bool   `protobuf:"varint,3,opt,name=Blocking,def=0" json:"Blocking,omitempty"`
-	XXX_unrecognized []byte  `json:"-"`
-}
-
-func (m *FetchDataRequest) Reset()         { *m = FetchDataRequest{} }
-func (m *FetchDataRequest) String() string { return proto.CompactTextString(m) }
-func (*FetchDataRequest) ProtoMessage()    {}
-
-const Default_FetchDataRequest_Blocking bool = false
-
-func (m *FetchDataRequest) GetIndex() uint64 {
-	if m != nil && m.Index != nil {
-		return *m.Index
-	}
-	return 0
-}
-
-func (m *FetchDataRequest) GetTerm() uint64 {
-	if m != nil && m.Term != nil {
-		return *m.Term
-	}
-	return 0
-}
-
-func (m *FetchDataRequest) GetBlocking() bool {
-	if m != nil && m.Blocking != nil {
-		return *m.Blocking
-	}
-	return Default_FetchDataRequest_Blocking
-}
-
-type FetchDataResponse struct {
-	Header           *ResponseHeader `protobuf:"bytes,1,req,name=Header" json:"Header,omitempty"`
-	Index            *uint64         `protobuf:"varint,2,req,name=Index" json:"Index,omitempty"`
-	Term             *uint64         `protobuf:"varint,3,req,name=Term" json:"Term,omitempty"`
-	Data             []byte          `protobuf:"bytes,4,opt,name=Data" json:"Data,omitempty"`
-	XXX_unrecognized []byte          `json:"-"`
-}
-
-func (m *FetchDataResponse) Reset()         { *m = FetchDataResponse{} }
-func (m *FetchDataResponse) String() string { return proto.CompactTextString(m) }
-func (*FetchDataResponse) ProtoMessage()    {}
-
-func (m *FetchDataResponse) GetHeader() *ResponseHeader {
-	if m != nil {
-		return m.Header
-	}
-	return nil
-}
-
-func (m *FetchDataResponse) GetIndex() uint64 {
-	if m != nil && m.Index != nil {
-		return *m.Index
-	}
-	return 0
-}
-
-func (m *FetchDataResponse) GetTerm() uint64 {
-	if m != nil && m.Term != nil {
-		return *m.Term
-	}
-	return 0
-}
-
-func (m *FetchDataResponse) GetData() []byte {
-	if m != nil {
-		return m.Data
-	}
-	return nil
-}
-
-type JoinRequest struct {
-	Addr             *string `protobuf:"bytes,1,req,name=Addr" json:"Addr,omitempty"`
-	XXX_unrecognized []byte  `json:"-"`
-}
-
-func (m *JoinRequest) Reset()         { *m = JoinRequest{} }
-func (m *JoinRequest) String() string { return proto.CompactTextString(m) }
-func (*JoinRequest) ProtoMessage()    {}
-
-func (m *JoinRequest) GetAddr() string {
-	if m != nil && m.Addr != nil {
-		return *m.Addr
-	}
-	return ""
-}
-
-type JoinResponse struct {
-	Header           *ResponseHeader `protobuf:"bytes,1,req,name=Header" json:"Header,omitempty"`
-	EnableRaft       *bool           `protobuf:"varint,2,opt,name=EnableRaft" json:"EnableRaft,omitempty"`
-	RaftNodes        []string        `protobuf:"bytes,3,rep,name=RaftNodes" json:"RaftNodes,omitempty"`
-	NodeID           *uint64         `protobuf:"varint,4,opt,name=NodeID" json:"NodeID,omitempty"`
-	XXX_unrecognized []byte          `json:"-"`
-}
-
-func (m *JoinResponse) Reset()         { *m = JoinResponse{} }
-func (m *JoinResponse) String() string { return proto.CompactTextString(m) }
-func (*JoinResponse) ProtoMessage()    {}
-
-func (m *JoinResponse) GetHeader() *ResponseHeader {
-	if m != nil {
-		return m.Header
-	}
-	return nil
-}
-
-func (m *JoinResponse) GetEnableRaft() bool {
-	if m != nil && m.EnableRaft != nil {
-		return *m.EnableRaft
-	}
-	return false
-}
-
-func (m *JoinResponse) GetRaftNodes() []string {
-	if m != nil {
-		return m.RaftNodes
-	}
-	return nil
-}
-
-func (m *JoinResponse) GetNodeID() uint64 {
-	if m != nil && m.NodeID != nil {
-		return *m.NodeID
-	}
-	return 0
-}
-
-type PromoteRaftRequest struct {
-	Addr             *string  `protobuf:"bytes,1,req,name=Addr" json:"Addr,omitempty"`
-	RaftNodes        []string `protobuf:"bytes,2,rep,name=RaftNodes" json:"RaftNodes,omitempty"`
-	XXX_unrecognized []byte   `json:"-"`
-}
-
-func (m *PromoteRaftRequest) Reset()         { *m = PromoteRaftRequest{} }
-func (m *PromoteRaftRequest) String() string { return proto.CompactTextString(m) }
-func (*PromoteRaftRequest) ProtoMessage()    {}
-
-func (m *PromoteRaftRequest) GetAddr() string {
-	if m != nil && m.Addr != nil {
-		return *m.Addr
-	}
-	return ""
-}
-
-func (m *PromoteRaftRequest) GetRaftNodes() []string {
-	if m != nil {
-		return m.RaftNodes
-	}
-	return nil
-}
-
-type PromoteRaftResponse struct {
-	Header           *ResponseHeader `protobuf:"bytes,1,req,name=Header" json:"Header,omitempty"`
-	Success          *bool           `protobuf:"varint,2,opt,name=Success" json:"Success,omitempty"`
-	XXX_unrecognized []byte          `json:"-"`
-}
-
-func (m *PromoteRaftResponse) Reset()         { *m = PromoteRaftResponse{} }
-func (m *PromoteRaftResponse) String() string { return proto.CompactTextString(m) }
-func (*PromoteRaftResponse) ProtoMessage()    {}
-
-func (m *PromoteRaftResponse) GetHeader() *ResponseHeader {
-	if m != nil {
-		return m.Header
-	}
-	return nil
-}
-
-func (m *PromoteRaftResponse) GetSuccess() bool {
-	if m != nil && m.Success != nil {
-		return *m.Success
-	}
-	return false
-}
-
 func init() {
-	proto.RegisterEnum("internal.RPCType", RPCType_name, RPCType_value)
+	proto.RegisterType((*Data)(nil), "internal.Data")
+	proto.RegisterType((*NodeInfo)(nil), "internal.NodeInfo")
+	proto.RegisterType((*DatabaseInfo)(nil), "internal.DatabaseInfo")
+	proto.RegisterType((*RetentionPolicyInfo)(nil), "internal.RetentionPolicyInfo")
+	proto.RegisterType((*ShardGroupInfo)(nil), "internal.ShardGroupInfo")
+	proto.RegisterType((*ShardInfo)(nil), "internal.ShardInfo")
+	proto.RegisterType((*SubscriptionInfo)(nil), "internal.SubscriptionInfo")
+	proto.RegisterType((*ShardOwner)(nil), "internal.ShardOwner")
+	proto.RegisterType((*ContinuousQueryInfo)(nil), "internal.ContinuousQueryInfo")
+	proto.RegisterType((*UserInfo)(nil), "internal.UserInfo")
+	proto.RegisterType((*UserPrivilege)(nil), "internal.UserPrivilege")
+	proto.RegisterType((*Command)(nil), "internal.Command")
+	proto.RegisterType((*CreateNodeCommand)(nil), "internal.CreateNodeCommand")
+	proto.RegisterType((*DeleteNodeCommand)(nil), "internal.DeleteNodeCommand")
+	proto.RegisterType((*CreateDatabaseCommand)(nil), "internal.CreateDatabaseCommand")
+	proto.RegisterType((*DropDatabaseCommand)(nil), "internal.DropDatabaseCommand")
+	proto.RegisterType((*CreateRetentionPolicyCommand)(nil), "internal.CreateRetentionPolicyCommand")
+	proto.RegisterType((*DropRetentionPolicyCommand)(nil), "internal.DropRetentionPolicyCommand")
+	proto.RegisterType((*SetDefaultRetentionPolicyCommand)(nil), "internal.SetDefaultRetentionPolicyCommand")
+	proto.RegisterType((*UpdateRetentionPolicyCommand)(nil), "internal.UpdateRetentionPolicyCommand")
+	proto.RegisterType((*CreateShardGroupCommand)(nil), "internal.CreateShardGroupCommand")
+	proto.RegisterType((*DeleteShardGroupCommand)(nil), "internal.DeleteShardGroupCommand")
+	proto.RegisterType((*CreateContinuousQueryCommand)(nil), "internal.CreateContinuousQueryCommand")
+	proto.RegisterType((*DropContinuousQueryCommand)(nil), "internal.DropContinuousQueryCommand")
+	proto.RegisterType((*CreateUserCommand)(nil), "internal.CreateUserCommand")
+	proto.RegisterType((*DropUserCommand)(nil), "internal.DropUserCommand")
+	proto.RegisterType((*UpdateUserCommand)(nil), "internal.UpdateUserCommand")
+	proto.RegisterType((*SetPrivilegeCommand)(nil), "internal.SetPrivilegeCommand")
+	proto.RegisterType((*SetDataCommand)(nil), "internal.SetDataCommand")
+	proto.RegisterType((*SetAdminPrivilegeCommand)(nil), "internal.SetAdminPrivilegeCommand")
+	proto.RegisterType((*UpdateNodeCommand)(nil), "internal.UpdateNodeCommand")
+	proto.RegisterType((*CreateSubscriptionCommand)(nil), "internal.CreateSubscriptionCommand")
+	proto.RegisterType((*DropSubscriptionCommand)(nil), "internal.DropSubscriptionCommand")
+	proto.RegisterType((*RemovePeerCommand)(nil), "internal.RemovePeerCommand")
+	proto.RegisterType((*CreateMetaNodeCommand)(nil), "internal.CreateMetaNodeCommand")
+	proto.RegisterType((*CreateDataNodeCommand)(nil), "internal.CreateDataNodeCommand")
+	proto.RegisterType((*UpdateDataNodeCommand)(nil), "internal.UpdateDataNodeCommand")
+	proto.RegisterType((*DeleteMetaNodeCommand)(nil), "internal.DeleteMetaNodeCommand")
+	proto.RegisterType((*DeleteDataNodeCommand)(nil), "internal.DeleteDataNodeCommand")
+	proto.RegisterType((*Response)(nil), "internal.Response")
 	proto.RegisterEnum("internal.Command_Type", Command_Type_name, Command_Type_value)
 	proto.RegisterExtension(E_CreateNodeCommand_Command)
 	proto.RegisterExtension(E_DeleteNodeCommand_Command)
@@ -1686,4 +1659,9 @@ func init() {
 	proto.RegisterExtension(E_CreateSubscriptionCommand_Command)
 	proto.RegisterExtension(E_DropSubscriptionCommand_Command)
 	proto.RegisterExtension(E_RemovePeerCommand_Command)
+	proto.RegisterExtension(E_CreateMetaNodeCommand_Command)
+	proto.RegisterExtension(E_CreateDataNodeCommand_Command)
+	proto.RegisterExtension(E_UpdateDataNodeCommand_Command)
+	proto.RegisterExtension(E_DeleteMetaNodeCommand_Command)
+	proto.RegisterExtension(E_DeleteDataNodeCommand_Command)
 }

--- a/services/meta/internal/meta.proto
+++ b/services/meta/internal/meta.proto
@@ -18,11 +18,16 @@ message Data {
 	required uint64 MaxNodeID = 7;
 	required uint64 MaxShardGroupID = 8;
 	required uint64 MaxShardID = 9;
+
+    // added for 0.10.0
+    repeated NodeInfo DataNodes = 10;
+    repeated NodeInfo MetaNodes = 11;
 }
 
 message NodeInfo {
 	required uint64 ID = 1;
 	required string Host = 2;
+    optional string TCPHost = 3;
 }
 
 message DatabaseInfo {
@@ -115,11 +120,18 @@ message Command {
 		CreateSubscriptionCommand        = 21;
 		DropSubscriptionCommand          = 22;
 		RemovePeerCommand                = 23;
+        CreateMetaNodeCommand            = 24;
+        CreateDataNodeCommand            = 25;
+        UpdateDataNodeCommand            = 26;
+        DeleteMetaNodeCommand            = 27;
+        DeleteDataNodeCommand            = 28;
     }
 
     required Type type = 1;
 }
 
+// This isn't used in >= 0.10.0. Kept around for upgrade purposes. Instead
+// look at CreateDataNodeCommand and CreateMetaNodeCommand
 message CreateNodeCommand {
     extend Command {
         optional CreateNodeCommand command = 101;
@@ -301,77 +313,51 @@ message RemovePeerCommand {
     extend Command {
         optional RemovePeerCommand command = 123;
     }
-	required uint64 ID = 1;
+	optional uint64 ID = 1;
 	required string Addr = 2;
+}
+
+message CreateMetaNodeCommand {
+    extend Command {
+        optional CreateMetaNodeCommand command = 124;
+    }
+    required string HTTPAddr = 1;
+    required string TCPAddr = 2;
+}
+
+message CreateDataNodeCommand {
+    extend Command {
+        optional CreateDataNodeCommand command = 125;
+    }
+    required string HTTPAddr = 1;
+    required string TCPAddr = 2;
+}
+
+message UpdateDataNodeCommand {
+    extend Command {
+        optional UpdateDataNodeCommand command = 126;
+    }
+    required uint64 ID = 1;
+    required string Host = 2;
+    required string TCPHost = 3;
+}
+
+message DeleteMetaNodeCommand {
+    extend Command {
+        optional DeleteMetaNodeCommand command = 127;
+    }
+    required uint64 ID = 1;
+}
+
+message DeleteDataNodeCommand {
+    extend Command {
+        optional DeleteDataNodeCommand command = 128;
+    }
+    required uint64 ID = 1;    
 }
 
 message Response {
 	required bool OK = 1;
 	optional string Error = 2;
 	optional uint64 Index = 3;
-}
-
-
-//========================================================================
-//
-// RPC - higher-level cluster communication operations
-//
-//========================================================================
-
-enum RPCType {
-    Error = 1;
-    FetchData = 2;
-    Join = 3;
-    PromoteRaft = 4;
-}
-
-message ResponseHeader {
-    required bool OK = 1;
-    optional string Error = 2;
-}
-
-message ErrorResponse {
-    required ResponseHeader Header = 1;
-}
-
-message FetchDataRequest {
-    required uint64 Index = 1;
-    required uint64 Term = 2;
-    optional bool Blocking = 3 [default = false];
-}
-
-message FetchDataResponse {
-    required ResponseHeader Header = 1;
-    required uint64 Index = 2;
-    required uint64 Term = 3;
-    optional bytes Data = 4;
-}
-
-message JoinRequest {
-    required string Addr = 1;
-}
-
-message JoinResponse {
-    required ResponseHeader Header = 1;
-
-    // Indicates that this node should take part in the raft cluster.
-    optional bool EnableRaft = 2;
-
-    // The addresses of raft peers to use if joining as a raft member. If not joining
-    // as a raft member, these are the nodes running raft.
-    repeated string RaftNodes = 3;
-
-    // The node ID assigned to the requesting node.
-    optional uint64 NodeID = 4;
-}
-
-message PromoteRaftRequest {
-    required string Addr = 1;
-    repeated string RaftNodes = 2;
-}
-
-message PromoteRaftResponse {
-    required ResponseHeader Header = 1;
-
-    optional bool Success = 2;
 }

--- a/services/meta/statement_executor.go
+++ b/services/meta/statement_executor.go
@@ -1,0 +1,457 @@
+package meta
+
+import (
+	"bytes"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/influxdb/influxdb"
+	"github.com/influxdb/influxdb/influxql"
+	"github.com/influxdb/influxdb/models"
+)
+
+// StatementExecutor translates InfluxQL queries to meta store methods.
+type StatementExecutor struct {
+	Store interface {
+		DataNode(id uint64) (ni *NodeInfo, err error)
+		DataNodes() ([]NodeInfo, error)
+		MetaNodes() ([]NodeInfo, error)
+		DeleteDataNode(nodeID uint64) error
+		DeleteMetaNode(nodeID uint64) error
+
+		Database(name string) (*DatabaseInfo, error)
+		Databases() ([]DatabaseInfo, error)
+		CreateDatabase(name string) (*DatabaseInfo, error)
+		CreateDatabaseWithRetentionPolicy(name string, rpi *RetentionPolicyInfo) (*DatabaseInfo, error)
+		DropDatabase(name string) error
+
+		CreateRetentionPolicy(database string, rpi *RetentionPolicyInfo) (*RetentionPolicyInfo, error)
+		UpdateRetentionPolicy(database, name string, rpu *RetentionPolicyUpdate) error
+		SetDefaultRetentionPolicy(database, name string) error
+		DropRetentionPolicy(database, name string) error
+
+		Users() ([]UserInfo, error)
+		CreateUser(name, password string, admin bool) (*UserInfo, error)
+		UpdateUser(name, password string) error
+		DropUser(name string) error
+		SetPrivilege(username, database string, p influxql.Privilege) error
+		SetAdminPrivilege(username string, admin bool) error
+		UserPrivileges(username string) (map[string]influxql.Privilege, error)
+		UserPrivilege(username, database string) (*influxql.Privilege, error)
+
+		CreateContinuousQuery(database, name, query string) error
+		DropContinuousQuery(database, name string) error
+
+		CreateSubscription(database, rp, name, mode string, destinations []string) error
+		DropSubscription(database, rp, name string) error
+	}
+}
+
+// ExecuteStatement executes stmt against the meta store as user.
+func (e *StatementExecutor) ExecuteStatement(stmt influxql.Statement) *influxql.Result {
+	switch stmt := stmt.(type) {
+	case *influxql.CreateDatabaseStatement:
+		return e.executeCreateDatabaseStatement(stmt)
+	case *influxql.DropDatabaseStatement:
+		return e.executeDropDatabaseStatement(stmt)
+	case *influxql.ShowDatabasesStatement:
+		return e.executeShowDatabasesStatement(stmt)
+	case *influxql.ShowGrantsForUserStatement:
+		return e.executeShowGrantsForUserStatement(stmt)
+	case *influxql.ShowServersStatement:
+		return e.executeShowServersStatement(stmt)
+	case *influxql.CreateUserStatement:
+		return e.executeCreateUserStatement(stmt)
+	case *influxql.SetPasswordUserStatement:
+		return e.executeSetPasswordUserStatement(stmt)
+	case *influxql.DropUserStatement:
+		return e.executeDropUserStatement(stmt)
+	case *influxql.ShowUsersStatement:
+		return e.executeShowUsersStatement(stmt)
+	case *influxql.GrantStatement:
+		return e.executeGrantStatement(stmt)
+	case *influxql.GrantAdminStatement:
+		return e.executeGrantAdminStatement(stmt)
+	case *influxql.RevokeStatement:
+		return e.executeRevokeStatement(stmt)
+	case *influxql.RevokeAdminStatement:
+		return e.executeRevokeAdminStatement(stmt)
+	case *influxql.CreateRetentionPolicyStatement:
+		return e.executeCreateRetentionPolicyStatement(stmt)
+	case *influxql.AlterRetentionPolicyStatement:
+		return e.executeAlterRetentionPolicyStatement(stmt)
+	case *influxql.DropRetentionPolicyStatement:
+		return e.executeDropRetentionPolicyStatement(stmt)
+	case *influxql.ShowRetentionPoliciesStatement:
+		return e.executeShowRetentionPoliciesStatement(stmt)
+	case *influxql.CreateContinuousQueryStatement:
+		return e.executeCreateContinuousQueryStatement(stmt)
+	case *influxql.DropContinuousQueryStatement:
+		return e.executeDropContinuousQueryStatement(stmt)
+	case *influxql.ShowContinuousQueriesStatement:
+		return e.executeShowContinuousQueriesStatement(stmt)
+	case *influxql.ShowShardsStatement:
+		return e.executeShowShardsStatement(stmt)
+	case *influxql.ShowShardGroupsStatement:
+		return e.executeShowShardGroupsStatement(stmt)
+	case *influxql.ShowStatsStatement:
+		return e.executeShowStatsStatement(stmt)
+	case *influxql.DropServerStatement:
+		return e.executeDropServerStatement(stmt)
+	case *influxql.CreateSubscriptionStatement:
+		return e.executeCreateSubscriptionStatement(stmt)
+	case *influxql.DropSubscriptionStatement:
+		return e.executeDropSubscriptionStatement(stmt)
+	case *influxql.ShowSubscriptionsStatement:
+		return e.executeShowSubscriptionsStatement(stmt)
+	default:
+		panic(fmt.Sprintf("unsupported statement type: %T", stmt))
+	}
+}
+
+func (e *StatementExecutor) executeCreateDatabaseStatement(q *influxql.CreateDatabaseStatement) *influxql.Result {
+	var err error
+	if q.RetentionPolicyCreate {
+		rpi := NewRetentionPolicyInfo(q.RetentionPolicyName)
+		rpi.Duration = q.RetentionPolicyDuration
+		rpi.ReplicaN = q.RetentionPolicyReplication
+		_, err = e.Store.CreateDatabaseWithRetentionPolicy(q.Name, rpi)
+	} else {
+		_, err = e.Store.CreateDatabase(q.Name)
+	}
+	if err == ErrDatabaseExists && q.IfNotExists {
+		err = nil
+	}
+
+	return &influxql.Result{Err: err}
+}
+
+func (e *StatementExecutor) executeDropDatabaseStatement(q *influxql.DropDatabaseStatement) *influxql.Result {
+	return &influxql.Result{Err: e.Store.DropDatabase(q.Name)}
+}
+
+func (e *StatementExecutor) executeShowDatabasesStatement(q *influxql.ShowDatabasesStatement) *influxql.Result {
+	dis, err := e.Store.Databases()
+	if err != nil {
+		return &influxql.Result{Err: err}
+	}
+
+	row := &models.Row{Name: "databases", Columns: []string{"name"}}
+	for _, di := range dis {
+		row.Values = append(row.Values, []interface{}{di.Name})
+	}
+	return &influxql.Result{Series: []*models.Row{row}}
+}
+
+func (e *StatementExecutor) executeShowGrantsForUserStatement(q *influxql.ShowGrantsForUserStatement) *influxql.Result {
+	priv, err := e.Store.UserPrivileges(q.Name)
+	if err != nil {
+		return &influxql.Result{Err: err}
+	}
+
+	row := &models.Row{Columns: []string{"database", "privilege"}}
+	for d, p := range priv {
+		row.Values = append(row.Values, []interface{}{d, p.String()})
+	}
+	return &influxql.Result{Series: []*models.Row{row}}
+}
+
+func (e *StatementExecutor) executeShowServersStatement(q *influxql.ShowServersStatement) *influxql.Result {
+	nis, err := e.Store.DataNodes()
+	if err != nil {
+		return &influxql.Result{Err: err}
+	}
+
+	dataNodes := &models.Row{Columns: []string{"id", "http_addr", "tcp_addr"}}
+	dataNodes.Name = "data_nodes"
+	for _, ni := range nis {
+		dataNodes.Values = append(dataNodes.Values, []interface{}{ni.ID, ni.Host, ni.TCPHost})
+	}
+
+	nis, err = e.Store.MetaNodes()
+	if err != nil {
+		return &influxql.Result{Err: err}
+	}
+
+	metaNodes := &models.Row{Columns: []string{"id", "http_addr", "tcp_addr"}}
+	metaNodes.Name = "meta_nodes"
+	for _, ni := range nis {
+		metaNodes.Values = append(metaNodes.Values, []interface{}{ni.ID, ni.Host, ni.TCPHost})
+	}
+
+	return &influxql.Result{Series: []*models.Row{dataNodes, metaNodes}}
+}
+
+func (e *StatementExecutor) executeDropServerStatement(q *influxql.DropServerStatement) *influxql.Result {
+	var err error
+	if q.Meta {
+		err = e.Store.DeleteMetaNode(q.NodeID)
+	} else {
+		err = e.Store.DeleteDataNode(q.NodeID)
+	}
+
+	return &influxql.Result{Err: err}
+}
+
+func (e *StatementExecutor) executeCreateUserStatement(q *influxql.CreateUserStatement) *influxql.Result {
+	_, err := e.Store.CreateUser(q.Name, q.Password, q.Admin)
+	return &influxql.Result{Err: err}
+}
+
+func (e *StatementExecutor) executeSetPasswordUserStatement(q *influxql.SetPasswordUserStatement) *influxql.Result {
+	return &influxql.Result{Err: e.Store.UpdateUser(q.Name, q.Password)}
+}
+
+func (e *StatementExecutor) executeDropUserStatement(q *influxql.DropUserStatement) *influxql.Result {
+	return &influxql.Result{Err: e.Store.DropUser(q.Name)}
+}
+
+func (e *StatementExecutor) executeShowUsersStatement(q *influxql.ShowUsersStatement) *influxql.Result {
+	uis, err := e.Store.Users()
+	if err != nil {
+		return &influxql.Result{Err: err}
+	}
+
+	row := &models.Row{Columns: []string{"user", "admin"}}
+	for _, ui := range uis {
+		row.Values = append(row.Values, []interface{}{ui.Name, ui.Admin})
+	}
+	return &influxql.Result{Series: []*models.Row{row}}
+}
+
+func (e *StatementExecutor) executeGrantStatement(stmt *influxql.GrantStatement) *influxql.Result {
+	return &influxql.Result{Err: e.Store.SetPrivilege(stmt.User, stmt.On, stmt.Privilege)}
+}
+
+func (e *StatementExecutor) executeGrantAdminStatement(stmt *influxql.GrantAdminStatement) *influxql.Result {
+	return &influxql.Result{Err: e.Store.SetAdminPrivilege(stmt.User, true)}
+}
+
+func (e *StatementExecutor) executeRevokeStatement(stmt *influxql.RevokeStatement) *influxql.Result {
+	priv := influxql.NoPrivileges
+
+	// Revoking all privileges means there's no need to look at existing user privileges.
+	if stmt.Privilege != influxql.AllPrivileges {
+		p, err := e.Store.UserPrivilege(stmt.User, stmt.On)
+		if err != nil {
+			return &influxql.Result{Err: err}
+		}
+		// Bit clear (AND NOT) the user's privilege with the revoked privilege.
+		priv = *p &^ stmt.Privilege
+	}
+
+	return &influxql.Result{Err: e.Store.SetPrivilege(stmt.User, stmt.On, priv)}
+}
+
+func (e *StatementExecutor) executeRevokeAdminStatement(stmt *influxql.RevokeAdminStatement) *influxql.Result {
+	return &influxql.Result{Err: e.Store.SetAdminPrivilege(stmt.User, false)}
+}
+
+func (e *StatementExecutor) executeCreateRetentionPolicyStatement(stmt *influxql.CreateRetentionPolicyStatement) *influxql.Result {
+	rpi := NewRetentionPolicyInfo(stmt.Name)
+	rpi.Duration = stmt.Duration
+	rpi.ReplicaN = stmt.Replication
+
+	// Create new retention policy.
+	_, err := e.Store.CreateRetentionPolicy(stmt.Database, rpi)
+	if err != nil {
+		return &influxql.Result{Err: err}
+	}
+
+	// If requested, set new policy as the default.
+	if stmt.Default {
+		err = e.Store.SetDefaultRetentionPolicy(stmt.Database, stmt.Name)
+	}
+
+	return &influxql.Result{Err: err}
+}
+
+func (e *StatementExecutor) executeAlterRetentionPolicyStatement(stmt *influxql.AlterRetentionPolicyStatement) *influxql.Result {
+	rpu := &RetentionPolicyUpdate{
+		Duration: stmt.Duration,
+		ReplicaN: stmt.Replication,
+	}
+
+	// Update the retention policy.
+	err := e.Store.UpdateRetentionPolicy(stmt.Database, stmt.Name, rpu)
+	if err != nil {
+		return &influxql.Result{Err: err}
+	}
+
+	// If requested, set as default retention policy.
+	if stmt.Default {
+		err = e.Store.SetDefaultRetentionPolicy(stmt.Database, stmt.Name)
+	}
+
+	return &influxql.Result{Err: err}
+}
+
+func (e *StatementExecutor) executeDropRetentionPolicyStatement(q *influxql.DropRetentionPolicyStatement) *influxql.Result {
+	return &influxql.Result{Err: e.Store.DropRetentionPolicy(q.Database, q.Name)}
+}
+
+func (e *StatementExecutor) executeShowRetentionPoliciesStatement(q *influxql.ShowRetentionPoliciesStatement) *influxql.Result {
+	di, err := e.Store.Database(q.Database)
+	if err != nil {
+		return &influxql.Result{Err: err}
+	} else if di == nil {
+		return &influxql.Result{Err: influxdb.ErrDatabaseNotFound(q.Database)}
+	}
+
+	row := &models.Row{Columns: []string{"name", "duration", "replicaN", "default"}}
+	for _, rpi := range di.RetentionPolicies {
+		row.Values = append(row.Values, []interface{}{rpi.Name, rpi.Duration.String(), rpi.ReplicaN, di.DefaultRetentionPolicy == rpi.Name})
+	}
+	return &influxql.Result{Series: []*models.Row{row}}
+}
+
+func (e *StatementExecutor) executeCreateContinuousQueryStatement(q *influxql.CreateContinuousQueryStatement) *influxql.Result {
+	return &influxql.Result{
+		Err: e.Store.CreateContinuousQuery(q.Database, q.Name, q.String()),
+	}
+}
+
+func (e *StatementExecutor) executeDropContinuousQueryStatement(q *influxql.DropContinuousQueryStatement) *influxql.Result {
+	return &influxql.Result{
+		Err: e.Store.DropContinuousQuery(q.Database, q.Name),
+	}
+}
+
+func (e *StatementExecutor) executeShowContinuousQueriesStatement(stmt *influxql.ShowContinuousQueriesStatement) *influxql.Result {
+	dis, err := e.Store.Databases()
+	if err != nil {
+		return &influxql.Result{Err: err}
+	}
+
+	rows := []*models.Row{}
+	for _, di := range dis {
+		row := &models.Row{Columns: []string{"name", "query"}, Name: di.Name}
+		for _, cqi := range di.ContinuousQueries {
+			row.Values = append(row.Values, []interface{}{cqi.Name, cqi.Query})
+		}
+		rows = append(rows, row)
+	}
+	return &influxql.Result{Series: rows}
+}
+
+func (e *StatementExecutor) executeCreateSubscriptionStatement(q *influxql.CreateSubscriptionStatement) *influxql.Result {
+	return &influxql.Result{
+		Err: e.Store.CreateSubscription(q.Database, q.RetentionPolicy, q.Name, q.Mode, q.Destinations),
+	}
+}
+
+func (e *StatementExecutor) executeDropSubscriptionStatement(q *influxql.DropSubscriptionStatement) *influxql.Result {
+	return &influxql.Result{
+		Err: e.Store.DropSubscription(q.Database, q.RetentionPolicy, q.Name),
+	}
+}
+
+func (e *StatementExecutor) executeShowSubscriptionsStatement(stmt *influxql.ShowSubscriptionsStatement) *influxql.Result {
+	dis, err := e.Store.Databases()
+	if err != nil {
+		return &influxql.Result{Err: err}
+	}
+
+	rows := []*models.Row{}
+	for _, di := range dis {
+		row := &models.Row{Columns: []string{"retention_policy", "name", "mode", "destinations"}, Name: di.Name}
+		for _, rpi := range di.RetentionPolicies {
+			for _, si := range rpi.Subscriptions {
+				row.Values = append(row.Values, []interface{}{rpi.Name, si.Name, si.Mode, si.Destinations})
+			}
+		}
+		if len(row.Values) > 0 {
+			rows = append(rows, row)
+		}
+	}
+	return &influxql.Result{Series: rows}
+}
+
+func (e *StatementExecutor) executeShowShardGroupsStatement(stmt *influxql.ShowShardGroupsStatement) *influxql.Result {
+	dis, err := e.Store.Databases()
+	if err != nil {
+		return &influxql.Result{Err: err}
+	}
+
+	row := &models.Row{Columns: []string{"id", "database", "retention_policy", "start_time", "end_time", "expiry_time"}, Name: "shard groups"}
+	for _, di := range dis {
+		for _, rpi := range di.RetentionPolicies {
+			for _, sgi := range rpi.ShardGroups {
+				// Shards associated with deleted shard groups are effectively deleted.
+				// Don't list them.
+				if sgi.Deleted() {
+					continue
+				}
+
+				row.Values = append(row.Values, []interface{}{
+					sgi.ID,
+					di.Name,
+					rpi.Name,
+					sgi.StartTime.UTC().Format(time.RFC3339),
+					sgi.EndTime.UTC().Format(time.RFC3339),
+					sgi.EndTime.Add(rpi.Duration).UTC().Format(time.RFC3339),
+				})
+			}
+		}
+	}
+
+	return &influxql.Result{Series: []*models.Row{row}}
+}
+
+func (e *StatementExecutor) executeShowShardsStatement(stmt *influxql.ShowShardsStatement) *influxql.Result {
+	dis, err := e.Store.Databases()
+	if err != nil {
+		return &influxql.Result{Err: err}
+	}
+
+	rows := []*models.Row{}
+	for _, di := range dis {
+		row := &models.Row{Columns: []string{"id", "database", "retention_policy", "shard_group", "start_time", "end_time", "expiry_time", "owners"}, Name: di.Name}
+		for _, rpi := range di.RetentionPolicies {
+			for _, sgi := range rpi.ShardGroups {
+				// Shards associated with deleted shard groups are effectively deleted.
+				// Don't list them.
+				if sgi.Deleted() {
+					continue
+				}
+
+				for _, si := range sgi.Shards {
+					ownerIDs := make([]uint64, len(si.Owners))
+					for i, owner := range si.Owners {
+						ownerIDs[i] = owner.NodeID
+					}
+
+					row.Values = append(row.Values, []interface{}{
+						si.ID,
+						di.Name,
+						rpi.Name,
+						sgi.ID,
+						sgi.StartTime.UTC().Format(time.RFC3339),
+						sgi.EndTime.UTC().Format(time.RFC3339),
+						sgi.EndTime.Add(rpi.Duration).UTC().Format(time.RFC3339),
+						joinUint64(ownerIDs),
+					})
+				}
+			}
+		}
+		rows = append(rows, row)
+	}
+	return &influxql.Result{Series: rows}
+}
+
+func (e *StatementExecutor) executeShowStatsStatement(stmt *influxql.ShowStatsStatement) *influxql.Result {
+	return &influxql.Result{Err: fmt.Errorf("SHOW STATS is not implemented yet")}
+}
+
+// joinUint64 returns a comma-delimited string of uint64 numbers.
+func joinUint64(a []uint64) string {
+	var buf bytes.Buffer
+	for i, x := range a {
+		buf.WriteString(strconv.FormatUint(x, 10))
+		if i < len(a)-1 {
+			buf.WriteRune(',')
+		}
+	}
+	return buf.String()
+}

--- a/services/meta/statement_executor_test.go
+++ b/services/meta/statement_executor_test.go
@@ -1,0 +1,1192 @@
+package meta_test
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/influxdb/influxdb"
+	"github.com/influxdb/influxdb/influxql"
+	"github.com/influxdb/influxdb/models"
+	"github.com/influxdb/influxdb/services/meta"
+)
+
+// Ensure a CREATE DATABASE statement can be executed.
+func TestStatementExecutor_ExecuteStatement_CreateDatabase(t *testing.T) {
+	e := NewStatementExecutor()
+	e.Store.CreateDatabaseFn = func(name string) (*meta.DatabaseInfo, error) {
+		if name != "foo" {
+			t.Fatalf("unexpected name: %s", name)
+		}
+		return &meta.DatabaseInfo{Name: name}, nil
+	}
+
+	if res := e.ExecuteStatement(influxql.MustParseStatement(`CREATE DATABASE foo`)); res.Err != nil {
+		t.Fatal(res.Err)
+	} else if res.Series != nil {
+		t.Fatalf("unexpected rows: %#v", res.Series)
+	}
+}
+
+// Ensure a DROP DATABASE statement can be executed.
+func TestStatementExecutor_ExecuteStatement_DropDatabase(t *testing.T) {
+	e := NewStatementExecutor()
+	e.Store.DropDatabaseFn = func(name string) error {
+		if name != "foo" {
+			t.Fatalf("unexpected name: %s", name)
+		}
+		return nil
+	}
+
+	if res := e.ExecuteStatement(influxql.MustParseStatement(`DROP DATABASE foo`)); res.Err != nil {
+		t.Fatal(res.Err)
+	} else if res.Series != nil {
+		t.Fatalf("unexpected rows: %#v", res.Series)
+	}
+}
+
+// Ensure a SHOW DATABASES statement can be executed.
+func TestStatementExecutor_ExecuteStatement_ShowDatabases(t *testing.T) {
+	e := NewStatementExecutor()
+	e.Store.DatabasesFn = func() ([]meta.DatabaseInfo, error) {
+		return []meta.DatabaseInfo{
+			{Name: "foo"},
+			{Name: "bar"},
+		}, nil
+	}
+
+	if res := e.ExecuteStatement(influxql.MustParseStatement(`SHOW DATABASES`)); res.Err != nil {
+		t.Fatal(res.Err)
+	} else if !reflect.DeepEqual(res.Series, models.Rows{
+		{
+			Name:    "databases",
+			Columns: []string{"name"},
+			Values: [][]interface{}{
+				{"foo"},
+				{"bar"},
+			},
+		},
+	}) {
+		t.Fatalf("unexpected rows: %s", spew.Sdump(res.Series))
+	}
+}
+
+// Ensure a SHOW DATABASES statement returns errors from the store.
+func TestStatementExecutor_ExecuteStatement_ShowDatabases_Err(t *testing.T) {
+	e := NewStatementExecutor()
+	e.Store.DatabasesFn = func() ([]meta.DatabaseInfo, error) {
+		return nil, errors.New("marker")
+	}
+
+	if res := e.ExecuteStatement(influxql.MustParseStatement(`SHOW DATABASES`)); res.Err == nil || res.Err.Error() != "marker" {
+		t.Fatalf("unexpected error: %s", res.Err)
+	}
+}
+
+// Ensure a SHOW GRANTS FOR statement can be executed.
+func TestStatementExecutor_ExecuteStatement_ShowGrantsFor(t *testing.T) {
+	t.Skip("Intermittent test failure: issue 3028")
+	e := NewStatementExecutor()
+	e.Store.UserPrivilegesFn = func(username string) (map[string]influxql.Privilege, error) {
+		if username != "dejan" {
+			t.Fatalf("unexpected username: %s", username)
+		}
+		return map[string]influxql.Privilege{
+			"dejan": influxql.ReadPrivilege,
+			"golja": influxql.WritePrivilege,
+		}, nil
+	}
+
+	if res := e.ExecuteStatement(influxql.MustParseStatement(`SHOW GRANTS FOR dejan`)); res.Err != nil {
+		t.Fatal(res.Err)
+	} else if !reflect.DeepEqual(res.Series, models.Rows{
+		{
+			Columns: []string{"database", "privilege"},
+			Values: [][]interface{}{
+				{"dejan", "READ"},
+				{"golja", "WRITE"},
+			},
+		},
+	}) {
+		t.Fatalf("unexpected rows: %s", spew.Sdump(res.Series))
+	}
+}
+
+// Ensure a SHOW SERVERS statement can be executed.
+func TestStatementExecutor_ExecuteStatement_ShowServers(t *testing.T) {
+	e := NewStatementExecutor()
+	e.Store.NodesFn = func() ([]meta.NodeInfo, error) {
+		return []meta.NodeInfo{
+			{ID: 1, Host: "node0"},
+			{ID: 2, Host: "node1"},
+		}, nil
+	}
+	e.Store.PeersFn = func() ([]string, error) {
+		return []string{"node0"}, nil
+	}
+	e.Store.LeaderFn = func() string {
+		return "node0"
+	}
+
+	if res := e.ExecuteStatement(influxql.MustParseStatement(`SHOW SERVERS`)); res.Err != nil {
+		t.Fatal(res.Err)
+	} else if !reflect.DeepEqual(res.Series, models.Rows{
+		{
+			Columns: []string{"id", "cluster_addr", "raft", "raft-leader"},
+			Values: [][]interface{}{
+				{uint64(1), "node0", true, true},
+				{uint64(2), "node1", false, false},
+			},
+		},
+	}) {
+		t.Fatalf("unexpected rows: %s", spew.Sdump(res.Series))
+	}
+}
+
+// Ensure a SHOW SERVERS statement returns errors from the store.
+func TestStatementExecutor_ExecuteStatement_ShowServers_Err(t *testing.T) {
+	e := NewStatementExecutor()
+	e.Store.NodesFn = func() ([]meta.NodeInfo, error) {
+		return nil, errors.New("marker")
+	}
+
+	if res := e.ExecuteStatement(influxql.MustParseStatement(`SHOW SERVERS`)); res.Err == nil || res.Err.Error() != "marker" {
+		t.Fatalf("unexpected error: %s", res.Err)
+	}
+}
+
+// Ensure a CREATE USER statement can be executed.
+func TestStatementExecutor_ExecuteStatement_CreateUser(t *testing.T) {
+	e := NewStatementExecutor()
+	e.Store.CreateUserFn = func(name, password string, admin bool) (*meta.UserInfo, error) {
+		if name != "susy" {
+			t.Fatalf("unexpected name: %s", name)
+		} else if password != "pass" {
+			t.Fatalf("unexpected password: %s", password)
+		} else if admin != true {
+			t.Fatalf("unexpected admin: %v", admin)
+		}
+		return &meta.UserInfo{Name: name, Admin: admin}, nil
+	}
+
+	if res := e.ExecuteStatement(influxql.MustParseStatement(`CREATE USER susy WITH PASSWORD 'pass' WITH ALL PRIVILEGES`)); res.Err != nil {
+		t.Fatal(res.Err)
+	} else if res.Series != nil {
+		t.Fatalf("unexpected rows: %#v", res.Series)
+	}
+}
+
+// Ensure a CREATE USER statement returns errors from the store.
+func TestStatementExecutor_ExecuteStatement_CreateUser_Err(t *testing.T) {
+	e := NewStatementExecutor()
+	e.Store.CreateUserFn = func(name, password string, admin bool) (*meta.UserInfo, error) {
+		return nil, errors.New("marker")
+	}
+
+	if res := e.ExecuteStatement(influxql.MustParseStatement(`CREATE USER susy WITH PASSWORD 'pass'`)); res.Err == nil || res.Err.Error() != "marker" {
+		t.Fatalf("unexpected error: %s", res.Err)
+	}
+}
+
+// Ensure a SET PASSWORD statement can be executed.
+func TestStatementExecutor_ExecuteStatement_SetPassword(t *testing.T) {
+	e := NewStatementExecutor()
+	e.Store.UpdateUserFn = func(name, password string) error {
+		if name != "susy" {
+			t.Fatalf("unexpected name: %s", name)
+		} else if password != "pass" {
+			t.Fatalf("unexpected password: %s", password)
+		}
+		return nil
+	}
+
+	if res := e.ExecuteStatement(influxql.MustParseStatement(`SET PASSWORD FOR susy = 'pass' WITH ALL PRIVILEGES`)); res.Err != nil {
+		t.Fatal(res.Err)
+	} else if res.Series != nil {
+		t.Fatalf("unexpected rows: %#v", res.Series)
+	}
+}
+
+// Ensure a SET PASSWORD statement returns errors from the store.
+func TestStatementExecutor_ExecuteStatement_SetPassword_Err(t *testing.T) {
+	e := NewStatementExecutor()
+	e.Store.UpdateUserFn = func(name, password string) error {
+		return errors.New("marker")
+	}
+
+	if res := e.ExecuteStatement(influxql.MustParseStatement(`SET PASSWORD FOR susy = 'pass'`)); res.Err == nil || res.Err.Error() != "marker" {
+		t.Fatalf("unexpected error: %s", res.Err)
+	}
+}
+
+// Ensure a DROP USER statement can be executed.
+func TestStatementExecutor_ExecuteStatement_DropUser(t *testing.T) {
+	e := NewStatementExecutor()
+	e.Store.DropUserFn = func(name string) error {
+		if name != "susy" {
+			t.Fatalf("unexpected name: %s", name)
+		}
+		return nil
+	}
+
+	if res := e.ExecuteStatement(influxql.MustParseStatement(`DROP USER susy`)); res.Err != nil {
+		t.Fatal(res.Err)
+	} else if res.Series != nil {
+		t.Fatalf("unexpected rows: %#v", res.Series)
+	}
+}
+
+// Ensure a DROP USER statement returns errors from the store.
+func TestStatementExecutor_ExecuteStatement_DropUser_Err(t *testing.T) {
+	e := NewStatementExecutor()
+	e.Store.DropUserFn = func(name string) error {
+		return errors.New("marker")
+	}
+
+	if res := e.ExecuteStatement(influxql.MustParseStatement(`DROP USER susy`)); res.Err == nil || res.Err.Error() != "marker" {
+		t.Fatalf("unexpected error: %s", res.Err)
+	}
+}
+
+// Ensure a SHOW USERS statement can be executed.
+func TestStatementExecutor_ExecuteStatement_ShowUsers(t *testing.T) {
+	e := NewStatementExecutor()
+	e.Store.UsersFn = func() ([]meta.UserInfo, error) {
+		return []meta.UserInfo{
+			{Name: "susy", Admin: true},
+			{Name: "bob", Admin: false},
+		}, nil
+	}
+
+	if res := e.ExecuteStatement(influxql.MustParseStatement(`SHOW USERS`)); res.Err != nil {
+		t.Fatal(res.Err)
+	} else if !reflect.DeepEqual(res.Series, models.Rows{
+		{
+			Columns: []string{"user", "admin"},
+			Values: [][]interface{}{
+				{"susy", true},
+				{"bob", false},
+			},
+		},
+	}) {
+		t.Fatalf("unexpected rows: %s", spew.Sdump(res.Series))
+	}
+}
+
+// Ensure a SHOW USERS statement returns an error from the store.
+func TestStatementExecutor_ExecuteStatement_ShowUsers_Err(t *testing.T) {
+	e := NewStatementExecutor()
+	e.Store.UsersFn = func() ([]meta.UserInfo, error) {
+		return nil, errors.New("marker")
+	}
+
+	if res := e.ExecuteStatement(influxql.MustParseStatement(`SHOW USERS`)); res.Err == nil || res.Err.Error() != "marker" {
+		t.Fatalf("unexpected error: %s", res.Err)
+	}
+}
+
+// Ensure a GRANT statement can be executed.
+func TestStatementExecutor_ExecuteStatement_Grant(t *testing.T) {
+	e := NewStatementExecutor()
+	e.Store.SetPrivilegeFn = func(username, database string, p influxql.Privilege) error {
+		if username != "susy" {
+			t.Fatalf("unexpected username: %s", username)
+		} else if database != "foo" {
+			t.Fatalf("unexpected database: %s", database)
+		} else if p != influxql.WritePrivilege {
+			t.Fatalf("unexpected privilege: %s", p)
+		}
+		return nil
+	}
+
+	if res := e.ExecuteStatement(influxql.MustParseStatement(`GRANT WRITE ON foo TO susy`)); res.Err != nil {
+		t.Fatal(res.Err)
+	} else if res.Series != nil {
+		t.Fatalf("unexpected rows: %#v", res.Series)
+	}
+}
+
+// Ensure a GRANT statement returns errors from the store.
+func TestStatementExecutor_ExecuteStatement_Grant_Err(t *testing.T) {
+	e := NewStatementExecutor()
+	e.Store.SetPrivilegeFn = func(username, database string, p influxql.Privilege) error {
+		return errors.New("marker")
+	}
+
+	if res := e.ExecuteStatement(influxql.MustParseStatement(`GRANT READ ON foo TO susy`)); res.Err == nil || res.Err.Error() != "marker" {
+		t.Fatalf("unexpected error: %s", res.Err)
+	}
+}
+
+// Ensure a GRANT statement for admin privilege can be executed.
+func TestStatementExecutor_ExecuteStatement_GrantAdmin(t *testing.T) {
+	e := NewStatementExecutor()
+	e.Store.SetAdminPrivilegeFn = func(username string, admin bool) error {
+		if username != "susy" {
+			t.Fatalf("unexpected username: %s", username)
+		} else if admin != true {
+			t.Fatalf("unexpected admin privilege: %t", admin)
+		}
+		return nil
+	}
+
+	if res := e.ExecuteStatement(influxql.MustParseStatement(`GRANT ALL TO susy`)); res.Err != nil {
+		t.Fatal(res.Err)
+	} else if res.Series != nil {
+		t.Fatalf("unexpected rows: %#v", res.Series)
+	}
+}
+
+// Ensure a GRANT statement for admin privilege returns errors from the store.
+func TestStatementExecutor_ExecuteStatement_GrantAdmin_Err(t *testing.T) {
+	e := NewStatementExecutor()
+	e.Store.SetAdminPrivilegeFn = func(username string, admin bool) error {
+		return errors.New("marker")
+	}
+
+	if res := e.ExecuteStatement(influxql.MustParseStatement(`GRANT ALL PRIVILEGES TO susy`)); res.Err == nil || res.Err.Error() != "marker" {
+		t.Fatalf("unexpected error: %s", res.Err)
+	}
+}
+
+// Ensure a REVOKE statement can be executed.
+func TestStatementExecutor_ExecuteStatement_Revoke(t *testing.T) {
+	e := NewStatementExecutor()
+	e.Store.SetPrivilegeFn = func(username, database string, p influxql.Privilege) error {
+		if username != "susy" {
+			t.Fatalf("unexpected username: %s", username)
+		} else if database != "foo" {
+			t.Fatalf("unexpected database: %s", database)
+		} else if p != influxql.NoPrivileges {
+			t.Fatalf("unexpected privilege: %s", p)
+		}
+		return nil
+	}
+
+	if res := e.ExecuteStatement(influxql.MustParseStatement(`REVOKE ALL PRIVILEGES ON foo FROM susy`)); res.Err != nil {
+		t.Fatal(res.Err)
+	} else if res.Series != nil {
+		t.Fatalf("unexpected rows: %#v", res.Series)
+	}
+}
+
+// Ensure a REVOKE statement returns errors from the store.
+func TestStatementExecutor_ExecuteStatement_Revoke_Err(t *testing.T) {
+	e := NewStatementExecutor()
+	e.Store.SetPrivilegeFn = func(username, database string, p influxql.Privilege) error {
+		return errors.New("marker")
+	}
+
+	if res := e.ExecuteStatement(influxql.MustParseStatement(`REVOKE ALL PRIVILEGES ON foo FROM susy`)); res.Err == nil || res.Err.Error() != "marker" {
+		t.Fatalf("unexpected error: %s", res.Err)
+	}
+}
+
+// Ensure a REVOKE statement for admin privilege can be executed.
+func TestStatementExecutor_ExecuteStatement_RevokeAdmin(t *testing.T) {
+	e := NewStatementExecutor()
+	e.Store.SetAdminPrivilegeFn = func(username string, admin bool) error {
+		if username != "susy" {
+			t.Fatalf("unexpected username: %s", username)
+		} else if admin != false {
+			t.Fatalf("unexpected admin privilege: %t", admin)
+		}
+		return nil
+	}
+
+	if res := e.ExecuteStatement(influxql.MustParseStatement(`REVOKE ALL PRIVILEGES FROM susy`)); res.Err != nil {
+		t.Fatal(res.Err)
+	} else if res.Series != nil {
+		t.Fatalf("unexpected rows: %#v", res.Series)
+	}
+}
+
+// Ensure a REVOKE statement for admin privilege returns errors from the store.
+func TestStatementExecutor_ExecuteStatement_RevokeAdmin_Err(t *testing.T) {
+	e := NewStatementExecutor()
+	e.Store.SetAdminPrivilegeFn = func(username string, admin bool) error {
+		return errors.New("marker")
+	}
+
+	if res := e.ExecuteStatement(influxql.MustParseStatement(`REVOKE ALL PRIVILEGES FROM susy`)); res.Err == nil || res.Err.Error() != "marker" {
+		t.Fatalf("unexpected error: %s", res.Err)
+	}
+}
+
+// Ensure a CREATE RETENTION POLICY statement can be executed.
+func TestStatementExecutor_ExecuteStatement_CreateRetentionPolicy(t *testing.T) {
+	e := NewStatementExecutor()
+	e.Store.CreateRetentionPolicyFn = func(database string, rpi *meta.RetentionPolicyInfo) (*meta.RetentionPolicyInfo, error) {
+		if database != "foo" {
+			t.Fatalf("unexpected database: %s", database)
+		} else if rpi.Name != "rp0" {
+			t.Fatalf("unexpected name: %s", rpi.Name)
+		} else if rpi.Duration != 2*time.Hour {
+			t.Fatalf("unexpected duration: %v", rpi.Duration)
+		} else if rpi.ReplicaN != 3 {
+			t.Fatalf("unexpected replication factor: %v", rpi.ReplicaN)
+		}
+		return nil, nil
+	}
+	e.Store.SetDefaultRetentionPolicyFn = func(database, name string) error {
+		if database != "foo" {
+			t.Fatalf("unexpected database: %s", database)
+		} else if name != "rp0" {
+			t.Fatalf("unexpected name: %s", name)
+		}
+		return nil
+	}
+
+	if res := e.ExecuteStatement(influxql.MustParseStatement(`CREATE RETENTION POLICY rp0 ON foo DURATION 2h REPLICATION 3 DEFAULT`)); res.Err != nil {
+		t.Fatal(res.Err)
+	} else if res.Series != nil {
+		t.Fatalf("unexpected rows: %#v", res.Series)
+	}
+}
+
+// Ensure a CREATE RETENTION POLICY statement returns errors from the store.
+func TestStatementExecutor_ExecuteStatement_CreateRetentionPolicy_Err(t *testing.T) {
+	e := NewStatementExecutor()
+	e.Store.CreateRetentionPolicyFn = func(database string, rpi *meta.RetentionPolicyInfo) (*meta.RetentionPolicyInfo, error) {
+		return nil, errors.New("marker")
+	}
+
+	if res := e.ExecuteStatement(influxql.MustParseStatement(`CREATE RETENTION POLICY rp0 ON foo DURATION 2h REPLICATION 1`)); res.Err == nil || res.Err.Error() != "marker" {
+		t.Fatalf("unexpected error: %s", res.Err)
+	}
+}
+
+// Ensure an ALTER RETENTION POLICY statement can execute.
+func TestStatementExecutor_ExecuteStatement_AlterRetentionPolicy(t *testing.T) {
+	e := NewStatementExecutor()
+	e.Store.UpdateRetentionPolicyFn = func(database, name string, rpu *meta.RetentionPolicyUpdate) error {
+		if database != "foo" {
+			t.Fatalf("unexpected database: %s", database)
+		} else if name != "rp0" {
+			t.Fatalf("unexpected name: %s", name)
+		} else if rpu.Duration != nil && *rpu.Duration != 7*24*time.Hour {
+			t.Fatalf("unexpected duration: %v", *rpu.Duration)
+		} else if rpu.ReplicaN != nil && *rpu.ReplicaN != 2 {
+			t.Fatalf("unexpected replication factor: %v", *rpu.ReplicaN)
+		}
+		return nil
+	}
+	e.Store.SetDefaultRetentionPolicyFn = func(database, name string) error {
+		if database != "foo" {
+			t.Fatalf("unexpected database: %s", database)
+		} else if name != "rp0" {
+			t.Fatalf("unexpected name: %s", name)
+		}
+		return nil
+	}
+
+	stmt := influxql.MustParseStatement(`ALTER RETENTION POLICY rp0 ON foo DURATION 7d REPLICATION 2 DEFAULT`)
+	if res := e.ExecuteStatement(stmt); res.Err != nil {
+		t.Fatalf("unexpected error: %s", res.Err)
+	}
+
+	stmt = influxql.MustParseStatement(`ALTER RETENTION POLICY rp0 ON foo DURATION 7d`)
+	if res := e.ExecuteStatement(stmt); res.Err != nil {
+		t.Fatalf("unexpected error: %s", res.Err)
+	}
+
+	stmt = influxql.MustParseStatement(`ALTER RETENTION POLICY rp0 ON foo REPLICATION 2`)
+	if res := e.ExecuteStatement(stmt); res.Err != nil {
+		t.Fatalf("unexpected error: %s", res.Err)
+	}
+}
+
+// Ensure a ALTER RETENTION POLICY statement returns errors from the store.
+func TestStatementExecutor_ExecuteStatement_AlterRetentionPolicy_Err(t *testing.T) {
+	e := NewStatementExecutor()
+	e.Store.UpdateRetentionPolicyFn = func(database, name string, rpu *meta.RetentionPolicyUpdate) error {
+		return errors.New("marker")
+	}
+
+	stmt := influxql.MustParseStatement(`ALTER RETENTION POLICY rp0 ON foo DURATION 1m REPLICATION 4 DEFAULT`)
+	if res := e.ExecuteStatement(stmt); res.Err == nil || res.Err.Error() != "marker" {
+		t.Fatalf("unexpected error: %s", res.Err)
+	}
+}
+
+// Ensure a ALTER RETENTION POLICY statement returns errors from the store.
+func TestStatementExecutor_ExecuteStatement_AlterRetentionPolicy_ErrSetDefault(t *testing.T) {
+	e := NewStatementExecutor()
+	e.Store.UpdateRetentionPolicyFn = func(database, name string, rpu *meta.RetentionPolicyUpdate) error {
+		return nil
+	}
+	e.Store.SetDefaultRetentionPolicyFn = func(database, name string) error {
+		return errors.New("marker")
+	}
+
+	stmt := influxql.MustParseStatement(`ALTER RETENTION POLICY rp0 ON foo DURATION 1m REPLICATION 4 DEFAULT`)
+	if res := e.ExecuteStatement(stmt); res.Err == nil || res.Err.Error() != "marker" {
+		t.Fatalf("unexpected error: %s", res.Err)
+	}
+}
+
+// Ensure a DROP RETENTION POLICY statement can execute.
+func TestStatementExecutor_ExecuteStatement_DropRetentionPolicy(t *testing.T) {
+	e := NewStatementExecutor()
+	e.Store.DropRetentionPolicyFn = func(database, name string) error {
+		if database != "foo" {
+			t.Fatalf("unexpected database: %s", database)
+		} else if name != "rp0" {
+			t.Fatalf("unexpected name: %s", name)
+		}
+		return nil
+	}
+
+	stmt := influxql.MustParseStatement(`DROP RETENTION POLICY rp0 ON foo`)
+	if res := e.ExecuteStatement(stmt); res.Err != nil {
+		t.Fatalf("unexpected error: %s", res.Err)
+	}
+}
+
+// Ensure a DROP RETENTION POLICY statement returns errors from the store.
+func TestStatementExecutor_ExecuteStatement_DropRetentionPolicy_Err(t *testing.T) {
+	e := NewStatementExecutor()
+	e.Store.DropRetentionPolicyFn = func(database, name string) error {
+		return errors.New("marker")
+	}
+
+	stmt := influxql.MustParseStatement(`DROP RETENTION POLICY rp0 ON foo`)
+	if res := e.ExecuteStatement(stmt); res.Err == nil || res.Err.Error() != "marker" {
+		t.Fatalf("unexpected error: %s", res.Err)
+	}
+}
+
+// Ensure a SHOW RETENTION POLICIES statement can be executed.
+func TestStatementExecutor_ExecuteStatement_ShowRetentionPolicies(t *testing.T) {
+	e := NewStatementExecutor()
+	e.Store.DatabaseFn = func(name string) (*meta.DatabaseInfo, error) {
+		if name != "db0" {
+			t.Fatalf("unexpected name: %s", name)
+		}
+		return &meta.DatabaseInfo{
+			Name: name,
+			DefaultRetentionPolicy: "rp1",
+			RetentionPolicies: []meta.RetentionPolicyInfo{
+				{
+					Name:     "rp0",
+					Duration: 2 * time.Hour,
+					ReplicaN: 3,
+				},
+				{
+					Name:     "rp1",
+					Duration: 24 * time.Hour,
+					ReplicaN: 1,
+				},
+			},
+		}, nil
+	}
+
+	if res := e.ExecuteStatement(influxql.MustParseStatement(`SHOW RETENTION POLICIES ON db0`)); res.Err != nil {
+		t.Fatal(res.Err)
+	} else if !reflect.DeepEqual(res.Series, models.Rows{
+		{
+			Columns: []string{"name", "duration", "replicaN", "default"},
+			Values: [][]interface{}{
+				{"rp0", "2h0m0s", 3, false},
+				{"rp1", "24h0m0s", 1, true},
+			},
+		},
+	}) {
+		t.Fatalf("unexpected rows: %s", spew.Sdump(res.Series))
+	}
+}
+
+// Ensure a SHOW RETENTION POLICIES statement can return an error from the store.
+func TestStatementExecutor_ExecuteStatement_ShowRetentionPolicies_Err(t *testing.T) {
+	e := NewStatementExecutor()
+	e.Store.DatabaseFn = func(name string) (*meta.DatabaseInfo, error) {
+		return nil, errors.New("marker")
+	}
+
+	if res := e.ExecuteStatement(influxql.MustParseStatement(`SHOW RETENTION POLICIES ON db0`)); res.Err == nil || res.Err.Error() != "marker" {
+		t.Fatalf("unexpected error: %s", res.Err)
+	}
+}
+
+// Ensure a SHOW RETENTION POLICIES statement can return an error if the database doesn't exist.
+func TestStatementExecutor_ExecuteStatement_ShowRetentionPolicies_ErrDatabaseNotFound(t *testing.T) {
+	e := NewStatementExecutor()
+	e.Store.DatabaseFn = func(name string) (*meta.DatabaseInfo, error) {
+		return nil, nil
+	}
+
+	expErr := influxdb.ErrDatabaseNotFound("db0")
+	if res := e.ExecuteStatement(influxql.MustParseStatement(`SHOW RETENTION POLICIES ON db0`)); res.Err.Error() != expErr.Error() {
+		t.Fatalf("unexpected error: %s", res.Err)
+	}
+}
+
+// Ensure a CREATE CONTINUOUS QUERY statement can be executed.
+func TestStatementExecutor_ExecuteStatement_CreateContinuousQuery(t *testing.T) {
+	e := NewStatementExecutor()
+	e.Store.CreateContinuousQueryFn = func(database, name, query string) error {
+		if database != "db0" {
+			t.Fatalf("unexpected database: %s", database)
+		} else if name != "cq0" {
+			t.Fatalf("unexpected name: %s", name)
+		} else if query != `CREATE CONTINUOUS QUERY cq0 ON db0 BEGIN SELECT count(field1) INTO db1 FROM db0 GROUP BY time(1h) END` {
+			t.Fatalf("unexpected query: %s", query)
+		}
+		return nil
+	}
+
+	stmt := influxql.MustParseStatement(`CREATE CONTINUOUS QUERY cq0 ON db0 BEGIN SELECT count(field1) INTO db1 FROM db0 GROUP BY time(1h) END`)
+	if res := e.ExecuteStatement(stmt); res.Err != nil {
+		t.Fatal(res.Err)
+	} else if res.Series != nil {
+		t.Fatalf("unexpected rows: %#v", res.Series)
+	}
+}
+
+// Ensure a CREATE CONTINUOUS QUERY statement can return an error from the store.
+func TestStatementExecutor_ExecuteStatement_CreateContinuousQuery_Err(t *testing.T) {
+	e := NewStatementExecutor()
+	e.Store.CreateContinuousQueryFn = func(database, name, query string) error {
+		return errors.New("marker")
+	}
+
+	stmt := influxql.MustParseStatement(`CREATE CONTINUOUS QUERY cq0 ON db0 BEGIN SELECT count(field1) INTO db1 FROM db0 GROUP BY time(1h) END`)
+	if res := e.ExecuteStatement(stmt); res.Err == nil || res.Err.Error() != "marker" {
+		t.Fatalf("unexpected error: %s", res.Err)
+	}
+}
+
+// Ensure a DROP CONTINUOUS QUERY statement can be executed.
+func TestStatementExecutor_ExecuteStatement_DropContinuousQuery(t *testing.T) {
+	e := NewStatementExecutor()
+	e.Store.DropContinuousQueryFn = func(database, name string) error {
+		if database != "db0" {
+			t.Fatalf("unexpected database: %s", database)
+		} else if name != "cq0" {
+			t.Fatalf("unexpected name: %s", name)
+		}
+		return nil
+	}
+
+	stmt := influxql.MustParseStatement(`DROP CONTINUOUS QUERY cq0 ON db0`)
+	if res := e.ExecuteStatement(stmt); res.Err != nil {
+		t.Fatal(res.Err)
+	} else if res.Series != nil {
+		t.Fatalf("unexpected rows: %#v", res.Series)
+	}
+}
+
+// Ensure a DROP CONTINUOUS QUERY statement can return an error from the store.
+func TestStatementExecutor_ExecuteStatement_DropContinuousQuery_Err(t *testing.T) {
+	e := NewStatementExecutor()
+	e.Store.DropContinuousQueryFn = func(database, name string) error {
+		return errors.New("marker")
+	}
+
+	stmt := influxql.MustParseStatement(`DROP CONTINUOUS QUERY cq0 ON db0`)
+	if res := e.ExecuteStatement(stmt); res.Err == nil || res.Err.Error() != "marker" {
+		t.Fatalf("unexpected error: %s", res.Err)
+	}
+}
+
+// Ensure a SHOW CONTINUOUS QUERIES statement can be executed.
+func TestStatementExecutor_ExecuteStatement_ShowContinuousQueries(t *testing.T) {
+	e := NewStatementExecutor()
+	e.Store.DatabasesFn = func() ([]meta.DatabaseInfo, error) {
+		return []meta.DatabaseInfo{
+			{
+				Name: "db0",
+				ContinuousQueries: []meta.ContinuousQueryInfo{
+					{Name: "cq0", Query: "SELECT count(field1) INTO db1 FROM db0"},
+					{Name: "cq1", Query: "SELECT count(field1) INTO db2 FROM db0"},
+				},
+			},
+			{
+				Name: "db1",
+				ContinuousQueries: []meta.ContinuousQueryInfo{
+					{Name: "cq2", Query: "SELECT count(field1) INTO db3 FROM db1"},
+				},
+			},
+		}, nil
+	}
+
+	stmt := influxql.MustParseStatement(`SHOW CONTINUOUS QUERIES`)
+	if res := e.ExecuteStatement(stmt); res.Err != nil {
+		t.Fatal(res.Err)
+	} else if !reflect.DeepEqual(res.Series, models.Rows{
+		{
+			Name:    "db0",
+			Columns: []string{"name", "query"},
+			Values: [][]interface{}{
+				{"cq0", "SELECT count(field1) INTO db1 FROM db0"},
+				{"cq1", "SELECT count(field1) INTO db2 FROM db0"},
+			},
+		},
+		{
+			Name:    "db1",
+			Columns: []string{"name", "query"},
+			Values: [][]interface{}{
+				{"cq2", "SELECT count(field1) INTO db3 FROM db1"},
+			},
+		},
+	}) {
+		t.Fatalf("unexpected rows: %s", spew.Sdump(res.Series))
+	}
+}
+
+// Ensure a SHOW CONTINUOUS QUERIES statement can return an error from the store.
+func TestStatementExecutor_ExecuteStatement_ShowContinuousQueries_Err(t *testing.T) {
+	e := NewStatementExecutor()
+	e.Store.DatabasesFn = func() ([]meta.DatabaseInfo, error) {
+		return nil, errors.New("marker")
+	}
+
+	stmt := influxql.MustParseStatement(`SHOW CONTINUOUS QUERIES`)
+	if res := e.ExecuteStatement(stmt); res.Err == nil || res.Err.Error() != "marker" {
+		t.Fatal(res.Err)
+	}
+}
+
+// Ensure a CREATE SUBSCRIPTION statement can be executed.
+func TestStatementExecutor_ExecuteStatement_CreateSubscription(t *testing.T) {
+	e := NewStatementExecutor()
+	e.Store.CreateSubscriptionFn = func(database, rp, name, mode string, destinations []string) error {
+		if database != "db0" {
+			t.Fatalf("unexpected database: %s", database)
+		} else if rp != "rp0" {
+			t.Fatalf("unexpected rp: %s", rp)
+		} else if name != "s0" {
+			t.Fatalf("unexpected name: %s", name)
+		} else if mode != "ANY" {
+			t.Fatalf("unexpected mode: %s", mode)
+		} else if len(destinations) != 2 {
+			t.Fatalf("unexpected destinations: %s", destinations)
+		} else if destinations[0] != "udp://h0:1234" {
+			t.Fatalf("unexpected destinations[0]: %s", destinations[0])
+		} else if destinations[1] != "udp://h1:1234" {
+			t.Fatalf("unexpected destinations[1]: %s", destinations[1])
+		}
+		return nil
+	}
+
+	stmt := influxql.MustParseStatement(`CREATE SUBSCRIPTION s0 ON db0.rp0 DESTINATIONS ANY 'udp://h0:1234', 'udp://h1:1234'`)
+	if res := e.ExecuteStatement(stmt); res.Err != nil {
+		t.Fatal(res.Err)
+	} else if res.Series != nil {
+		t.Fatalf("unexpected rows: %#v", res.Series)
+	}
+}
+
+// Ensure a CREATE SUBSCRIPTION statement can return an error from the store.
+func TestStatementExecutor_ExecuteStatement_CreateSubscription_Err(t *testing.T) {
+	e := NewStatementExecutor()
+	e.Store.CreateSubscriptionFn = func(database, rp, name, mode string, destinations []string) error {
+		return errors.New("marker")
+	}
+
+	stmt := influxql.MustParseStatement(`CREATE SUBSCRIPTION s0 ON db0.rp0 DESTINATIONS ANY 'udp://h0:1234', 'udp://h1:1234'`)
+	if res := e.ExecuteStatement(stmt); res.Err == nil || res.Err.Error() != "marker" {
+		t.Fatalf("unexpected error: %s", res.Err)
+	}
+}
+
+// Ensure a DROP SUBSCRIPTION statement can be executed.
+func TestStatementExecutor_ExecuteStatement_DropSubscription(t *testing.T) {
+	e := NewStatementExecutor()
+	e.Store.DropSubscriptionFn = func(database, rp, name string) error {
+		if database != "db0" {
+			t.Fatalf("unexpected database: %s", database)
+		} else if rp != "rp0" {
+			t.Fatalf("unexpected rp: %s", rp)
+		} else if name != "s0" {
+			t.Fatalf("unexpected name: %s", name)
+		}
+		return nil
+	}
+
+	stmt := influxql.MustParseStatement(`DROP SUBSCRIPTION s0 ON db0.rp0`)
+	if res := e.ExecuteStatement(stmt); res.Err != nil {
+		t.Fatal(res.Err)
+	} else if res.Series != nil {
+		t.Fatalf("unexpected rows: %#v", res.Series)
+	}
+}
+
+// Ensure a DROP SUBSCRIPTION statement can return an error from the store.
+func TestStatementExecutor_ExecuteStatement_DropSubscription_Err(t *testing.T) {
+	e := NewStatementExecutor()
+	e.Store.DropSubscriptionFn = func(database, rp, name string) error {
+		return errors.New("marker")
+	}
+
+	stmt := influxql.MustParseStatement(`DROP SUBSCRIPTION s0 ON db0.rp0`)
+	if res := e.ExecuteStatement(stmt); res.Err == nil || res.Err.Error() != "marker" {
+		t.Fatalf("unexpected error: %s", res.Err)
+	}
+}
+
+// Ensure a SHOW SUBSCRIPTIONS statement can be executed.
+func TestStatementExecutor_ExecuteStatement_ShowSubscriptions(t *testing.T) {
+	e := NewStatementExecutor()
+	e.Store.DatabasesFn = func() ([]meta.DatabaseInfo, error) {
+		return []meta.DatabaseInfo{
+			{
+				Name: "db0",
+				RetentionPolicies: []meta.RetentionPolicyInfo{
+					{
+						Name: "rp0",
+						Subscriptions: []meta.SubscriptionInfo{
+							{Name: "s0", Mode: "ALL", Destinations: []string{"udp://h0:1234", "udp://h1:1234"}},
+							{Name: "s1", Mode: "ANY", Destinations: []string{"udp://h2:1234", "udp://h3:1234"}},
+						},
+					},
+					{
+						Name: "rp1",
+						Subscriptions: []meta.SubscriptionInfo{
+							{Name: "s2", Mode: "ALL", Destinations: []string{"udp://h4:1234", "udp://h5:1234"}},
+						},
+					},
+				},
+			},
+			{
+				Name: "db1",
+				RetentionPolicies: []meta.RetentionPolicyInfo{
+					{
+						Name: "rp2",
+						Subscriptions: []meta.SubscriptionInfo{
+							{Name: "s3", Mode: "ANY", Destinations: []string{"udp://h6:1234", "udp://h7:1234"}},
+						},
+					},
+				},
+			},
+		}, nil
+	}
+
+	stmt := influxql.MustParseStatement(`SHOW SUBSCRIPTIONS`)
+	if res := e.ExecuteStatement(stmt); res.Err != nil {
+		t.Fatal(res.Err)
+	} else if !reflect.DeepEqual(res.Series, models.Rows{
+		{
+			Name:    "db0",
+			Columns: []string{"retention_policy", "name", "mode", "destinations"},
+			Values: [][]interface{}{
+				{"rp0", "s0", "ALL", []string{"udp://h0:1234", "udp://h1:1234"}},
+				{"rp0", "s1", "ANY", []string{"udp://h2:1234", "udp://h3:1234"}},
+				{"rp1", "s2", "ALL", []string{"udp://h4:1234", "udp://h5:1234"}},
+			},
+		},
+		{
+			Name:    "db1",
+			Columns: []string{"retention_policy", "name", "mode", "destinations"},
+			Values: [][]interface{}{
+				{"rp2", "s3", "ANY", []string{"udp://h6:1234", "udp://h7:1234"}},
+			},
+		},
+	}) {
+		t.Fatalf("unexpected rows: %s", spew.Sdump(res.Series))
+	}
+}
+
+// Ensure a SHOW SUBSCRIPTIONS statement can return an error from the store.
+func TestStatementExecutor_ExecuteStatement_ShowSubscriptions_Err(t *testing.T) {
+	e := NewStatementExecutor()
+	e.Store.DatabasesFn = func() ([]meta.DatabaseInfo, error) {
+		return nil, errors.New("marker")
+	}
+
+	stmt := influxql.MustParseStatement(`SHOW SUBSCRIPTIONS`)
+	if res := e.ExecuteStatement(stmt); res.Err == nil || res.Err.Error() != "marker" {
+		t.Fatal(res.Err)
+	}
+}
+
+// Ensure that executing an unsupported statement will panic.
+func TestStatementExecutor_ExecuteStatement_Unsupported(t *testing.T) {
+	var panicked bool
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				panicked = true
+			}
+		}()
+
+		// Execute a SELECT statement.
+		NewStatementExecutor().ExecuteStatement(
+			influxql.MustParseStatement(`SELECT count(field1) FROM db0`),
+		)
+	}()
+
+	// Ensure that the executor panicked.
+	if !panicked {
+		t.Fatal("executor did not panic")
+	}
+}
+
+// Ensure a SHOW SHARD GROUPS statement can be executed.
+func TestStatementExecutor_ExecuteStatement_ShowShardGroups(t *testing.T) {
+	e := NewStatementExecutor()
+	e.Store.DatabasesFn = func() ([]meta.DatabaseInfo, error) {
+		return []meta.DatabaseInfo{
+			{
+				Name: "foo",
+				RetentionPolicies: []meta.RetentionPolicyInfo{
+					{
+						Name:     "rpi_foo",
+						Duration: time.Second,
+						ShardGroups: []meta.ShardGroupInfo{
+							{
+								ID:        66,
+								StartTime: time.Unix(0, 0),
+								EndTime:   time.Unix(1, 0),
+							},
+						},
+					},
+				},
+			},
+			{
+				Name: "foo",
+				RetentionPolicies: []meta.RetentionPolicyInfo{
+					{
+						Name:     "rpi_foo",
+						Duration: time.Second,
+						ShardGroups: []meta.ShardGroupInfo{
+							{
+								ID:        77,
+								StartTime: time.Unix(2, 0),
+								EndTime:   time.Unix(3, 0),
+							},
+						},
+					},
+				},
+			},
+		}, nil
+	}
+
+	if res := e.ExecuteStatement(influxql.MustParseStatement(`SHOW SHARD GROUPS`)); res.Err != nil {
+		t.Fatal(res.Err)
+	} else if !reflect.DeepEqual(res.Series, models.Rows{
+		{
+			Name:    "shard groups",
+			Columns: []string{"id", "database", "retention_policy", "start_time", "end_time", "expiry_time"},
+			Values: [][]interface{}{
+				{uint64(66), "foo", "rpi_foo", "1970-01-01T00:00:00Z", "1970-01-01T00:00:01Z", "1970-01-01T00:00:02Z"},
+				{uint64(77), "foo", "rpi_foo", "1970-01-01T00:00:02Z", "1970-01-01T00:00:03Z", "1970-01-01T00:00:04Z"},
+			},
+		},
+	}) {
+		t.Fatalf("unexpected rows: %s", spew.Sdump(res.Series))
+	}
+}
+
+// Ensure a SHOW SHARDS statement can be executed.
+func TestStatementExecutor_ExecuteStatement_ShowShards(t *testing.T) {
+	e := NewStatementExecutor()
+	e.Store.DatabasesFn = func() ([]meta.DatabaseInfo, error) {
+		return []meta.DatabaseInfo{
+			{
+				Name: "foo",
+				RetentionPolicies: []meta.RetentionPolicyInfo{
+					{
+						Name:     "rpi_foo",
+						Duration: time.Second,
+						ShardGroups: []meta.ShardGroupInfo{
+							{
+								ID:        66,
+								StartTime: time.Unix(0, 0),
+								EndTime:   time.Unix(1, 0),
+								Shards: []meta.ShardInfo{
+									{
+										ID: 1,
+										Owners: []meta.ShardOwner{
+											{NodeID: 1},
+											{NodeID: 2},
+											{NodeID: 3},
+										},
+									},
+									{
+										ID: 2,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}, nil
+	}
+
+	if res := e.ExecuteStatement(influxql.MustParseStatement(`SHOW SHARDS`)); res.Err != nil {
+		t.Fatal(res.Err)
+	} else if !reflect.DeepEqual(res.Series, models.Rows{
+		{
+			Name:    "foo",
+			Columns: []string{"id", "database", "retention_policy", "shard_group", "start_time", "end_time", "expiry_time", "owners"},
+			Values: [][]interface{}{
+				{uint64(1), "foo", "rpi_foo", uint64(66), "1970-01-01T00:00:00Z", "1970-01-01T00:00:01Z", "1970-01-01T00:00:02Z", "1,2,3"},
+				{uint64(2), "foo", "rpi_foo", uint64(66), "1970-01-01T00:00:00Z", "1970-01-01T00:00:01Z", "1970-01-01T00:00:02Z", ""},
+			},
+		},
+	}) {
+		t.Fatalf("unexpected rows: %s", spew.Sdump(res.Series))
+	}
+}
+
+// StatementExecutor represents a test wrapper for meta.StatementExecutor.
+type StatementExecutor struct {
+	*meta.StatementExecutor
+	Store StatementExecutorStore
+}
+
+// NewStatementExecutor returns a new instance of StatementExecutor with a mock store.
+func NewStatementExecutor() *StatementExecutor {
+	e := &StatementExecutor{}
+	e.StatementExecutor = &meta.StatementExecutor{Store: &e.Store}
+	return e
+}
+
+// StatementExecutorStore represents a mock implementation of StatementExecutor.Store.
+type StatementExecutorStore struct {
+	NodeFn                              func(id uint64) (*meta.NodeInfo, error)
+	NodesFn                             func() ([]meta.NodeInfo, error)
+	PeersFn                             func() ([]string, error)
+	LeaderFn                            func() string
+	DatabaseFn                          func(name string) (*meta.DatabaseInfo, error)
+	DatabasesFn                         func() ([]meta.DatabaseInfo, error)
+	CreateDatabaseFn                    func(name string) (*meta.DatabaseInfo, error)
+	CreateDatabaseWithRetentionPolicyFn func(name string, rpi *meta.RetentionPolicyInfo) (*meta.DatabaseInfo, error)
+	DropDatabaseFn                      func(name string) error
+	DeleteDataNodeFn                    func(nodeID uint64) error
+	DeleteMetaNodeFn                    func(nodeID uint64) error
+	DefaultRetentionPolicyFn            func(database string) (*meta.RetentionPolicyInfo, error)
+	CreateRetentionPolicyFn             func(database string, rpi *meta.RetentionPolicyInfo) (*meta.RetentionPolicyInfo, error)
+	UpdateRetentionPolicyFn             func(database, name string, rpu *meta.RetentionPolicyUpdate) error
+	SetDefaultRetentionPolicyFn         func(database, name string) error
+	DropRetentionPolicyFn               func(database, name string) error
+	UsersFn                             func() ([]meta.UserInfo, error)
+	CreateUserFn                        func(name, password string, admin bool) (*meta.UserInfo, error)
+	UpdateUserFn                        func(name, password string) error
+	DropUserFn                          func(name string) error
+	SetPrivilegeFn                      func(username, database string, p influxql.Privilege) error
+	SetAdminPrivilegeFn                 func(username string, admin bool) error
+	UserPrivilegesFn                    func(username string) (map[string]influxql.Privilege, error)
+	UserPrivilegeFn                     func(username, database string) (*influxql.Privilege, error)
+	ContinuousQueriesFn                 func() ([]meta.ContinuousQueryInfo, error)
+	CreateContinuousQueryFn             func(database, name, query string) error
+	DropContinuousQueryFn               func(database, name string) error
+	CreateSubscriptionFn                func(database, rp, name, typ string, hosts []string) error
+	DropSubscriptionFn                  func(database, rp, name string) error
+}
+
+func (s *StatementExecutorStore) DataNode(id uint64) (*meta.NodeInfo, error) {
+	return s.NodeFn(id)
+}
+
+func (s *StatementExecutorStore) DataNodes() ([]meta.NodeInfo, error) {
+	return s.NodesFn()
+}
+
+func (s *StatementExecutorStore) MetaNodes() ([]meta.NodeInfo, error) {
+	return s.NodesFn()
+}
+
+func (s *StatementExecutorStore) DeleteDataNode(nodeID uint64) error {
+	return s.DeleteDataNodeFn(nodeID)
+}
+
+func (s *StatementExecutorStore) DeleteMetaNode(nodeID uint64) error {
+	return s.DeleteMetaNodeFn(nodeID)
+}
+
+func (s *StatementExecutorStore) Database(name string) (*meta.DatabaseInfo, error) {
+	return s.DatabaseFn(name)
+}
+
+func (s *StatementExecutorStore) Databases() ([]meta.DatabaseInfo, error) {
+	return s.DatabasesFn()
+}
+
+func (s *StatementExecutorStore) CreateDatabase(name string) (*meta.DatabaseInfo, error) {
+	return s.CreateDatabaseFn(name)
+}
+
+func (s *StatementExecutorStore) CreateDatabaseWithRetentionPolicy(name string, rpi *meta.RetentionPolicyInfo) (*meta.DatabaseInfo, error) {
+	return s.CreateDatabaseWithRetentionPolicy(name, rpi)
+}
+
+func (s *StatementExecutorStore) DropDatabase(name string) error {
+	return s.DropDatabaseFn(name)
+}
+
+func (s *StatementExecutorStore) DefaultRetentionPolicy(database string) (*meta.RetentionPolicyInfo, error) {
+	return s.DefaultRetentionPolicyFn(database)
+}
+
+func (s *StatementExecutorStore) CreateRetentionPolicy(database string, rpi *meta.RetentionPolicyInfo) (*meta.RetentionPolicyInfo, error) {
+	return s.CreateRetentionPolicyFn(database, rpi)
+}
+
+func (s *StatementExecutorStore) UpdateRetentionPolicy(database, name string, rpu *meta.RetentionPolicyUpdate) error {
+	return s.UpdateRetentionPolicyFn(database, name, rpu)
+}
+
+func (s *StatementExecutorStore) SetDefaultRetentionPolicy(database, name string) error {
+	return s.SetDefaultRetentionPolicyFn(database, name)
+}
+
+func (s *StatementExecutorStore) DropRetentionPolicy(database, name string) error {
+	return s.DropRetentionPolicyFn(database, name)
+}
+
+func (s *StatementExecutorStore) Users() ([]meta.UserInfo, error) {
+	return s.UsersFn()
+}
+
+func (s *StatementExecutorStore) CreateUser(name, password string, admin bool) (*meta.UserInfo, error) {
+	return s.CreateUserFn(name, password, admin)
+}
+
+func (s *StatementExecutorStore) UpdateUser(name, password string) error {
+	return s.UpdateUserFn(name, password)
+}
+
+func (s *StatementExecutorStore) DropUser(name string) error {
+	return s.DropUserFn(name)
+}
+
+func (s *StatementExecutorStore) SetPrivilege(username, database string, p influxql.Privilege) error {
+	return s.SetPrivilegeFn(username, database, p)
+}
+
+func (s *StatementExecutorStore) SetAdminPrivilege(username string, admin bool) error {
+	return s.SetAdminPrivilegeFn(username, admin)
+}
+
+func (s *StatementExecutorStore) UserPrivileges(username string) (map[string]influxql.Privilege, error) {
+	return s.UserPrivilegesFn(username)
+}
+
+func (s *StatementExecutorStore) UserPrivilege(username, database string) (*influxql.Privilege, error) {
+	return s.UserPrivilegeFn(username, database)
+}
+
+func (s *StatementExecutorStore) ContinuousQueries() ([]meta.ContinuousQueryInfo, error) {
+	return s.ContinuousQueriesFn()
+}
+
+func (s *StatementExecutorStore) CreateContinuousQuery(database, name, query string) error {
+	return s.CreateContinuousQueryFn(database, name, query)
+}
+
+func (s *StatementExecutorStore) DropContinuousQuery(database, name string) error {
+	return s.DropContinuousQueryFn(database, name)
+}
+
+func (s *StatementExecutorStore) CreateSubscription(database, rp, name, typ string, hosts []string) error {
+	return s.CreateSubscriptionFn(database, rp, name, typ, hosts)
+}
+
+func (s *StatementExecutorStore) DropSubscription(database, rp, name string) error {
+	return s.DropSubscriptionFn(database, rp, name)
+}

--- a/services/meta/store.go
+++ b/services/meta/store.go
@@ -1,25 +1,24 @@
 package meta
 
 import (
-	"bytes"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io/ioutil"
 	"log"
 	"net"
 	"os"
-	"path/filepath"
-	"strconv"
 	"sync"
 	"time"
 
+	"github.com/influxdb/influxdb/services/meta/internal"
+
+	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/raft"
 )
 
-type store struct {
-	id uint64 // local node id
+const raftListenerStartupTimeout = time.Second
 
+type store struct {
 	mu      sync.RWMutex
 	closing chan struct{}
 
@@ -27,12 +26,8 @@ type store struct {
 	data        *Data
 	raftState   *raftState
 	dataChanged chan struct{}
-	ready       chan struct{}
-	addr        string
-	raftln      net.Listener
 	path        string
 	opened      bool
-	peers       []string
 	logger      *log.Logger
 
 	// Authentication cache.
@@ -44,15 +39,14 @@ type authUser struct {
 	hash []byte
 }
 
+// newStore will create a new metastore with the passed in config
 func newStore(c *Config) *store {
 	s := store{
 		data: &Data{
 			Index: 1,
 		},
-		ready:       make(chan struct{}),
 		closing:     make(chan struct{}),
 		dataChanged: make(chan struct{}),
-		addr:        c.RaftBindAddress,
 		path:        c.Dir,
 		config:      c,
 	}
@@ -66,15 +60,32 @@ func newStore(c *Config) *store {
 }
 
 // open opens and initializes the raft store.
-func (s *store) open() error {
-	ln, err := net.Listen("tcp", s.addr)
-	if err != nil {
-		return err
-	}
-	s.raftln = ln
-	s.addr = ln.Addr().String()
-
+func (s *store) open(addr string, raftln net.Listener) error {
 	s.logger.Printf("Using data dir: %v", s.path)
+
+	// wait for the raft listener to start
+	timeout := time.Now().Add(raftListenerStartupTimeout)
+	for {
+		if raftln.Addr() != nil {
+			break
+		}
+
+		if time.Now().After(timeout) {
+			return fmt.Errorf("unable to open without raft listener running")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	// See if this server needs to join the raft consensus group
+	var initializePeers []string
+	if len(s.config.JoinPeers) > 0 {
+		c := NewClient(s.config.JoinPeers, s.config.HTTPSEnabled)
+		data := c.retryUntilSnapshot(0)
+		for _, n := range data.MetaNodes {
+			initializePeers = append(initializePeers, n.TCPHost)
+		}
+		initializePeers = append(initializePeers, raftln.Addr().String())
+	}
 
 	if err := func() error {
 		s.mu.Lock()
@@ -86,29 +97,14 @@ func (s *store) open() error {
 		}
 		s.opened = true
 
-		// load our raft peers
-		if err := s.loadPeers(); err != nil {
-			return err
-		}
-
 		// Create the root directory if it doesn't already exist.
 		if err := os.MkdirAll(s.path, 0777); err != nil {
 			return fmt.Errorf("mkdir all: %s", err)
 		}
 
 		// Open the raft store.
-		if err := s.openRaft(); err != nil {
+		if err := s.openRaft(initializePeers, raftln); err != nil {
 			return fmt.Errorf("raft: %s", err)
-		}
-
-		// Initialize the store, if necessary.
-		if err := s.raftState.initialize(); err != nil {
-			return fmt.Errorf("initialize raft: %s", err)
-		}
-
-		// Load existing ID, if exists.
-		if err := s.readID(); err != nil {
-			return fmt.Errorf("read id: %s", err)
 		}
 
 		return nil
@@ -116,154 +112,53 @@ func (s *store) open() error {
 		return err
 	}
 
-	// Join an existing cluster if we needed
-	if err := s.joinCluster(); err != nil {
-		return fmt.Errorf("join: %v", err)
-	}
+	if len(s.config.JoinPeers) > 0 {
+		c := NewClient(s.config.JoinPeers, s.config.HTTPSEnabled)
+		if err := c.Open(); err != nil {
+			return err
+		}
+		defer c.Close()
 
-	// If the ID doesn't exist then create a new node.
-	if s.id == 0 {
-		go s.raftState.initialize()
-	} else {
-		// TODO: enable node info sync
-		// all this does is update the raft peers with the new hostname of this node if it changed
-		// based on the ID of this node
-
-		// go s.syncNodeInfo()
-		close(s.ready)
-	}
-
-	// Wait for a leader to be elected so we know the raft log is loaded
-	// and up to date
-	//<-s.ready
-	if err := s.waitForLeader(0); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// loadPeers sets the appropriate peers from our persistent storage
-func (s *store) loadPeers() error {
-	peers, err := readPeersJSON(filepath.Join(s.path, "peers.json"))
-	if err != nil {
-		return err
-	}
-
-	// If we have existing peers, use those.  This will override what's in the
-	// config.
-	if len(peers) > 0 {
-		s.peers = peers
-
-		if _, err := os.Stat(filepath.Join(s.path, "raft.db")); err != nil {
+		if err := c.JoinMetaServer(addr, raftln.Addr().String()); err != nil {
 			return err
 		}
 	}
 
-	return nil
-}
-
-func readPeersJSON(path string) ([]string, error) {
-	// Read the file
-	buf, err := ioutil.ReadFile(path)
-	if err != nil && !os.IsNotExist(err) {
-		return nil, err
+	// Wait for a leader to be elected so we know the raft log is loaded
+	// and up to date
+	if err := s.waitForLeader(0); err != nil {
+		return err
 	}
 
-	// Check for no peers
-	if len(buf) == 0 {
-		return nil, nil
-	}
-
-	// Decode the peers
-	var peers []string
-	dec := json.NewDecoder(bytes.NewReader(buf))
-	if err := dec.Decode(&peers); err != nil {
-		return nil, err
-	}
-
-	return peers, nil
-}
-
-// IDPath returns the path to the local node ID file.
-func (s *store) IDPath() string { return filepath.Join(s.path, "id") }
-
-// readID reads the local node ID from the ID file.
-func (s *store) readID() error {
-	b, err := ioutil.ReadFile(s.IDPath())
-	if os.IsNotExist(err) {
-		s.id = 0
-		return nil
-	} else if err != nil {
-		return fmt.Errorf("read file: %s", err)
-	}
-
-	id, err := strconv.ParseUint(string(b), 10, 64)
+	// Make sure this server is in the list of metanodes
+	peers, err := s.raftState.peers()
 	if err != nil {
-		return fmt.Errorf("parse id: %s", err)
+		return err
 	}
-	s.id = id
+	if len(peers) <= 1 {
+		if err := s.createMetaNode(addr, raftln.Addr().String()); err != nil {
+			return err
+		}
+	}
+
+	// if we joined this server to the cluster, we need to add it as a metanode
+	if len(s.config.JoinPeers) > 0 {
+	}
 
 	return nil
 }
 
-func (s *store) openRaft() error {
-	rs := newRaftState(s.config, s.peers)
-	rs.ln = s.raftln
+func (s *store) openRaft(initializePeers []string, raftln net.Listener) error {
+	rs := newRaftState(s.config)
 	rs.logger = s.logger
 	rs.path = s.path
-	rs.remoteAddr = s.raftln.Addr()
-	if err := rs.open(s); err != nil {
+
+	if err := rs.open(s, raftln, initializePeers); err != nil {
 		return err
 	}
 	s.raftState = rs
 
 	return nil
-}
-
-func (s *store) joinCluster() error {
-
-	// No join options, so nothing to do
-	if len(s.peers) == 0 {
-		return nil
-	}
-
-	// We already have a node ID so were already part of a cluster,
-	// don't join again so we can use our existing state.
-	if s.id != 0 {
-		s.logger.Printf("Skipping cluster join: already member of cluster: nodeId=%v raftEnabled=%v peers=%v",
-			s.id, raft.PeerContained(s.peers, s.addr), s.peers)
-		return nil
-	}
-
-	s.logger.Printf("Joining cluster at: %v", s.peers)
-	for {
-		for _, join := range s.peers {
-			// delete me:
-			_ = join
-
-			// TODO rework this to use the HTTP endpoint for joining
-			//res, err := s.rpc.join(s.RemoteAddr.String(), join)
-			//if err != nil {
-			//s.logger.Printf("Join node %v failed: %v: retrying...", join, err)
-			//continue
-			//}
-
-			//s.logger.Printf("Joined remote node %v", join)
-			//s.logger.Printf("nodeId=%v raftEnabled=%v peers=%v", res.NodeID, res.RaftEnabled, res.RaftNodes)
-
-			//s.peers = res.RaftNodes
-			//s.id = res.NodeID
-
-			//if err := s.writeNodeID(res.NodeID); err != nil {
-			//s.logger.Printf("Write node id failed: %v", err)
-			//break
-			//}
-
-			return nil
-		}
-		time.Sleep(time.Second)
-	}
 }
 
 func (s *store) close() error {
@@ -342,6 +237,25 @@ func (s *store) leader() string {
 	return s.raftState.raft.Leader()
 }
 
+// leaderHTTP returns the HTTP API connection info for the metanode
+// that is the raft leader
+func (s *store) leaderHTTP() string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.raftState == nil {
+		return ""
+	}
+	l := s.raftState.raft.Leader()
+
+	for _, n := range s.data.MetaNodes {
+		if n.TCPHost == l {
+			return n.Host
+		}
+	}
+
+	return ""
+}
+
 // index returns the current store index.
 func (s *store) index() uint64 {
 	s.mu.RLock()
@@ -352,6 +266,39 @@ func (s *store) index() uint64 {
 // apply applies a command to raft.
 func (s *store) apply(b []byte) error {
 	return s.raftState.apply(b)
+}
+
+// join adds a new server to the metaservice and raft
+func (s *store) join(n *NodeInfo) error {
+	if err := s.raftState.addPeer(n.TCPHost); err != nil {
+		return err
+	}
+
+	return s.createMetaNode(n.Host, n.TCPHost)
+}
+
+// leave removes a server from the metaservice and raft
+func (s *store) leave(n *NodeInfo) error {
+	return s.raftState.removePeer(n.TCPHost)
+}
+
+func (s *store) createMetaNode(addr, raftAddr string) error {
+	val := &internal.CreateMetaNodeCommand{
+		HTTPAddr: proto.String(addr),
+		TCPAddr:  proto.String(raftAddr),
+	}
+	t := internal.Command_CreateMetaNodeCommand
+	cmd := &internal.Command{Type: &t}
+	if err := proto.SetExtension(cmd, internal.E_CreateMetaNodeCommand_Command, val); err != nil {
+		panic(err)
+	}
+
+	b, err := proto.Marshal(cmd)
+	if err != nil {
+		return err
+	}
+
+	return s.apply(b)
 }
 
 // RetentionPolicyUpdate represents retention policy fields to be updated.


### PR DESCRIPTION
* Add dir, hostname, and bind address to top level config since it applies to services other than meta
* Add enabled flags to example toml for data and meta services
* Wire up add/remove raft peers and meta servers to meta service
* Update DROP SERVER to be either DROP META SERVER or DROP DATA SERVER
* Bring over statement executor from old meta package
* Start meta service client implementation
* Update meta service test to use the client
* Wire up node ID/meta server storage information

cc @corylanou @dgnorton 