### PR TITLE
Fix panic: runtime error: slice bounds out of range

### DIFF
--- a/tsdb/engine/tsm1/reader.go
+++ b/tsdb/engine/tsm1/reader.go
@@ -607,7 +607,7 @@ func (d *indirectIndex) UnmarshalBinary(b []byte) error {
 		i++
 
 		// 2 byte count of index entries
-		count := btou16(b[i : i+indexCountSize])
+		count := int32(btou16(b[i : i+indexCountSize]))
 		i += indexCountSize
 
 		// Find the min time for the block


### PR DESCRIPTION
The block count was an uint16 when incrementing the index location
which was an int32.  This caused the value the uint16 value to overflow
before the index location was incremented causing the wrong location
to be read on the next iteration of the loop.  This triggers the slice
out of range errors.

Added a test that recreates the panic seen in #5257 and possibly #5202 which
is older code.

Fixes #5257