### PR TITLE
Wire up meta service and client recovery

### DIFF
--- a/services/meta/client.go
+++ b/services/meta/client.go
@@ -154,7 +154,6 @@ func (c *Client) CreateDatabase(name string) (*DatabaseInfo, error) {
 
 	err := c.retryUntilExec(internal.Command_CreateDatabaseCommand, internal.E_CreateDatabaseCommand_Command, cmd)
 	if err != nil {
-		fmt.Println("ERROR: ", err)
 		return nil, err
 	}
 
@@ -543,7 +542,6 @@ func (c *Client) exec(url string, typ internal.Command_Type, desc *proto.Extensi
 func (c *Client) waitForIndex(idx uint64) {
 	for {
 		c.mu.RLock()
-		fmt.Println("waitForIndex: ", idx, c.data.Index)
 		if c.data.Index >= idx {
 			c.mu.RUnlock()
 			return

--- a/services/meta/client.go
+++ b/services/meta/client.go
@@ -556,6 +556,8 @@ func (c *Client) pollForUpdates() {
 	for {
 		data := c.retryUntilSnapshot(c.index())
 		if data == nil {
+			// this will only be nil if the client has been closed,
+			// so we can exit out
 			return
 		}
 

--- a/services/meta/data.go
+++ b/services/meta/data.go
@@ -1,6 +1,7 @@
 package meta
 
 import (
+	"fmt"
 	"sort"
 	"time"
 
@@ -136,6 +137,24 @@ func (data *Data) CreateMetaNode(httpAddr, tcpAddr string) error {
 		Host:    httpAddr,
 		TCPHost: tcpAddr,
 	})
+
+	return nil
+}
+
+// SetMetaNode will update the information for the single meta
+// node or create a new metanode. If there are more than 1 meta
+// nodes already, an error will be returned
+func (data *Data) SetMetaNode(httpAddr, tcpAddr string) error {
+	if len(data.MetaNodes) > 1 {
+		return fmt.Errorf("can't set meta node when there are more than 1 in the metastore")
+	}
+
+	if len(data.MetaNodes) == 0 {
+		return data.CreateMetaNode(httpAddr, tcpAddr)
+	}
+
+	data.MetaNodes[0].Host = httpAddr
+	data.MetaNodes[0].TCPHost = tcpAddr
 
 	return nil
 }

--- a/services/meta/handler.go
+++ b/services/meta/handler.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -37,14 +38,20 @@ type handler struct {
 		apply(b []byte) error
 		join(n *NodeInfo) error
 	}
+	s *Service
+
+	mu      sync.RWMutex
+	closing chan struct{}
 }
 
 // newHandler returns a new instance of handler with routes.
-func newHandler(c *Config) *handler {
+func newHandler(c *Config, s *Service) *handler {
 	h := &handler{
+		s:              s,
 		config:         c,
 		logger:         log.New(os.Stderr, "[meta-http] ", log.LstdFlags),
 		loggingEnabled: c.LoggingEnabled,
+		closing:        make(chan struct{}),
 	}
 
 	return h
@@ -79,8 +86,36 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+func (h *handler) Close() error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	select {
+	case <-h.closing:
+		// do nothing here
+	default:
+		close(h.closing)
+	}
+	return nil
+}
+
+func (h *handler) isClosed() error {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	select {
+	case <-h.closing:
+		return fmt.Errorf("server closed")
+	default:
+		return nil
+	}
+}
+
 // serveExec executes the requested command.
 func (h *handler) serveExec(w http.ResponseWriter, r *http.Request) {
+	if err := h.isClosed(); err != nil {
+		h.httpError(err, w, http.StatusInternalServerError)
+		return
+	}
+
 	// Read the command from the request body.
 	body, err := ioutil.ReadAll(r.Body)
 	if err != nil {
@@ -183,6 +218,11 @@ func validateCommand(b []byte) error {
 
 // serveSnapshot is a long polling http connection to server cache updates
 func (h *handler) serveSnapshot(w http.ResponseWriter, r *http.Request) {
+	if err := h.isClosed(); err != nil {
+		h.httpError(err, w, http.StatusInternalServerError)
+		return
+	}
+
 	// get the current index that client has
 	index, err := strconv.ParseUint(r.URL.Query().Get("index"), 10, 64)
 	if err != nil {
@@ -206,6 +246,9 @@ func (h *handler) serveSnapshot(w http.ResponseWriter, r *http.Request) {
 		return
 	case <-w.(http.CloseNotifier).CloseNotify():
 		// Client closed the connection so we're done.
+		return
+	case <-h.closing:
+		h.httpError(fmt.Errorf("server closed"), w, http.StatusInternalServerError)
 		return
 	}
 }

--- a/services/meta/internal/meta.pb.go
+++ b/services/meta/internal/meta.pb.go
@@ -49,6 +49,7 @@ It has these top-level messages:
 	DeleteMetaNodeCommand
 	DeleteDataNodeCommand
 	Response
+	SetMetaNodeCommand
 */
 package internal
 
@@ -91,6 +92,7 @@ const (
 	Command_UpdateDataNodeCommand            Command_Type = 26
 	Command_DeleteMetaNodeCommand            Command_Type = 27
 	Command_DeleteDataNodeCommand            Command_Type = 28
+	Command_SetMetaNodeCommand               Command_Type = 29
 )
 
 var Command_Type_name = map[int32]string{
@@ -121,6 +123,7 @@ var Command_Type_name = map[int32]string{
 	26: "UpdateDataNodeCommand",
 	27: "DeleteMetaNodeCommand",
 	28: "DeleteDataNodeCommand",
+	29: "SetMetaNodeCommand",
 }
 var Command_Type_value = map[string]int32{
 	"CreateNodeCommand":                1,
@@ -150,6 +153,7 @@ var Command_Type_value = map[string]int32{
 	"UpdateDataNodeCommand":            26,
 	"DeleteMetaNodeCommand":            27,
 	"DeleteDataNodeCommand":            28,
+	"SetMetaNodeCommand":               29,
 }
 
 func (x Command_Type) Enum() *Command_Type {
@@ -1595,6 +1599,40 @@ func (m *Response) GetIndex() uint64 {
 	return 0
 }
 
+// SetMetaNodeCommand is for the initial metanode in a cluster or
+// if the single host restarts and its hostname changes, this will update it
+type SetMetaNodeCommand struct {
+	HTTPAddr         *string `protobuf:"bytes,1,req,name=HTTPAddr" json:"HTTPAddr,omitempty"`
+	TCPAddr          *string `protobuf:"bytes,2,req,name=TCPAddr" json:"TCPAddr,omitempty"`
+	XXX_unrecognized []byte  `json:"-"`
+}
+
+func (m *SetMetaNodeCommand) Reset()         { *m = SetMetaNodeCommand{} }
+func (m *SetMetaNodeCommand) String() string { return proto.CompactTextString(m) }
+func (*SetMetaNodeCommand) ProtoMessage()    {}
+
+func (m *SetMetaNodeCommand) GetHTTPAddr() string {
+	if m != nil && m.HTTPAddr != nil {
+		return *m.HTTPAddr
+	}
+	return ""
+}
+
+func (m *SetMetaNodeCommand) GetTCPAddr() string {
+	if m != nil && m.TCPAddr != nil {
+		return *m.TCPAddr
+	}
+	return ""
+}
+
+var E_SetMetaNodeCommand_Command = &proto.ExtensionDesc{
+	ExtendedType:  (*Command)(nil),
+	ExtensionType: (*SetMetaNodeCommand)(nil),
+	Field:         129,
+	Name:          "internal.SetMetaNodeCommand.command",
+	Tag:           "bytes,129,opt,name=command",
+}
+
 func init() {
 	proto.RegisterType((*Data)(nil), "internal.Data")
 	proto.RegisterType((*NodeInfo)(nil), "internal.NodeInfo")
@@ -1636,6 +1674,7 @@ func init() {
 	proto.RegisterType((*DeleteMetaNodeCommand)(nil), "internal.DeleteMetaNodeCommand")
 	proto.RegisterType((*DeleteDataNodeCommand)(nil), "internal.DeleteDataNodeCommand")
 	proto.RegisterType((*Response)(nil), "internal.Response")
+	proto.RegisterType((*SetMetaNodeCommand)(nil), "internal.SetMetaNodeCommand")
 	proto.RegisterEnum("internal.Command_Type", Command_Type_name, Command_Type_value)
 	proto.RegisterExtension(E_CreateNodeCommand_Command)
 	proto.RegisterExtension(E_DeleteNodeCommand_Command)
@@ -1664,4 +1703,5 @@ func init() {
 	proto.RegisterExtension(E_UpdateDataNodeCommand_Command)
 	proto.RegisterExtension(E_DeleteMetaNodeCommand_Command)
 	proto.RegisterExtension(E_DeleteDataNodeCommand_Command)
+	proto.RegisterExtension(E_SetMetaNodeCommand_Command)
 }

--- a/services/meta/internal/meta.proto
+++ b/services/meta/internal/meta.proto
@@ -125,6 +125,7 @@ message Command {
         UpdateDataNodeCommand            = 26;
         DeleteMetaNodeCommand            = 27;
         DeleteDataNodeCommand            = 28;
+        SetMetaNodeCommand               = 29;
     }
 
     required Type type = 1;
@@ -360,4 +361,14 @@ message Response {
 	required bool OK = 1;
 	optional string Error = 2;
 	optional uint64 Index = 3;
+}
+
+// SetMetaNodeCommand is for the initial metanode in a cluster or
+// if the single host restarts and its hostname changes, this will update it
+message SetMetaNodeCommand {
+    extend Command {
+        optional SetMetaNodeCommand command = 129;
+    }
+    required string HTTPAddr = 1;
+    required string TCPAddr = 2;
 }

--- a/services/meta/store.go
+++ b/services/meta/store.go
@@ -45,6 +45,9 @@ type store struct {
 
 	// Authentication cache.
 	authCache map[string]authUser
+
+	raftAddr string
+	httpAddr string
 }
 
 type authUser struct {
@@ -53,7 +56,7 @@ type authUser struct {
 }
 
 // newStore will create a new metastore with the passed in config
-func newStore(c *Config) *store {
+func newStore(c *Config, httpAddr, raftAddr string) *store {
 	s := store{
 		data: &Data{
 			Index: 1,
@@ -62,6 +65,8 @@ func newStore(c *Config) *store {
 		dataChanged: make(chan struct{}),
 		path:        c.Dir,
 		config:      c,
+		httpAddr:    httpAddr,
+		raftAddr:    raftAddr,
 	}
 	if c.LoggingEnabled {
 		s.logger = log.New(os.Stderr, "[metastore] ", log.LstdFlags)
@@ -73,21 +78,8 @@ func newStore(c *Config) *store {
 }
 
 // open opens and initializes the raft store.
-func (s *store) open(addr string, raftln net.Listener) error {
+func (s *store) open(raftln net.Listener) error {
 	s.logger.Printf("Using data dir: %v", s.path)
-
-	// wait for the raft listener to start
-	timeout := time.Now().Add(raftListenerStartupTimeout)
-	for {
-		if raftln.Addr() != nil {
-			break
-		}
-
-		if time.Now().After(timeout) {
-			return fmt.Errorf("unable to open without raft listener running")
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
 
 	// See if this server needs to join the raft consensus group
 	var initializePeers []string
@@ -97,7 +89,7 @@ func (s *store) open(addr string, raftln net.Listener) error {
 		for _, n := range data.MetaNodes {
 			initializePeers = append(initializePeers, n.TCPHost)
 		}
-		initializePeers = append(initializePeers, raftln.Addr().String())
+		initializePeers = append(initializePeers, s.raftAddr)
 	}
 
 	if err := func() error {
@@ -132,7 +124,7 @@ func (s *store) open(addr string, raftln net.Listener) error {
 		}
 		defer c.Close()
 
-		if err := c.JoinMetaServer(addr, raftln.Addr().String()); err != nil {
+		if err := c.JoinMetaServer(s.httpAddr, s.raftAddr); err != nil {
 			return err
 		}
 	}
@@ -149,20 +141,23 @@ func (s *store) open(addr string, raftln net.Listener) error {
 		return err
 	}
 	if len(peers) <= 1 {
-		if err := s.createMetaNode(addr, raftln.Addr().String()); err != nil {
-			return err
+		// we have to loop here because if the hostname has changed
+		// raft will take a little bit to normalize so that this host
+		// will be marked as the leader
+		for {
+			err := s.setMetaNode(s.httpAddr, s.raftAddr)
+			if err == nil {
+				break
+			}
+			time.Sleep(100 * time.Millisecond)
 		}
-	}
-
-	// if we joined this server to the cluster, we need to add it as a metanode
-	if len(s.config.JoinPeers) > 0 {
 	}
 
 	return nil
 }
 
 func (s *store) openRaft(initializePeers []string, raftln net.Listener) error {
-	rs := newRaftState(s.config)
+	rs := newRaftState(s.config, s.raftAddr)
 	rs.logger = s.logger
 	rs.path = s.path
 
@@ -302,6 +297,8 @@ func (s *store) leave(n *NodeInfo) error {
 	return s.raftState.removePeer(n.TCPHost)
 }
 
+// createMetaNode is used by the join command to create the metanode int
+// the metastore
 func (s *store) createMetaNode(addr, raftAddr string) error {
 	val := &internal.CreateMetaNodeCommand{
 		HTTPAddr: proto.String(addr),
@@ -310,6 +307,28 @@ func (s *store) createMetaNode(addr, raftAddr string) error {
 	t := internal.Command_CreateMetaNodeCommand
 	cmd := &internal.Command{Type: &t}
 	if err := proto.SetExtension(cmd, internal.E_CreateMetaNodeCommand_Command, val); err != nil {
+		panic(err)
+	}
+
+	b, err := proto.Marshal(cmd)
+	if err != nil {
+		return err
+	}
+
+	return s.apply(b)
+}
+
+// setMetaNode is used when the raft group has only a single peer. It will
+// either create a metanode or update the information for the one metanode
+// that is there. It's used because hostnames can change
+func (s *store) setMetaNode(addr, raftAddr string) error {
+	val := &internal.SetMetaNodeCommand{
+		HTTPAddr: proto.String(addr),
+		TCPAddr:  proto.String(raftAddr),
+	}
+	t := internal.Command_SetMetaNodeCommand
+	cmd := &internal.Command{Type: &t}
+	if err := proto.SetExtension(cmd, internal.E_SetMetaNodeCommand_Command, val); err != nil {
 		panic(err)
 	}
 

--- a/services/meta/store_fsm.go
+++ b/services/meta/store_fsm.go
@@ -82,6 +82,8 @@ func (fsm *storeFSM) Apply(l *raft.Log) interface{} {
 			return fsm.applyCreateMetaNodeCommand(&cmd)
 		case internal.Command_DeleteMetaNodeCommand:
 			return fsm.applyDeleteMetaNodeCommand(&cmd, s)
+		case internal.Command_SetMetaNodeCommand:
+			return fsm.applySetMetaNodeCommand(&cmd)
 		default:
 			panic(fmt.Errorf("cannot apply command: %x", l.Data))
 		}
@@ -479,6 +481,16 @@ func (fsm *storeFSM) applyCreateMetaNodeCommand(cmd *internal.Command) interface
 
 	other := fsm.data.Clone()
 	other.CreateMetaNode(v.GetHTTPAddr(), v.GetTCPAddr())
+	fsm.data = other
+	return nil
+}
+
+func (fsm *storeFSM) applySetMetaNodeCommand(cmd *internal.Command) interface{} {
+	ext, _ := proto.GetExtension(cmd, internal.E_SetMetaNodeCommand_Command)
+	v := ext.(*internal.SetMetaNodeCommand)
+
+	other := fsm.data.Clone()
+	other.SetMetaNode(v.GetHTTPAddr(), v.GetTCPAddr())
 	fsm.data = other
 	return nil
 }


### PR DESCRIPTION
* increase sleep on error in client exec in case a server went down so we don't max out retries before a new leader gets elected
* update and add close logic to service, handler, raft state, and the client

cc @dgnorton, @corylanou 